### PR TITLE
Phase 5.1: plot_power_forecast job

### DIFF
--- a/docs/ml_experimentation/dagster-workflow.md
+++ b/docs/ml_experimentation/dagster-workflow.md
@@ -116,6 +116,42 @@ Experiment "xgboost_smoke_test"
 
 ---
 
+## Inspecting a forecast — `plot_power_forecast_job`
+
+Once forecasts exist in the `power_forecasts` Delta table, this job renders an interactive HTML
+plot of a single forecast so you can eyeball it. It is independent of the training flow above —
+launch it any time there are forecasts on disk to inspect.
+
+**Trigger:** Dagster UI → Jobs → `plot_power_forecast_job` → "Launch run". The default run config
+plots an existing smoke-test forecast, so you can launch it as-is; override the
+`PlotPowerForecastConfig` fields to plot a different forecast:
+
+| Field | Example | Notes |
+|---|---|---|
+| `experiment_name` | `"xgboost_smoke_test_3"` | Selects the `(experiment_name, fold_id)` Delta partition to read |
+| `fold_id` | `"smoke_test"` | Use `"live"` for a production forecast |
+| `power_fcst_init_time` | `"2025-01-29T06:00:00+00:00"` | ISO-8601 (Dagster config has no native datetime type); a naive value is read as UTC. The plot spans this time plus the 14-day horizon |
+| `time_series_ids` | `[1, 2, 3, 4]` | Between 1 and 4 ids; each is drawn on its own panel |
+
+**What the job does:**
+
+1. Reads `power_forecasts` for `(experiment_name, fold_id)` at the chosen `power_fcst_init_time`,
+   filtered to `time_series_ids`. Errors if no rows match — check the matching partition has been
+   materialised.
+2. Reads observed power over the 14-day horizon and the series metadata.
+3. Builds an Altair chart with one panel per `time_series_id`: all 51 ensemble members as thin
+   grey lines, ground truth (where available) as a thick blue line, and a shared, zoomable x-axis
+   so panning one panel moves them all.
+4. Saves it as a self-contained interactive HTML file under `plots_data_path` (`data/plots/`),
+   named `{experiment_name}__{fold_id}__{init_time}__ts-{ids}.html`. Open it in a browser to zoom
+   and hover (tooltips show the `ensemble_member` and value).
+
+This is a **job, not an asset**, because the plot is a throwaway artifact for human inspection —
+keyed by init time and series ids, with no lineage or durable catalog identity — rather than a
+tracked data object in the pipeline.
+
+---
+
 ## Why `trained_cv_model` reads config from MLflow, not from YAML
 
 When `register_experiment_job` runs, it resolves the base YAML plus any overrides into a single

--- a/packages/contracts/src/contracts/settings.py
+++ b/packages/contracts/src/contracts/settings.py
@@ -104,6 +104,14 @@ class Settings(BaseSettings):
     nwp_data_path: Path = PROJECT_ROOT / "data" / "NWP"
     power_forecasts_data_path: Path = PROJECT_ROOT / "data" / "power_forecasts"
     forecast_metrics_data_path: Path = PROJECT_ROOT / "data" / "forecast_metrics"
+    plots_data_path: Path = Field(
+        default=PROJECT_ROOT / "data" / "plots",
+        description=(
+            "Directory where plot_power_forecast writes interactive forecast HTML files, one per"
+            " materialisation (filename derived from experiment, fold, init time, and the plotted"
+            " time_series_ids)."
+        ),
+    )
     eligible_time_series_data_path: Path = Field(
         default=PROJECT_ROOT / "data" / "eligible_time_series",
         description=(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
 ]
 dependencies = [
+    "altair>=6.0.0",
     "dagster>=1.12.11",
     "dagster-webserver>=1.12.11",
     "patito",

--- a/src/nged_substation_forecast/definitions.py
+++ b/src/nged_substation_forecast/definitions.py
@@ -3,9 +3,9 @@
 from dagster import Definitions, load_assets_from_modules
 from contracts.settings import Settings
 
-from nged_substation_forecast.defs import assets, cv_assets, jobs, schedules
+from nged_substation_forecast.defs import assets, cv_assets, jobs, plot_assets, schedules
 
-all_assets = load_assets_from_modules([assets, cv_assets])
+all_assets = load_assets_from_modules([assets, cv_assets, plot_assets])
 
 settings = Settings()
 

--- a/src/nged_substation_forecast/definitions.py
+++ b/src/nged_substation_forecast/definitions.py
@@ -3,14 +3,14 @@
 from dagster import Definitions, load_assets_from_modules
 from contracts.settings import Settings
 
-from nged_substation_forecast.defs import assets, cv_assets, jobs, plot_assets, schedules
+from nged_substation_forecast.defs import assets, cv_assets, jobs, plot_jobs, schedules
 
-all_assets = load_assets_from_modules([assets, cv_assets, plot_assets])
+all_assets = load_assets_from_modules([assets, cv_assets])
 
 settings = Settings()
 
 defs = Definitions(
     assets=all_assets,
-    jobs=[jobs.register_experiment_job],
+    jobs=[jobs.register_experiment_job, plot_jobs.plot_power_forecast_job],
     schedules=[schedules.power_time_series_and_metadata_schedule],
 )

--- a/src/nged_substation_forecast/defs/plot_assets.py
+++ b/src/nged_substation_forecast/defs/plot_assets.py
@@ -1,0 +1,215 @@
+"""Ad-hoc visualisation assets for inspecting forecasts.
+
+``plot_power_forecast`` is an unpartitioned, config-driven asset: rather than producing a data
+artifact for the pipeline it renders an interactive HTML plot of forecasts that already exist in
+the ``power_forecasts`` Delta table, so a human can eyeball one forecast. It reads the Delta/parquet
+sources directly (no ``deps`` into the partitioned CV graph) and delegates chart construction to the
+pure, unit-testable :func:`build_forecast_chart`.
+"""
+
+import warnings
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Final
+
+import altair as alt
+import polars as pl
+from contracts.settings import Settings
+from dagster import AssetExecutionContext, Config, MetadataValue, asset
+from pydantic import Field
+
+FORECAST_HORIZON: Final[timedelta] = timedelta(days=14)
+"""Length of the forecast horizon plotted from ``power_fcst_init_time``."""
+
+_PANEL_WIDTH: Final[int] = 800
+"""Pixel width of every panel; a fixed, shared width keeps the x-axes aligned across panels."""
+
+_PANEL_HEIGHT: Final[int] = 250
+"""Pixel height of each per-time-series panel."""
+
+
+class PlotPowerForecastConfig(Config):
+    """Run config for ``plot_power_forecast``.
+
+    The defaults point at the smoke-test forecasts currently materialised in the
+    ``power_forecasts`` Delta table, so the asset is runnable with no config edits.
+    """
+
+    experiment_name: str = Field(
+        default="xgboost_smoke_test_3",
+        description="Experiment whose forecasts to plot; selects the Delta partition to read.",
+    )
+    fold_id: str = Field(
+        default="smoke_test",
+        description="CV fold (or 'live') whose forecasts to plot; selects the Delta partition.",
+    )
+    power_fcst_init_time: str = Field(
+        default="2025-01-29T06:00:00+00:00",
+        description=(
+            "ISO-8601 forecast init time to plot (Dagster config has no native datetime type)."
+            " The plot spans this time to this time plus the 14-day forecast horizon. A naive"
+            " value is interpreted as UTC."
+        ),
+    )
+    time_series_ids: list[int] = Field(
+        default=[1, 2, 3, 4],
+        min_length=1,
+        max_length=4,
+        description="Between 1 and 4 time_series_ids; each is drawn on its own panel.",
+    )
+
+
+def build_forecast_chart(
+    forecasts: pl.DataFrame,
+    ground_truth: pl.DataFrame,
+    metadata: pl.DataFrame,
+    time_series_ids: list[int],
+) -> alt.VConcatChart:
+    """Build a stacked, interactive forecast chart — one panel per ``time_series_id``.
+
+    Each panel layers all 51 ensemble members as thin grey lines (``power_fcst`` vs ``valid_time``)
+    and, where ground truth is available for that series, the observed power as a thick blue line.
+    Panels are stacked vertically with independent y-scales but a shared, zoomable x-scale so
+    panning/zooming one panel moves them all and the time axes stay aligned.
+
+    Args:
+        forecasts: ``PowerForecast`` rows for the chosen init time, already filtered to
+            ``time_series_ids``.
+        ground_truth: ``PowerTimeSeries`` observations over the plotted window (may be empty for
+            some or all series).
+        metadata: ``TimeSeriesMetadata`` for the plotted series, used for panel titles and units.
+        time_series_ids: The series to plot, in the order their panels should appear.
+
+    Returns:
+        A vertically concatenated Altair chart ready to ``.save(...)`` as interactive HTML.
+    """
+    # The full ensemble across up to 4 panels far exceeds Altair's 5000-row default guard.
+    alt.data_transformers.disable_max_rows()
+
+    # One shared, explicitly-named interval selection bound to the x-scale; adding the same param to
+    # every panel makes Vega-Lite hoist it to a single top-level param, so zoom/pan is synchronised
+    # across panels (and the time axes stay aligned).
+    x_zoom = alt.selection_interval(bind="scales", encodings=["x"], name="shared_x_zoom")
+
+    panels: list[alt.LayerChart | alt.FacetChart] = []
+    for time_series_id in time_series_ids:
+        forecast_panel = forecasts.filter(pl.col("time_series_id") == time_series_id)
+        truth_panel = ground_truth.filter(pl.col("time_series_id") == time_series_id)
+        meta_row = metadata.filter(pl.col("time_series_id") == time_series_id)
+
+        units = meta_row["units"].item() if meta_row.height else "MW/MVA"
+        name = meta_row["time_series_name"].item() if meta_row.height else str(time_series_id)
+        series_type = meta_row["time_series_type"].item() if meta_row.height else "unknown"
+
+        ensemble_layer = (
+            alt.Chart(forecast_panel)
+            .mark_line(strokeWidth=1, opacity=0.3, color="lightgray")
+            .encode(
+                x=alt.X("valid_time:T", title="Valid time"),
+                y=alt.Y("power_fcst:Q", title=f"Power ({units})"),
+                detail="ensemble_member:N",
+                tooltip=["ensemble_member", "valid_time", "power_fcst"],
+            )
+        )
+
+        layers: list[alt.Chart] = [ensemble_layer]
+        if truth_panel.height:
+            truth_layer = (
+                alt.Chart(truth_panel)
+                .mark_line(strokeWidth=2.5, color="steelblue")
+                .encode(
+                    x=alt.X("time:T"),
+                    y=alt.Y("power:Q"),
+                    tooltip=["time", "power"],
+                )
+            )
+            layers.append(truth_layer)
+
+        panel = (
+            alt.layer(*layers)
+            .properties(
+                title=f"{name} (id={time_series_id}) — {series_type}",
+                width=_PANEL_WIDTH,
+                height=_PANEL_HEIGHT,
+            )
+            .add_params(x_zoom)
+        )
+        panels.append(panel)
+
+    # Altair warns that it deduplicated the identical x_zoom param across panels — that dedup is
+    # exactly how the shared zoom is achieved here, so the warning is expected, not a problem.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="Automatically deduplicated selection parameter")
+        return alt.vconcat(*panels).resolve_scale(y="independent")
+
+
+@asset
+def plot_power_forecast(context: AssetExecutionContext, config: PlotPowerForecastConfig) -> None:
+    """Render an interactive HTML plot of one forecast for 1–4 ``time_series_id``s.
+
+    Reads the ``power_forecasts`` Delta table for ``(experiment_name, fold_id)`` at the chosen
+    ``power_fcst_init_time``, the observed power over the 14-day horizon, and the series metadata,
+    then writes an interactive Altair HTML file to ``settings.plots_data_path``. The asset is
+    unpartitioned and reads Delta directly (no ``deps``), so it plots whatever forecasts already
+    exist on disk.
+    """
+    settings = Settings()
+    init_time = datetime.fromisoformat(config.power_fcst_init_time)
+    if init_time.tzinfo is None:
+        init_time = init_time.replace(tzinfo=UTC)
+    window_end = init_time + FORECAST_HORIZON
+
+    forecasts = (
+        pl.scan_delta(str(settings.power_forecasts_data_path))
+        .filter(
+            pl.col("experiment_name") == config.experiment_name,
+            pl.col("fold_id") == config.fold_id,
+            pl.col("time_series_id").is_in(config.time_series_ids),
+            pl.col("power_fcst_init_time") == init_time,
+        )
+        .collect()
+    )
+    if forecasts.height == 0:
+        raise ValueError(
+            "No forecasts found for "
+            f"experiment_name={config.experiment_name!r}, fold_id={config.fold_id!r}, "
+            f"power_fcst_init_time={init_time.isoformat()}, "
+            f"time_series_ids={config.time_series_ids}. "
+            "Check that the matching partition has been materialised."
+        )
+
+    ground_truth = (
+        pl.scan_delta(str(settings.nged_data_path / "power_time_series.delta"))
+        .filter(
+            pl.col("time_series_id").is_in(config.time_series_ids),
+            pl.col("time") >= init_time,
+            pl.col("time") <= window_end,
+        )
+        .collect()
+    )
+    metadata = pl.read_parquet(settings.nged_data_path / "metadata.parquet").filter(
+        pl.col("time_series_id").is_in(config.time_series_ids)
+    )
+
+    chart = build_forecast_chart(forecasts, ground_truth, metadata, config.time_series_ids)
+
+    settings.plots_data_path.mkdir(parents=True, exist_ok=True)
+    ids_label = "-".join(str(i) for i in config.time_series_ids)
+    filename = (
+        f"{config.experiment_name}__{config.fold_id}__{init_time:%Y%m%dT%H%MZ}__ts-{ids_label}.html"
+    )
+    out_path: Path = settings.plots_data_path / filename
+    chart.save(str(out_path))
+
+    context.add_output_metadata(
+        {
+            "plot_path": MetadataValue.path(str(out_path)),
+            "experiment_name": config.experiment_name,
+            "fold_id": config.fold_id,
+            "power_fcst_init_time": init_time.isoformat(),
+            "time_series_ids": str(config.time_series_ids),
+            "n_forecast_rows": forecasts.height,
+            "n_ensemble_members": forecasts["ensemble_member"].n_unique(),
+            "n_ground_truth_rows": ground_truth.height,
+        }
+    )

--- a/src/nged_substation_forecast/defs/plot_jobs.py
+++ b/src/nged_substation_forecast/defs/plot_jobs.py
@@ -1,10 +1,11 @@
-"""Ad-hoc visualisation assets for inspecting forecasts.
+"""Manually launched visualisation jobs for inspecting forecasts.
 
-``plot_power_forecast`` is an unpartitioned, config-driven asset: rather than producing a data
-artifact for the pipeline it renders an interactive HTML plot of forecasts that already exist in
-the ``power_forecasts`` Delta table, so a human can eyeball one forecast. It reads the Delta/parquet
-sources directly (no ``deps`` into the partitioned CV graph) and delegates chart construction to the
-pure, unit-testable :func:`build_forecast_chart`.
+``plot_power_forecast_job`` renders an interactive HTML plot of forecasts that already exist in the
+``power_forecasts`` Delta table, so a human can eyeball one forecast. It is a job (not an asset)
+because the plot is a throwaway artifact for human eyes — keyed by ``(init time, time_series_ids)``,
+with no lineage and no durable catalog identity — rather than a tracked data object. Its op reads
+the Delta/parquet sources directly and delegates chart construction to the pure, unit-testable
+:func:`build_forecast_chart`.
 """
 
 import warnings
@@ -15,7 +16,7 @@ from typing import Final
 import altair as alt
 import polars as pl
 from contracts.settings import Settings
-from dagster import AssetExecutionContext, Config, MetadataValue, asset
+from dagster import Config, MetadataValue, OpExecutionContext, job, op
 from pydantic import Field
 
 FORECAST_HORIZON: Final[timedelta] = timedelta(days=14)
@@ -29,10 +30,10 @@ _PANEL_HEIGHT: Final[int] = 250
 
 
 class PlotPowerForecastConfig(Config):
-    """Run config for ``plot_power_forecast``.
+    """Run config for ``plot_power_forecast_job``.
 
     The defaults point at the smoke-test forecasts currently materialised in the
-    ``power_forecasts`` Delta table, so the asset is runnable with no config edits.
+    ``power_forecasts`` Delta table, so the job is runnable with no config edits.
     """
 
     experiment_name: str = Field(
@@ -143,15 +144,14 @@ def build_forecast_chart(
         return alt.vconcat(*panels).resolve_scale(y="independent")
 
 
-@asset
-def plot_power_forecast(context: AssetExecutionContext, config: PlotPowerForecastConfig) -> None:
+@op
+def plot_power_forecast(context: OpExecutionContext, config: PlotPowerForecastConfig) -> None:
     """Render an interactive HTML plot of one forecast for 1–4 ``time_series_id``s.
 
     Reads the ``power_forecasts`` Delta table for ``(experiment_name, fold_id)`` at the chosen
     ``power_fcst_init_time``, the observed power over the 14-day horizon, and the series metadata,
-    then writes an interactive Altair HTML file to ``settings.plots_data_path``. The asset is
-    unpartitioned and reads Delta directly (no ``deps``), so it plots whatever forecasts already
-    exist on disk.
+    then writes an interactive Altair HTML file to ``settings.plots_data_path``. Reads Delta
+    directly, so it plots whatever forecasts already exist on disk.
     """
     settings = Settings()
     init_time = datetime.fromisoformat(config.power_fcst_init_time)
@@ -213,3 +213,9 @@ def plot_power_forecast(context: AssetExecutionContext, config: PlotPowerForecas
             "n_ground_truth_rows": ground_truth.height,
         }
     )
+
+
+@job
+def plot_power_forecast_job() -> None:
+    """Render an interactive HTML plot of one forecast for 1–4 ``time_series_id``s."""
+    plot_power_forecast()

--- a/tests/test_plot_power_forecast.py
+++ b/tests/test_plot_power_forecast.py
@@ -1,0 +1,146 @@
+"""Tests for the ``plot_power_forecast`` asset and its pure chart builder.
+
+The chart builder and config bounds are exercised as fast unit tests; the asset itself is run
+end-to-end against temp Delta/parquet sources via ``materialize`` to confirm an HTML file lands on
+disk.
+"""
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import polars as pl
+import pytest
+from altair import VConcatChart
+from dagster import DagsterInstance, RunConfig, materialize
+from pydantic import ValidationError
+
+from nged_substation_forecast.defs.plot_assets import (
+    PlotPowerForecastConfig,
+    build_forecast_chart,
+    plot_power_forecast,
+)
+
+EXPERIMENT_NAME = "exp_plot"
+FOLD_ID = "smoke_test"
+INIT_TIME = datetime(2025, 1, 29, 6, 0, tzinfo=UTC)
+
+
+def _valid_times() -> pl.Series:
+    return pl.datetime_range(
+        INIT_TIME, INIT_TIME + timedelta(hours=4), interval="30m", time_zone="UTC", eager=True
+    )
+
+
+def _forecasts(time_series_ids: tuple[int, ...], members: tuple[int, ...]) -> pl.DataFrame:
+    rows = [
+        {
+            "experiment_name": EXPERIMENT_NAME,
+            "fold_id": FOLD_ID,
+            "time_series_id": ts,
+            "ensemble_member": m,
+            "power_fcst_init_time": INIT_TIME,
+            "valid_time": vt,
+            "power_fcst": 10.0 + m + i,
+        }
+        for ts in time_series_ids
+        for m in members
+        for i, vt in enumerate(_valid_times())
+    ]
+    return pl.DataFrame(rows).cast(
+        {
+            "time_series_id": pl.Int32,
+            "ensemble_member": pl.Int8,
+            "power_fcst_init_time": pl.Datetime("us", "UTC"),
+            "valid_time": pl.Datetime("us", "UTC"),
+            "power_fcst": pl.Float32,
+        }
+    )
+
+
+def _ground_truth(time_series_ids: tuple[int, ...]) -> pl.DataFrame:
+    rows = [
+        {"time_series_id": ts, "time": t, "power": 12.0 + i}
+        for ts in time_series_ids
+        for i, t in enumerate(_valid_times())
+    ]
+    return pl.DataFrame(rows).cast(
+        {"time_series_id": pl.Int32, "time": pl.Datetime("us", "UTC"), "power": pl.Float32}
+    )
+
+
+def _metadata(time_series_ids: tuple[int, ...]) -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "time_series_id": pl.Series(list(time_series_ids), dtype=pl.Int32),
+            "units": [("MW" if ts % 2 else "MVA") for ts in time_series_ids],
+            "time_series_name": [f"Substation {ts}" for ts in time_series_ids],
+            "time_series_type": ["PV" for _ in time_series_ids],
+        }
+    )
+
+
+def test_build_forecast_chart_one_panel_per_series_with_optional_truth() -> None:
+    # ts1 has ground truth (ensemble + truth layers); ts2 has none (ensemble layer only).
+    forecasts = _forecasts((1, 2), (0, 1, 2))
+    ground_truth = _ground_truth((1,))
+    metadata = _metadata((1, 2))
+
+    chart = build_forecast_chart(forecasts, ground_truth, metadata, [1, 2])
+
+    assert isinstance(chart, VConcatChart)
+    assert len(chart.vconcat) == 2
+    assert len(chart.vconcat[0].layer) == 2  # ts1: ensemble + ground truth
+    assert len(chart.vconcat[1].layer) == 1  # ts2: ensemble only
+    assert "ensemble_member" in chart.to_html()
+
+
+def test_config_rejects_out_of_range_time_series_id_counts() -> None:
+    with pytest.raises(ValidationError):
+        PlotPowerForecastConfig(time_series_ids=[])
+    with pytest.raises(ValidationError):
+        PlotPowerForecastConfig(time_series_ids=[1, 2, 3, 4, 5])
+
+
+@pytest.fixture
+def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    nged_path = tmp_path / "NGED"
+    nged_path.mkdir()
+    plots_path = tmp_path / "plots"
+    monkeypatch.setenv("NGED_S3_BUCKET_URL", "https://example.com")
+    monkeypatch.setenv("NGED_S3_BUCKET_ACCESS_KEY", "dummy")
+    monkeypatch.setenv("NGED_S3_BUCKET_SECRET", "dummy")
+    monkeypatch.setenv("NGED_DATA_PATH", str(nged_path))
+    monkeypatch.setenv("POWER_FORECASTS_DATA_PATH", str(tmp_path / "power_forecasts"))
+    monkeypatch.setenv("PLOTS_DATA_PATH", str(plots_path))
+
+    _forecasts((1, 2), (0, 1, 2)).write_delta(
+        str(tmp_path / "power_forecasts"),
+        delta_write_options={"partition_by": ["experiment_name", "fold_id"]},
+    )
+    _ground_truth((1, 2)).write_delta(str(nged_path / "power_time_series.delta"))
+    _metadata((1, 2)).write_parquet(nged_path / "metadata.parquet")
+    return plots_path
+
+
+@pytest.mark.integration
+def test_plot_power_forecast_writes_html(env: Path) -> None:
+    result = materialize(
+        [plot_power_forecast],
+        instance=DagsterInstance.ephemeral(),
+        run_config=RunConfig(
+            ops={
+                "plot_power_forecast": PlotPowerForecastConfig(
+                    experiment_name=EXPERIMENT_NAME,
+                    fold_id=FOLD_ID,
+                    power_fcst_init_time=INIT_TIME.isoformat(),
+                    time_series_ids=[1, 2],
+                )
+            }
+        ),
+    )
+    assert result.success
+
+    html_files = list(env.glob("*.html"))
+    assert len(html_files) == 1
+    assert html_files[0].stat().st_size > 0
+    assert "ensemble_member" in html_files[0].read_text()

--- a/tests/test_plot_power_forecast.py
+++ b/tests/test_plot_power_forecast.py
@@ -1,8 +1,7 @@
-"""Tests for the ``plot_power_forecast`` asset and its pure chart builder.
+"""Tests for the ``plot_power_forecast_job`` and its pure chart builder.
 
-The chart builder and config bounds are exercised as fast unit tests; the asset itself is run
-end-to-end against temp Delta/parquet sources via ``materialize`` to confirm an HTML file lands on
-disk.
+The chart builder and config bounds are exercised as fast unit tests; the job itself is run
+end-to-end against temp Delta/parquet sources to confirm an HTML file lands on disk.
 """
 
 from datetime import UTC, datetime, timedelta
@@ -11,13 +10,13 @@ from pathlib import Path
 import polars as pl
 import pytest
 from altair import VConcatChart
-from dagster import DagsterInstance, RunConfig, materialize
+from dagster import RunConfig
 from pydantic import ValidationError
 
-from nged_substation_forecast.defs.plot_assets import (
+from nged_substation_forecast.defs.plot_jobs import (
     PlotPowerForecastConfig,
     build_forecast_chart,
-    plot_power_forecast,
+    plot_power_forecast_job,
 )
 
 EXPERIMENT_NAME = "exp_plot"
@@ -124,9 +123,7 @@ def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 @pytest.mark.integration
 def test_plot_power_forecast_writes_html(env: Path) -> None:
-    result = materialize(
-        [plot_power_forecast],
-        instance=DagsterInstance.ephemeral(),
+    result = plot_power_forecast_job.execute_in_process(
         run_config=RunConfig(
             ops={
                 "plot_power_forecast": PlotPowerForecastConfig(

--- a/uv.lock
+++ b/uv.lock
@@ -2204,6 +2204,7 @@ name = "nged-substation-forecast"
 version = "0.0.1"
 source = { editable = "." }
 dependencies = [
+    { name = "altair" },
     { name = "contracts" },
     { name = "dagster" },
     { name = "dagster-webserver" },
@@ -2236,6 +2237,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "altair", specifier = ">=6.0.0" },
     { name = "contracts", editable = "packages/contracts" },
     { name = "dagster", specifier = ">=1.12.11" },
     { name = "dagster-webserver", specifier = ">=1.12.11" },
@@ -3138,7 +3140,7 @@ name = "pyzmq"
 version = "27.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "implementation_name == 'pypy'" },
+    { name = "cffi", marker = "implementation_name == 'pypy' and sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [


### PR DESCRIPTION
## Phase 5.1 — \`plot_power_forecast_job\`

Implements §7.5.1: a manually-launched Dagster **job** that reads already-materialised forecasts
from the \`power_forecasts\` Delta table and writes an **interactive Altair HTML plot** to disk.

For a given \`power_fcst_init_time\` and 1–4 \`time_series_id\`s it renders:
- all 51 ensemble members as thin grey lines,
- ground-truth power (where available) as a thick blue line,
- one panel per \`time_series_id\`, with a shared, zoomable x-axis.

### Approach
- Reads the \`power_forecasts\` Delta table directly (no on-the-fly inference); run config names
  \`experiment_name\` + \`fold_id\` to pick the Delta partition. Defaults point at the
  \`xgboost_smoke_test_3\` / \`smoke_test\` data currently on disk so the job is runnable as-is.
- New \`plots_data_path\` Setting (\`data/plots/\`) with an auto-derived filename.
- Pure, unit-tested \`build_forecast_chart\` helper; thin op wrapped in \`plot_power_forecast_job\`.

### Asset → job
Originally drafted as an asset (per the plan wording), then converted to a **job**: the plot is a
throwaway artifact for human inspection — keyed by init time + ids, with no lineage or durable
catalog identity — so a job models it more honestly. Sits alongside \`register_experiment_job\`.

### Docs
Documented in \`docs/ml_experimentation/dagster-workflow.md\`.

### Tests
Pure chart-builder unit test, config 1–4 bounds test, and an end-to-end job run writing HTML to a
temp dir. Full suite: 146 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)