### PR TITLE
ML Dagster Phase 2: `eligible_time_series` asset (canonical per-fold population)

### DIFF
--- a/docs/temp/dagster_plan.md
+++ b/docs/temp/dagster_plan.md
@@ -1210,7 +1210,7 @@ lagged power.
 - **User can verify:** `uv run pytest` green; the equivalence test now asserts power lags **and**
   the weather rolling mean match across modes.
 
-### 7.2 Phase 2 — `eligible_time_series` asset - Completed
+### 7.2 Phase 2 — `eligible_time_series` asset - Completed in PR #184
 
 - Implement the fold-partitioned, experiment-independent asset (§4.5.1) over `_cv_helpers`.
 - Tests: unit (from Phase 1) + an integration test materialising it on synthetic data.

--- a/docs/temp/dagster_plan.md
+++ b/docs/temp/dagster_plan.md
@@ -1152,7 +1152,7 @@ against a clean baseline instead of diffing against soon-to-be-deleted code.
 - **User can verify:** `uv run pytest` is green (and smaller); `uv run dg dev` loads with the
   monolithic CV assets gone and the data-layer assets intact.
 
-### 7.1 Phase 1 — Contracts, settings, pure helpers, equivalence test (foundation)
+### 7.1 Phase 1 — Contracts, settings, pure helpers, equivalence test (foundation) - Completed in PR #183
 
 *No new Dagster asset yet — this is the typed foundation everything else builds on.*
 
@@ -1175,7 +1175,7 @@ against a clean baseline instead of diffing against soon-to-be-deleted code.
 - **User can verify:** `uv run pytest` green; the new helper + equivalence tests demonstrate the
   `train_end` fix and the no-skew guarantee.
 
-### 7.1.5 Phase 1.5 — Unify power-lag source (Option B)
+### 7.1.5 Phase 1.5 — Unify power-lag source (Option B) - Completed in PR #183
 
 *Small standalone change; must land before Phase 5 (backtesting), where the bug below surfaces.*
 
@@ -1210,7 +1210,7 @@ lagged power.
 - **User can verify:** `uv run pytest` green; the equivalence test now asserts power lags **and**
   the weather rolling mean match across modes.
 
-### 7.2 Phase 2 — `eligible_time_series` asset
+### 7.2 Phase 2 — `eligible_time_series` asset - Completed
 
 - Implement the fold-partitioned, experiment-independent asset (§4.5.1) over `_cv_helpers`.
 - Tests: unit (from Phase 1) + an integration test materialising it on synthetic data.

--- a/packages/contracts/pyproject.toml
+++ b/packages/contracts/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "patito>=0.8.0",
     "polars>=1.0.0",
     "pydantic-settings>=2.4.0",
+    "omegaconf>=2.3.0",
 ]
 
 [build-system]

--- a/packages/contracts/src/contracts/hydra_schemas.py
+++ b/packages/contracts/src/contracts/hydra_schemas.py
@@ -1,7 +1,9 @@
 """Hydra configuration schemas for the NGED substation forecast project."""
 
 from datetime import date
+from pathlib import Path
 
+from omegaconf import OmegaConf
 from pydantic import BaseModel, Field
 
 from contracts.power_schemas import FoldId
@@ -31,3 +33,43 @@ class CvConfig(BaseModel):
 
     folds: list[CvFoldConfig]
     min_training_months: int = Field(default=6, ge=1)
+
+    @property
+    def fold_ids(self) -> list[str]:
+        """The fold ids in declaration order (e.g. ``["2022", "2023", ...]``).
+
+        Used to build the ``cv_experiment_folds`` partitions and to expand experiment
+        registration into per-fold partition keys — always read from config, never hard-coded.
+        """
+        return [fold.fold_id for fold in self.folds]
+
+    def get_fold(self, fold_id: str) -> CvFoldConfig:
+        """Return the fold with the given ``fold_id``.
+
+        Args:
+            fold_id: The fold identifier to look up (e.g. ``"2022"``).
+
+        Raises:
+            KeyError: If no fold with that id exists in the config.
+        """
+        for fold in self.folds:
+            if fold.fold_id == fold_id:
+                return fold
+        raise KeyError(f"No fold with fold_id={fold_id!r}; available folds: {self.fold_ids}")
+
+
+def load_cv_config(path: Path) -> CvConfig:
+    """Load and validate the cross-validation config from a YAML file.
+
+    The CV folds are the leaderboard's evaluation protocol and must be read from
+    ``conf/cv/default.yaml`` (never hard-coded) so every experiment and asset shares one
+    canonical definition.
+
+    Args:
+        path: Path to the CV config YAML (e.g. ``conf/cv/default.yaml``).
+
+    Returns:
+        The validated ``CvConfig``.
+    """
+    raw = OmegaConf.to_container(OmegaConf.load(path), resolve=True)
+    return CvConfig.model_validate(raw)

--- a/packages/contracts/src/contracts/ml_schemas.py
+++ b/packages/contracts/src/contracts/ml_schemas.py
@@ -338,3 +338,22 @@ class Metrics(pt.Model):
             "Null for 'ad_hoc' rows, which have no MLflow run."
         ),
     )
+
+
+class EligibleTimeSeries(pt.Model):
+    """The canonical per-fold population of eligible ``time_series_id``s.
+
+    Written by the ``eligible_time_series`` Dagster asset (one Delta partition per ``fold_id``)
+    and read by ``trained_cv_model`` and ``cv_power_forecasts``. Eligibility is a function of
+    data coverage and the fold dates **only** — never the model or experiment config — so every
+    experiment trains and scores a fold on the identical population, which is what makes
+    leaderboard comparisons apples-to-apples.
+
+    One row per eligible ``(fold_id, time_series_id)``.
+    """
+
+    fold_id: str = pt.Field(
+        dtype=pl.String,
+        description="The CV fold this eligibility row belongs to (e.g. '2022'); the Delta partition key.",
+    )
+    time_series_id: int = _get_time_series_id_dtype()

--- a/packages/contracts/src/contracts/settings.py
+++ b/packages/contracts/src/contracts/settings.py
@@ -91,11 +91,28 @@ class Settings(BaseSettings):
         ),
     )
 
+    cv_config_path: Path = Field(
+        default=PROJECT_ROOT / "conf" / "cv" / "default.yaml",
+        description=(
+            "Path to the canonical cross-validation fold definitions. These folds are the"
+            " shared leaderboard evaluation protocol; read them from here, never hard-coded."
+        ),
+    )
+
     # Paths to the data we manage
     nged_data_path: Path = PROJECT_ROOT / "data" / "NGED"
     nwp_data_path: Path = PROJECT_ROOT / "data" / "NWP"
     power_forecasts_data_path: Path = PROJECT_ROOT / "data" / "power_forecasts"
     forecast_metrics_data_path: Path = PROJECT_ROOT / "data" / "forecast_metrics"
+    eligible_time_series_data_path: Path = Field(
+        default=PROJECT_ROOT / "data" / "eligible_time_series",
+        description=(
+            "Delta table of the canonical per-fold eligible time_series_id population, written"
+            " by the eligible_time_series asset (partitioned by fold_id) and read by"
+            " trained_cv_model and cv_power_forecasts so every experiment scores a fold on the"
+            " identical, experiment-independent population."
+        ),
+    )
     trained_ml_model_params_base_path: Path = PROJECT_ROOT / "data" / "trained_ML_model_params"
     h3_grid_weights_path: Path = PROJECT_ROOT / "data" / "h3_grid_weights.parquet"
     model_cache_base_path: Path = Field(

--- a/packages/contracts/tests/test_hydra_schemas.py
+++ b/packages/contracts/tests/test_hydra_schemas.py
@@ -5,7 +5,30 @@ from pydantic import ValidationError
 from contracts.hydra_schemas import (
     CvConfig,
     CvFoldConfig,
+    load_cv_config,
 )
+from contracts.settings import PROJECT_ROOT
+
+
+def _two_fold_config() -> CvConfig:
+    return CvConfig(
+        folds=[
+            CvFoldConfig(
+                fold_id="2022",
+                train_start=date(2020, 1, 1),
+                train_end=date(2021, 12, 31),
+                val_start=date(2022, 1, 1),
+                val_end=date(2022, 12, 31),
+            ),
+            CvFoldConfig(
+                fold_id="2023",
+                train_start=date(2020, 1, 1),
+                train_end=date(2022, 12, 31),
+                val_start=date(2023, 1, 1),
+                val_end=date(2023, 12, 31),
+            ),
+        ]
+    )
 
 
 def test_cv_fold_config_valid():
@@ -70,3 +93,25 @@ def test_cv_config_custom_min_training_months():
         min_training_months=3,
     )
     assert config.min_training_months == 3
+
+
+def test_cv_config_fold_ids_order():
+    assert _two_fold_config().fold_ids == ["2022", "2023"]
+
+
+def test_cv_config_get_fold():
+    config = _two_fold_config()
+    assert config.get_fold("2023").val_start == date(2023, 1, 1)
+
+
+def test_cv_config_get_fold_unknown_raises():
+    with pytest.raises(KeyError):
+        _two_fold_config().get_fold("2099")
+
+
+def test_load_cv_config_reads_canonical_yaml():
+    """The canonical conf/cv/default.yaml loads, validates, and coerces dates."""
+    config = load_cv_config(PROJECT_ROOT / "conf" / "cv" / "default.yaml")
+    assert config.fold_ids[0] == "2022"
+    assert config.min_training_months == 6
+    assert config.get_fold("2022").train_start == date(2020, 1, 1)

--- a/src/nged_substation_forecast/definitions.py
+++ b/src/nged_substation_forecast/definitions.py
@@ -3,9 +3,9 @@
 from dagster import Definitions, load_assets_from_modules
 from contracts.settings import Settings
 
-from nged_substation_forecast.defs import assets, schedules
+from nged_substation_forecast.defs import assets, cv_assets, schedules
 
-all_assets = load_assets_from_modules([assets])
+all_assets = load_assets_from_modules([assets, cv_assets])
 
 settings = Settings()
 

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -1,0 +1,91 @@
+"""Cross-validation Dagster assets.
+
+These assets implement the experiment-independent, fold-partitioned CV layer. Each asset is a
+thin orchestration shell delegating its logic to the pure helpers in ``ml_core._cv_helpers`` so
+the logic stays fast to unit-test and the assets stay readable.
+"""
+
+import polars as pl
+from contracts.hydra_schemas import load_cv_config
+from contracts.ml_schemas import EligibleTimeSeries
+from contracts.settings import Settings
+from dagster import AssetExecutionContext, StaticPartitionsDefinition, asset
+from deltalake import write_deltalake
+from ml_core._cv_helpers import eligible_time_series_ids
+
+# The CV folds are the shared leaderboard evaluation protocol, read from conf/cv/default.yaml
+# (never hard-coded) so every experiment and asset agrees on the same folds. Loaded at import so
+# the partition keys are available when Dagster builds the asset graph. PROJECT_ROOT is used here
+# (rather than Settings, which needs the .env secrets) so the partition set can be built without
+# any credentials.
+_cv_config = load_cv_config(Settings.model_fields["cv_config_path"].default)
+
+cv_fold_partitions = StaticPartitionsDefinition(_cv_config.fold_ids)
+"""One partition per canonical CV fold (by fold year, e.g. "2022"). Experiment-independent."""
+
+
+@asset(
+    partitions_def=cv_fold_partitions,
+    deps=["power_time_series_and_metadata"],
+)
+def eligible_time_series(context: AssetExecutionContext) -> None:
+    """Compute and persist the canonical eligible ``time_series_id``s for one CV fold.
+
+    A time series is eligible for a fold when its observed-power coverage has at least
+    ``min_training_months`` of history before the fold's ``val_start`` *and* reaches the fold's
+    ``val_end``. Eligibility is derived from data coverage alone (not from any model/config), so
+    every experiment evaluates the fold on the identical population — this is what keeps the
+    leaderboard apples-to-apples (see plan §4.5.1).
+
+    The result is written to the ``eligible_time_series`` Delta table as one partition per
+    ``fold_id`` via an idempotent partition overwrite, so re-materialising a fold replaces its
+    rows rather than duplicating them.
+    """
+    settings = Settings()
+    fold_id = context.partition_key
+    fold = _cv_config.get_fold(fold_id)
+
+    power_path = settings.nged_data_path / "power_time_series.delta"
+    coverage = (
+        pl.scan_delta(str(power_path))
+        .group_by("time_series_id")
+        .agg(
+            first_time=pl.col("time").min(),
+            last_time=pl.col("time").max(),
+        )
+        .collect()
+    )
+
+    eligible_ids = eligible_time_series_ids(
+        coverage, fold, min_training_months=_cv_config.min_training_months
+    )
+
+    eligible_df = EligibleTimeSeries.validate(
+        pl.DataFrame(
+            {
+                "fold_id": pl.Series([fold_id] * len(eligible_ids), dtype=pl.String),
+                "time_series_id": pl.Series(eligible_ids, dtype=pl.Int32),
+            }
+        )
+    )
+
+    settings.eligible_time_series_data_path.parent.mkdir(parents=True, exist_ok=True)
+    write_deltalake(
+        table_or_uri=settings.eligible_time_series_data_path,
+        data=eligible_df.to_arrow(),
+        mode="overwrite",
+        predicate=f"fold_id = '{fold_id}'",
+        partition_by=["fold_id"],
+    )
+
+    context.add_output_metadata(
+        {
+            "fold_id": fold_id,
+            "n_eligible_time_series": len(eligible_ids),
+            "n_time_series_in_coverage": len(coverage),
+            "eligible_time_series_ids": str(eligible_ids),
+            "val_start": str(fold.val_start),
+            "val_end": str(fold.val_end),
+            "min_training_months": _cv_config.min_training_months,
+        }
+    )

--- a/tests/test_cv_assets.py
+++ b/tests/test_cv_assets.py
@@ -1,0 +1,102 @@
+"""Integration tests for the CV Dagster assets.
+
+These materialise ``eligible_time_series`` in-process against synthetic power data written to a
+temporary Delta table, exercising the real asset wiring (Dagster + Delta). The pure eligibility
+logic itself is unit-tested in ``packages/ml_core/tests/test_cv_helpers.py``.
+"""
+
+from datetime import datetime, timezone
+
+import polars as pl
+import pytest
+from dagster import materialize
+
+from nged_substation_forecast.defs.cv_assets import eligible_time_series
+
+
+def _utc(year: int, month: int, day: int) -> datetime:
+    return datetime(year, month, day, tzinfo=timezone.utc)
+
+
+def _write_synthetic_power(power_delta_path: str) -> None:
+    """Write a tiny synthetic power Delta with hand-picked coverage per time series.
+
+    Only the per-series min/max observation times matter for eligibility, so two rows per series
+    (first + last) suffice. Coverage is chosen so the eligible set differs between folds 2022 and
+    2023 (min_training_months=6):
+
+    - ts1: 2021-01-01 .. 2024-01-01 -> eligible for both 2022 and 2023.
+    - ts2: 2021-01-01 .. 2023-06-01 -> eligible 2022 (reaches val_end), not 2023 (stops mid-year).
+    - ts3: 2021-01-01 .. 2022-06-01 -> eligible for neither (stops before 2022 val_end).
+    """
+    coverage = {
+        1: (_utc(2021, 1, 1), _utc(2024, 1, 1)),
+        2: (_utc(2021, 1, 1), _utc(2023, 6, 1)),
+        3: (_utc(2021, 1, 1), _utc(2022, 6, 1)),
+    }
+    rows = [
+        {"time_series_id": ts, "time": t, "power": 1.0}
+        for ts, (first, last) in coverage.items()
+        for t in (first, last)
+    ]
+    df = pl.DataFrame(rows).cast(
+        {
+            "time_series_id": pl.Int32,
+            "time": pl.Datetime("us", "UTC"),
+            "power": pl.Float32,
+        }
+    )
+    df.write_delta(power_delta_path)
+
+
+@pytest.fixture
+def cv_paths(tmp_path, monkeypatch) -> dict[str, str]:
+    """Redirect Settings' data paths to a temp dir and supply dummy required secrets.
+
+    Settings reads these from the environment, which takes precedence over any ``.env`` file, so
+    the test never touches real data or credentials.
+    """
+    nged_path = tmp_path / "NGED"
+    eligible_path = tmp_path / "eligible_time_series"
+    nged_path.mkdir()
+    monkeypatch.setenv("NGED_S3_BUCKET_URL", "https://example.com")
+    monkeypatch.setenv("NGED_S3_BUCKET_ACCESS_KEY", "dummy")
+    monkeypatch.setenv("NGED_S3_BUCKET_SECRET", "dummy")
+    monkeypatch.setenv("NGED_DATA_PATH", str(nged_path))
+    monkeypatch.setenv("ELIGIBLE_TIME_SERIES_DATA_PATH", str(eligible_path))
+
+    _write_synthetic_power(str(nged_path / "power_time_series.delta"))
+    return {"eligible": str(eligible_path)}
+
+
+def _read_eligible(eligible_path: str, fold_id: str) -> list[int]:
+    return sorted(
+        pl.read_delta(eligible_path)
+        .filter(pl.col("fold_id") == fold_id)["time_series_id"]
+        .to_list()
+    )
+
+
+def test_eligible_time_series_materialises_per_fold_population(cv_paths) -> None:
+    assert materialize([eligible_time_series], partition_key="2022").success
+    assert _read_eligible(cv_paths["eligible"], "2022") == [1, 2]
+
+
+def test_eligible_time_series_differs_between_folds(cv_paths) -> None:
+    """The eligible population is fold-specific: a later val_end excludes shorter series."""
+    assert materialize([eligible_time_series], partition_key="2022").success
+    assert materialize([eligible_time_series], partition_key="2023").success
+
+    # Both fold partitions coexist (writing 2023 must not clobber 2022).
+    assert _read_eligible(cv_paths["eligible"], "2022") == [1, 2]
+    assert _read_eligible(cv_paths["eligible"], "2023") == [1]
+
+
+def test_eligible_time_series_is_idempotent(cv_paths) -> None:
+    """Re-materialising a fold overwrites its partition rather than appending duplicates."""
+    assert materialize([eligible_time_series], partition_key="2022").success
+    assert materialize([eligible_time_series], partition_key="2022").success
+
+    fold_rows = pl.read_delta(cv_paths["eligible"]).filter(pl.col("fold_id") == "2022")
+    assert len(fold_rows) == 2  # not 4
+    assert sorted(fold_rows["time_series_id"].to_list()) == [1, 2]

--- a/uv.lock
+++ b/uv.lock
@@ -471,6 +471,7 @@ name = "contracts"
 version = "0.0.1"
 source = { editable = "packages/contracts" }
 dependencies = [
+    { name = "omegaconf" },
     { name = "patito" },
     { name = "polars" },
     { name = "pydantic-settings" },
@@ -478,6 +479,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "omegaconf", specifier = ">=2.3.0" },
     { name = "patito", specifier = ">=0.8.0" },
     { name = "polars", specifier = ">=1.0.0" },
     { name = "pydantic-settings", specifier = ">=2.4.0" },
@@ -3136,7 +3138,7 @@ name = "pyzmq"
 version = "27.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "implementation_name == 'pypy'" },
+    { name = "cffi", marker = "implementation_name == 'pypy' and sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [


### PR DESCRIPTION
Continues from #183. Implements Phase 2 from #171.

Implements the fold-partitioned, experiment-independent `eligible_time_series` asset (plan §4.5.1), the first tangible Dagster CV deliverable. Eligibility is derived from power-data coverage and fold dates alone — never the model or config — so every experiment trains and scores a fold on the identical population, which is what makes leaderboard comparisons apples-to-apples.

New asset (src/nged_substation_forecast/defs/cv_assets.py):
- `cv_fold_partitions`: StaticPartitionsDefinition built from the fold ids in conf/cv/default.yaml (2022..2026), never hard-coded.
- `eligible_time_series` (deps: power_time_series_and_metadata): reads per-series coverage (min/max observation time) from the power Delta, delegates to the pure `eligible_time_series_ids()` helper from Phase 1, and writes one Delta partition per fold_id via an idempotent partition overwrite (predicate "fold_id = '...'"), so re-materialising a fold replaces rather than duplicates its rows. Loaded into the asset graph via definitions.py.

Supporting contracts/config:
- hydra_schemas: `load_cv_config(path)` (OmegaConf -> validated CvConfig with date coercion), plus `CvConfig.fold_ids` and `CvConfig.get_fold(fold_id)`.
- ml_schemas: new `EligibleTimeSeries` Patito schema (fold_id, time_series_id).
- settings: `cv_config_path` and `eligible_time_series_data_path`.
- pyproject: declare the omegaconf dependency (already in the lockfile via hydra-core).

Tests:
- Integration (tests/test_cv_assets.py): materialises the asset in-process on synthetic power data — asserts the correct per-fold population, that folds differ (a series stopping mid-year drops out of the later fold) with both partitions coexisting, and idempotency on re-materialisation.
- Unit (test_hydra_schemas.py): load_cv_config on the canonical YAML, plus fold_ids / get_fold. Eligibility logic itself stays covered by the Phase 1 unit tests on eligible_time_series_ids.
