### PR TITLE
Fix MalformedZarrError in ecmwf_ens_forecast

### DIFF
--- a/packages/dynamical_data/src/dynamical_data/processing.py
+++ b/packages/dynamical_data/src/dynamical_data/processing.py
@@ -83,10 +83,8 @@ def validate_dataset_schema(ds: xr.Dataset) -> None:
         actual_dims = [d for d in da.dims if d in expected_dims]
         expected_dims_filtered = [d for d in expected_dims if d in da.dims]
         if actual_dims != expected_dims_filtered:
-            raise MalformedZarrError(
-                f"Variable '{var_name}' has wrong dimension order: {da.dims}, "
-                f"expected {expected_dims}"
-            )
+            # Transpose the data to the expected order
+            ds[var_name] = da.transpose(*expected_dims_filtered)
 
     # Check coordinate dtypes
     if not np.issubdtype(ds.latitude.dtype, np.floating):

--- a/tests/test_reproduce_dimension_order_bug.py
+++ b/tests/test_reproduce_dimension_order_bug.py
@@ -1,0 +1,40 @@
+import xarray as xr
+import numpy as np
+from dynamical_data.processing import validate_dataset_schema, REQUIRED_NWP_VARS
+
+
+def test_fix_dimension_order_bug():
+    """Verify that incorrect dimension order is fixed by validate_dataset_schema."""
+    init_time = np.datetime64("2026-03-01T00:00:00")
+
+    # Create a dataset with the WRONG dimension order for categorical_precipitation_type_surface
+    # Expected: ('latitude', 'longitude', 'init_time', 'lead_time', 'ensemble_member')
+    # Actual: ('init_time', 'lead_time', 'ensemble_member', 'latitude', 'longitude')
+
+    wrong_dims = ("init_time", "lead_time", "ensemble_member", "latitude", "longitude")
+    correct_dims = ("latitude", "longitude", "init_time", "lead_time", "ensemble_member")
+    shape = (1, 1, 1, 1, 1)
+
+    data_vars = {}
+    for var in REQUIRED_NWP_VARS:
+        if var == "categorical_precipitation_type_surface":
+            data_vars[var] = (wrong_dims, np.zeros(shape))
+        else:
+            data_vars[var] = (correct_dims, np.zeros(shape))
+
+    ds = xr.Dataset(
+        {
+            "latitude": (["latitude"], [56.0]),
+            "longitude": (["longitude"], [-3.25]),
+            "init_time": (["init_time"], [init_time]),
+            "lead_time": (["lead_time"], np.array([0], dtype="timedelta64[h]")),
+            "ensemble_member": (["ensemble_member"], [0]),
+            **data_vars,
+        }
+    )
+
+    # This should NOT raise MalformedZarrError anymore
+    validate_dataset_schema(ds)
+
+    # Verify the dimension order is now correct
+    assert ds["categorical_precipitation_type_surface"].dims == correct_dims


### PR DESCRIPTION
## Summary
- Fixed `MalformedZarrError` in `ecmwf_ens_forecast` by automatically transposing variables with incorrect dimension order in `validate_dataset_schema`.
- Added a regression test `tests/test_reproduce_dimension_order_bug.py` to verify the fix.