### PR TITLE
Train CV models on the control member only to fix training OOM

### DIFF
--- a/packages/contracts/src/contracts/weather_schemas.py
+++ b/packages/contracts/src/contracts/weather_schemas.py
@@ -427,10 +427,14 @@ class NwpOnDisk(_NwpBase):
         """Scale integer columns to floating point representations in physical units."""
         scaling_params = NwpScalingParams.load() if scaling_params is None else scaling_params
 
+        # Resolve column names once: `LazyFrame.columns` raises a PerformanceWarning per access
+        # because it resolves the schema, and we'd otherwise hit it once per scaling-param row.
+        available_cols = nwp_on_disk.collect_schema().names()
+
         exprs = []
         for row in scaling_params.to_dicts():
             col_name = row["col_name"]
-            if col_name not in nwp_on_disk.columns:
+            if col_name not in available_cols:
                 raise ValueError(f"Column {col_name} is not in `nwp_on_disk`!")
 
             buffered_min = row["buffered_min"]

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -133,6 +133,7 @@ def _load_engineering_inputs(
     time_series_ids: list[int],
     window_start: datetime,
     window_end: datetime,
+    ensemble_members: list[int] | None = None,
 ) -> tuple[
     pt.LazyFrame[PowerTimeSeries], pt.DataFrame[TimeSeriesMetadata], pt.LazyFrame[NwpInMemory]
 ]:
@@ -141,8 +142,15 @@ def _load_engineering_inputs(
     Shared by ``trained_cv_model`` (training window + eligible population) and
     ``cv_power_forecasts`` (validation window + trained population). Power and NWP are filtered to
     the inclusive ``[window_start, window_end]`` window; all three inputs are filtered to
-    ``time_series_ids``. NWP is **not** filtered to the control member, so every ensemble member is
-    carried through to feature engineering.
+    ``time_series_ids``.
+
+    Args:
+        ensemble_members: If provided, NWP is filtered to these ``ensemble_member`` indices (the
+            predicate pushes down to the Delta scan, so unwanted members never enter memory). If
+            ``None`` (the default), every ensemble member is carried through. Training restricts to
+            the control member (``[0]``) to avoid fanning every forecast row out across all ~51
+            members against the same power target; prediction passes ``None`` because the
+            probabilistic leaderboard metrics need the full ensemble.
     """
     power_lf = pl.scan_delta(str(settings.nged_data_path / "power_time_series.delta")).filter(
         pl.col("time_series_id").is_in(time_series_ids),
@@ -154,6 +162,8 @@ def _load_engineering_inputs(
     nwp_in_window = NwpOnDisk.to_nwp_in_memory(NwpOnDisk.scan_delta(settings.nwp_data_path)).filter(
         pl.col("valid_time") >= window_start, pl.col("valid_time") <= window_end
     )
+    if ensemble_members is not None:
+        nwp_in_window = nwp_in_window.filter(pl.col("ensemble_member").is_in(ensemble_members))
     nwp_lf = pt.LazyFrame.from_existing(nwp_in_window).set_model(NwpInMemory)
 
     metadata_df = pt.DataFrame(
@@ -202,7 +212,7 @@ def trained_cv_model(context: AssetExecutionContext) -> None:
     )
 
     power_ts, metadata_df, nwp_lf = _load_engineering_inputs(
-        settings, eligible_ids, train_start, train_end
+        settings, eligible_ids, train_start, train_end, ensemble_members=[0]
     )
 
     forecaster = forecaster_cls(model_params=config)

--- a/tests/test_trained_cv_model.py
+++ b/tests/test_trained_cv_model.py
@@ -18,7 +18,9 @@ from deltalake import write_deltalake
 from mlflow.tracking import MlflowClient
 from xgboost_forecaster.forecaster import XGBoostForecaster
 
-from nged_substation_forecast.defs.cv_assets import trained_cv_model
+from contracts.settings import Settings
+
+from nged_substation_forecast.defs.cv_assets import _load_engineering_inputs, trained_cv_model
 from nged_substation_forecast.defs.jobs import RegisterExperimentConfig, register_experiment_job
 
 pytestmark = pytest.mark.integration
@@ -69,24 +71,34 @@ def _write_power(path: str) -> None:
     ).write_delta(path)
 
 
+_NWP_ENSEMBLE_MEMBERS = (0, 1, 2)
+"""Members written to the synthetic NWP. Member 0 is the control; 1 and 2 exercise the
+``ensemble_members`` filter in ``_load_engineering_inputs`` (training keeps only the control)."""
+
+
 def _write_nwp(path: str) -> None:
-    """Write a minimal NwpOnDisk-shaped Delta (integer weather cols) for two cells/days."""
+    """Write a minimal NwpOnDisk-shaped Delta (integer weather cols) for two cells/days.
+
+    Each (cell, valid_time) carries all of ``_NWP_ENSEMBLE_MEMBERS`` so tests can assert that
+    training narrows NWP to the control member while prediction would keep every member.
+    """
     records = []
     for cell, day in ((_TS1_CELL, _IN_WINDOW), (_TS2_CELL, _AFTER_TRAIN_END)):
         init_time = day.replace(hour=0)
         for valid_time in pl.datetime_range(
             day.replace(hour=6), day.replace(hour=8), interval="30m", time_zone="UTC", eager=True
         ):
-            record = {
-                "nwp_model_id": "ECMWF_ENS_0_25_degree",
-                "init_time": init_time,
-                "valid_time": valid_time,
-                "ensemble_member": 0,
-                "h3_index": cell,
-                "categorical_precipitation_type_surface": None,
-            }
-            record.update({col: 2000 for col in _NWP_CONTINUOUS_COLS})
-            records.append(record)
+            for member in _NWP_ENSEMBLE_MEMBERS:
+                record = {
+                    "nwp_model_id": "ECMWF_ENS_0_25_degree",
+                    "init_time": init_time,
+                    "valid_time": valid_time,
+                    "ensemble_member": member,
+                    "h3_index": cell,
+                    "categorical_precipitation_type_surface": None,
+                }
+                record.update({col: 2000 for col in _NWP_CONTINUOUS_COLS})
+                records.append(record)
     df = pl.DataFrame(records).cast(
         {
             "init_time": pl.Datetime("us", "UTC"),
@@ -161,6 +173,27 @@ def _register(instance: DagsterInstance) -> None:
         instance=instance,
     )
     assert result.success
+
+
+def test_load_engineering_inputs_filters_ensemble_members(env: dict[str, str]) -> None:
+    """``ensemble_members`` narrows NWP at the scan; ``None`` keeps every member.
+
+    This is the lever that keeps training (control member only) from fanning every forecast row out
+    across all ~51 members against the same power target — the source of the training OOM.
+    """
+    settings = Settings()
+    train_start = datetime(2024, 4, 1, tzinfo=timezone.utc)
+    train_end = datetime(2025, 6, 30, 23, 59, 59, tzinfo=timezone.utc)
+
+    _, _, nwp_control = _load_engineering_inputs(
+        settings, [1, 2], train_start, train_end, ensemble_members=[0]
+    )
+    assert nwp_control.collect()["ensemble_member"].unique().sort().to_list() == [0]
+
+    _, _, nwp_all = _load_engineering_inputs(settings, [1, 2], train_start, train_end)
+    assert nwp_all.collect()["ensemble_member"].unique().sort().to_list() == list(
+        _NWP_ENSEMBLE_MEMBERS
+    )
 
 
 def test_trained_cv_model_trains_and_saves_to_mlflow(env: dict[str, str]) -> None:


### PR DESCRIPTION
## Problem

`trained_cv_model` ran out of RAM on any training window beyond ~1 day (a 1-month `smoke_test` window crashed the machine almost instantly).

The experiment config declares its weather strategy as `weather_source: ecmwf_control` (`conf/model/xgboost.yaml`), i.e. *train on the ECMWF control member only*. But the training data path didn't honour that: `_load_engineering_inputs` loaded NWP for **every** ensemble member, so each forecast row was fanned out across all ~51 members (each a different perturbed weather scenario against the *same* observed-power target). `XGBoostForecaster.train()` then materialises the whole frame in one `data.collect()`. The result is a ~51×-inflated training frame; widening the window from 1 day to 1 month tips it over RAM.

## Fix

- `_load_engineering_inputs` gains an `ensemble_members: list[int] | None` parameter. When set, it filters NWP to those members with the predicate pushed down to the Delta scan, so unwanted members never enter memory.
- `trained_cv_model` requests the control member only (`[0]`), matching the declared `ecmwf_control` strategy.
- `cv_power_forecasts` keeps the default `None` (all members) — the probabilistic leaderboard metrics need the full ensemble.

The `list[int] | None` shape (rather than a bool) leaves room to train on a subset of members later while still serving inference on all 51.

## Also

- Hoist the column lookup in `NwpOnDisk.to_nwp_in_memory` out of its per-row loop so it resolves the LazyFrame schema once, instead of raising a `PerformanceWarning` on every scaling-param row. (This warning was a red herring re: the OOM, but worth fixing.)

## Tests

- New `test_load_engineering_inputs_filters_ensemble_members` asserts `ensemble_members=[0]` yields only the control member while `None` keeps every member; the synthetic NWP fixture now carries multiple members.
- Full suite green (`ruff`, `ty`, `pytest`).

## Out of scope (follow-ups)

- Per-`time_series_id` streaming/batching in `train()` / `predict()` to bound memory for the full 14-month fold and the all-member prediction path.
- A dedicated quick-iteration `smoke_test` CV config (kept out of the canonical leaderboard `default.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)