### PR TITLE
Revert val_end of mid_2025_to_mid_2026 fold to 2026-06-30

### DIFF
--- a/conf/cv/default.yaml
+++ b/conf/cv/default.yaml
@@ -20,7 +20,7 @@ folds:
     train_start: "2024-04-01"
     train_end:   "2025-06-30"
     val_start:   "2025-07-01"
-    val_end:     "2026-05-13"  # TEMP: power archive ends 2026-05-14; revert to 2026-06-30
+    val_end:     "2026-06-30"
 
   # Non-leaderboard dev fold: ~1 month train / ~1 month val for fast end-to-end sanity checks.
   # min_training_months matches the short train window so eligibility doesn't demand 6 months.

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -439,7 +439,10 @@ def cv_power_forecasts(context: AssetExecutionContext) -> None:
     n_time_series = len(time_series_seen)
     n_ensemble_members = len(ensemble_members_seen)
     with mlflow.start_run(run_id=fold_run_id):
-        mlflow.log_params({"val_start": val_start.isoformat(), "val_end": val_end.isoformat()})
+        # Use set_tag (not log_params) so re-materialising with an extended val_end doesn't
+        # raise "Changing param values is not allowed" — the covered window is mutable metadata.
+        mlflow.set_tag("val_start", val_start.isoformat())
+        mlflow.set_tag("val_end", val_end.isoformat())
         mlflow.log_metrics(
             {
                 "n_forecast_rows": float(n_rows),


### PR DESCRIPTION
## Summary

- Reverts `val_end` of the `mid_2025_to_mid_2026` leaderboard fold from the temporary `2026-05-13` cutoff back to `2026-06-30`
- Power archive and NWP backfill are now complete, unblocking the full validation window

Closes #199.

## Test plan

- [x] Run `cv_power_forecasts` Dagster asset for the `mid_2025_to_mid_2026` fold and confirm it completes without error
- [x] Run `plot_power_forecast_job` for `power_fcst_init_time = 2026-06-30T06` and confirm plots look sensible

🤖 Generated with [Claude Code](https://claude.com/claude-code)