### PR TITLE
Phase 3.5: single MVP CV fold; str FoldId; docs reorg

### DIFF
--- a/conf/cv/default.yaml
+++ b/conf/cv/default.yaml
@@ -2,38 +2,21 @@
 # All models MUST be evaluated against these exact folds so leaderboard comparisons
 # are apples-to-apples.  Change these only when founding a new leaderboard epoch.
 #
-# Training always starts from 2020-01-01 (earliest available NGED trial data).
-# Each fold adds one calendar year of training data and validates on the next year.
+# Current state: a single MVP fold. Honest forecast-skill validation needs real forecast NWP
+# (ECMWF ENS) for both training and validation, and our ECMWF ENS archive only reaches back to
+# 2024-04-01 (Dynamical.org are backfilling earlier years, but slowly). So we train on the longest
+# honest window we have and validate on the following 12 months.
+#
+# Once Dynamical.org has backfilled ECMWF ENS to earlier years, we will move to the target
+# multiple-yearly-fold protocol (expanding training window, one validation year per fold) via a new
+# leaderboard epoch.  See docs/ml_experimentation/cross-validation-folds.md.
 
 folds:
-  - fold_id: "2022"
-    train_start: "2020-01-01"
-    train_end:   "2021-12-31"
-    val_start:   "2022-01-01"
-    val_end:     "2022-12-31"
-
-  - fold_id: "2023"
-    train_start: "2020-01-01"
-    train_end:   "2022-12-31"
-    val_start:   "2023-01-01"
-    val_end:     "2023-12-31"
-
-  - fold_id: "2024"
-    train_start: "2020-01-01"
-    train_end:   "2023-12-31"
-    val_start:   "2024-01-01"
-    val_end:     "2024-12-31"
-
-  - fold_id: "2025"
-    train_start: "2020-01-01"
-    train_end:   "2024-12-31"
-    val_start:   "2025-01-01"
-    val_end:     "2025-12-31"
-
-# Complete years only: a fold may only validate once its year has finished and the NGED data has
-# landed, otherwise it would validate on partial data and corrupt the mean-across-folds
-# leaderboard. Add "2026" here once 2026 is over. (FoldId in power_schemas.py still lists "2026"
-# as a valid future value.)
+  - fold_id: "mid_2025_to_mid_2026"
+    train_start: "2024-04-01"
+    train_end:   "2025-06-30"
+    val_start:   "2025-07-01"
+    val_end:     "2026-06-30"
 
 # Minimum months of observations before val_start for a time series to be eligible.
 min_training_months: 6

--- a/docs/index.md
+++ b/docs/index.md
@@ -27,4 +27,7 @@ Each forecast is:
 - [Architecture & Philosophy](architecture/philosophy.md) — design goals and principles
 - [Architecture Overview](architecture/overview.md) — technical components and data flow
 - [Code Style](architecture/code-style.md) — code conventions
+- [ML Experimentation](ml_experimentation/index.md) — methodology for our implemented ML experimentation: cross-validation folds, the leaderboard, and how we evaluate models
 - [Roadmap](roadmap/index.md) — planned future work, plus detailed design docs for the delivery tables, forecast building blocks, metrics & leaderboard, data sources, differentiable physics, switching events, disaggregation evaluation, and encoders
+
+> Documentation convention: `roadmap/` holds **only not-yet-implemented** design. Once a feature ships, its docs move out to a permanent home (e.g. `architecture/` or `ml_experimentation/`), leaving a one-line pointer behind.

--- a/docs/ml_experimentation/cross-validation-folds.md
+++ b/docs/ml_experimentation/cross-validation-folds.md
@@ -1,0 +1,115 @@
+# Cross-validation folds
+
+How we split data into training and validation windows to score and compare forecasting
+experiments on the leaderboard.
+
+> **Status legend:**
+>
+> - ✅ Implemented
+> - 🚧 Planned
+> - 🔬 Research
+
+The fold definitions live in `conf/cv/default.yaml` and are read by every experiment, so all
+models are scored on the **same** folds (apples-to-apples). The fold windowing in
+`ml_core._cv_helpers` is generic over arbitrary `train_start/train_end/val_start/val_end` dates, so
+changing the fold set is a config edit, not a code change.
+
+---
+
+## Why expanding-window cross-validation
+
+We use **expanding-window** CV: the training period grows each fold while the validation window
+stays a fixed length and lies strictly *after* training. This mimics production (we never train on
+the future), and validating across a whole year per fold gives balanced **seasonal** coverage.
+
+We chose expanding over sliding windows to maximise data for data-hungry models (neural nets). The
+trade-off is that it confounds "algorithmic improvement" with "more data", so we never compare one
+fold against another directly — we aggregate folds into a single leaderboard figure (mean across
+folds).
+
+---
+
+## Current state: a single MVP fold ✅
+
+Honest forecast-skill validation needs **real forecast NWP (ECMWF ENS) for both training and
+validation**. Our ECMWF ENS archive only reaches back to **2024-04-01** (Dynamical.org are
+back-filling earlier years, but slowly), so the entire usable window is ~2024-04 to mid-2026 —
+only enough for roughly **one** seasonally-complete fold. We therefore run a single MVP fold:
+
+| `fold_id` | Train | Validate | Weather source |
+|---|---|---|---|
+| `mid_2025_to_mid_2026` | 2024-04-01 → 2025-06-30 (15 months) | 2025-07-01 → 2026-06-30 (12 months) | ECMWF ENS only |
+
+The training window is stretched to 15 months to use all the honest data available before the
+validation window. This code is not expected to train a model until **after 2026-06-30**, by which
+point the validation window has closed and validates on complete data.
+
+A single fold gives no across-fold variance estimate, but it is still ample for the leaderboard's
+main job: each fold scores ~22–32 time series × 51 ensemble members at half-hourly resolution —
+millions of prediction points, more than enough statistical power to **rank** experiments against
+each other.
+
+### Eligibility
+
+A time series is eligible for a fold when its observed-power coverage has at least
+`min_training_months` (default **6**) of history *before* `val_start` **and** reaches `val_end`.
+Eligibility is derived from data coverage alone — never from the model or config — so every
+experiment evaluates the fold on the identical population. The eligible set is computed and frozen
+per leaderboard epoch by the `eligible_time_series` asset.
+
+---
+
+## Target: multiple yearly folds 🚧
+
+**Once Dynamical.org has backfilled ECMWF ENS to the earlier years**, we will move to the original
+target protocol: an expanding training window with one **complete-year** validation fold per year
+(2022, 2023, 2024, 2025, …), validated on real forecast NWP throughout. Adding those folds starts
+a **new leaderboard epoch** (every experiment is re-scored against the new fold set), and is a
+`conf/cv/default.yaml` edit with no schema change.
+
+Separately, and later, we plan to **pre-train** on weather reanalysis (CERRA) so models can use the
+long power histories that some assets have back to 2020, then fine-tune on ECMWF ENS. Pre-training
+is a training-time technique, distinct from the validation folds described here.
+
+---
+
+## Alternatives considered
+
+We considered three other ways to slice the limited honest data and chose the single fold above.
+These are recorded so the decision is auditable and so we can revisit them as more data lands.
+
+### Monthly expanding CV — rejected (redundant folds)
+
+Slide a 12-month validation window forward by one month per fold, expanding training by one month
+each time (fold 1 validates 2025-04→2026-03, fold 2 validates 2025-05→2026-04, …). This "buys"
+several folds from today's data, but consecutive folds share **11/12 of the validation window** and
+>90% of the training data, so their metrics are correlated ~0.9+. The effective number of
+independent folds is barely more than one; the small spread across them **understates** true
+sampling variance (false confidence in stability), at N× the compute for almost-duplicate
+information. One month is too small a change to make the folds meaningfully different.
+
+### Quarterly non-overlapping walk-forward — deferred (the sound multi-fold option)
+
+Expanding training, but validate on the **next 3 months, non-overlapping**:
+
+| Fold | Train | Validate (3 mo, non-overlapping) |
+|---|---|---|
+| 2025-Q2 | 2024-04-01 → 2025-03-31 | 2025-04 → 2025-06 |
+| 2025-Q3 | 2024-04-01 → 2025-06-30 | 2025-07 → 2025-09 |
+| 2025-Q4 | 2024-04-01 → 2025-09-30 | 2025-10 → 2025-12 |
+| 2026-Q1 | 2024-04-01 → 2025-12-31 | 2026-01 → 2026-03 |
+
+Because the validation windows do not overlap, the folds are **genuinely independent**
+measurements, and the set covers all four seasons (so you see seasonal skill variation, then report
+per-season and the mean). This is the statistically sound version of what monthly CV reaches for.
+We deferred it to keep the MVP minimal; it is the recommended next step if we want multiple folds
+*before* the ECMWF back-fill enables the full yearly protocol.
+
+### Yearly folds backed by CERRA — rejected for validation
+
+Keep the yearly 2022–2025 folds now by training on **CERRA reanalysis** for the pre-2024-04-01
+years. Rejected: CERRA is *reanalysis* (it ingests future observations), so validating on it
+measures the model's response to near-perfect weather, not **forecast** skill — systematically
+misleading — and a leaderboard mixing CERRA folds and ECMWF folds is apples-to-oranges. It would
+also pull a large CERRA-ingestion effort forward. CERRA is valuable, but for **pre-training**
+(above), not for validation.

--- a/docs/ml_experimentation/index.md
+++ b/docs/ml_experimentation/index.md
@@ -1,0 +1,13 @@
+# ML Experimentation
+
+How we run and evaluate ML forecasting experiments. Unlike the [roadmap](../roadmap/index.md)
+(which holds forward-looking design for work not yet built), this area documents methodology that
+is **implemented** and in use — the durable home for ML experimentation docs once they leave the
+roadmap.
+
+
+## Documents
+
+- [Cross-validation folds](cross-validation-folds.md) — the expanding-window CV protocol, the
+  current single MVP fold and why the data constrains us to it, the target multiple-yearly-fold
+  protocol, and the fold-design alternatives we considered.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -7,11 +7,19 @@ This roadmap outlines the planned order of development toward the v1.0 live fore
 > 🚧 **Planned** — designed, not yet built ·
 > 🔬 **Research** — exploratory / v2.
 
+## How this folder is organised
+
+`docs/roadmap/` contains **only design for work that is not yet implemented**. It is a
+forward-looking backlog, never a mirror of the code. When a feature ships, its documentation
+**moves out** of `roadmap/` to its permanent home — `architecture/` for system design,
+[`ml_experimentation/`](../ml_experimentation/index.md) for ML methodology, and so on — and the
+roadmap entry shrinks to a one-line pointer. This keeps the roadmap from going stale and gives
+each implemented feature a single, durable home.
+
 ## Design documents
 
 This folder captures the detailed technical plans from the Milestone 1 report, so they can be
-pointed at when the time comes to implement them. Each doc marks clearly what is implemented vs.
-planned.
+pointed at when the time comes to implement them.
 
 - [Delivery tables](delivery-tables.md) — the five Delta Lake tables OCF delivers to NGED
   (`power_forecast`, `power_forecast_warnings`, `asset_health_history`, `effective_capacity`,

--- a/docs/roadmap/metrics-and-leaderboard.md
+++ b/docs/roadmap/metrics-and-leaderboard.md
@@ -2,9 +2,10 @@
 
 How OCF measures the skill of its forecasts and compares forecasting approaches.
 
-> **Status legend** — ✅ Implemented · 🚧 Planned · 🔬 Research. The CV cross-validation assets and the
-> `Metrics` schema exist in code (✅); the interactive leaderboard visualisation and several metrics
-> are 🚧 planned. See the [roadmap index](index.md) for status conventions.
+> **Status legend** — ✅ Implemented · 🚧 Planned · 🔬 Research. The `Metrics` schema exists in code
+> (✅); the interactive leaderboard visualisation and several metrics are 🚧 planned. The
+> implemented [cross-validation protocol](../ml_experimentation/cross-validation-folds.md) has moved
+> out of the roadmap. See the [roadmap index](index.md) for status conventions.
 
 ---
 
@@ -24,44 +25,13 @@ database. The leaderboard will be displayed as an interactive table (inspiration
 
 ---
 
-## Cross-fold validation: expanding training window ✅
+## Cross-fold validation
 
-We use **expanding-window** cross-fold validation: the training period grows each fold while the
-validation window stays the same length and strictly *after* training. This mimics production
-(never train on the future) and lets us measure seasonal variation by validating across a whole
-year per fold.
-
-| Fold | Train | Validate |
-|---|---|---|
-| 1 | 2020 → 2021 | 2022 |
-| 2 | 2020 → 2022 | 2023 |
-| 3 | 2020 → 2023 | 2024 |
-| 4 | 2020 → 2024 | 2025 |
-| 5 | 2020 → 2025 | 2026 *(excluded from the leaderboard until 2026 is complete)* |
-
-Notes:
-
-- We train/evaluate across all time series in a category, **provided** each series has valid data
-  for the whole validation period and ≥ 6 months of training data. (E.g. time series ID 24 only has
-  data from early 2024, so it is excluded from folds 1–3.)
-- Full half-hourly predictions are saved as Delta tables per fold, per time series, per experiment —
-  so we can refine how we measure performance **without re-running** past experiments.
-- **Expanding vs. sliding window**: we chose expanding to maximise data for data-hungry models
-  (neural nets). The trade-off: it confounds "algorithmic improvement" with "more data", so we don't
-  compare fold 5 against fold 1 directly — we aggregate folds into a single leaderboard figure.
-
-> Implementation detail: only **complete-year** folds enter the leaderboard (the "2026 problem"),
-> and data sources with shorter history than the canonical folds (e.g. ICON-EU) are first assessed
-> via a controlled ad-hoc ablation, then promoted to a new leaderboard epoch once they have ~1–2
-> years of history.
-
-> **Bootstrapping note — the initial leaderboard has a single fold.** The canonical five-fold table
-> above is the *target*. It needs NWP back to 2020, but our ECMWF ENS archive currently only reaches
-> back to **2024-04-01** (Dynamical.org are back-filling earlier years, but slowly) and we have not
-> yet ingested CERRA. So, to get a minimal leaderboard running before either lands, we start with a
-> **single fold**: train on **2024-04-01 → 2025-04-01**, validate on **2025-04-01 → 2026-04-01**.
-> This is deliberately an ugly stop-gap; the full expanding-window protocol above switches on once
-> the back-fill and/or CERRA provide pre-2024 weather.
+The cross-validation protocol is **implemented**, so it has moved to its permanent home:
+[ML Experimentation → Cross-validation folds](../ml_experimentation/cross-validation-folds.md).
+That page covers the expanding-window protocol, the current single MVP fold (and why the available
+weather data constrains us to it), the target multiple-yearly-fold protocol, and the fold-design
+alternatives we considered.
 
 ---
 

--- a/docs/temp/dagster_plan.md
+++ b/docs/temp/dagster_plan.md
@@ -1224,7 +1224,7 @@ lagged power.
 - **User can verify:** materialise `eligible_time_series` in the Dagster UI and inspect the
   per-fold eligible `time_series_id` lists. *(First tangible Dagster deliverable.)*
 
-### 7.3 Phase 3 — MLflow run resolution, model store, `register_experiment_job`
+### 7.3 Phase 3 — MLflow run resolution, model store, `register_experiment_job` - Completed in PR #185
 
 - `_mlflow_runs.py` (§5.6), the `BaseForecaster.save_to_mlflow` / `load_from_mlflow` methods
   (§4.5), `register_experiment_job` / `RegisterExperimentConfig`, and the `cv_experiment_folds`
@@ -1236,7 +1236,7 @@ lagged power.
   experiment + parent run (config params + grouping tags) appear, and the new
   `__mid_2025_to_mid_2026` key shows up in the `cv_experiment_folds` partition set.
 
-### 7.3.1 Phase 3.5 - Re-consider CV folds — Decided
+### 7.3.1 Phase 3.5 - Re-consider CV folds — Completed in PR #186
 
 **Decision:** use a **single MVP fold** for now (ECMWF ENS only), because honest forecast-skill
 validation needs real forecast NWP for both training and validation, and our ECMWF ENS archive

--- a/docs/temp/dagster_plan.md
+++ b/docs/temp/dagster_plan.md
@@ -29,15 +29,16 @@ redesign needed to support research at scale and production simultaneously.
 
 ### Functional
 - Run 100s to 1000s of ML experiments, each with full expanding-window CV over the
-  canonical **complete-year folds** (currently 2022–2025; see §4.1).
+  canonical folds (see §4.1). The canonical fold set is currently a **single MVP fold**
+  (`mid_2025_to_mid_2026`); the multiple-yearly-fold protocol is the target once ECMWF ENS is
+  backfilled (see §7.3.1 and docs/ml_experimentation/cross-validation-folds.md).
 - All experiments evaluated on **identical canonical CV folds** — scientific fairness
-  for the leaderboard is non-negotiable. (Although note that, because the ECMWF numerical weather
-  predictions available from Dynamical.org only go back to 2024-04-01 for now (although
-  Dynamical.org are back-filling). So, for a minimal MVP, we will only use a single fold: train on
-  12 months of data starting on 2024-04-01; and test on 12 months of data started on 2025-04-01).
+  for the leaderboard is non-negotiable. (We use a single fold for now because the ECMWF numerical
+  weather predictions available from Dynamical.org only go back to 2024-04-01; Dynamical.org are
+  back-filling earlier years, and we move to multiple yearly folds once they do.)
 - Per-fold observability: know which folds succeeded or failed for each experiment.
 - Retry individual failed folds from the Dagster UI without re-running others.
-- Kick off a **smoke test** (just the earliest fold, 2022) before committing to a
+- Kick off a **smoke test** (just the earliest fold) before committing to a
   full CV run, so bad configs fail fast and cheaply.
 - Run production inference every 6 hours; track which runs failed and rerun them.
   Although the production inference will happen on one machine (with its own Dagster
@@ -155,11 +156,11 @@ e.g. `"42__2022"`.
 | Concept | Definition |
 |---|---|
 | **Experiment** | One specific combination of model class + config (features, hyperparameters). Identified by a human-readable `experiment_name` string. Stamped onto every forecast row in a dedicated `experiment_name` column (see §4.7, §5.1) — **not** overloaded onto `power_fcst_model_name`, which keeps its meaning as the model *family* (`MODEL_NAME`). |
-| **CV Fold** | One expanding-window training/validation window, identified by its validation calendar year. The canonical leaderboard folds are **complete years only**: currently `"2022"`–`"2025"`. `"2026"` is **excluded until the year completes** (a partial year cannot be fairly compared; see §4.1.2). Date ranges live in `conf/cv/default.yaml` and are immutable per leaderboard epoch. |
-| **Dagster partition key** | `"{experiment_name}__{fold_id}"`, e.g. `"xgboost_with_solar__2022"`. Encodes both the experiment and the fold; unique by construction (MLflow enforces unique experiment names). |
+| **CV Fold** | One expanding-window training/validation window, identified by a short label (`fold_id`). The canonical fold set is currently a **single MVP fold** (`"mid_2025_to_mid_2026"`); the target multiple-yearly-fold protocol switches on once ECMWF ENS is backfilled (§7.3.1, docs/ml_experimentation/cross-validation-folds.md). Validation windows must be **complete** before they enter the leaderboard (a partial window cannot be fairly compared; see §4.1.2). Date ranges live in `conf/cv/default.yaml` and are immutable per leaderboard epoch. |
+| **Dagster partition key** | `"{experiment_name}__{fold_id}"`, e.g. `"xgboost_with_solar__mid_2025_to_mid_2026"`. Encodes both the experiment and the fold; unique by construction (MLflow enforces unique experiment names). |
 | **MLflow experiment** | One per `experiment_name`. Stores the resolved config as experiment tags. Holds all runs for that experiment. |
 | **MLflow parent run** | One per experiment. Holds the resolved config params and the aggregate (mean-across-folds) metrics — the row the leaderboard sorts on. Tagged `cv_role="parent"`. |
-| **MLflow fold (child) run** | One per fold, nested under the parent run. Holds per-fold training params and per-fold metrics. Tagged `cv_role="fold"`, `fold_id="2022"`. |
+| **MLflow fold (child) run** | One per fold, nested under the parent run. Holds per-fold training params and per-fold metrics. Tagged `cv_role="fold"`, `fold_id="mid_2025_to_mid_2026"`. |
 
 ### 4.1.1 MLflow Run Model and Cross-Process Run Resolution
 
@@ -168,12 +169,9 @@ You do **not** need a separate MLflow experiment per fold. MLflow's *run* is exa
 
 ```
 Experiment  "xgboost_with_solar"  (experiment_id = 42)
-└── Parent run  "cv_summary"      tags: cv_role=parent      ← aggregate metrics (leaderboard row)
-    ├── Child run  "2022"         tags: cv_role=fold, fold_id=2022   ← per-fold params + metrics
-    ├── Child run  "2023"         tags: cv_role=fold, fold_id=2023
-    ├── Child run  "2024"
-    ├── Child run  "2025"
-    └── Child run  "2026"
+└── Parent run  "cv_summary"               tags: cv_role=parent   ← aggregate metrics (leaderboard row)
+    └── Child run  "mid_2025_to_mid_2026"  tags: cv_role=fold, fold_id=mid_2025_to_mid_2026
+                                           ↑ per-fold params + metrics (one child per canonical fold)
 ```
 
 **The coordination problem:** `trained_cv_model`, `cv_power_forecasts`, and `metrics` are
@@ -207,18 +205,20 @@ the assets is only a self-healing fallback. Fold child runs are created per-part
 never collide, because each fold is a distinct Dagster partition that Dagster will not run
 concurrently with itself.
 
-### 4.1.2 Complete-Year Folds Only (the 2026 problem)
+### 4.1.2 Complete Validation Windows Only
 
-Fold eligibility requires a time series to have observations through the fold's `val_end`
-(31 Dec). For the **current** year that is impossible — the year hasn't finished — so the
-current-year fold would silently validate on zero (or partial) data and corrupt the
-"mean-across-folds" leaderboard number. Therefore:
+Fold eligibility requires a time series to have observations through the fold's `val_end`. A fold
+whose validation window has not yet finished would silently validate on zero (or partial) data and
+corrupt the "mean-across-folds" leaderboard number. Therefore:
 
-- `conf/cv/default.yaml` contains **complete years only**. As of this writing that is
-  `"2022"`–`"2025"`; `"2026"` is added only once 2026 has finished and its NGED data has landed.
-- The `FoldId` `Literal` may still *list* `"2026"` (it is a valid future value), but it is not a
-  canonical leaderboard fold until promoted in the YAML.
-- Mid-year performance on the current (incomplete) year is obtained through **arbitrary-period
+- `conf/cv/default.yaml` contains **only folds whose validation window is complete** by the time
+  the experiment runs. The current MVP fold validates `2025-07-01 → 2026-06-30`; this code is not
+  expected to train until after that window has closed. When the multiple-yearly-fold protocol
+  switches on, each yearly fold is added only once its validation year has finished and the NGED
+  data has landed.
+- `fold_id` is a plain `str` (`contracts.power_schemas.FoldId`) whose canonical values come from
+  the YAML, so adding a fold is a config edit, not a schema change.
+- Mid-window performance on an as-yet-incomplete window is obtained through **arbitrary-period
   evaluation** (§4.8, `evaluation_scope="ad_hoc"`), which never feeds the leaderboard.
 
 ### 4.2 Dagster Asset Graph
@@ -287,9 +287,10 @@ class RegisterExperimentConfig(Config):
     config_overrides: dict       # Hydra-style key-value overrides applied on top of
                                  # the base YAML, e.g. {"selected_features": ["lag_1h"]}
     run_mode: Literal["smoke_test", "full_cv", "register_only"]
-                                 # smoke_test: adds only the earliest fold (__2022)
+                                 # smoke_test: adds only the earliest fold
                                  # full_cv:    adds one partition key per canonical fold in
-                                 #             conf/cv/default.yaml (currently __2022...__2025)
+                                 #             conf/cv/default.yaml (currently the single
+                                 #             __mid_2025_to_mid_2026 fold)
                                  # register_only: adds all keys but triggers nothing
     description: str = ""        # stored as an MLflow experiment tag
 ```
@@ -313,9 +314,9 @@ The job performs these steps in order:
    to create it. (The helper is idempotent, so a re-registration is harmless.)
 5. Based on `run_mode`, determine which fold IDs to add (read from `conf/cv/default.yaml`, never
    hard-coded — §4.1.2):
-   - `"smoke_test"` → just the earliest fold, e.g. `["2022"]`
-   - `"full_cv"` or `"register_only"` → every canonical fold, currently `["2022", "2023",
-     "2024", "2025"]`
+   - `"smoke_test"` → just the earliest fold, e.g. `["mid_2025_to_mid_2026"]`
+   - `"full_cv"` or `"register_only"` → every canonical fold, currently
+     `["mid_2025_to_mid_2026"]`
 6. Add Dagster partition keys `[f"{experiment_name}__{fid}" for fid in fold_ids]` to the
    `cv_experiment_folds` `DynamicPartitionsDefinition`.
    Use `context.instance.add_dynamic_partitions("cv_experiment_folds", keys)`.
@@ -323,7 +324,8 @@ The job performs these steps in order:
 
 After the job completes, the user materialises the new partitions from the Dagster asset
 catalog (selecting `trained_cv_model` + `cv_power_forecasts` for the new experiment).
-For a smoke test, only the `__2022` partition exists, so only one fold runs.
+For a smoke test, only the earliest fold's partition exists, so only one fold runs. (With the
+current single-fold config, `smoke_test` and `full_cv` add the same one partition.)
 
 The `register_experiment_job` uses `context.instance.add_dynamic_partitions()` which requires Dagster's instance object inside an op. Make sure to use `OpExecutionContext` (not `AssetExecutionContext`) for that job's ops, since it's a job not an asset.
 
@@ -490,7 +492,7 @@ Per materialisation:
    exactly the trained population, even if power coverage changed since training.
 5. Call `engineer_features()`, then `forecaster.predict()` (across all 51 NWP ensemble members
    — §6).
-6. Overwrite `fold_id` column with the string `fold_id` (year string, e.g. `"2022"`).
+6. Overwrite `fold_id` column with the string `fold_id` (the fold's label, e.g. `"mid_2025_to_mid_2026"`).
    `predict()` stamps each row's identity columns: `power_fcst_model_name`/`power_fcst_model_version`
    carry the model **family** identity (`MODEL_NAME`/`MODEL_VERSION` class constants), while the
    dedicated `experiment_name` column carries the experiment (from
@@ -564,7 +566,7 @@ space — which is also what keeps the leaderboard apples-to-apples.
   metrics" stays a trivial filter, while full window expressiveness lives in dedicated columns.
 - **Scope decides where results go.** All three scopes write to `forecast_metrics` Delta
   (tagged with the scope); they differ only in MLflow logging:
-  - `evaluation_scope="leaderboard"` (canonical complete-year folds only) → the **golden
+  - `evaluation_scope="leaderboard"` (canonical complete-window folds only) → the **golden
     leaderboard** experiments. Logs **per-fold** metrics to each fold child run and
     **aggregate** (mean-across-folds) metrics to the experiment's **parent run**, both resumed
     by tag (§4.1.1) — `experiment_id = get_or_create_experiment(...)`, `parent_run_id =
@@ -580,7 +582,7 @@ space — which is also what keeps the leaderboard apples-to-apples.
     time — e.g. trailing-24h and trailing-7d RMSE per `time_series_type`. The monitoring runs
     are resolved by tag (one persistent run per `(window, …)`), mirroring §4.1.1.
   - `evaluation_scope="ad_hoc"` → **no MLflow at all**, Delta only. For one-off analysis (e.g.
-    scoring the current incomplete year §4.1.2, or a researcher's manual slice).
+    scoring an as-yet-incomplete validation window §4.1.2, or a researcher's manual slice).
 
 Note on actuals: evaluating "the last 24h / 7d / month of production" scores forecasts whose
 `valid_time` has already passed and now has observed power — not freshly issued forward
@@ -629,7 +631,7 @@ The existing `cv_metrics` Dagster asset is **deleted** and replaced by `metrics`
 
 We will sometimes want to test a **new input data source whose history is shorter than the
 canonical folds** — the motivating case is adding **ICON-EU NWP** (from Dynamical.org), whose
-history only starts in **early 2026**, well after the 2022–2025 leaderboard folds. Such a source
+history starts later than the canonical leaderboard folds. Such a source
 **cannot** enter the canonical CV folds (there is no overlapping history), so by construction this
 evaluation lives entirely in `evaluation_scope="ad_hoc"` (§4.8) and **never** feeds the
 leaderboard. Two patterns, answering two different questions:
@@ -654,7 +656,7 @@ rather than letting each experiment pick its own population. (`trained_time_seri
 experiments to share a population — the frozen set does.)
 
 **2. Confound warning (do NOT read this as the ablation).** The tempting shortcut — take the
-2022–2025 **leaderboard champion**, run it on 2026, and compare against an ICON-EU model on 2026 —
+canonical **leaderboard champion**, run it on 2026, and compare against an ICON-EU model on 2026 —
 is **statistically confounded** and must not be read as evidence about the new source. The two
 models differ in **two** variables at once: the feature set *and* the **training window** (the
 champion trained on four full years; the ICON-EU model is forced onto a 2026-only sliver, because
@@ -746,9 +748,9 @@ the model is downloaded from that MLflow run into the local cache, then served f
 - **Add a dedicated `experiment_name` column to `PowerForecast`** (Categorical). This is the
   per-experiment key; do **not** overload `power_fcst_model_name` (which stays the model family
   identity from `MODEL_NAME`). Forecasts are partitioned in Delta by `(experiment_name, fold_id)`.
-- `FoldId` is a `Literal["live", "2022", …]`; it may list `"2026"` as a valid value, but `"2026"`
-  is not a canonical leaderboard fold until 2026 completes and is promoted in
-  `conf/cv/default.yaml` (§4.1.2). Extend the `Literal` when new CV epochs are added.
+- `FoldId` is a plain `str` (`"live"` is the reserved production sentinel); canonical fold labels
+  come from `conf/cv/default.yaml`, so adding a fold or epoch is a config edit, not a schema change
+  (§4.1.2).
 - `PowerForecast.fold_id` is unchanged.
 - **Internal vs delivered schema (Milestone 1 report Table 1, p.28):** the columns
   `experiment_name`, `fold_id`, and `ml_flow_experiment_id` are **internal-only** — they exist
@@ -871,7 +873,7 @@ The following are correct and require no changes:
 - `packages/contracts/src/contracts/ml_schemas.py` — `AllFeatures` is unchanged; the `Metrics`
   schema gains `evaluation_scope` and `time_series_type` columns (§5.1).
 - `conf/cv/default.yaml` — canonical fold definitions; immutable per leaderboard epoch.
-  Currently holds complete years 2022–2025 (§4.1.2).
+  Currently holds the single MVP fold `mid_2025_to_mid_2026` (§4.1.2).
 - `conf/model/xgboost.yaml` — default XGBoost config.
 - All NWP, geo, and NGED data assets.
 
@@ -944,7 +946,7 @@ from mlflow.tracking import MlflowClient
 client = MlflowClient()  # honours the tracking URI set via mlflow.set_tracking_uri(...)
 runs = client.search_runs(
     experiment_ids=[experiment_id],
-    filter_string="tags.cv_role = 'fold' and tags.fold_id = '2022'",
+    filter_string="tags.cv_role = 'fold' and tags.fold_id = 'mid_2025_to_mid_2026'",
     max_results=1,
 )
 fold_run_id = runs[0].info.run_id if runs else _create_fold_run(...)
@@ -1070,11 +1072,11 @@ mistake.
   metrics consume that ensemble. (Training-on-control + inference-on-51 matches the Milestone 1
   report and `docs/roadmap/index.md` v0.1.)
 
-- **Completing a year (fold promotion):** when the current year finishes (e.g. 2026 completes
-  and its NGED data lands), promote it by adding the fold to `conf/cv/default.yaml` and ensuring
-  the `FoldId` `Literal` in `contracts/power_schemas.py` lists it (§4.1.2). Promotion starts a
-  *new leaderboard epoch* (every experiment must be re-scored against the new fold set for
-  apples-to-apples comparison).
+- **Adding a fold (fold promotion):** when a new validation window completes and its NGED data
+  lands (and, for the move to the yearly protocol, once ECMWF ENS is backfilled), promote it by
+  adding the fold to `conf/cv/default.yaml`. No schema change is needed — `FoldId` is a plain `str`
+  (§4.1.2). Promotion starts a *new leaderboard epoch* (every experiment must be re-scored against
+  the new fold set for apples-to-apples comparison).
 
 - **Concurrent Delta writes:** parallel experiments are safe because they write to different
   `experiment_name` partition directories, and re-runs are safe because each write is an
@@ -1231,36 +1233,30 @@ lagged power.
   `save_to_mlflow`/`load_from_mlflow` round-trip + cache hit/miss; register job creates experiment
   + parent run + grouping tags + the right partition keys (§5.8).
 - **User can verify:** run `register_experiment_job` from the Dagster UI/CLI; see the MLflow
-  experiment + parent run (config params + grouping tags) appear, and the new `__2022…` keys show
-  up in the `cv_experiment_folds` partition set.
+  experiment + parent run (config params + grouping tags) appear, and the new
+  `__mid_2025_to_mid_2026` key shows up in the `cv_experiment_folds` partition set.
 
-### 7.3.1 Phase 3.5 - Re-consider CV folds
+### 7.3.1 Phase 3.5 - Re-consider CV folds — Decided
 
-- The design currently specifies that we should use yearly CV folds, with expanding training
-  horizons. The validation years will be 2022, 2023, 2024, and 2025. But I'm worried we may not have
-  enough data for this approach. At least, not yet.
-- Facts to consider:
-    - Dynamical.org currently only provides ECMWF back to 2024-04-01. Dynamical.org are actively
-      backfilling. But the backfill will take months.
-    - Later in the project, we have to ingest CERRA (a European re-analysis) dataset anyway. So we
-      could ingest CERRA soon, and use CERRA to train on times before 2024-04-01. But then we
-      wouldn't be training on a weather _forecast_, so the validation results for 2022, 2023, and
-      2024 would be misleading.
-    - Only 22 of the 32 time series for the trial area have data going back to 2020-01-01 (see plot
-      in Milestone 1 report)
-- Some options I can think of:
-    - **A: Current plan: Just use a single fold for now:** Continue with the current plan. Only use ECMWF ENS. For now, we'll only be able to use a
-      "temporary fold" that trains on the 12 months from 2024-04-01, and tests on the 12 months from
-      2025-04-01. That feels fine for a MVP. The main issue is that it only gives us one fold.
-    - **B: Monthly CV:** Similar to option A, but we "buy" the ability to have multiple folds by
-      expanding the training window by **1 month** per fold. e.g.:
-         - fold 1: train on 12 months from 2024-04-01. Test on 12 months from 2025-04-01.
-         - fold 2: train on 13 months from 2024-04-01. Test on 12 months from 2025-05-01.
-         - fold 3: train on 14 months from 2024-04-01. Test on 12 months from 2025-06-01.
-    - **C: Stick with yearly folds. Use CERRA for folds before 2024-04-01.***
-- Later in the project, when we're really optimising for performance, we will want to try
-  "pre-training" on weather re-analysis datasets, so we can make full use of the long power time
-  series we have for some (but not all) assets.
+**Decision:** use a **single MVP fold** for now (ECMWF ENS only), because honest forecast-skill
+validation needs real forecast NWP for both training and validation, and our ECMWF ENS archive
+only reaches back to 2024-04-01.
+
+- Fold `mid_2025_to_mid_2026`: train `2024-04-01 → 2025-06-30` (15 months, maximising training
+  data), validate `2025-07-01 → 2026-06-30` (12 months, seasonally complete). This code won't be
+  ready to train until after 2026-06-30, by which point the validation window has closed.
+- **The plan is to move to the target multiple-yearly-fold protocol** (expanding training window,
+  one validation year per fold — the original §4.1 design) **once Dynamical.org has backfilled
+  ECMWF ENS** to the earlier years.
+- `FoldId` becomes a plain `str` (`"live"` stays the production sentinel) so fold identity is fully
+  config-driven; switching fold sets is then a `conf/cv/default.yaml` edit, not a schema change.
+- Alternatives considered and why they were not chosen (monthly expanding CV — redundant,
+  correlated folds; quarterly non-overlapping walk-forward — the sound multi-fold option, deferred;
+  CERRA for pre-2024 validation — reanalysis ≠ forecast, reserved for pre-training) are recorded in
+  **docs/ml_experimentation/cross-validation-folds.md**.
+- Implementation: rewrite `conf/cv/default.yaml` to the single fold; relax `FoldId` to `str`;
+  update the affected schema/asset docstrings and tests. No fold-*mechanics* code changes (the
+  windowing in `ml_core._cv_helpers` is already generic over arbitrary train/val dates).
 
 ### 7.4 Phase 4 — `trained_cv_model` asset
 
@@ -1268,7 +1264,8 @@ lagged power.
   `save_to_mlflow`, log training params to the fold run).
 - Tests: integration test materialising one fold (uses Phases 2 + 3).
 - **User can verify:** register a `smoke_test` experiment, materialise `trained_cv_model` for the
-  `__2022` partition; see the model artifact + fold run with training params in MLflow.
+  `__mid_2025_to_mid_2026` partition; see the model artifact + fold run with training params in
+  MLflow.
 
 ### 7.5 Phase 5 — `cv_power_forecasts` asset
 
@@ -1277,8 +1274,8 @@ lagged power.
   prediction metrics to the fold run). **Delete the old monolithic `cv_power_forecasts`.**
 - Tests: materialise predict for the smoke-test fold; **idempotency** (materialise twice →
   `power_forecasts` row count unchanged); assert 51 ensemble members present.
-- **User can verify:** materialise `cv_power_forecasts` for `__2022`, query the `power_forecasts`
-  Delta table; re-materialise and confirm no duplicate rows.
+- **User can verify:** materialise `cv_power_forecasts` for `__mid_2025_to_mid_2026`, query the
+  `power_forecasts` Delta table; re-materialise and confirm no duplicate rows.
 
 ### 7.6 Phase 6 — `metrics` asset (leaderboard + ad_hoc) → full CV loop works
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,9 @@ nav:
       - Philosophy: architecture/philosophy.md
       - Overview: architecture/overview.md
       - Code Style: architecture/code-style.md
+  - ML Experimentation:
+      - Overview: ml_experimentation/index.md
+      - Cross-validation folds: ml_experimentation/cross-validation-folds.md
   - Roadmap:
       - Overview: roadmap/index.md
       - Delivery Tables: roadmap/delivery-tables.md

--- a/packages/contracts/src/contracts/ml_schemas.py
+++ b/packages/contracts/src/contracts/ml_schemas.py
@@ -354,6 +354,6 @@ class EligibleTimeSeries(pt.Model):
 
     fold_id: str = pt.Field(
         dtype=pl.String,
-        description="The CV fold this eligibility row belongs to (e.g. '2022'); the Delta partition key.",
+        description="The CV fold this eligibility row belongs to (e.g. 'mid_2025_to_mid_2026'); the Delta partition key.",
     )
     time_series_id: int = _get_time_series_id_dtype()

--- a/packages/contracts/src/contracts/power_schemas.py
+++ b/packages/contracts/src/contracts/power_schemas.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Sequence
 from datetime import datetime
-from typing import ClassVar, Final, Literal, Self
+from typing import ClassVar, Final, Self
 
 import patito as pt
 import polars as pl
@@ -198,12 +198,12 @@ class TimeSeriesMetadata(pt.Model):
     )
 
 
-FoldId = Literal["live", "2022", "2023", "2024", "2025", "2026"]
+FoldId = str
 """Fold identifier for ``PowerForecast.fold_id``.
 
-Each fold validates on one whole year. Each validation year in the CV protocol gets a string label
-matching that year. ``"live"`` denotes a production forecast (no CV fold). Extend this Literal as
-new CV epochs are added.
+A CV fold's id is a short label defined in ``conf/cv/default.yaml`` (e.g.
+``"mid_2025_to_mid_2026"``); fold identity is config-driven, never hard-coded here. ``"live"`` is
+the reserved sentinel for a production forecast that belongs to no CV fold.
 """
 
 
@@ -289,11 +289,10 @@ class PowerForecast(pt.Model):
         dtype=pl.Categorical,
         description=(
             "Identifies the source of this forecast row.  "
-            "For cross-validation runs, the value is the validation year (e.g. '2022'), "
-            "matching the CV fold whose validation period starts on 1 Jan of that year.  "
+            "For cross-validation runs, the value is the fold's label from conf/cv/default.yaml "
+            "(e.g. 'mid_2025_to_mid_2026').  "
             "'live' means a production forecast with no associated CV fold.  "
             "All forecasts — CV and live — live in the same Delta table; "
-            "filter on this column to select the population you need.  "
-            "Extend the FoldId Literal in power_schemas.py as new CV epochs are added."
+            "filter on this column to select the population you need."
         ),
     )

--- a/packages/contracts/tests/test_hydra_schemas.py
+++ b/packages/contracts/tests/test_hydra_schemas.py
@@ -1,7 +1,6 @@
 from datetime import date
 
 import pytest
-from pydantic import ValidationError
 from contracts.hydra_schemas import (
     CvConfig,
     CvFoldConfig,
@@ -41,19 +40,6 @@ def test_cv_fold_config_valid():
     )
     assert fold.fold_id == "2022"
     assert fold.val_end == date(2022, 12, 31)
-
-
-def test_cv_fold_config_invalid_fold_id():
-    with pytest.raises(ValidationError):
-        CvFoldConfig.model_validate(
-            {
-                "fold_id": "9999",  # not in FoldId Literal
-                "train_start": date(2020, 1, 1),
-                "train_end": date(2021, 12, 31),
-                "val_start": date(2022, 1, 1),
-                "val_end": date(2022, 12, 31),
-            }
-        )
 
 
 def test_cv_config_valid():
@@ -112,6 +98,6 @@ def test_cv_config_get_fold_unknown_raises():
 def test_load_cv_config_reads_canonical_yaml():
     """The canonical conf/cv/default.yaml loads, validates, and coerces dates."""
     config = load_cv_config(PROJECT_ROOT / "conf" / "cv" / "default.yaml")
-    assert config.fold_ids[0] == "2022"
+    assert config.fold_ids[0] == "mid_2025_to_mid_2026"
     assert config.min_training_months == 6
-    assert config.get_fold("2022").train_start == date(2020, 1, 1)
+    assert config.get_fold("mid_2025_to_mid_2026").train_start == date(2024, 4, 1)

--- a/tests/test_cv_assets.py
+++ b/tests/test_cv_assets.py
@@ -1,17 +1,24 @@
 """Integration tests for the CV Dagster assets.
 
 These materialise ``eligible_time_series`` in-process against synthetic power data written to a
-temporary Delta table, exercising the real asset wiring (Dagster + Delta). The pure eligibility
-logic itself is unit-tested in ``packages/ml_core/tests/test_cv_helpers.py``.
+temporary Delta table, exercising the real asset wiring (Dagster + Delta) for the single canonical
+fold in ``conf/cv/default.yaml``. The pure, fold-specific eligibility logic is unit-tested in
+``packages/ml_core/tests/test_cv_helpers.py``.
 """
 
 from datetime import datetime, timezone
 
 import polars as pl
 import pytest
+from contracts.ml_schemas import EligibleTimeSeries
 from dagster import materialize
+from deltalake import write_deltalake
 
 from nged_substation_forecast.defs.cv_assets import eligible_time_series
+
+# The single canonical fold (conf/cv/default.yaml): train 2024-04-01..2025-06-30,
+# validate 2025-07-01..2026-06-30, min_training_months=6.
+FOLD_ID = "mid_2025_to_mid_2026"
 
 
 def _utc(year: int, month: int, day: int) -> datetime:
@@ -22,17 +29,18 @@ def _write_synthetic_power(power_delta_path: str) -> None:
     """Write a tiny synthetic power Delta with hand-picked coverage per time series.
 
     Only the per-series min/max observation times matter for eligibility, so two rows per series
-    (first + last) suffice. Coverage is chosen so the eligible set differs between folds 2022 and
-    2023 (min_training_months=6):
+    (first + last) suffice. Coverage is chosen so eligibility differs across series for the
+    canonical fold (val_start 2025-07-01, val_end 2026-06-30, min_training_months=6 ⇒ first obs
+    must be ≤ 2025-01-01 and last obs ≥ 2026-06-30):
 
-    - ts1: 2021-01-01 .. 2024-01-01 -> eligible for both 2022 and 2023.
-    - ts2: 2021-01-01 .. 2023-06-01 -> eligible 2022 (reaches val_end), not 2023 (stops mid-year).
-    - ts3: 2021-01-01 .. 2022-06-01 -> eligible for neither (stops before 2022 val_end).
+    - ts1: 2024-06-01 .. 2026-07-01 -> eligible (enough history, reaches val_end).
+    - ts2: 2024-06-01 .. 2026-03-01 -> not eligible (stops before val_end).
+    - ts3: 2025-03-01 .. 2026-07-01 -> not eligible (< 6 months history before val_start).
     """
     coverage = {
-        1: (_utc(2021, 1, 1), _utc(2024, 1, 1)),
-        2: (_utc(2021, 1, 1), _utc(2023, 6, 1)),
-        3: (_utc(2021, 1, 1), _utc(2022, 6, 1)),
+        1: (_utc(2024, 6, 1), _utc(2026, 7, 1)),
+        2: (_utc(2024, 6, 1), _utc(2026, 3, 1)),
+        3: (_utc(2025, 3, 1), _utc(2026, 7, 1)),
     }
     rows = [
         {"time_series_id": ts, "time": t, "power": 1.0}
@@ -78,25 +86,42 @@ def _read_eligible(eligible_path: str, fold_id: str) -> list[int]:
 
 
 def test_eligible_time_series_materialises_per_fold_population(cv_paths) -> None:
-    assert materialize([eligible_time_series], partition_key="2022").success
-    assert _read_eligible(cv_paths["eligible"], "2022") == [1, 2]
-
-
-def test_eligible_time_series_differs_between_folds(cv_paths) -> None:
-    """The eligible population is fold-specific: a later val_end excludes shorter series."""
-    assert materialize([eligible_time_series], partition_key="2022").success
-    assert materialize([eligible_time_series], partition_key="2023").success
-
-    # Both fold partitions coexist (writing 2023 must not clobber 2022).
-    assert _read_eligible(cv_paths["eligible"], "2022") == [1, 2]
-    assert _read_eligible(cv_paths["eligible"], "2023") == [1]
+    assert materialize([eligible_time_series], partition_key=FOLD_ID).success
+    assert _read_eligible(cv_paths["eligible"], FOLD_ID) == [1]
 
 
 def test_eligible_time_series_is_idempotent(cv_paths) -> None:
     """Re-materialising a fold overwrites its partition rather than appending duplicates."""
-    assert materialize([eligible_time_series], partition_key="2022").success
-    assert materialize([eligible_time_series], partition_key="2022").success
+    assert materialize([eligible_time_series], partition_key=FOLD_ID).success
+    assert materialize([eligible_time_series], partition_key=FOLD_ID).success
 
-    fold_rows = pl.read_delta(cv_paths["eligible"]).filter(pl.col("fold_id") == "2022")
-    assert len(fold_rows) == 2  # not 4
-    assert sorted(fold_rows["time_series_id"].to_list()) == [1, 2]
+    fold_rows = pl.read_delta(cv_paths["eligible"]).filter(pl.col("fold_id") == FOLD_ID)
+    assert len(fold_rows) == 1  # not 2
+    assert fold_rows["time_series_id"].to_list() == [1]
+
+
+def test_eligible_time_series_overwrite_is_partition_scoped(cv_paths) -> None:
+    """The partition overwrite touches only its own fold, leaving sibling folds intact.
+
+    Pre-seed the eligible table with a row for an unrelated fold (e.g. a prior leaderboard epoch),
+    then materialise the canonical fold and assert the sibling partition survives.
+    """
+    seeded = EligibleTimeSeries.validate(
+        pl.DataFrame(
+            {
+                "fold_id": pl.Series(["prior_epoch"], dtype=pl.String),
+                "time_series_id": pl.Series([99], dtype=pl.Int32),
+            }
+        )
+    )
+    write_deltalake(
+        table_or_uri=cv_paths["eligible"],
+        data=seeded.to_arrow(),
+        mode="overwrite",
+        partition_by=["fold_id"],
+    )
+
+    assert materialize([eligible_time_series], partition_key=FOLD_ID).success
+
+    assert _read_eligible(cv_paths["eligible"], "prior_epoch") == [99]
+    assert _read_eligible(cv_paths["eligible"], FOLD_ID) == [1]

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,13 +1,20 @@
-"""Unit tests for the pure config-resolution helper in ``defs/jobs.py``.
+"""Unit tests for the pure helpers in ``defs/jobs.py``.
 
-These call ``_resolve_forecaster_config`` directly against the real ``conf/model/xgboost.yaml`` —
-no MLflow, Dagster, or Settings — so they stay in the fast, unmarked unit tier. The job wiring
-itself is covered by the integration test in ``test_register_experiment_job.py``.
+These call ``_resolve_forecaster_config`` (against the real ``conf/model/xgboost.yaml``) and
+``_fold_ids_for_run_mode`` (against a synthetic CV config) directly — no MLflow, Dagster, or
+Settings — so they stay in the fast, unmarked unit tier. The job wiring itself is covered by the
+integration test in ``test_register_experiment_job.py``.
 """
 
+from datetime import date
+
+from contracts.hydra_schemas import CvConfig, CvFoldConfig
 from xgboost_forecaster import XGBoostConfig, XGBoostForecaster
 
-from nged_substation_forecast.defs.jobs import _resolve_forecaster_config
+from nged_substation_forecast.defs.jobs import (
+    _fold_ids_for_run_mode,
+    _resolve_forecaster_config,
+)
 
 _BASE_CONFIG = "conf/model/xgboost.yaml"
 
@@ -37,3 +44,36 @@ def test_resolve_no_overrides_uses_yaml_defaults() -> None:
     assert isinstance(config, XGBoostConfig)
     assert config.n_estimators == 500
     assert config.experiment_name == "exp"
+
+
+def _three_fold_config() -> CvConfig:
+    """A synthetic 3-fold config so the run-mode distinction is testable independently of the
+    canonical (currently single-fold) conf/cv/default.yaml."""
+    return CvConfig(
+        folds=[
+            CvFoldConfig(
+                fold_id=f"fold_{i}",
+                train_start=date(2024, 4, 1),
+                train_end=date(2025, 1, 1),
+                val_start=date(2025, 1, 2),
+                val_end=date(2025, 6, 1),
+            )
+            for i in range(3)
+        ]
+    )
+
+
+def test_smoke_test_uses_only_the_earliest_fold() -> None:
+    assert _fold_ids_for_run_mode("smoke_test", _three_fold_config()) == ["fold_0"]
+
+
+def test_full_cv_uses_every_fold() -> None:
+    assert _fold_ids_for_run_mode("full_cv", _three_fold_config()) == ["fold_0", "fold_1", "fold_2"]
+
+
+def test_register_only_uses_every_fold() -> None:
+    assert _fold_ids_for_run_mode("register_only", _three_fold_config()) == [
+        "fold_0",
+        "fold_1",
+        "fold_2",
+    ]

--- a/tests/test_register_experiment_job.py
+++ b/tests/test_register_experiment_job.py
@@ -74,19 +74,17 @@ def test_smoke_test_registers_experiment_and_earliest_fold(mlflow_env: None) -> 
     # Resolved config is logged as flattened params (e.g. an XGBoost hyperparameter).
     assert "n_estimators" in parent.data.params
 
-    assert _partition_keys(instance) == ["exp_smoke__2022"]
+    # conf/cv/default.yaml currently holds a single canonical fold.
+    assert _partition_keys(instance) == ["exp_smoke__mid_2025_to_mid_2026"]
 
 
 def test_full_cv_registers_every_canonical_fold(mlflow_env: None) -> None:
     instance = DagsterInstance.ephemeral()
     _run(instance, "exp_full", run_mode="full_cv")
 
-    assert _partition_keys(instance) == [
-        "exp_full__2022",
-        "exp_full__2023",
-        "exp_full__2024",
-        "exp_full__2025",
-    ]
+    # conf/cv/default.yaml currently holds a single canonical fold; the smoke-test-vs-full-CV
+    # fold-selection distinction is unit-tested in tests/test_jobs.py against a multi-fold config.
+    assert _partition_keys(instance) == ["exp_full__mid_2025_to_mid_2026"]
 
 
 def test_re_registration_is_idempotent(mlflow_env: None) -> None:
@@ -98,9 +96,4 @@ def test_re_registration_is_idempotent(mlflow_env: None) -> None:
     experiment = mlflow.get_experiment_by_name("exp_idem")
     assert experiment is not None
     _parent_run(experiment.experiment_id)  # asserts exactly one parent run
-    assert _partition_keys(instance) == [
-        "exp_idem__2022",
-        "exp_idem__2023",
-        "exp_idem__2024",
-        "exp_idem__2025",
-    ]
+    assert _partition_keys(instance) == ["exp_idem__mid_2025_to_mid_2026"]


### PR DESCRIPTION
Continues from #185. Part of #171.

Replace the four yearly CV folds with a single honest MVP fold (mid_2025_to_mid_2026: train 2024-04-01..2025-06-30, validate 2025-07-01..2026-06-30, ECMWF ENS only), because real forecast NWP only exists from 2024-04-01. The multiple-yearly-fold protocol becomes the target once Dynamical.org backfills ECMWF ENS.

- Relax FoldId from a calendar-year Literal to a plain str ("live" stays the production sentinel) so fold identity is fully config-driven; the windowing in _cv_helpers is already generic, so no fold-mechanics code changes.
- Update affected schema/asset docstrings and tests; add unit tests for _fold_ids_for_run_mode so the smoke-vs-full-CV distinction stays covered against a synthetic multi-fold config.
- Document the roadmap convention: docs/roadmap/ holds only not-yet-implemented design; implemented docs move out, leaving a pointer.
- Add docs/ml_experimentation/ with cross-validation-folds.md (current fold, target protocol, and the alternatives considered: monthly = redundant, quarterly walk-forward = deferred, CERRA = pre-training only); migrate the implemented CV section out of the roadmap's metrics-and-leaderboard.md as the first worked example.


