### PR TITLE
Add plotting package with OCF brand theme (closes #95)

### DIFF
--- a/packages/dashboard/main.py
+++ b/packages/dashboard/main.py
@@ -19,9 +19,11 @@ with app.setup:
     import lonboard
     import marimo as mo
     import patito as pt
+    import plotting.ocf_theme  # noqa: F401 — registers OCF Altair theme as side effect
     import polars as pl
     import pyarrow
     from contracts.power_schemas import PowerTimeSeries, TimeSeriesMetadata
+    from plotting.ocf_theme import BLUE
 
     BASE_DELTA_PATH = PROJECT_ROOT / settings.nged_data_path / "power_time_series.delta"
 
@@ -130,7 +132,7 @@ def _(delta_df, df, layer_widget, map):
                             axis=alt.Axis(format="%H:%M %b %d"),
                         ),
                         y=alt.Y("power:Q", title=f"Power ({selected_df['units'].item()})"),
-                        color=alt.value("teal"),
+                        color=alt.value(BLUE),
                         tooltip=["time", "power"],
                     )
                     .properties(

--- a/packages/dashboard/pyproject.toml
+++ b/packages/dashboard/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "altair>=6.0.0",
     "lonboard>=0.13.0",
     "marimo>=0.19.7",
+    "plotting",
     "polars>=1.37.1",
     "pyarrow>=23.0.0",
     "geoarrow-pyarrow>=0.2.0",

--- a/packages/notebooks/plot_missing_NWP_data.py
+++ b/packages/notebooks/plot_missing_NWP_data.py
@@ -5,8 +5,11 @@ app = marimo.App()
 
 with app.setup:
     from datetime import datetime, timezone
+
     import altair as alt
+    import plotting.ocf_theme  # noqa: F401 — registers OCF Altair theme as side effect
     import polars as pl
+    from plotting.ocf_theme import GRID, ORANGE_RED
 
 
 @app.cell
@@ -66,7 +69,7 @@ def _(df, nwp_vars):
         )
 
         # Layer 1: A light gray background line showing the full time series extent
-        background_lines = base.mark_line(color="lightgray", strokeWidth=1).encode(
+        background_lines = base.mark_line(color=GRID, strokeWidth=1).encode(
             x=alt.X("valid_time:T", title="Valid Time"),
             detail="row_label:N",  # Ensures lines don't connect across different rows
         )
@@ -75,7 +78,7 @@ def _(df, nwp_vars):
         missing_marks = (
             base.transform_filter(alt.datum.is_missing)
             .mark_tick(
-                color="red",
+                color=ORANGE_RED,
                 thickness=3,  # Make the red mark stand out
                 size=12,  # Height of the tick mark
             )

--- a/packages/notebooks/pyproject.toml
+++ b/packages/notebooks/pyproject.toml
@@ -11,5 +11,6 @@ dependencies = [
     "lonboard>=0.16.0",
     "marimo>=0.19.7",
     "palettable>=3.3.3",
+    "plotting",
     "polars>=1.37.1",
 ]

--- a/packages/plotting/pyproject.toml
+++ b/packages/plotting/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "plotting"
+version = "0.1.0"
+description = "OCF brand theme and chart-building utilities"
+requires-python = ">=3.14"
+dependencies = [
+    "altair>=6.0.0",
+    "polars>=1.0.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"

--- a/packages/plotting/src/plotting/forecast_chart.py
+++ b/packages/plotting/src/plotting/forecast_chart.py
@@ -58,7 +58,7 @@ def build_forecast_chart(
 
         ensemble_layer = (
             alt.Chart(forecast_panel)
-            .mark_line(strokeWidth=1, opacity=0.3, color=ocf_theme.GRID)
+            .mark_line(strokeWidth=1, opacity=0.3, color=ocf_theme.ENSEMBLE_LINE)
             .encode(
                 x=alt.X("valid_time:T", title="Valid time"),
                 y=alt.Y("power_fcst:Q", title=f"Power ({units})"),

--- a/packages/plotting/src/plotting/forecast_chart.py
+++ b/packages/plotting/src/plotting/forecast_chart.py
@@ -1,0 +1,98 @@
+"""Power forecast chart builder."""
+
+import warnings
+from typing import Final
+
+import altair as alt
+import polars as pl
+from plotting import ocf_theme
+
+_PANEL_WIDTH: Final[int] = 800
+"""Pixel width of every panel; a fixed, shared width keeps the x-axes aligned across panels."""
+
+_PANEL_HEIGHT: Final[int] = 250
+"""Pixel height of each per-time-series panel."""
+
+
+def build_forecast_chart(
+    forecasts: pl.DataFrame,
+    ground_truth: pl.DataFrame,
+    metadata: pl.DataFrame,
+    time_series_ids: list[int],
+) -> alt.VConcatChart:
+    """Build a stacked, interactive forecast chart — one panel per ``time_series_id``.
+
+    Each panel layers all 51 ensemble members as thin lines (``power_fcst`` vs ``valid_time``)
+    and, where ground truth is available for that series, the observed power as a thick line.
+    Panels are stacked vertically with independent y-scales but a shared, zoomable x-scale so
+    panning/zooming one panel moves them all and the time axes stay aligned.
+
+    Args:
+        forecasts: ``PowerForecast`` rows for the chosen init time, already filtered to
+            ``time_series_ids``.
+        ground_truth: ``PowerTimeSeries`` observations over the plotted window (may be empty for
+            some or all series).
+        metadata: ``TimeSeriesMetadata`` for the plotted series, used for panel titles and units.
+        time_series_ids: The series to plot, in the order their panels should appear.
+
+    Returns:
+        A vertically concatenated Altair chart ready to ``.save(...)`` as interactive HTML.
+    """
+    # The full ensemble across up to 4 panels far exceeds Altair's 5000-row default guard.
+    alt.data_transformers.disable_max_rows()
+
+    # One shared, explicitly-named interval selection bound to the x-scale; adding the same param to
+    # every panel makes Vega-Lite hoist it to a single top-level param, so zoom/pan is synchronised
+    # across panels (and the time axes stay aligned).
+    x_zoom = alt.selection_interval(bind="scales", encodings=["x"], name="shared_x_zoom")
+
+    panels: list[alt.LayerChart | alt.FacetChart] = []
+    for time_series_id in time_series_ids:
+        forecast_panel = forecasts.filter(pl.col("time_series_id") == time_series_id)
+        truth_panel = ground_truth.filter(pl.col("time_series_id") == time_series_id)
+        meta_row = metadata.filter(pl.col("time_series_id") == time_series_id)
+
+        units = meta_row["units"].item() if meta_row.height else "MW/MVA"
+        name = meta_row["time_series_name"].item() if meta_row.height else str(time_series_id)
+        series_type = meta_row["time_series_type"].item() if meta_row.height else "unknown"
+
+        ensemble_layer = (
+            alt.Chart(forecast_panel)
+            .mark_line(strokeWidth=1, opacity=0.3, color=ocf_theme.GRID)
+            .encode(
+                x=alt.X("valid_time:T", title="Valid time"),
+                y=alt.Y("power_fcst:Q", title=f"Power ({units})"),
+                detail="ensemble_member:N",
+                tooltip=["ensemble_member", "valid_time", "power_fcst"],
+            )
+        )
+
+        layers: list[alt.Chart] = [ensemble_layer]
+        if truth_panel.height:
+            truth_layer = (
+                alt.Chart(truth_panel)
+                .mark_line(strokeWidth=2.5, color=ocf_theme.BLUE)
+                .encode(
+                    x=alt.X("time:T"),
+                    y=alt.Y("power:Q"),
+                    tooltip=["time", "power"],
+                )
+            )
+            layers.append(truth_layer)
+
+        panel = (
+            alt.layer(*layers)
+            .properties(
+                title=f"{name} (id={time_series_id}) — {series_type}",
+                width=_PANEL_WIDTH,
+                height=_PANEL_HEIGHT,
+            )
+            .add_params(x_zoom)
+        )
+        panels.append(panel)
+
+    # Altair warns that it deduplicated the identical x_zoom param across panels — that dedup is
+    # exactly how the shared zoom is achieved here, so the warning is expected, not a problem.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message="Automatically deduplicated selection parameter")
+        return alt.vconcat(*panels).resolve_scale(y="independent")

--- a/packages/plotting/src/plotting/ocf_theme.py
+++ b/packages/plotting/src/plotting/ocf_theme.py
@@ -1,0 +1,73 @@
+"""OCF brand Altair theme.
+
+Import this module to register and enable the OCF theme for Altair charts.
+The ``@alt.theme.register`` decorator fires at import time, so a bare
+``import plotting.ocf_theme`` is sufficient to activate it.
+"""
+
+from typing import Any, Final
+
+import altair as alt
+
+PALETTE: Final[tuple[str, ...]] = (
+    "#FF4901",  # Orange-Red
+    "#306BFF",  # Blue
+    "#B701FF",  # Purple
+    "#17E58F",  # Spring Green
+    "#10C5F7",  # Sky Blue
+    "#FC9700",  # Mustard
+    "#009C75",  # Dark green
+    "#BF4F04",  # Brown
+    "#B8F5DB",  # Mint
+    "#EFC8FF",  # Lavender
+)
+"""OCF brand colour palette, ordered by visual priority."""
+
+ORANGE_RED: Final[str] = PALETTE[0]
+BLUE: Final[str] = PALETTE[1]
+PURPLE: Final[str] = PALETTE[2]
+SPRING_GREEN: Final[str] = PALETTE[3]
+SKY_BLUE: Final[str] = PALETTE[4]
+MUSTARD: Final[str] = PALETTE[5]
+DARK_GREEN: Final[str] = PALETTE[6]
+BROWN: Final[str] = PALETTE[7]
+MINT: Final[str] = PALETTE[8]
+LAVENDER: Final[str] = PALETTE[9]
+
+BACKGROUND: Final[str] = "#FFFBF5"
+"""Chart background colour."""
+
+GRID: Final[str] = "#EAEAEA"
+"""Axis grid line colour; also used for unobtrusive background elements."""
+
+_TEXT: Final[str] = "#292B2B"
+
+
+@alt.theme.register("ocf", enable=True)
+def _ocf_theme() -> dict[str, Any]:
+    palette = list(PALETTE)
+    return {
+        "config": {
+            "background": BACKGROUND,
+            "view": {
+                "stroke": "transparent",
+                "fill": BACKGROUND,
+            },
+            "range": {
+                "category": palette,
+                "ordinal": palette,
+                "ramp": palette,
+            },
+            "axis": {
+                "domainColor": _TEXT,
+                "gridColor": GRID,
+                "tickColor": _TEXT,
+                "labelColor": _TEXT,
+                "titleColor": _TEXT,
+            },
+            "legend": {
+                "labelColor": _TEXT,
+                "titleColor": _TEXT,
+            },
+        }
+    }

--- a/packages/plotting/src/plotting/ocf_theme.py
+++ b/packages/plotting/src/plotting/ocf_theme.py
@@ -38,7 +38,10 @@ BACKGROUND: Final[str] = "#FFFBF5"
 """Chart background colour."""
 
 GRID: Final[str] = "#EAEAEA"
-"""Axis grid line colour; also used for unobtrusive background elements."""
+"""Axis grid line colour."""
+
+ENSEMBLE_LINE: Final[str] = "#808080"
+"""Colour for individual ensemble member lines; mid-grey stays visible at low opacity on BACKGROUND."""
 
 _TEXT: Final[str] = "#292B2B"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ dependencies = [
     "nged_data",
     "obstore",
     "patito",
+    "plotting",
     "polars>=1.0.0",
     "pyarrow",
     "requests>=2.31.0",
@@ -65,6 +66,7 @@ members = ["packages/*"]
 nged_data = { workspace = true }
 contracts = { workspace = true }
 ml_core = { workspace = true }
+plotting = { workspace = true }
 xgboost_forecaster = { workspace = true }
 dynamical_data = { workspace = true }
 geo = { workspace = true }

--- a/src/nged_substation_forecast/defs/plot_jobs.py
+++ b/src/nged_substation_forecast/defs/plot_jobs.py
@@ -5,28 +5,21 @@
 because the plot is a throwaway artifact for human eyes — keyed by ``(init time, time_series_ids)``,
 with no lineage and no durable catalog identity — rather than a tracked data object. Its op reads
 the Delta/parquet sources directly and delegates chart construction to the pure, unit-testable
-:func:`build_forecast_chart`.
+:func:`plotting.forecast_chart.build_forecast_chart`.
 """
 
-import warnings
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Final
 
-import altair as alt
 import polars as pl
 from contracts.settings import Settings
 from dagster import Config, MetadataValue, OpExecutionContext, job, op
+from plotting.forecast_chart import build_forecast_chart
 from pydantic import Field
 
 FORECAST_HORIZON: Final[timedelta] = timedelta(days=14)
 """Length of the forecast horizon plotted from ``power_fcst_init_time``."""
-
-_PANEL_WIDTH: Final[int] = 800
-"""Pixel width of every panel; a fixed, shared width keeps the x-axes aligned across panels."""
-
-_PANEL_HEIGHT: Final[int] = 250
-"""Pixel height of each per-time-series panel."""
 
 
 class PlotPowerForecastConfig(Config):
@@ -58,90 +51,6 @@ class PlotPowerForecastConfig(Config):
         max_length=4,
         description="Between 1 and 4 time_series_ids; each is drawn on its own panel.",
     )
-
-
-def build_forecast_chart(
-    forecasts: pl.DataFrame,
-    ground_truth: pl.DataFrame,
-    metadata: pl.DataFrame,
-    time_series_ids: list[int],
-) -> alt.VConcatChart:
-    """Build a stacked, interactive forecast chart — one panel per ``time_series_id``.
-
-    Each panel layers all 51 ensemble members as thin grey lines (``power_fcst`` vs ``valid_time``)
-    and, where ground truth is available for that series, the observed power as a thick blue line.
-    Panels are stacked vertically with independent y-scales but a shared, zoomable x-scale so
-    panning/zooming one panel moves them all and the time axes stay aligned.
-
-    Args:
-        forecasts: ``PowerForecast`` rows for the chosen init time, already filtered to
-            ``time_series_ids``.
-        ground_truth: ``PowerTimeSeries`` observations over the plotted window (may be empty for
-            some or all series).
-        metadata: ``TimeSeriesMetadata`` for the plotted series, used for panel titles and units.
-        time_series_ids: The series to plot, in the order their panels should appear.
-
-    Returns:
-        A vertically concatenated Altair chart ready to ``.save(...)`` as interactive HTML.
-    """
-    # The full ensemble across up to 4 panels far exceeds Altair's 5000-row default guard.
-    alt.data_transformers.disable_max_rows()
-
-    # One shared, explicitly-named interval selection bound to the x-scale; adding the same param to
-    # every panel makes Vega-Lite hoist it to a single top-level param, so zoom/pan is synchronised
-    # across panels (and the time axes stay aligned).
-    x_zoom = alt.selection_interval(bind="scales", encodings=["x"], name="shared_x_zoom")
-
-    panels: list[alt.LayerChart | alt.FacetChart] = []
-    for time_series_id in time_series_ids:
-        forecast_panel = forecasts.filter(pl.col("time_series_id") == time_series_id)
-        truth_panel = ground_truth.filter(pl.col("time_series_id") == time_series_id)
-        meta_row = metadata.filter(pl.col("time_series_id") == time_series_id)
-
-        units = meta_row["units"].item() if meta_row.height else "MW/MVA"
-        name = meta_row["time_series_name"].item() if meta_row.height else str(time_series_id)
-        series_type = meta_row["time_series_type"].item() if meta_row.height else "unknown"
-
-        ensemble_layer = (
-            alt.Chart(forecast_panel)
-            .mark_line(strokeWidth=1, opacity=0.3, color="lightgray")
-            .encode(
-                x=alt.X("valid_time:T", title="Valid time"),
-                y=alt.Y("power_fcst:Q", title=f"Power ({units})"),
-                detail="ensemble_member:N",
-                tooltip=["ensemble_member", "valid_time", "power_fcst"],
-            )
-        )
-
-        layers: list[alt.Chart] = [ensemble_layer]
-        if truth_panel.height:
-            truth_layer = (
-                alt.Chart(truth_panel)
-                .mark_line(strokeWidth=2.5, color="steelblue")
-                .encode(
-                    x=alt.X("time:T"),
-                    y=alt.Y("power:Q"),
-                    tooltip=["time", "power"],
-                )
-            )
-            layers.append(truth_layer)
-
-        panel = (
-            alt.layer(*layers)
-            .properties(
-                title=f"{name} (id={time_series_id}) — {series_type}",
-                width=_PANEL_WIDTH,
-                height=_PANEL_HEIGHT,
-            )
-            .add_params(x_zoom)
-        )
-        panels.append(panel)
-
-    # Altair warns that it deduplicated the identical x_zoom param across panels — that dedup is
-    # exactly how the shared zoom is achieved here, so the warning is expected, not a problem.
-    with warnings.catch_warnings():
-        warnings.filterwarnings("ignore", message="Automatically deduplicated selection parameter")
-        return alt.vconcat(*panels).resolve_scale(y="independent")
 
 
 @op

--- a/tests/test_plot_power_forecast.py
+++ b/tests/test_plot_power_forecast.py
@@ -11,11 +11,11 @@ import polars as pl
 import pytest
 from altair import VConcatChart
 from dagster import RunConfig
+from plotting.forecast_chart import build_forecast_chart
 from pydantic import ValidationError
 
 from nged_substation_forecast.defs.plot_jobs import (
     PlotPowerForecastConfig,
-    build_forecast_chart,
     plot_power_forecast_job,
 )
 

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ members = [
     "nged-data",
     "nged-substation-forecast",
     "notebooks",
+    "plotting",
     "xgboost-forecaster",
 ]
 
@@ -730,6 +731,7 @@ dependencies = [
     { name = "lonboard" },
     { name = "marimo" },
     { name = "patito" },
+    { name = "plotting" },
     { name = "polars" },
     { name = "pyarrow" },
 ]
@@ -748,6 +750,7 @@ requires-dist = [
     { name = "lonboard", specifier = ">=0.13.0" },
     { name = "marimo", specifier = ">=0.19.7" },
     { name = "patito", specifier = ">=0.8.5" },
+    { name = "plotting", editable = "packages/plotting" },
     { name = "polars", specifier = ">=1.37.1" },
     { name = "pyarrow", specifier = ">=23.0.0" },
 ]
@@ -2059,6 +2062,7 @@ dependencies = [
     { name = "nged-data" },
     { name = "obstore" },
     { name = "patito" },
+    { name = "plotting" },
     { name = "polars" },
     { name = "pyarrow" },
     { name = "requests" },
@@ -2093,6 +2097,7 @@ requires-dist = [
     { name = "nged-data", editable = "packages/nged_data" },
     { name = "obstore" },
     { name = "patito" },
+    { name = "plotting", editable = "packages/plotting" },
     { name = "polars", specifier = ">=1.0.0" },
     { name = "pyarrow" },
     { name = "requests", specifier = ">=2.31.0" },
@@ -2132,6 +2137,7 @@ dependencies = [
     { name = "lonboard" },
     { name = "marimo" },
     { name = "palettable" },
+    { name = "plotting" },
     { name = "polars" },
 ]
 
@@ -2143,6 +2149,7 @@ requires-dist = [
     { name = "lonboard", specifier = ">=0.16.0" },
     { name = "marimo", specifier = ">=0.19.7" },
     { name = "palettable", specifier = ">=3.3.3" },
+    { name = "plotting", editable = "packages/plotting" },
     { name = "polars", specifier = ">=1.37.1" },
 ]
 
@@ -2415,6 +2422,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/47/e4501f49c178ae1d9f4a75073fda4204f52647993f075a9db4d14930e0c5/platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7", size = 31224, upload-time = "2026-05-28T03:32:53.587Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/e6/cd9575ac904136b3cbf7aa7ee819ef86eedb7274e46f230e94ea4342e729/platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a", size = 22743, upload-time = "2026-05-28T03:32:52.175Z" },
+]
+
+[[package]]
+name = "plotting"
+version = "0.1.0"
+source = { editable = "packages/plotting" }
+dependencies = [
+    { name = "altair" },
+    { name = "polars" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "altair", specifier = ">=6.0.0" },
+    { name = "polars", specifier = ">=1.0.0" },
 ]
 
 [[package]]
@@ -2942,7 +2964,7 @@ name = "pyzmq"
 version = "27.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "implementation_name == 'pypy'" },
+    { name = "cffi", marker = "implementation_name == 'pypy' and sys_platform != 'emscripten'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/04/0b/3c9baedbdf613ecaa7aa07027780b8867f57b6293b6ee50de316c9f3222b/pyzmq-27.1.0.tar.gz", hash = "sha256:ac0765e3d44455adb6ddbf4417dcce460fc40a05978c08efdf2948072f6db540", size = 281750, upload-time = "2025-09-08T23:10:18.157Z" }
 wheels = [


### PR DESCRIPTION
## Summary

- Introduces `packages/plotting/` — a new workspace package for shared charting utilities
- `plotting.ocf_theme`: OCF brand palette constants (`ORANGE_RED`, `BLUE`, `PURPLE`, etc.) and an Altair theme registered on import, setting background (`#FFFBF5`), axis/legend colours, and the full 10-colour category range, based on code by @AUdaltsova (thanks Alex!)
- `plotting.forecast_chart`: `build_forecast_chart` extracted from `plot_jobs.py` so it can be shared across the app, dashboard, and notebooks — hardcoded `"steelblue"` → `ocf_theme.BLUE`, `"lightgray"` → `ocf_theme.GRID`
- `plot_jobs.py` slimmed to just Dagster op/job wiring; imports `build_forecast_chart` from `plotting`
- `dashboard/main.py` and `plot_missing_NWP_data.py` import `plotting.ocf_theme` (side-effect activates the theme) and use OCF colour constants in place of `"teal"` and `"red"`
- `plotting` added as a workspace dependency in the root, `dashboard`, and `notebooks` `pyproject.toml`s

## Test plan

- [x] `uv run pytest tests/test_plot_power_forecast.py -v` — all 3 tests pass
- [x] `python -c "from plotting.forecast_chart import build_forecast_chart; import altair as alt; assert alt.theme.active == 'ocf'"` — theme activates on import
- [x] Run `plot_power_forecast_job` in Dagster UI and inspect the generated HTML for OCF colours

🤖 Generated with [Claude Code](https://claude.com/claude-code)