### PR TITLE
Phase 5.2: smoke_test fold (fast-iteration, non-leaderboard)

### DIFF
--- a/conf/cv/default.yaml
+++ b/conf/cv/default.yaml
@@ -1,9 +1,13 @@
-# Expanding-window cross-validation folds shared by all experiments on the leaderboard.
-# All models MUST be evaluated against these exact folds so leaderboard comparisons
-# are apples-to-apples.  Change these only when founding a new leaderboard epoch.
+# The CV fold registry. Two kinds of fold live here, distinguished by the `leaderboard` flag:
 #
-# Current state: a single MVP fold. Honest forecast-skill validation needs real forecast NWP
-# (ECMWF ENS) for both training and validation, and our ECMWF ENS archive only reaches back to
+#   * leaderboard: true  — the epoch-pinned evaluation protocol shared by all experiments. All
+#     models MUST be evaluated against these exact folds so leaderboard comparisons are
+#     apples-to-apples.  Change these only when founding a new leaderboard epoch.
+#   * leaderboard: false — optional non-leaderboard dev folds (e.g. smoke_test) for fast end-to-end
+#     sanity checks. They reuse the identical pipeline but never feed the leaderboard.
+#
+# Current leaderboard state: a single MVP fold. Honest forecast-skill validation needs real forecast
+# NWP (ECMWF ENS) for both training and validation, and our ECMWF ENS archive only reaches back to
 # 2024-04-01 (Dynamical.org are backfilling earlier years, but slowly). So we train on the longest
 # honest window we have and validate on the following 12 months.
 #
@@ -18,5 +22,16 @@ folds:
     val_start:   "2025-07-01"
     val_end:     "2026-06-30"
 
-# Minimum months of observations before val_start for a time series to be eligible.
+  # Non-leaderboard dev fold: ~1 month train / ~1 month val for fast end-to-end sanity checks.
+  # min_training_months matches the short train window so eligibility doesn't demand 6 months.
+  - fold_id: "smoke_test"
+    leaderboard: false
+    min_training_months: 1
+    train_start: "2025-01-01"
+    train_end:   "2025-01-31"
+    val_start:   "2025-02-01"
+    val_end:     "2025-02-28"
+
+# Default minimum months of observations before val_start for a time series to be eligible.
+# A fold may override this with its own `min_training_months`.
 min_training_months: 6

--- a/docs/ml_experimentation/dagster-workflow.md
+++ b/docs/ml_experimentation/dagster-workflow.md
@@ -62,7 +62,7 @@ step before training.**
 | `experiment_name` | `"xgboost_smoke_test"` | Unique; becomes the MLflow experiment name and partition-key prefix |
 | `base_model_config` | `"conf/model/xgboost.yaml"` | Path relative to `PROJECT_ROOT` |
 | `config_overrides` | `{"n_estimators": 100}` | Merged onto `model_params` in the YAML |
-| `run_mode` | `"smoke_test"` | `smoke_test` adds only the earliest fold; `full_cv` or `register_only` adds all folds |
+| `run_mode` | `"smoke_test"` | `smoke_test` adds the non-leaderboard dev folds (e.g. `smoke_test`); `full_cv` or `register_only` adds the leaderboard folds |
 | `description` | `"Quick sanity check"` | Stored as an MLflow tag — optional |
 
 `smoke_test` is the right choice for a first run: it adds only one partition key, so you can
@@ -86,7 +86,7 @@ MLflow experiment and partition keys rather than creating duplicates.
 ## Step 6 — Materialise `trained_cv_model`
 
 **Trigger:** Materialise the partition `"{experiment_name}__{fold_id}"`, e.g.
-`"xgboost_smoke_test__mid_2025_to_mid_2026"`. The partition only appears after step 5 has run.
+`"xgboost_smoke_test__smoke_test"`. The partition only appears after step 5 has run.
 
 **What the asset does:**
 
@@ -109,7 +109,7 @@ The MLflow run structure looks like this:
 Experiment "xgboost_smoke_test"
 └── cv_summary (parent run)   tags={cv_role: parent}
     │   params: n_estimators=100, learning_rate=0.05, …
-    └── mid_2025_to_mid_2026  tags={cv_role: fold, fold_id: mid_2025_to_mid_2026}
+    └── smoke_test  tags={cv_role: fold, fold_id: smoke_test}
             params: train_start, train_end, n_eligible_time_series
             artifacts: model/   ← trained model binary files
 ```

--- a/packages/contracts/src/contracts/hydra_schemas.py
+++ b/packages/contracts/src/contracts/hydra_schemas.py
@@ -10,13 +10,24 @@ from contracts.power_schemas import FoldId
 
 
 class CvFoldConfig(BaseModel):
-    """Configuration for a single expanding-window CV fold."""
+    """Configuration for a single expanding-window CV fold.
+
+    ``leaderboard`` distinguishes the epoch-pinned leaderboard folds (the apples-to-apples
+    evaluation protocol) from optional non-leaderboard dev folds such as ``smoke_test``: a
+    ``leaderboard=False`` fold runs through the identical pipeline but never feeds the leaderboard.
+
+    ``min_training_months`` overrides ``CvConfig.min_training_months`` for this fold alone (``None``
+    falls back to the config-level value). A short dev fold sets it to its train length so
+    eligibility does not demand the leaderboard's longer history.
+    """
 
     fold_id: FoldId
     train_start: date
     train_end: date
     val_start: date
     val_end: date
+    leaderboard: bool = True
+    min_training_months: int | None = Field(default=None, ge=1)
 
 
 class CvConfig(BaseModel):
@@ -42,6 +53,15 @@ class CvConfig(BaseModel):
         registration into per-fold partition keys — always read from config, never hard-coded.
         """
         return [fold.fold_id for fold in self.folds]
+
+    @property
+    def leaderboard_fold_ids(self) -> list[str]:
+        """The fold ids of the leaderboard folds only, in declaration order.
+
+        Non-leaderboard dev folds (e.g. ``smoke_test``) are excluded. Used to expand the
+        ``full_cv`` / ``register_only`` run modes and to scope leaderboard metrics.
+        """
+        return [fold.fold_id for fold in self.folds if fold.leaderboard]
 
     def get_fold(self, fold_id: str) -> CvFoldConfig:
         """Return the fold with the given ``fold_id``.

--- a/packages/contracts/tests/test_hydra_schemas.py
+++ b/packages/contracts/tests/test_hydra_schemas.py
@@ -95,9 +95,50 @@ def test_cv_config_get_fold_unknown_raises():
         _two_fold_config().get_fold("2099")
 
 
+def test_cv_fold_config_defaults_leaderboard_true_and_no_override():
+    fold = CvFoldConfig(
+        fold_id="2022",
+        train_start=date(2020, 1, 1),
+        train_end=date(2021, 12, 31),
+        val_start=date(2022, 1, 1),
+        val_end=date(2022, 12, 31),
+    )
+    assert fold.leaderboard is True
+    assert fold.min_training_months is None
+
+
+def test_cv_config_leaderboard_fold_ids_excludes_dev_folds():
+    config = CvConfig(
+        folds=[
+            CvFoldConfig(
+                fold_id="2022",
+                train_start=date(2020, 1, 1),
+                train_end=date(2021, 12, 31),
+                val_start=date(2022, 1, 1),
+                val_end=date(2022, 12, 31),
+            ),
+            CvFoldConfig(
+                fold_id="smoke_test",
+                leaderboard=False,
+                min_training_months=1,
+                train_start=date(2021, 12, 1),
+                train_end=date(2021, 12, 31),
+                val_start=date(2022, 1, 1),
+                val_end=date(2022, 1, 31),
+            ),
+        ]
+    )
+    assert config.fold_ids == ["2022", "smoke_test"]
+    assert config.leaderboard_fold_ids == ["2022"]
+
+
 def test_load_cv_config_reads_canonical_yaml():
     """The canonical conf/cv/default.yaml loads, validates, and coerces dates."""
     config = load_cv_config(PROJECT_ROOT / "conf" / "cv" / "default.yaml")
-    assert config.fold_ids[0] == "mid_2025_to_mid_2026"
+    assert config.leaderboard_fold_ids == ["mid_2025_to_mid_2026"]
     assert config.min_training_months == 6
     assert config.get_fold("mid_2025_to_mid_2026").train_start == date(2024, 4, 1)
+
+    smoke = config.get_fold("smoke_test")
+    assert smoke.leaderboard is False
+    assert smoke.min_training_months == 1

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -93,9 +93,8 @@ def eligible_time_series(context: AssetExecutionContext) -> None:
         .collect()
     )
 
-    eligible_ids = eligible_time_series_ids(
-        coverage, fold, min_training_months=_cv_config.min_training_months
-    )
+    min_training_months = fold.min_training_months or _cv_config.min_training_months
+    eligible_ids = eligible_time_series_ids(coverage, fold, min_training_months=min_training_months)
 
     eligible_df = EligibleTimeSeries.validate(
         pl.DataFrame(
@@ -123,7 +122,7 @@ def eligible_time_series(context: AssetExecutionContext) -> None:
             "eligible_time_series_ids": str(eligible_ids),
             "val_start": str(fold.val_start),
             "val_end": str(fold.val_end),
-            "min_training_months": _cv_config.min_training_months,
+            "min_training_months": min_training_months,
         }
     )
 

--- a/src/nged_substation_forecast/defs/jobs.py
+++ b/src/nged_substation_forecast/defs/jobs.py
@@ -45,8 +45,9 @@ class RegisterExperimentConfig(Config):
     run_mode: Literal["smoke_test", "full_cv", "register_only"] = Field(
         default="smoke_test",
         description=(
-            "smoke_test: add only the earliest fold; full_cv / register_only: add every canonical"
-            " fold from conf/cv/default.yaml. No assets are materialised by the job itself."
+            "smoke_test: add the non-leaderboard dev folds; full_cv / register_only: add the"
+            " leaderboard folds from conf/cv/default.yaml. No assets are materialised by the job"
+            " itself."
         ),
     )
     description: str = Field(default="", description="Stored as an MLflow experiment tag.")
@@ -95,12 +96,12 @@ def _class_target(obj: type | object) -> str:
 def _fold_ids_for_run_mode(run_mode: str, cv_config: CvConfig) -> list[str]:
     """Return the fold ids a run mode expands to (read from the CV config, never hard-coded).
 
-    ``smoke_test`` uses only the earliest fold; ``full_cv`` and ``register_only`` use every
-    canonical fold.
+    Selection keys off the ``leaderboard`` flag, not fold position: ``smoke_test`` uses the
+    non-leaderboard dev folds; ``full_cv`` and ``register_only`` use the leaderboard folds.
     """
     if run_mode == "smoke_test":
-        return [cv_config.fold_ids[0]]
-    return cv_config.fold_ids
+        return [fold.fold_id for fold in cv_config.folds if not fold.leaderboard]
+    return cv_config.leaderboard_fold_ids
 
 
 @op

--- a/tests/test_cv_assets.py
+++ b/tests/test_cv_assets.py
@@ -1,9 +1,9 @@
 """Integration tests for the CV Dagster assets.
 
 These materialise ``eligible_time_series`` in-process against synthetic power data written to a
-temporary Delta table, exercising the real asset wiring (Dagster + Delta) for the single canonical
-fold in ``conf/cv/default.yaml``. The pure, fold-specific eligibility logic is unit-tested in
-``packages/ml_core/tests/test_cv_helpers.py``.
+temporary Delta table, exercising the real asset wiring (Dagster + Delta) for the leaderboard fold
+and the non-leaderboard ``smoke_test`` fold in ``conf/cv/default.yaml``. The pure, fold-specific
+eligibility logic is unit-tested in ``packages/ml_core/tests/test_cv_helpers.py``.
 """
 
 from datetime import datetime, timezone
@@ -16,9 +16,13 @@ from deltalake import write_deltalake
 
 from nged_substation_forecast.defs.cv_assets import eligible_time_series
 
-# The single canonical fold (conf/cv/default.yaml): train 2024-04-01..2025-06-30,
+# The leaderboard fold (conf/cv/default.yaml): train 2024-04-01..2025-06-30,
 # validate 2025-07-01..2026-06-30, min_training_months=6.
 FOLD_ID = "mid_2025_to_mid_2026"
+
+# The non-leaderboard dev fold (conf/cv/default.yaml): validate 2025-02-01..2025-02-28 with the
+# per-fold override min_training_months=1.
+SMOKE_FOLD_ID = "smoke_test"
 
 
 def _utc(year: int, month: int, day: int) -> datetime:
@@ -30,17 +34,22 @@ def _write_synthetic_power(power_delta_path: str) -> None:
 
     Only the per-series min/max observation times matter for eligibility, so two rows per series
     (first + last) suffice. Coverage is chosen so eligibility differs across series for the
-    canonical fold (val_start 2025-07-01, val_end 2026-06-30, min_training_months=6 ⇒ first obs
+    leaderboard fold (val_start 2025-07-01, val_end 2026-06-30, min_training_months=6 ⇒ first obs
     must be ≤ 2025-01-01 and last obs ≥ 2026-06-30):
 
     - ts1: 2024-06-01 .. 2026-07-01 -> eligible (enough history, reaches val_end).
     - ts2: 2024-06-01 .. 2026-03-01 -> not eligible (stops before val_end).
     - ts3: 2025-03-01 .. 2026-07-01 -> not eligible (< 6 months history before val_start).
+    - ts4: 2024-12-01 .. 2025-03-01 -> not eligible for the leaderboard fold (stops before val_end),
+      but eligible for the smoke fold *only because* its per-fold min_training_months=1 override is
+      honoured: smoke val_start 2025-02-01 needs first obs ≤ 2025-01-01 (met by 2024-12-01), whereas
+      the default 6 months would require ≤ 2024-08-01 (not met). So ts4 is the override's witness.
     """
     coverage = {
         1: (_utc(2024, 6, 1), _utc(2026, 7, 1)),
         2: (_utc(2024, 6, 1), _utc(2026, 3, 1)),
         3: (_utc(2025, 3, 1), _utc(2026, 7, 1)),
+        4: (_utc(2024, 12, 1), _utc(2025, 3, 1)),
     }
     rows = [
         {"time_series_id": ts, "time": t, "power": 1.0}
@@ -98,6 +107,16 @@ def test_eligible_time_series_is_idempotent(cv_paths) -> None:
     fold_rows = pl.read_delta(cv_paths["eligible"]).filter(pl.col("fold_id") == FOLD_ID)
     assert len(fold_rows) == 1  # not 2
     assert fold_rows["time_series_id"].to_list() == [1]
+
+
+def test_eligible_time_series_honours_per_fold_min_training_months_override(cv_paths) -> None:
+    """The smoke fold's min_training_months=1 override widens eligibility to include ts4.
+
+    ts4 (first obs 2024-12-01) would be excluded under the config-level default of 6 months but is
+    eligible here because the fold's own override of 1 month is applied (see ts4 in the fixture).
+    """
+    assert materialize([eligible_time_series], partition_key=SMOKE_FOLD_ID).success
+    assert _read_eligible(cv_paths["eligible"], SMOKE_FOLD_ID) == [1, 2, 4]
 
 
 def test_eligible_time_series_overwrite_is_partition_scoped(cv_paths) -> None:

--- a/tests/test_cv_power_forecasts.py
+++ b/tests/test_cv_power_forecasts.py
@@ -160,7 +160,9 @@ def _register(instance: DagsterInstance) -> None:
                     experiment_name=EXPERIMENT_NAME,
                     base_model_config="conf/model/xgboost.yaml",
                     config_overrides={"selected_features": ["temperature_2m"], "n_estimators": 5},
-                    run_mode="smoke_test",
+                    # full_cv so the leaderboard fold's partition (FOLD_ID) is registered; this test
+                    # drives that fold's window and synthetic data, not the smoke_test fold.
+                    run_mode="full_cv",
                 )
             }
         ),

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -46,34 +46,38 @@ def test_resolve_no_overrides_uses_yaml_defaults() -> None:
     assert config.experiment_name == "exp"
 
 
-def _three_fold_config() -> CvConfig:
-    """A synthetic 3-fold config so the run-mode distinction is testable independently of the
-    canonical (currently single-fold) conf/cv/default.yaml."""
-    return CvConfig(
-        folds=[
-            CvFoldConfig(
-                fold_id=f"fold_{i}",
-                train_start=date(2024, 4, 1),
-                train_end=date(2025, 1, 1),
-                val_start=date(2025, 1, 2),
-                val_end=date(2025, 6, 1),
-            )
-            for i in range(3)
-        ]
-    )
-
-
-def test_smoke_test_uses_only_the_earliest_fold() -> None:
-    assert _fold_ids_for_run_mode("smoke_test", _three_fold_config()) == ["fold_0"]
-
-
-def test_full_cv_uses_every_fold() -> None:
-    assert _fold_ids_for_run_mode("full_cv", _three_fold_config()) == ["fold_0", "fold_1", "fold_2"]
-
-
-def test_register_only_uses_every_fold() -> None:
-    assert _fold_ids_for_run_mode("register_only", _three_fold_config()) == [
-        "fold_0",
-        "fold_1",
-        "fold_2",
+def _mixed_fold_config() -> CvConfig:
+    """A synthetic config mixing leaderboard folds with a non-leaderboard dev fold, so the
+    flag-based run-mode selection is testable independently of conf/cv/default.yaml."""
+    leaderboard_folds = [
+        CvFoldConfig(
+            fold_id=f"fold_{i}",
+            train_start=date(2024, 4, 1),
+            train_end=date(2025, 1, 1),
+            val_start=date(2025, 1, 2),
+            val_end=date(2025, 6, 1),
+        )
+        for i in range(2)
     ]
+    dev_fold = CvFoldConfig(
+        fold_id="dev",
+        leaderboard=False,
+        min_training_months=1,
+        train_start=date(2025, 1, 1),
+        train_end=date(2025, 1, 31),
+        val_start=date(2025, 2, 1),
+        val_end=date(2025, 2, 28),
+    )
+    return CvConfig(folds=[*leaderboard_folds, dev_fold])
+
+
+def test_smoke_test_uses_the_non_leaderboard_folds() -> None:
+    assert _fold_ids_for_run_mode("smoke_test", _mixed_fold_config()) == ["dev"]
+
+
+def test_full_cv_uses_the_leaderboard_folds() -> None:
+    assert _fold_ids_for_run_mode("full_cv", _mixed_fold_config()) == ["fold_0", "fold_1"]
+
+
+def test_register_only_uses_the_leaderboard_folds() -> None:
+    assert _fold_ids_for_run_mode("register_only", _mixed_fold_config()) == ["fold_0", "fold_1"]

--- a/tests/test_register_experiment_job.py
+++ b/tests/test_register_experiment_job.py
@@ -59,7 +59,7 @@ def _parent_run(experiment_id: str):
     return runs[0]
 
 
-def test_smoke_test_registers_experiment_and_earliest_fold(mlflow_env: None) -> None:
+def test_smoke_test_registers_experiment_and_dev_fold(mlflow_env: None) -> None:
     instance = DagsterInstance.ephemeral()
     _run(instance, "exp_smoke", run_mode="smoke_test")
 
@@ -77,16 +77,16 @@ def test_smoke_test_registers_experiment_and_earliest_fold(mlflow_env: None) -> 
     # Resolved config is logged as flattened params (e.g. an XGBoost hyperparameter).
     assert "n_estimators" in parent.data.params
 
-    # conf/cv/default.yaml currently holds a single canonical fold.
-    assert _partition_keys(instance) == ["exp_smoke__mid_2025_to_mid_2026"]
+    # smoke_test selects the non-leaderboard dev folds; conf/cv/default.yaml holds one (smoke_test).
+    assert _partition_keys(instance) == ["exp_smoke__smoke_test"]
 
 
-def test_full_cv_registers_every_canonical_fold(mlflow_env: None) -> None:
+def test_full_cv_registers_the_leaderboard_folds(mlflow_env: None) -> None:
     instance = DagsterInstance.ephemeral()
     _run(instance, "exp_full", run_mode="full_cv")
 
-    # conf/cv/default.yaml currently holds a single canonical fold; the smoke-test-vs-full-CV
-    # fold-selection distinction is unit-tested in tests/test_jobs.py against a multi-fold config.
+    # full_cv selects the leaderboard folds; conf/cv/default.yaml currently holds a single one. The
+    # flag-based smoke-test-vs-full-CV distinction is unit-tested in tests/test_jobs.py.
     assert _partition_keys(instance) == ["exp_full__mid_2025_to_mid_2026"]
 
 

--- a/tests/test_trained_cv_model.py
+++ b/tests/test_trained_cv_model.py
@@ -166,7 +166,9 @@ def _register(instance: DagsterInstance) -> None:
                     experiment_name=EXPERIMENT_NAME,
                     base_model_config="conf/model/xgboost.yaml",
                     config_overrides={"selected_features": ["temperature_2m"], "n_estimators": 5},
-                    run_mode="smoke_test",
+                    # full_cv so the leaderboard fold's partition (FOLD_ID) is registered; this test
+                    # drives that fold's window and synthetic data, not the smoke_test fold.
+                    run_mode="full_cv",
                 )
             }
         ),


### PR DESCRIPTION
## Context

The CV pipeline (`register → eligible_time_series → trained_cv_model → cv_power_forecasts`)
currently only knows the leaderboard fold `mid_2025_to_mid_2026` (15-month train / 12-month val).
Iterating against it is slow and pollutes the leaderboard. This adds a first-class, **hard-coded
non-leaderboard** `smoke_test` fold (~1 month train / ~1 month val) so the whole
`register → train → predict → eyeball` loop runs in well under a minute, reusing the existing
pipeline unchanged. What keeps it off the leaderboard is a **flag, not a separate file**.

Implements plan §4.10 / §7.5.2. Independent of Phases 6–8.

## Changes

- `CvFoldConfig` gains `leaderboard: bool = True` and `min_training_months: int | None = None`;
  `CvConfig` gains a `leaderboard_fold_ids` property.
- `conf/cv/default.yaml` becomes the fold **registry** and gains the `smoke_test` fold.
- `eligible_time_series` honours the per-fold `min_training_months` override.
- `_fold_ids_for_run_mode` selects by the `leaderboard` flag instead of fold position.
- Docs + tests updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)