### PR TITLE
Phase 6: metrics asset (leaderboard + ad_hoc)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,7 @@ Each `BaseForecaster` also carries a `feature_engineer: ClassVar[FeatureEngineer
 - **Python 3.14+** required.
 - **Polars only** — pandas is strictly forbidden. Use `pl.LazyFrame` and only `.collect()` when necessary.
 - **Patito** for all DataFrame schema definitions and validation. Use Patito type annotations (`pt.DataFrame[Schema]`, `pt.LazyFrame[Schema]`) whenever a function consumes or returns data that conforms to an existing schema — whether the function is public or private. Don't invent a new schema just to annotate a private helper; if no existing schema fits, use plain `pl.DataFrame` / `pl.LazyFrame`.
+- **Prefer small functions.** Extract private helpers (`_name`) rather than letting a function body grow long, even if that means more parameters. A well-named helper with a clear docstring beats a long inline block. Eight parameters is acceptable when each is distinct and the division of labour is clear.
 - **Ruff**: 100-char line length, double quotes, Google-style docstrings.
 - **Comments must reflect current state only** — never reference previous iterations of the
   code or deleted files.
@@ -115,6 +116,18 @@ These rules are all about making Polars code easy to read.
 - When using `.with_columns`, prefer specifying the destination column name as a key word argument
   like this: `df.with_columns(bar=pl.col("foo").expression())` instead of using `alias` like this:
   `df.with_columns(pl.col("foo").expression().alias("bar"))`
+
+- **`Literal` type aliases — use a `Type` suffix** to distinguish them from the runtime tuples
+  that drive Polars `Enum` declarations. Example:
+  ```python
+  EVALUATION_SCOPES: Final[tuple[str, ...]] = ("leaderboard", "production_monitoring", "ad_hoc")
+  """Runtime tuple — used as pl.Enum(EVALUATION_SCOPES)."""
+
+  EvalScopeType = Literal["leaderboard", "ad_hoc"]
+  """Type annotation — currently-implemented subset; update when adding a new scope."""
+  ```
+  The `Type`-suffixed alias is what goes in function signatures; the `UPPER_SNAKE_CASE` tuple is
+  what goes into `pl.Enum(...)`. They serve different purposes and should both exist.
 
 ### Patito + Polars Gotcha: cross-model LazyFrame joins
 
@@ -159,6 +172,44 @@ result = pl.DataFrame._from_pydf(patito_df._df).cast({"foo": pl.Categorical})
 (No-arg `df.cast()` — casting a model-bearing frame to its declared dtypes — *is* the intended
 Patito use and is correct. Expression/Series casts like `pl.col("foo").cast(pl.Int8)` are always
 plain Polars and unaffected.)
+
+### Delta Lake read-path: cast `String→Categorical` lazily, before filtering
+
+delta-rs stores all Arrow dictionary-encoded columns (`Categorical`, `Enum`) as plain `String` in
+Parquet (this is the write-path gotcha documented in `_write_metrics_to_delta`). On the **read**
+path, cast them back *lazily* — in the `pl.scan_delta(...)` result — before wrapping with
+`set_model` and passing to any typed helper:
+
+```python
+# Cast lazily so the scan is typed from the start; zero-cost until .collect().
+typed_scan = pt.LazyFrame.from_existing(
+    pl.scan_delta(str(path)).with_columns(
+        experiment_name=pl.col("experiment_name").cast(pl.Categorical),
+        fold_id=pl.col("fold_id").cast(pl.Categorical),
+    )
+).set_model(MySchema)
+```
+
+Casting after `.collect()` also works but is later than necessary: typed helpers that receive the
+scan (e.g. a filter method) would then have to accept `pl.LazyFrame` instead of
+`pt.LazyFrame[MySchema]`.
+
+### Patito + Polars Gotcha: `pt.LazyFrame.filter()` drops the Patito subclass
+
+Most Polars operations on a `pt.LazyFrame` return a plain `pl.LazyFrame`, including `.filter()`.
+Reassigning `scan = scan.filter(...)` where `scan: pt.LazyFrame[Schema]` therefore fails `ty`'s
+assignment check.
+
+Workaround: rebind to a plain `pl.LazyFrame` local for the filter accumulation, then re-wrap before
+returning:
+
+```python
+def apply(self, scan: pt.LazyFrame[MySchema]) -> pt.LazyFrame[MySchema]:
+    lf: pl.LazyFrame = scan  # .filter() drops the pt subclass; accumulate on a plain LazyFrame
+    if self.foo is not None:
+        lf = lf.filter(pl.col("foo") == self.foo)
+    return pt.LazyFrame.from_existing(lf).set_model(MySchema)  # zero-copy re-wrap
+```
 
 ## This is a young project
 

--- a/docs/ml_experimentation/dagster-workflow.md
+++ b/docs/ml_experimentation/dagster-workflow.md
@@ -3,7 +3,7 @@
 How to go from raw data to a trained, MLflow-tracked model using the Dagster pipeline.
 
 The pipeline has two layers. The **data layer** (steps 1–4) is built once and refreshed as new
-data arrives; it is shared by all experiments. The **experiment layer** (steps 5–7) is repeated
+data arrives; it is shared by all experiments. The **experiment layer** (steps 5–8) is repeated
 for each new model or hyperparameter configuration — see [Model configuration](model-configuration.md)
 for how to choose features and set hyperparameters.
 
@@ -109,7 +109,7 @@ MLflow experiment and partition keys rather than creating duplicates.
 9. Logs training params (`fold_id`, `train_start`, `train_end`, `n_eligible_time_series`,
    `n_trained_time_series`) to the fold run.
 
-The MLflow run structure looks like this:
+The MLflow run structure after training looks like this:
 
 ```
 Experiment "xgboost_smoke_test"
@@ -179,6 +179,51 @@ plots an existing smoke-test forecast, so you can launch it as-is; override the
 This is a **job, not an asset**, because the plot is a throwaway artifact for human inspection —
 keyed by init time and series ids, with no lineage or durable catalog identity — rather than a
 tracked data object in the pipeline.
+
+---
+
+## Step 8 — Materialise `metrics`
+
+**Trigger:** Materialise (unpartitioned — not tied to a single fold). Fill in `MetricsConfig`
+in the run config dialog before launching.
+
+| Field | Example | Notes |
+|---|---|---|
+| `population_filter.experiment_name` | `"xgboost_smoke_test"` | Filters `power_forecasts` to one experiment; leave null to score all experiments at once |
+| `population_filter.fold_id` | `"mid_2025_to_mid_2026"` | Filters to one fold; leave null to score all folds for the experiment |
+| `population_filter.valid_time_min/max` | `"2025-10-01T00:00:00+00:00"` | ISO-8601 UTC; trims the valid_time window for ad_hoc scoring |
+| `evaluation_scope` | `"leaderboard"` | `"leaderboard"` logs to MLflow; `"ad_hoc"` writes Delta only |
+
+**What the asset does:**
+
+1. Scans `power_forecasts` Delta, applying any non-null `PopulationFilter` predicates.
+2. Groups the matched rows by `(experiment_name, fold_id)` and for each group:
+   a. Calls `compute_metrics()` — joins observed power, averages ensemble members, computes
+      MAE / NMAE / RMSE / MBE per `(time_series_id, fold_id, power_fcst_model_name)`.
+   b. Enriches rows with scope (`evaluation_scope`), window bounds (`window_start`, `window_end`,
+      `window_label`), `computed_at`, and the MLflow fold run id (leaderboard scope only).
+   c. Writes to `forecast_metrics` Delta, partitioned by `(experiment_name, fold_id)` with an
+      idempotent overwrite predicate — safe to re-run without duplicating rows.
+3. For `evaluation_scope="leaderboard"`: builds a per-type + overall aggregate metric dict (e.g.
+   `rmse__all`, `rmse__disaggregated_demand`) and logs it to the fold's MLflow child run, then
+   averages across folds and logs the mean to the parent run.
+
+After step 8, the MLflow run structure looks like this:
+
+```
+Experiment "xgboost_smoke_test"
+└── cv_summary (parent run)   tags={cv_role: parent}
+    │   params: n_estimators=100, learning_rate=0.05, …
+    │   metrics: rmse__all=4.3, rmse__disaggregated_demand=4.1, …   ← mean across folds
+    └── smoke_test  tags={cv_role: fold, fold_id: smoke_test}
+            params: train_start, train_end, …
+            metrics: rmse__all=4.3, rmse__disaggregated_demand=4.1, …   ← per-fold aggregate
+            artifacts: model/
+```
+
+The `forecast_metrics` Delta table stores one row per
+`(time_series_id, fold_id, power_fcst_model_name, horizon_slice, metric_name, metric_param)`,
+with `time_series_type` populated from metadata so per-type queries need only a simple filter.
 
 ---
 

--- a/docs/roadmap/delivery-tables.md
+++ b/docs/roadmap/delivery-tables.md
@@ -35,7 +35,7 @@ There are **five** tables. This table tracks where each one stands today:
 | 1 | `power_forecast` | ✅ Implemented (deterministic-ensemble flavour only) | `contracts.power_schemas.PowerForecast` |
 | 2 | `power_forecast_warnings` | 🚧 Planned (partial in MVP) | not yet in code |
 | 3 | `asset_health_history` | 🚧 Planned | not yet in code |
-| 4 | `effective_capacity` | 🚧 Planned (v0.6 / v0.7) | not yet in code |
+| 4 | `effective_capacity` | 🚧 MVP in v0.1 (P99 estimate); DP upgrade planned for v0.6 / v0.7 | `contracts.power_schemas.EffectiveCapacity` |
 | 5 | `substation_switching` | 🚧 Planned (v0.6 / v0.7) | not yet in code |
 
 > **Naming note.** The Milestone 1 report drafted these tables with the column name `timeseries_id`,
@@ -184,29 +184,36 @@ Notes on specific flags:
 
 ## Table 4 — `effective_capacity` 🚧
 
-> **Status: 🚧 Planned (v0.6 / v0.7).** Depends on differentiable-physics capacity estimation; see
+> **Status: 🚧 MVP in v0.1** using P99 of observed power as a static capacity proxy.
+> Schema lives in `contracts.power_schemas.EffectiveCapacity`.
+> **Planned upgrade in v0.6 / v0.7** to differentiable-physics capacity estimation — see
 > [Differentiable Physics](differentiable-physics.md).
 
-OCF's probabilistic estimate of each generator's **effective capacity** at every half-hourly
-timestep of the historical data, plus the effective "capacity" (max observed load) of substations.
-This table is **backward-looking only** — it does not cover the forecast period.
+OCF's estimate of each generator's or substation's **effective capacity** at every half-hourly
+timestep of the historical time series data. This table is **backward-looking only** — it does
+not cover the forecast period.
 
-- **Generators:** the prior comes from the Embedded Capacity Register; the estimate is then updated
-  at each half-hour from the generator's power time series. Represented as the mean + standard
-  deviation of a Normal distribution. Effective capacity **absorbs** PV-panel degradation, partial
-  inverter trips, etc., but **ignores ANM**: if a wind farm *could* generate 10 MW but ANM ramps it
-  to 5 MW, effective capacity is still 10 MW.
-- **Substations:** the 99th percentile of observed load over a rolling window. Only populated with
-  "normal arrangement" load — *not* updated during switching events. During a switching event, the
-  effective capacity is obtained by adding the "transferred power" from
-  [Table 5](#table-5-substation_switching) to the last-known "normal arrangement" capacity.
+**MVP approach (v0.1):** one row per `time_series_id`, `effective_capacity_mw` = P99 of
+`|power|` over the full available observation history. This is a static scalar per series — a
+robust capacity proxy that is less sensitive to outlier spikes than the maximum, and more
+capacity-representative than the mean (which is dragged down by zero-output periods for PV/wind).
+It is also the denominator used to normalise NMAE in the `forecast_metrics` table.
+
+**DP upgrade (v0.6 / v0.7):** replace the static P99 with a time-varying estimate from the
+differentiable-physics model. For generators, the prior comes from the Embedded Capacity Register
+and is updated at each half-hour from the generator's power time series, absorbing PV-panel
+degradation, partial inverter trips, etc., but **ignoring ANM** (a wind farm ANM-capped at 5 MW
+with 10 MW physical capability has `effective_capacity_mw = 10`). For substations, the 99th
+percentile of observed load over a rolling window, under normal running arrangement only. During a
+switching event, effective capacity = last known normal-arrangement value plus the "switched
+power" from [Table 5](#table-5-substation_switching). The schema is unchanged between MVP and DP;
+only the Dagster asset body changes.
 
 | Field | Data type | Notes |
 |---|---|---|
 | `time_series_id` | `int32` | NGED's time-series ID. |
-| `time` | `datetime` (UTC), every half hour | Timestamp from the original NGED time series. |
-| `effective_capacity_MW_mean` | `float32` | Mean of OCF's probabilistic capacity estimate. |
-| `effective_capacity_MW_std` | `float32` | Standard deviation of OCF's probabilistic capacity estimate. |
+| `time` | `datetime` (UTC), every half hour | The half-hourly timestep this estimate applies to. In the MVP, set to the end of the available observation history for that series. |
+| `effective_capacity_mw` | `float32` | OCF's estimate of the effective capacity (MW) at this timestep. |
 
 ---
 

--- a/docs/roadmap/metrics-and-leaderboard.md
+++ b/docs/roadmap/metrics-and-leaderboard.md
@@ -2,10 +2,11 @@
 
 How OCF measures the skill of its forecasts and compares forecasting approaches.
 
-> **Status legend** — ✅ Implemented · 🚧 Planned · 🔬 Research. The `Metrics` schema exists in code
-> (✅); the interactive leaderboard visualisation and several metrics are 🚧 planned. The
-> implemented [cross-validation protocol](../ml_experimentation/cross-validation-folds.md) has moved
-> out of the roadmap. See the [roadmap index](index.md) for status conventions.
+> **Status legend** — ✅ Implemented · 🚧 Planned · 🔬 Research. The `Metrics` schema, the
+> `metrics` Dagster asset, and the deterministic metrics (MAE, NMAE, RMSE, MBE) are ✅
+> implemented. The interactive leaderboard visualisation and probabilistic metrics are 🚧 planned.
+> The implemented [cross-validation protocol](../ml_experimentation/cross-validation-folds.md) has
+> moved out of the roadmap. See the [roadmap index](index.md) for status conventions.
 
 ---
 
@@ -39,19 +40,23 @@ alternatives we considered.
 
 | Metric | Type | Status | Purpose |
 |---|---|---|---|
-| Normalised mean bias error (MBE) | Deterministic | 🚧 | Systematic over/under-prediction. |
+| Mean absolute error (MAE) | Deterministic | ✅ | Typical error magnitude (MW). |
+| Normalised MAE (NMAE) | Deterministic | ✅ | MAE normalised by mean absolute power — comparable across substations of different sizes. |
+| Root mean squared error (RMSE) | Deterministic | ✅ | Heavily penalises large misses (one 100 MW error costs more than two 50 MW errors). |
+| Mean bias error (MBE) | Deterministic | ✅ | Systematic over/under-prediction. |
 | Histogram of errors | Deterministic | 🚧 | Visual check that errors are ~Normal. |
-| Normalised mean absolute error (MAE) | Deterministic | 🚧 | Typical error magnitude (normalised by capacity). |
-| Root mean squared error (RMSE) | Deterministic | 🚧 | Arguably the most critical grid metric — squares errors, so heavily penalises large misses (one 100 MW error costs more than two 50 MW errors). |
 | Pinball loss (quantile loss) | Quantile | 🚧 | Penalises asymmetrically by target quantile. Averaged across quantiles for a single quantile-skill score. |
 | PICP (Prediction Interval Coverage Probability) | Quantile | 🚧 | Of a P10–P90 band, exactly 80% of observations should fall inside. < 80% ⇒ overconfident. |
 | CRPS (Continuous Ranked Probability Score) | Ensemble | 🚧 | Probabilistic equivalent of MAE; rewards both accuracy and sharpness. |
 | Spread-Skill Ratio | Ensemble | 🚧 | Ensemble spread ÷ RMSE of the ensemble mean. 1.0 = well-calibrated; < 1 under-dispersed (overconfident); > 1 over-dispersed (underconfident). |
 
-> The `Metrics` schema (`contracts.ml_schemas.Metrics`) is ✅ implemented and stores results as
+> The `Metrics` schema (`contracts.ml_schemas.Metrics`) stores results as
 > `(time_series_id, power_fcst_model_name, fold_id, horizon_slice, metric_name, metric_param,
 > metric_value)`. `metric_param` carries, e.g., the quantile for Pinball Loss (`p10`) or the band
-> for PICP (`p10_p90`).
+> for PICP (`p10_p90`). The `metrics` Dagster asset computes the deterministic metrics ✅ and writes
+> per-series rows to `forecast_metrics` Delta (partitioned by `experiment_name, fold_id`), with
+> per-fold and mean-across-folds aggregates logged to MLflow — see
+> [Running an ML experiment end-to-end](../ml_experimentation/dagster-workflow.md#step-8--materialise-metrics).
 
 ### Peak events — the metric filter that matters most for flexibility
 

--- a/packages/contracts/src/contracts/ml_schemas.py
+++ b/packages/contracts/src/contracts/ml_schemas.py
@@ -291,12 +291,11 @@ class Metrics(pt.Model):
     metric rows and have the asset enrich them with scope/window provenance before the frame is
     written to the ``forecast_metrics`` Delta table."""
 
-    time_series_type: str = pt.Field(
+    time_series_type: str | None = pt.Field(
         dtype=pl.Enum(TIME_SERIES_TYPE_SLICES),
         allow_missing=True,
         description=(
-            "The time-series category this row aggregates, or the sentinel 'all' for the "
-            "across-everything aggregate."
+            "The time-series category for this row. Null when metadata is unavailable for a series."
         ),
     )
 
@@ -336,6 +335,16 @@ class Metrics(pt.Model):
         description=(
             "Convenience cross-link to the MLflow run this metric row belongs to. "
             "Null for 'ad_hoc' rows, which have no MLflow run."
+        ),
+    )
+
+    experiment_name: str = pt.Field(
+        dtype=pl.Categorical,
+        allow_missing=True,
+        description=(
+            "Experiment that produced these forecasts. Delta partition key alongside fold_id. "
+            "Populated by the metrics Dagster asset after compute_metrics() returns; "
+            "allow_missing so compute_metrics() itself need not produce it."
         ),
     )
 

--- a/packages/contracts/src/contracts/ml_schemas.py
+++ b/packages/contracts/src/contracts/ml_schemas.py
@@ -215,6 +215,14 @@ EVALUATION_SCOPES: Final[tuple[str, ...]] = ("leaderboard", "production_monitori
 - `"ad_hoc"`: one-off analyses (no MLflow run)
 """
 
+EvalScopeType = Literal["leaderboard", "ad_hoc"]
+"""Type annotation for the evaluation scopes currently accepted by the ``metrics`` asset config.
+
+Distinct from ``EVALUATION_SCOPES`` (the runtime tuple driving the Polars Enum): that tuple
+includes ``"production_monitoring"`` for future use; this ``Literal`` reflects only the scopes
+the asset actually handles today. Expand to match ``EVALUATION_SCOPES`` when Phase 8 lands.
+"""
+
 TIME_SERIES_TYPE_SLICES: Final[tuple[str, ...]] = ("all", *LIST_OF_TIME_SERIES_TYPES)
 """Values for the `time_series_type` metric slice.
 

--- a/packages/contracts/src/contracts/power_schemas.py
+++ b/packages/contracts/src/contracts/power_schemas.py
@@ -296,3 +296,45 @@ class PowerForecast(pt.Model):
             "filter on this column to select the population you need."
         ),
     )
+
+
+class EffectiveCapacity(pt.Model):
+    """Effective capacity of each time series at each half-hourly timestep.
+
+    Delivered to NGED as ``effective_capacity`` Delta table (Table 4 in the Milestone 1 report,
+    ``docs/roadmap/delivery-tables.md``). This table is backward-looking only — it does not cover
+    the forecast period.
+
+    **MVP implementation (v0.1):** one row per ``time_series_id``, ``time`` set to the end of
+    the available observation history, ``effective_capacity_mw`` = P99 of ``abs(power)`` over
+    the full observed history. This is a static scalar per series.
+
+    **Planned upgrade (v0.6 / v0.7):** replace the P99 scalar with a time-varying estimate from
+    the differentiable-physics capacity model (see ``docs/roadmap/differentiable-physics.md``),
+    giving one row per ``(time_series_id, time)`` half-hourly timestep. Schema and interface are
+    unchanged; only the asset body changes.
+    """
+
+    time_series_id: int = _get_time_series_id_dtype()
+
+    time: datetime = pt.Field(
+        dtype=UTC_DATETIME_DTYPE,
+        description=(
+            "The half-hourly timestep this capacity estimate applies to. "
+            "In the MVP, this is the end of the available observation history for that series."
+        ),
+    )
+
+    effective_capacity_mw: float = pt.Field(
+        dtype=pl.Float32,
+        gt=0,
+        description=(
+            "OCF's estimate of the effective capacity (MW) of this asset at this timestep. "
+            "For generators: absorbs PV panel degradation, partial inverter trips, etc., "
+            "but ignores ANM curtailment — a wind farm ANM-capped at 5 MW with 10 MW physical "
+            "capability has effective_capacity_mw = 10. "
+            "For substations: the 99th percentile of observed load over a rolling time window, "
+            "under normal running arrangement only. 'Switched' power (Table 5) should be "
+            "added or subtracted when a switching event is in effect."
+        ),
+    )

--- a/packages/ml_core/src/ml_core/metrics.py
+++ b/packages/ml_core/src/ml_core/metrics.py
@@ -11,13 +11,13 @@ from contracts.ml_schemas import (
     TIME_SERIES_TYPE_SLICES,
     Metrics,
 )
-from contracts.power_schemas import PowerTimeSeries
+from contracts.power_schemas import PowerForecast, PowerTimeSeries, TimeSeriesMetadata
 
 
 def compute_metrics(
-    cv_forecasts: pl.DataFrame,
+    cv_forecasts: pt.DataFrame[PowerForecast],
     actuals: pt.LazyFrame[PowerTimeSeries],
-    metadata: pl.DataFrame,
+    metadata: pt.DataFrame[TimeSeriesMetadata],
 ) -> pt.DataFrame[Metrics]:
     """Compute evaluation metrics from CV predictions and observed power.
 
@@ -38,14 +38,11 @@ def compute_metrics(
     added here later without changing the schema.
 
     Args:
-        cv_forecasts: CV predictions to evaluate. May be a Patito-validated
-            ``PowerForecast`` frame or a plain Polars DataFrame (e.g. read from Delta).
+        cv_forecasts: CV predictions to evaluate.
             Must not contain ``fold_id="live"`` rows — pass only CV fold predictions.
         actuals: Observed half-hourly power (lazy — only the joined subset is collected).
-        metadata: DataFrame with at least ``time_series_id`` (Int32) and
-            ``time_series_type`` columns. Values in ``time_series_type`` must be members of
-            ``TIME_SERIES_TYPE_SLICES``. Used to enrich each metric row with the series' type;
-            unmatched series get a null ``time_series_type``.
+        metadata: Substation metadata used to join ``time_series_type`` onto each metric row.
+            Series absent from ``metadata`` receive a null ``time_series_type``.
 
     Returns:
         A validated tall ``Metrics`` DataFrame with ``time_series_type`` populated.

--- a/packages/ml_core/src/ml_core/metrics.py
+++ b/packages/ml_core/src/ml_core/metrics.py
@@ -12,6 +12,7 @@ from contracts.ml_schemas import (
     METRIC_NAMES,
     METRIC_PARAMS,
     TIME_SERIES_TYPE_SLICES,
+    EvalScopeType,
     Metrics,
 )
 from contracts.power_schemas import PowerForecast, PowerTimeSeries, TimeSeriesMetadata
@@ -182,7 +183,7 @@ def build_mlflow_aggregate_metrics(
 def enrich_metrics_rows(
     per_series_metrics: pt.DataFrame[Metrics],
     experiment_name: str,
-    evaluation_scope: str,
+    evaluation_scope: EvalScopeType,
     window_start: datetime,
     window_end: datetime,
     window_label: str,

--- a/packages/ml_core/src/ml_core/metrics.py
+++ b/packages/ml_core/src/ml_core/metrics.py
@@ -1,19 +1,23 @@
 """Metric computation for cross-validation results."""
 
+import re
+
 import patito as pt
 import polars as pl
 from contracts.ml_schemas import (
     HORIZON_SLICES,
     METRIC_NAMES,
     METRIC_PARAMS,
+    TIME_SERIES_TYPE_SLICES,
     Metrics,
 )
-from contracts.power_schemas import PowerForecast, PowerTimeSeries
+from contracts.power_schemas import PowerTimeSeries
 
 
 def compute_metrics(
-    cv_forecasts: pt.DataFrame[PowerForecast],
+    cv_forecasts: pl.DataFrame,
     actuals: pt.LazyFrame[PowerTimeSeries],
+    metadata: pl.DataFrame,
 ) -> pt.DataFrame[Metrics]:
     """Compute evaluation metrics from CV predictions and observed power.
 
@@ -22,7 +26,8 @@ def compute_metrics(
     1. Joins predictions to observed ``power`` on ``(time_series_id, valid_time)``.
     2. Averages across ``ensemble_member`` to form a deterministic ensemble mean.
     3. Computes MAE, NMAE, RMSE, and MBE.
-    4. Returns one row per ``(time_series_id, fold_id, power_fcst_model_name,
+    4. Joins ``time_series_type`` from ``metadata`` onto each row.
+    5. Returns one row per ``(time_series_id, fold_id, power_fcst_model_name,
        horizon_slice, metric_name, metric_param)`` in the tall ``Metrics`` format.
 
     NMAE is normalised by the mean absolute observed power within the same group,
@@ -33,12 +38,17 @@ def compute_metrics(
     added here later without changing the schema.
 
     Args:
-        cv_forecasts: CV predictions to evaluate.
+        cv_forecasts: CV predictions to evaluate. May be a Patito-validated
+            ``PowerForecast`` frame or a plain Polars DataFrame (e.g. read from Delta).
             Must not contain ``fold_id="live"`` rows — pass only CV fold predictions.
         actuals: Observed half-hourly power (lazy — only the joined subset is collected).
+        metadata: DataFrame with at least ``time_series_id`` (Int32) and
+            ``time_series_type`` columns. Values in ``time_series_type`` must be members of
+            ``TIME_SERIES_TYPE_SLICES``. Used to enrich each metric row with the series' type;
+            unmatched series get a null ``time_series_type``.
 
     Returns:
-        A validated tall ``Metrics`` DataFrame.
+        A validated tall ``Metrics`` DataFrame with ``time_series_type`` populated.
 
     Raises:
         ValueError: If no rows survive the inner join (forecasts cover a period
@@ -104,4 +114,60 @@ def compute_metrics(
             "Check that cv_forecasts and actuals overlap in time."
         )
 
+    # Join time_series_type from metadata (left — keeps all metric rows; unmatched → null).
+    type_map = metadata.select(["time_series_id", "time_series_type"])
+    metrics_tall = metrics_tall.join(type_map, on="time_series_id", how="left").with_columns(
+        time_series_type=pl.col("time_series_type").cast(pl.Enum(TIME_SERIES_TYPE_SLICES))
+    )
+
     return Metrics.validate(metrics_tall, allow_superfluous_columns=True)
+
+
+def _type_slug(type_str: str) -> str:
+    """Convert a ``time_series_type`` label to an MLflow metric key slug.
+
+    Lowercases, replaces any run of non-alphanumeric characters with a single underscore,
+    and strips leading/trailing underscores.  Examples:
+    ``"Disaggregated Demand"`` → ``"disaggregated_demand"``,
+    ``"Other (Demand)"`` → ``"other_demand"``, ``"PV"`` → ``"pv"``.
+    """
+    return re.sub(r"[^a-z0-9]+", "_", type_str.lower()).strip("_")
+
+
+def build_mlflow_aggregate_metrics(
+    metrics_df: pl.DataFrame,
+) -> dict[str, float]:
+    """Return a flat ``{metric_key: value}`` dict for ``mlflow.log_metrics``.
+
+    Computes mean ``metric_value`` across all series (``"all"`` aggregate) and per
+    ``time_series_type``, restricted to ``horizon_slice="all"`` and ``metric_param="all"``
+    (the scalar metrics). Key format: ``"{metric_name}__all"`` for the overall aggregate
+    and ``"{metric_name}__{type_slug}"`` for per-type aggregates.
+
+    Args:
+        metrics_df: Per-series ``Metrics`` rows with ``time_series_type`` populated.
+
+    Returns:
+        Flat dict of MLflow metric key → mean float value.
+    """
+    base = metrics_df.filter((pl.col("horizon_slice") == "all") & (pl.col("metric_param") == "all"))
+
+    result: dict[str, float] = {}
+
+    # Per-type aggregates (only for non-null time_series_type values).
+    if "time_series_type" in base.columns:
+        per_type = (
+            base.filter(pl.col("time_series_type").is_not_null())
+            .group_by(["metric_name", "time_series_type"])
+            .agg(mean_value=pl.col("metric_value").mean())
+        )
+        for row in per_type.iter_rows(named=True):
+            key = f"{row['metric_name']}__{_type_slug(str(row['time_series_type']))}"
+            result[key] = float(row["mean_value"])
+
+    # Overall "all" aggregate (includes all series regardless of type).
+    overall = base.group_by("metric_name").agg(mean_value=pl.col("metric_value").mean())
+    for row in overall.iter_rows(named=True):
+        result[f"{row['metric_name']}__all"] = float(row["mean_value"])
+
+    return result

--- a/packages/ml_core/src/ml_core/metrics.py
+++ b/packages/ml_core/src/ml_core/metrics.py
@@ -39,7 +39,8 @@ def compute_metrics(
 
     Args:
         cv_forecasts: CV predictions to evaluate.
-            Must not contain ``fold_id="live"`` rows — pass only CV fold predictions.
+            Currently only CV fold rows are handled; ``fold_id="live"`` support will
+            be added with the ``production_monitoring`` scope in Phase 8.
         actuals: Observed half-hourly power (lazy — only the joined subset is collected).
         metadata: Substation metadata used to join ``time_series_type`` onto each metric row.
             Series absent from ``metadata`` receive a null ``time_series_type``.

--- a/packages/ml_core/src/ml_core/metrics.py
+++ b/packages/ml_core/src/ml_core/metrics.py
@@ -30,8 +30,13 @@ def compute_metrics(
     5. Returns one row per ``(time_series_id, fold_id, power_fcst_model_name,
        horizon_slice, metric_name, metric_param)`` in the tall ``Metrics`` format.
 
-    NMAE is normalised by the mean absolute observed power within the same group,
-    making it comparable across substations of different sizes.
+    NMAE is normalised by the 99th percentile of absolute observed power within the
+    same group (``P99(|power_actual|)``), giving a capacity-like denominator that is
+    more comparable across asset types than the mean — intermittent generators (PV, wind)
+    have a low mean due to night/calm periods, which would inflate their NMAE relative to
+    demand substations of similar peak capacity. Once the ``effective_capacity`` Dagster
+    asset exists (Phase 6.5), the denominator will be upgraded to that pre-computed
+    full-history P99 rather than the validation-window P99 used here.
 
     Currently only the ``"all"`` horizon slice and ``"all"`` metric_param are computed.
     Horizon-sliced metrics and parametric metrics (Pinball Loss, PICP) can be
@@ -78,7 +83,7 @@ def compute_metrics(
     # Wide metrics: one row per (time_series_id, fold_id, power_fcst_model_name).
     metrics_wide = with_error.group_by(["time_series_id", "fold_id", "power_fcst_model_name"]).agg(
         mae=pl.col("error").abs().mean(),
-        nmae=pl.col("error").abs().mean() / pl.col("power_actual").abs().mean(),
+        nmae=pl.col("error").abs().mean() / pl.col("power_actual").abs().quantile(0.99),
         rmse=(pl.col("error").pow(2).mean()).sqrt(),
         mbe=pl.col("error").mean(),
     )

--- a/packages/ml_core/src/ml_core/metrics.py
+++ b/packages/ml_core/src/ml_core/metrics.py
@@ -1,10 +1,13 @@
 """Metric computation for cross-validation results."""
 
 import re
+from datetime import datetime
 
 import patito as pt
 import polars as pl
+from contracts.common import UTC_DATETIME_DTYPE
 from contracts.ml_schemas import (
+    EVALUATION_SCOPES,
     HORIZON_SLICES,
     METRIC_NAMES,
     METRIC_PARAMS,
@@ -174,3 +177,43 @@ def build_mlflow_aggregate_metrics(
         result[f"{row['metric_name']}__all"] = float(row["mean_value"])
 
     return result
+
+
+def enrich_metrics_rows(
+    per_series_metrics: pt.DataFrame[Metrics],
+    experiment_name: str,
+    evaluation_scope: str,
+    window_start: datetime,
+    window_end: datetime,
+    window_label: str,
+    computed_at: datetime,
+    mlflow_run_id: str | None,
+) -> pl.DataFrame:
+    """Add scope and evaluation-window provenance columns to a per-series Metrics frame.
+
+    Called by the ``metrics`` Dagster asset after ``compute_metrics()`` returns, once the
+    window bounds and MLflow run ID are known. Kept here so the enrichment logic is
+    unit-testable without Dagster.
+
+    Args:
+        per_series_metrics: Frame produced by ``compute_metrics()``.
+        experiment_name: Experiment that produced these forecasts.
+        evaluation_scope: ``"leaderboard"`` or ``"ad_hoc"``.
+        window_start: Inclusive start of the evaluated ``valid_time`` window.
+        window_end: Inclusive end of the evaluated ``valid_time`` window.
+        window_label: Human-readable label (``fold_id`` for leaderboard; ``"ad_hoc"``).
+        computed_at: UTC timestamp when this metric batch was computed.
+        mlflow_run_id: MLflow fold run ID; ``None`` for ``ad_hoc``.
+
+    Returns:
+        A ``pl.DataFrame`` with all ``Metrics`` columns fully populated.
+    """
+    return per_series_metrics.with_columns(
+        experiment_name=pl.lit(experiment_name).cast(pl.Categorical),
+        evaluation_scope=pl.lit(evaluation_scope).cast(pl.Enum(EVALUATION_SCOPES)),
+        window_start=pl.lit(window_start).cast(UTC_DATETIME_DTYPE),
+        window_end=pl.lit(window_end).cast(UTC_DATETIME_DTYPE),
+        window_label=pl.lit(window_label),
+        computed_at=pl.lit(computed_at).cast(UTC_DATETIME_DTYPE),
+        mlflow_run_id=pl.lit(mlflow_run_id),
+    )

--- a/packages/ml_core/src/ml_core/metrics.py
+++ b/packages/ml_core/src/ml_core/metrics.py
@@ -189,7 +189,7 @@ def enrich_metrics_rows(
     window_label: str,
     computed_at: datetime,
     mlflow_run_id: str | None,
-) -> pl.DataFrame:
+) -> pt.DataFrame[Metrics]:
     """Add scope and evaluation-window provenance columns to a per-series Metrics frame.
 
     Called by the ``metrics`` Dagster asset after ``compute_metrics()`` returns, once the
@@ -207,14 +207,16 @@ def enrich_metrics_rows(
         mlflow_run_id: MLflow fold run ID; ``None`` for ``ad_hoc``.
 
     Returns:
-        A ``pl.DataFrame`` with all ``Metrics`` columns fully populated.
+        A validated ``Metrics`` DataFrame with all columns fully populated.
     """
-    return per_series_metrics.with_columns(
-        experiment_name=pl.lit(experiment_name).cast(pl.Categorical),
-        evaluation_scope=pl.lit(evaluation_scope).cast(pl.Enum(EVALUATION_SCOPES)),
-        window_start=pl.lit(window_start).cast(UTC_DATETIME_DTYPE),
-        window_end=pl.lit(window_end).cast(UTC_DATETIME_DTYPE),
-        window_label=pl.lit(window_label),
-        computed_at=pl.lit(computed_at).cast(UTC_DATETIME_DTYPE),
-        mlflow_run_id=pl.lit(mlflow_run_id),
+    return Metrics.validate(
+        per_series_metrics.with_columns(
+            experiment_name=pl.lit(experiment_name).cast(pl.Categorical),
+            evaluation_scope=pl.lit(evaluation_scope).cast(pl.Enum(EVALUATION_SCOPES)),
+            window_start=pl.lit(window_start).cast(UTC_DATETIME_DTYPE),
+            window_end=pl.lit(window_end).cast(UTC_DATETIME_DTYPE),
+            window_label=pl.lit(window_label),
+            computed_at=pl.lit(computed_at).cast(UTC_DATETIME_DTYPE),
+            mlflow_run_id=pl.lit(mlflow_run_id),
+        )
     )

--- a/packages/ml_core/tests/test_metrics.py
+++ b/packages/ml_core/tests/test_metrics.py
@@ -1,4 +1,4 @@
-"""Tests for compute_metrics()."""
+"""Tests for compute_metrics() and build_mlflow_aggregate_metrics()."""
 
 import math
 from datetime import datetime, timezone
@@ -8,7 +8,7 @@ import polars as pl
 import pytest
 from contracts.ml_schemas import Metrics
 from contracts.power_schemas import PowerForecast, PowerTimeSeries
-from ml_core.metrics import compute_metrics
+from ml_core.metrics import build_mlflow_aggregate_metrics, compute_metrics
 
 
 def _utc(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
@@ -56,8 +56,19 @@ def _make_cv_forecasts(
     return PowerForecast.validate(df, allow_superfluous_columns=True)
 
 
+def _make_metadata(
+    time_series_ids: list[int], time_series_type: str = "Disaggregated Demand"
+) -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            "time_series_id": pl.Series(time_series_ids, dtype=pl.Int32),
+            "time_series_type": pl.Series([time_series_type] * len(time_series_ids)),
+        }
+    )
+
+
 # ---------------------------------------------------------------------------
-# Tests
+# compute_metrics tests
 # ---------------------------------------------------------------------------
 
 
@@ -65,7 +76,7 @@ def test_compute_metrics_returns_metrics_schema():
     times = [_utc(2022, 1, 1, 0, 0), _utc(2022, 1, 1, 0, 30)]
     actuals = _make_actuals(1, times, [10.0, 10.0])
     forecasts = _make_cv_forecasts(1, times, [12.0, 8.0])
-    result = compute_metrics(forecasts, actuals)
+    result = compute_metrics(forecasts, actuals, _make_metadata([1]))
     assert isinstance(result, pl.DataFrame)
     Metrics.validate(result, allow_superfluous_columns=True)
 
@@ -76,7 +87,7 @@ def test_compute_metrics_mae_correctness():
     actuals = _make_actuals(1, times, [10.0, 10.0])
     # errors: +2, -2 → MAE = 2.0
     forecasts = _make_cv_forecasts(1, times, [12.0, 8.0])
-    result = compute_metrics(forecasts, actuals)
+    result = compute_metrics(forecasts, actuals, _make_metadata([1]))
     mae_row = result.filter((pl.col("metric_name") == "mae") & (pl.col("horizon_slice") == "all"))
     assert math.isclose(mae_row["metric_value"][0], 2.0, rel_tol=1e-5)
 
@@ -86,7 +97,7 @@ def test_compute_metrics_mbe_sign():
     times = [_utc(2022, 1, 1, 0, 0), _utc(2022, 1, 1, 0, 30)]
     actuals = _make_actuals(1, times, [10.0, 10.0])
     forecasts = _make_cv_forecasts(1, times, [15.0, 15.0])  # over-predict by 5
-    result = compute_metrics(forecasts, actuals)
+    result = compute_metrics(forecasts, actuals, _make_metadata([1]))
     mbe_row = result.filter((pl.col("metric_name") == "mbe") & (pl.col("horizon_slice") == "all"))
     assert mbe_row["metric_value"][0] > 0
 
@@ -96,7 +107,7 @@ def test_compute_metrics_nmae_normalisation():
     times = [_utc(2022, 1, 1, 0, 0), _utc(2022, 1, 1, 0, 30)]
     actuals = _make_actuals(1, times, [10.0, 10.0])
     forecasts = _make_cv_forecasts(1, times, [12.0, 8.0])  # MAE=2, mean|actual|=10
-    result = compute_metrics(forecasts, actuals)
+    result = compute_metrics(forecasts, actuals, _make_metadata([1]))
     nmae_row = result.filter((pl.col("metric_name") == "nmae") & (pl.col("horizon_slice") == "all"))
     assert math.isclose(nmae_row["metric_value"][0], 0.2, rel_tol=1e-5)
 
@@ -125,7 +136,7 @@ def test_compute_metrics_ensemble_averaging():
     )
     forecasts = PowerForecast.validate(df, allow_superfluous_columns=True)
     actuals = _make_actuals(1, [time], [10.0])
-    result = compute_metrics(forecasts, actuals)
+    result = compute_metrics(forecasts, actuals, _make_metadata([1]))
     mae_row = result.filter(pl.col("metric_name") == "mae")
     assert math.isclose(mae_row["metric_value"][0], 0.0, abs_tol=1e-5)
 
@@ -137,7 +148,7 @@ def test_compute_metrics_multiple_folds():
     fold1 = _make_cv_forecasts(1, [times[0]], [15.0], fold_id="2022")
     fold2 = _make_cv_forecasts(1, [times[1]], [10.0], fold_id="2023")
     forecasts = PowerForecast.validate(pl.concat([fold1, fold2]), allow_superfluous_columns=True)
-    result = compute_metrics(forecasts, actuals)
+    result = compute_metrics(forecasts, actuals, _make_metadata([1]))
     fold1_mae = result.filter((pl.col("fold_id") == "2022") & (pl.col("metric_name") == "mae"))
     fold2_mae = result.filter((pl.col("fold_id") == "2023") & (pl.col("metric_name") == "mae"))
     assert math.isclose(fold1_mae["metric_value"][0], 5.0, rel_tol=1e-5)
@@ -151,4 +162,107 @@ def test_compute_metrics_raises_on_no_join():
         _make_cv_forecasts(1, [_utc(2023, 6, 1)], [10.0]), allow_superfluous_columns=True
     )
     with pytest.raises(ValueError, match="No rows"):
-        compute_metrics(forecasts, actuals)
+        compute_metrics(forecasts, actuals, _make_metadata([1]))
+
+
+def test_compute_metrics_populates_time_series_type():
+    """time_series_type from metadata is joined onto each metric row."""
+    times = [_utc(2022, 1, 1, 0, 0)]
+    actuals = _make_actuals(1, times, [10.0])
+    forecasts = _make_cv_forecasts(1, times, [10.0])
+    result = compute_metrics(forecasts, actuals, _make_metadata([1], "PV"))
+    assert (result["time_series_type"] == "PV").all()
+
+
+def test_compute_metrics_unknown_series_gets_null_type():
+    """Series absent from metadata receive null time_series_type (left join)."""
+    times = [_utc(2022, 1, 1, 0, 0)]
+    actuals = _make_actuals(1, times, [10.0])
+    forecasts = _make_cv_forecasts(1, times, [10.0])
+    empty_metadata = pl.DataFrame(
+        {"time_series_id": pl.Series([], dtype=pl.Int32), "time_series_type": pl.Series([])}
+    )
+    result = compute_metrics(forecasts, actuals, empty_metadata)
+    assert result["time_series_type"].is_null().all()
+
+
+# ---------------------------------------------------------------------------
+# build_mlflow_aggregate_metrics tests
+# ---------------------------------------------------------------------------
+
+
+def _make_metrics_df(
+    rmse_by_type: dict[str, float],
+) -> pl.DataFrame:
+    """Build a minimal Metrics-shaped DataFrame for aggregate metric tests."""
+    rows = []
+    for ts_type, rmse in rmse_by_type.items():
+        rows.append(
+            {
+                "time_series_id": 1,
+                "metric_name": "rmse",
+                "metric_value": rmse,
+                "time_series_type": ts_type,
+                "horizon_slice": "all",
+                "metric_param": "all",
+            }
+        )
+    return pl.DataFrame(rows).cast(
+        {
+            "time_series_id": pl.Int32,
+            "metric_value": pl.Float32,
+        }
+    )
+
+
+def test_build_mlflow_aggregate_metrics_all_key():
+    """rmse__all is the mean RMSE across all series."""
+    df = _make_metrics_df({"PV": 2.0, "Wind": 4.0})
+    result = build_mlflow_aggregate_metrics(df)
+    assert math.isclose(result["rmse__all"], 3.0, rel_tol=1e-5)
+
+
+def test_build_mlflow_aggregate_metrics_per_type_keys():
+    """Per-type keys use slugified type names."""
+    df = _make_metrics_df({"PV": 2.0, "Disaggregated Demand": 6.0})
+    result = build_mlflow_aggregate_metrics(df)
+    assert "rmse__pv" in result
+    assert "rmse__disaggregated_demand" in result
+    assert math.isclose(result["rmse__pv"], 2.0, rel_tol=1e-5)
+    assert math.isclose(result["rmse__disaggregated_demand"], 6.0, rel_tol=1e-5)
+
+
+def test_build_mlflow_aggregate_metrics_other_demand_slug():
+    """Parentheses in type names are stripped from the slug."""
+    df = _make_metrics_df({"Other (Demand)": 3.0})
+    result = build_mlflow_aggregate_metrics(df)
+    assert "rmse__other_demand" in result
+
+
+def test_build_mlflow_aggregate_metrics_null_type_excluded_from_per_type():
+    """Series with null time_series_type contribute to 'all' but not to per-type keys."""
+    rows = [
+        {
+            "time_series_id": 1,
+            "metric_name": "rmse",
+            "metric_value": 2.0,
+            "time_series_type": "PV",
+            "horizon_slice": "all",
+            "metric_param": "all",
+        },
+        {
+            "time_series_id": 2,
+            "metric_name": "rmse",
+            "metric_value": 4.0,
+            "time_series_type": None,
+            "horizon_slice": "all",
+            "metric_param": "all",
+        },
+    ]
+    df = pl.DataFrame(rows).cast({"time_series_id": pl.Int32, "metric_value": pl.Float32})
+    result = build_mlflow_aggregate_metrics(df)
+    # null type: only "pv" per-type key, not a null-type key
+    assert "rmse__pv" in result
+    assert all("__none" not in k and "null" not in k for k in result)
+    # "all" includes both series
+    assert math.isclose(result["rmse__all"], 3.0, rel_tol=1e-5)

--- a/packages/ml_core/tests/test_metrics.py
+++ b/packages/ml_core/tests/test_metrics.py
@@ -123,7 +123,7 @@ def test_compute_metrics_mbe_sign():
 
 
 def test_compute_metrics_nmae_normalisation():
-    """NMAE = MAE / mean(|actual|). When actuals are all 10 and MAE=2, NMAE=0.2."""
+    """NMAE = MAE / P99(|actual|). When actuals are all 10 and MAE=2, NMAE=0.2."""
     times = [_utc(2022, 1, 1, 0, 0), _utc(2022, 1, 1, 0, 30)]
     actuals = _make_actuals(1, times, [10.0, 10.0])
     forecasts = _make_cv_forecasts(1, times, [12.0, 8.0])  # MAE=2, mean|actual|=10

--- a/packages/ml_core/tests/test_metrics.py
+++ b/packages/ml_core/tests/test_metrics.py
@@ -7,7 +7,12 @@ import patito as pt
 import polars as pl
 import pytest
 from contracts.ml_schemas import Metrics
-from contracts.power_schemas import PowerForecast, PowerTimeSeries
+from contracts.power_schemas import (
+    LIST_OF_TIME_SERIES_TYPES,
+    PowerForecast,
+    PowerTimeSeries,
+    TimeSeriesMetadata,
+)
 from ml_core.metrics import build_mlflow_aggregate_metrics, compute_metrics
 
 
@@ -58,12 +63,27 @@ def _make_cv_forecasts(
 
 def _make_metadata(
     time_series_ids: list[int], time_series_type: str = "Disaggregated Demand"
-) -> pl.DataFrame:
-    return pl.DataFrame(
-        {
-            "time_series_id": pl.Series(time_series_ids, dtype=pl.Int32),
-            "time_series_type": pl.Series([time_series_type] * len(time_series_ids)),
-        }
+) -> pt.DataFrame[TimeSeriesMetadata]:
+    n = len(time_series_ids)
+    return TimeSeriesMetadata.validate(
+        pl.DataFrame(
+            {
+                "time_series_id": pl.Series(time_series_ids, dtype=pl.Int32),
+                "time_series_name": [f"Substation {i}" for i in time_series_ids],
+                "time_series_type": pl.Series([time_series_type] * n).cast(
+                    pl.Enum(LIST_OF_TIME_SERIES_TYPES)
+                ),
+                "units": pl.Series(["MW"] * n).cast(pl.Enum(["MW", "MVA"])),
+                "licence_area": pl.Series(["EMids"] * n).cast(pl.Enum(["EMids"])),
+                "substation_number": pl.Series([i + 1 for i in range(n)], dtype=pl.Int32),
+                "substation_type": pl.Series(["Primary"] * n).cast(
+                    pl.Enum(["BSP", "EHV Customer", "GSP", "HV Customer", "Primary"])
+                ),
+                "latitude": pl.Series([53.0] * n, dtype=pl.Float32),
+                "longitude": pl.Series([-0.5] * n, dtype=pl.Float32),
+                "h3_res_5": pl.Series([617700169958293503] * n, dtype=pl.UInt64),
+            }
+        )
     )
 
 
@@ -179,10 +199,8 @@ def test_compute_metrics_unknown_series_gets_null_type():
     times = [_utc(2022, 1, 1, 0, 0)]
     actuals = _make_actuals(1, times, [10.0])
     forecasts = _make_cv_forecasts(1, times, [10.0])
-    empty_metadata = pl.DataFrame(
-        {"time_series_id": pl.Series([], dtype=pl.Int32), "time_series_type": pl.Series([])}
-    )
-    result = compute_metrics(forecasts, actuals, empty_metadata)
+    # ts_id=1 is absent — metadata only knows about ts_id=99.
+    result = compute_metrics(forecasts, actuals, _make_metadata([99]))
     assert result["time_series_type"].is_null().all()
 
 

--- a/plans/dagster_plan.md
+++ b/plans/dagster_plan.md
@@ -1390,7 +1390,7 @@ Implements §4.10. Independent of Phases 6–8 — it works with the already-bui
   the full loop finishes in under a minute and the smoke forecasts never appear in leaderboard
   metrics.
 
-### 7.6 Phase 6 — `metrics` asset (leaderboard + ad_hoc) → full CV loop works
+### 7.6 Phase 6 — `metrics` asset (leaderboard + ad_hoc) → full CV loop works - Underway in PR 205
 
 - Implement §4.8 for the `leaderboard` and `ad_hoc` scopes (typed `PopulationFilter`, join
   actuals, `compute_metrics`, per-`time_series_type` + `"all"` aggregation, write

--- a/plans/dagster_plan.md
+++ b/plans/dagster_plan.md
@@ -1418,6 +1418,9 @@ Implements §4.10. Independent of Phases 6–8 — it works with the already-bui
 - Add the `production_monitoring` scope to `metrics` (time-series logging to the dedicated
   experiment + trailing 24h/7d window columns; §4.8.1), the `monitoring_sensor` (§4.8.1), and
   `retire_experiment_job` (§4.3.1).
+- Remove the `fold_id="live"` restriction in `compute_metrics()` (currently documented in its
+  docstring); live rows use the same join logic but need the trailing-window bounds from the
+  monitoring sensor rather than fold dates.
 - Tests: sensor fires on a power update and runs `metrics(production_monitoring)`; monitoring rows
   land in Delta + the `production_monitoring` experiment and **never** on the leaderboard; retire
   job refuses to delete when results are absent and deletes when present.

--- a/plans/dagster_plan.md
+++ b/plans/dagster_plan.md
@@ -1467,6 +1467,7 @@ only the `effective_capacity` asset body changes.
 - Add the `production_monitoring` scope to `metrics` (time-series logging to the dedicated
   experiment + trailing 24h/7d window columns; §4.8.1), the `monitoring_sensor` (§4.8.1), and
   `retire_experiment_job` (§4.3.1).
+- Expand `EvalScopeType` in `ml_schemas.py` to `Literal["leaderboard", "production_monitoring", "ad_hoc"]`, bringing it fully in sync with `EVALUATION_SCOPES`.
 - Remove the `fold_id="live"` restriction in `compute_metrics()` (currently documented in its
   docstring); live rows use the same join logic but need the trailing-window bounds from the
   monitoring sensor rather than fold dates.

--- a/plans/dagster_plan.md
+++ b/plans/dagster_plan.md
@@ -1404,6 +1404,55 @@ Implements §4.10. Independent of Phases 6–8 — it works with the already-bui
   materialising the smoke-test fold + `metrics`, the MLflow parent run shows the aggregate
   leaderboard metrics and `forecast_metrics` holds the per-type/overall rows. *(Milestone.)*
 
+### 7.6.5 Phase 6.5 — MVP `effective_capacity` asset + NMAE normalisation upgrade
+
+*The data contract (`EffectiveCapacity`) and the NMAE P99 change in `compute_metrics` are already
+landed. This phase adds the Dagster asset that computes and persists the capacity estimate, then
+wires it into the `metrics` asset so the NMAE denominator uses full-history P99 rather than the
+validation-window P99 computed inline today.*
+
+**Background.** NMAE is currently normalised by P99 of `|power_actual|` computed within the
+joined forecast/actuals window. This is validation-window-dependent: an unusually calm year for a
+wind farm gives a low P99, inflating its NMAE. Pre-computing P99 over the full history fixes this.
+It also establishes the `effective_capacity` Delta table and schema that the v0.6 / v0.7
+differentiable-physics upgrade will slot into without schema or interface changes.
+
+**Already done:**
+- `EffectiveCapacity` data contract added to `contracts.power_schemas` — fields
+  `(time_series_id, time, effective_capacity_mw: Float32)`.
+- `compute_metrics` NMAE denominator changed from `mean(|power|)` to `quantile(0.99)(|power|)`.
+
+**To implement:**
+
+- **`effective_capacity` Dagster asset** (unpartitioned; deps: `power_time_series_and_metadata`):
+  read the `power_time_series` Delta table as a `LazyFrame`, compute
+  `P99(abs(power))` per `time_series_id` over the full available history, set `time` to the
+  latest observed `time` per series. Write one row per `time_series_id` to
+  `effective_capacity.delta` (path from `Settings.effective_capacity_data_path`, a new field).
+  Validate output against `EffectiveCapacity`.
+
+- **`Settings.effective_capacity_data_path`**: new `Path` field pointing at the MVP Delta table.
+
+- **Wire into `compute_metrics`**: add an optional third positional parameter
+  `capacity: pt.DataFrame[EffectiveCapacity] | None = None`. When provided, join on
+  `time_series_id` and use `effective_capacity_mw` as the NMAE denominator (replacing the inline
+  `quantile(0.99)` computation, which stays as the fallback when `capacity` is `None`).
+  The `metrics` Dagster asset reads `effective_capacity.delta` and passes it in.
+
+- **Tests:** unit test that `compute_metrics` uses the joined `effective_capacity_mw` when a
+  capacity frame is provided (and falls back to inline P99 when not). Integration test materialising
+  `effective_capacity` on synthetic power data and confirming one row per series with a physically
+  plausible P99 value.
+
+- **User can verify:** materialise `effective_capacity`; inspect the Delta table to confirm P99
+  values are physically reasonable (e.g. a 10 MW solar farm has `effective_capacity_mw ≈ 10`).
+  Re-run `metrics`; confirm NMAE values change slightly (validation-window P99 → full-history P99).
+
+**Future upgrade (v0.6 / v0.7):** replace the P99 computation in `effective_capacity` with the
+differentiable-physics capacity model (see `docs/roadmap/differentiable-physics.md` §5). The
+`EffectiveCapacity` schema, `compute_metrics` interface, and the `metrics` asset are all unchanged;
+only the `effective_capacity` asset body changes.
+
 ### 7.7 Phase 7 — `live_forecasts` asset
 
 - Implement §4.9 (`load_from_mlflow` from cache by `production_model_run_id`, single-run inference

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -5,19 +5,21 @@ thin orchestration shell delegating its logic to the pure helpers in ``ml_core._
 the logic stays fast to unit-test and the assets stay readable.
 """
 
-from datetime import datetime, timedelta
-from typing import Final
+from datetime import datetime, timedelta, timezone
+from typing import Final, Literal
 
 import mlflow
 import patito as pt
 import polars as pl
+from contracts.common import UTC_DATETIME_DTYPE
 from contracts.hydra_schemas import load_cv_config
-from contracts.ml_schemas import EligibleTimeSeries
+from contracts.ml_schemas import EVALUATION_SCOPES, EligibleTimeSeries
 from contracts.power_schemas import PowerTimeSeries, TimeSeriesMetadata
 from contracts.settings import Settings
 from contracts.weather_schemas import NwpInMemory, NwpOnDisk
 from dagster import (
     AssetExecutionContext,
+    Config,
     DynamicPartitionsDefinition,
     StaticPartitionsDefinition,
     asset,
@@ -28,6 +30,7 @@ from ml_core._cv_helpers import (
     eligible_time_series_ids,
     parse_cv_partition_key,
 )
+from ml_core.metrics import build_mlflow_aggregate_metrics, compute_metrics
 from ml_core._mlflow_runs import (
     get_or_create_experiment,
     get_or_create_fold_run,
@@ -461,5 +464,178 @@ def cv_power_forecasts(context: AssetExecutionContext) -> None:
             "val_start": str(val_start),
             "val_end": str(val_end),
             "fold_run_id": fold_run_id,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# metrics asset
+# ---------------------------------------------------------------------------
+
+
+class PopulationFilter(Config):
+    """Typed filter over ``power_forecasts`` rows to score (§4.8).
+
+    All fields default to ``None`` (= no filter on that dimension). A mistyped field name is a
+    Dagster config validation error, not a silent wrong population — that is the whole point of
+    using a typed config rather than a free ``dict``.
+    """
+
+    experiment_name: str | None = None
+    fold_id: str | None = None
+    valid_time_min: str | None = None
+    """ISO-8601 UTC timestamp; rows with ``valid_time`` before this are excluded."""
+    valid_time_max: str | None = None
+    """ISO-8601 UTC timestamp; rows with ``valid_time`` after this are excluded."""
+
+
+class MetricsConfig(Config):
+    """Run config for the ``metrics`` asset (§4.8)."""
+
+    population_filter: PopulationFilter = PopulationFilter()
+    evaluation_scope: Literal["leaderboard", "ad_hoc"] = "leaderboard"
+    """Which evaluation scope this run produces.
+
+    - ``"leaderboard"``: logs per-fold + aggregate metrics to the golden leaderboard MLflow
+      experiments (canonical complete-window folds only).
+    - ``"ad_hoc"``: writes to ``forecast_metrics`` Delta only; no MLflow logging.
+    """
+
+
+@asset(deps=["cv_power_forecasts"])
+def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
+    """Compute evaluation metrics and write to ``forecast_metrics``.
+
+    Reads the filtered ``power_forecasts`` Delta, joins observed power, computes MAE/NMAE/RMSE/MBE
+    per series (via ``compute_metrics()``), enriches each row with scope and evaluation-window
+    provenance, and writes to the ``forecast_metrics`` Delta table partitioned by
+    ``(experiment_name, fold_id)``.
+
+    For ``evaluation_scope="leaderboard"``, also logs per-type + overall aggregate metrics to each
+    fold's MLflow child run and the mean-across-folds aggregates to the experiment's parent run.
+    Lookup is by tag (§4.1.1) so this is idempotent under Dagster retries.
+    """
+    settings = Settings()
+    mlflow.set_tracking_uri(settings.mlflow_tracking_uri)
+
+    # --- Read forecasts with population filter ------------------------------------------------
+    forecasts_scan = pl.scan_delta(str(settings.power_forecasts_data_path))
+    pf = config.population_filter
+    if pf.experiment_name is not None:
+        forecasts_scan = forecasts_scan.filter(pl.col("experiment_name") == pf.experiment_name)
+    if pf.fold_id is not None:
+        forecasts_scan = forecasts_scan.filter(pl.col("fold_id") == pf.fold_id)
+    if pf.valid_time_min is not None:
+        min_dt = datetime.fromisoformat(pf.valid_time_min)
+        if min_dt.tzinfo is None:
+            min_dt = min_dt.replace(tzinfo=timezone.utc)
+        forecasts_scan = forecasts_scan.filter(pl.col("valid_time") >= min_dt)
+    if pf.valid_time_max is not None:
+        max_dt = datetime.fromisoformat(pf.valid_time_max)
+        if max_dt.tzinfo is None:
+            max_dt = max_dt.replace(tzinfo=timezone.utc)
+        forecasts_scan = forecasts_scan.filter(pl.col("valid_time") <= max_dt)
+
+    forecasts_df = forecasts_scan.collect()
+    if forecasts_df.height == 0:
+        context.log.warning("No forecasts matched the population filter — nothing to score.")
+        context.add_output_metadata({"n_rows_written": 0, "n_groups": 0})
+        return
+
+    # --- Read supporting data -----------------------------------------------------------------
+    actuals_lf = pt.LazyFrame.from_existing(
+        pl.scan_delta(str(settings.nged_data_path / "power_time_series.delta"))
+    ).set_model(PowerTimeSeries)
+    metadata_df = pl.read_parquet(settings.nged_data_path / "metadata.parquet")
+
+    # --- Process each (experiment_name, fold_id) group ---------------------------------------
+    groups = (
+        forecasts_df.select(["experiment_name", "fold_id"])
+        .unique()
+        .sort(["experiment_name", "fold_id"])
+        .rows()
+    )
+
+    settings.forecast_metrics_data_path.parent.mkdir(parents=True, exist_ok=True)
+    now = datetime.now(timezone.utc)
+    total_rows = 0
+
+    # Accumulate per-fold metric dicts per experiment for parent-run aggregation.
+    experiment_fold_metrics: dict[str, dict[str, list[float]]] = {}
+
+    for exp_name, fold_id in groups:
+        group_df = forecasts_df.filter(
+            (pl.col("experiment_name") == exp_name) & (pl.col("fold_id") == fold_id)
+        )
+
+        per_series_metrics = compute_metrics(group_df, actuals_lf, metadata_df)
+
+        # Resolve evaluation-window bounds.
+        if config.evaluation_scope == "leaderboard":
+            fold = _cv_config.get_fold(fold_id)
+            window_start = date_to_utc_datetime(fold.val_start)
+            window_end = date_to_utc_datetime(fold.val_end, end_of_day=True)
+            window_label = fold_id
+        else:
+            window_start = group_df["valid_time"].min()
+            window_end = group_df["valid_time"].max()
+            window_label = "ad_hoc"
+
+        # Resolve MLflow fold run id (leaderboard only).
+        mlflow_run_id: str | None = None
+        if config.evaluation_scope == "leaderboard":
+            experiment_id = get_or_create_experiment(exp_name)
+            parent_run_id = get_or_create_parent_run(experiment_id)
+            mlflow_run_id = get_or_create_fold_run(experiment_id, parent_run_id, fold_id)
+
+        # Enrich per-series rows with scope and window provenance.
+        enriched = per_series_metrics.with_columns(
+            experiment_name=pl.lit(exp_name).cast(pl.Categorical),
+            evaluation_scope=pl.lit(config.evaluation_scope).cast(pl.Enum(EVALUATION_SCOPES)),
+            window_start=pl.lit(window_start).cast(UTC_DATETIME_DTYPE),
+            window_end=pl.lit(window_end).cast(UTC_DATETIME_DTYPE),
+            window_label=pl.lit(window_label),
+            computed_at=pl.lit(now).cast(UTC_DATETIME_DTYPE),
+            mlflow_run_id=pl.lit(mlflow_run_id),
+        )
+
+        # Write to forecast_metrics Delta, idempotent overwrite per (experiment, fold) partition.
+        delta_data = enriched.with_columns(
+            experiment_name=pl.col("experiment_name").cast(pl.String),
+            fold_id=pl.col("fold_id").cast(pl.String),
+        ).to_arrow()
+        write_deltalake(
+            table_or_uri=settings.forecast_metrics_data_path,
+            data=delta_data,
+            mode="overwrite",
+            predicate=f"experiment_name = '{exp_name}' AND fold_id = '{fold_id}'",
+            partition_by=["experiment_name", "fold_id"],
+        )
+        total_rows += enriched.height
+
+        # Leaderboard scope: log per-fold metrics to the fold MLflow run.
+        if config.evaluation_scope == "leaderboard":
+            fold_metric_dict = build_mlflow_aggregate_metrics(per_series_metrics)
+            with mlflow.start_run(run_id=mlflow_run_id):
+                mlflow.log_metrics(fold_metric_dict)
+            exp_metrics = experiment_fold_metrics.setdefault(exp_name, {})
+            for key, value in fold_metric_dict.items():
+                exp_metrics.setdefault(key, []).append(value)
+
+    # Leaderboard scope: log mean-across-folds aggregates to each experiment's parent run.
+    if config.evaluation_scope == "leaderboard":
+        for exp_name, fold_metrics in experiment_fold_metrics.items():
+            experiment_id = get_or_create_experiment(exp_name)
+            parent_run_id = get_or_create_parent_run(experiment_id)
+            parent_metric_dict = {k: sum(v) / len(v) for k, v in fold_metrics.items()}
+            with mlflow.start_run(run_id=parent_run_id):
+                mlflow.log_metrics(parent_metric_dict)
+
+    context.add_output_metadata(
+        {
+            "n_rows_written": total_rows,
+            "n_groups": len(groups),
+            "evaluation_scope": config.evaluation_scope,
+            "groups": str(groups),
         }
     )

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -498,35 +498,38 @@ class PopulationFilter(Config):
     valid_time_max: str | None = None
     """ISO-8601 UTC timestamp; rows with ``valid_time`` after this are excluded."""
 
-    def apply(self, scan: pl.LazyFrame) -> pl.LazyFrame:
+    def apply(self, scan: pt.LazyFrame[PowerForecast]) -> pt.LazyFrame[PowerForecast]:
         """Return ``scan`` with all non-``None`` filter fields applied as Polars predicates.
 
         Args:
-            scan: Lazy scan of the ``power_forecasts`` Delta table. Conceptually this is
-                ``PowerForecast`` data, but delta-rs stores all Categorical columns as plain
-                ``String`` on disk, so the scan does not yet conform to
-                ``pt.LazyFrame[PowerForecast]``. The caller casts Categorical columns back to
-                their declared dtypes immediately after ``.collect()``; this method operates on
-                the raw pre-cast scan.
+            scan: Typed lazy scan of the ``power_forecasts`` Delta table. The caller is
+                responsible for casting any ``String`` columns that ``PowerForecast`` declares as
+                ``Categorical`` before passing the scan here (delta-rs stores all
+                dictionary-encoded columns as plain ``String`` on disk; casting lazily via
+                ``.with_columns()`` before ``.collect()`` is zero-cost).
 
         Returns:
             The same lazy scan with each non-``None`` field added as a ``.filter()`` predicate.
         """
+        # Rebind to plain pl.LazyFrame: Polars' .filter() drops the pt.LazyFrame subclass, so
+        # accumulating filters via scan = scan.filter(...) would fail ty's assignment check.
+        # Re-wrap as pt.LazyFrame[PowerForecast] before returning (zero-copy).
+        lf: pl.LazyFrame = scan
         if self.experiment_name is not None:
-            scan = scan.filter(pl.col("experiment_name") == self.experiment_name)
+            lf = lf.filter(pl.col("experiment_name") == self.experiment_name)
         if self.fold_id is not None:
-            scan = scan.filter(pl.col("fold_id") == self.fold_id)
+            lf = lf.filter(pl.col("fold_id") == self.fold_id)
         if self.valid_time_min is not None:
             min_dt = datetime.fromisoformat(self.valid_time_min)
             if min_dt.tzinfo is None:
                 min_dt = min_dt.replace(tzinfo=timezone.utc)
-            scan = scan.filter(pl.col("valid_time") >= min_dt)
+            lf = lf.filter(pl.col("valid_time") >= min_dt)
         if self.valid_time_max is not None:
             max_dt = datetime.fromisoformat(self.valid_time_max)
             if max_dt.tzinfo is None:
                 max_dt = max_dt.replace(tzinfo=timezone.utc)
-            scan = scan.filter(pl.col("valid_time") <= max_dt)
-        return scan
+            lf = lf.filter(pl.col("valid_time") <= max_dt)
+        return pt.LazyFrame.from_existing(lf).set_model(PowerForecast)
 
 
 class MetricsConfig(Config):
@@ -636,17 +639,16 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     mlflow.set_tracking_uri(settings.mlflow_tracking_uri)
 
     # delta-rs stores all Arrow dictionary-encoded columns (Categorical, Enum) as plain String on
-    # disk. Cast them back immediately after collecting so the rest of the asset works with a
-    # properly-typed PowerForecast frame and avoids repeating the cast inside the loop.
-    forecasts_df = (
-        config.population_filter.apply(pl.scan_delta(str(settings.power_forecasts_data_path)))
-        .collect()
-        .with_columns(
+    # disk. Cast lazily before filtering so PopulationFilter.apply receives a properly-typed
+    # pt.LazyFrame[PowerForecast] and the collected frame already has the correct dtypes.
+    typed_scan = pt.LazyFrame.from_existing(
+        pl.scan_delta(str(settings.power_forecasts_data_path)).with_columns(
             experiment_name=pl.col("experiment_name").cast(pl.Categorical),
             fold_id=pl.col("fold_id").cast(pl.Categorical),
             power_fcst_model_name=pl.col("power_fcst_model_name").cast(pl.Categorical),
         )
-    )
+    ).set_model(PowerForecast)
+    forecasts_df = config.population_filter.apply(typed_scan).collect()
     if forecasts_df.height == 0:
         context.log.warning("No forecasts matched the population filter — nothing to score.")
         context.add_output_metadata({"n_rows_written": 0, "n_groups": 0})

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -184,6 +184,12 @@ def _load_engineering_inputs(
       that cell by the feature engineer's spatial join.
 
     Args:
+        settings: Application settings (data paths, credentials).
+        time_series_ids: IDs to include; all three inputs are filtered to this population.
+        window_start: Inclusive start of the time window for power observations and NWP
+            ``valid_time``.
+        window_end: Inclusive end of the time window for power observations and NWP
+            ``valid_time``.
         ensemble_members: If provided, NWP is filtered to these ``ensemble_member`` indices. If
             ``None`` (the default), every ensemble member is carried through. Training restricts to
             the control member (``[0]``) to avoid fanning every forecast row out across all ~51
@@ -194,6 +200,10 @@ def _load_engineering_inputs(
             can cover the window). ``cv_power_forecasts`` passes a narrower sub-range to process the
             validation window in ``init_time`` chunks, so the full-ensemble forecast frame for one
             chunk stays in RAM while the rest streams from the partition-pruned scan.
+
+    Returns:
+        ``(power_time_series, metadata, nwp)`` — a lazy power frame, an eager metadata frame, and a
+        lazy in-memory NWP frame, all filtered to ``time_series_ids`` and the requested window.
     """
     if init_time_start is None:
         init_time_start = window_start - _MAX_NWP_LEAD
@@ -489,7 +499,16 @@ class PopulationFilter(Config):
     """ISO-8601 UTC timestamp; rows with ``valid_time`` after this are excluded."""
 
     def apply(self, scan: pl.LazyFrame) -> pl.LazyFrame:
-        """Return ``scan`` with all non-``None`` filter fields applied as Polars predicates."""
+        """Return ``scan`` with all non-``None`` filter fields applied as Polars predicates.
+
+        Args:
+            scan: Lazy scan of the ``power_forecasts`` Delta table. The raw Delta scan has
+                Categorical columns stored as ``String``, so the frame does not yet conform to
+                ``PowerForecast`` — this method filters at the string level before any casting.
+
+        Returns:
+            The same lazy scan with each non-``None`` field added as a ``.filter()`` predicate.
+        """
         if self.experiment_name is not None:
             scan = scan.filter(pl.col("experiment_name") == self.experiment_name)
         if self.fold_id is not None:
@@ -529,6 +548,17 @@ def _resolve_eval_window(
 
     For ``"leaderboard"`` scope the bounds come from the fold config; for ``"ad_hoc"``
     they are the observed ``valid_time`` extent of the forecast group.
+
+    Args:
+        evaluation_scope: ``"leaderboard"`` uses fold-config dates; ``"ad_hoc"`` uses the
+            observed ``valid_time`` range of the forecast group.
+        fold_id: Fold identifier; only used when ``evaluation_scope == "leaderboard"``.
+        group_df: Raw forecast rows for this ``(experiment_name, fold_id)`` group. Only
+            ``valid_time`` is accessed, and only for the ``"ad_hoc"`` branch.
+
+    Returns:
+        ``(window_start, window_end, window_label)`` — the inclusive evaluation window bounds
+        and a human-readable label (``fold_id`` for leaderboard; ``"ad_hoc"`` otherwise).
     """
     if evaluation_scope == "leaderboard":
         fold = _cv_config.get_fold(fold_id)
@@ -557,6 +587,14 @@ def _write_metrics_to_delta(
     String. Re-sending Enum/Categorical data on an overwrite would cause a schema-mismatch
     error. Performs an idempotent overwrite of the ``(experiment_name, fold_id)`` partition
     so re-materialising the asset replaces rows rather than duplicating them.
+
+    Args:
+        path: Filesystem path to the ``forecast_metrics`` Delta table.
+        enriched: Fully populated ``Metrics`` rows, with all provenance columns set by
+            ``enrich_metrics_rows()``.
+        exp_name: Experiment name; used in the Delta overwrite predicate to scope the
+            replacement to this ``(experiment_name, fold_id)`` partition.
+        fold_id: Fold identifier; used alongside ``exp_name`` in the predicate.
     """
     cat_cols = [
         c
@@ -585,6 +623,11 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     For ``evaluation_scope="leaderboard"``, also logs per-type + overall aggregate metrics to each
     fold's MLflow child run and the mean-across-folds aggregates to the experiment's parent run.
     Lookup is by tag (§4.1.1) so this is idempotent under Dagster retries.
+
+    Args:
+        context: Dagster execution context; used for logging and ``add_output_metadata``.
+        config: Population filter and evaluation scope for this materialisation. Defaults to
+            no filter and ``"leaderboard"`` scope.
     """
     settings = Settings()
     mlflow.set_tracking_uri(settings.mlflow_tracking_uri)

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -14,7 +14,7 @@ import polars as pl
 from contracts.common import UTC_DATETIME_DTYPE
 from contracts.hydra_schemas import load_cv_config
 from contracts.ml_schemas import EVALUATION_SCOPES, EligibleTimeSeries
-from contracts.power_schemas import PowerTimeSeries, TimeSeriesMetadata
+from contracts.power_schemas import PowerForecast, PowerTimeSeries, TimeSeriesMetadata
 from contracts.settings import Settings
 from contracts.weather_schemas import NwpInMemory, NwpOnDisk
 from dagster import (
@@ -546,7 +546,12 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     actuals_lf = pt.LazyFrame.from_existing(
         pl.scan_delta(str(settings.nged_data_path / "power_time_series.delta"))
     ).set_model(PowerTimeSeries)
-    metadata_df = pl.read_parquet(settings.nged_data_path / "metadata.parquet")
+    # Validate metadata at the boundary; allow_superfluous_columns=True because the parquet
+    # also carries geo columns (e.g. h3_res_5) that are not part of TimeSeriesMetadata.
+    metadata_df = TimeSeriesMetadata.validate(
+        pl.read_parquet(settings.nged_data_path / "metadata.parquet"),
+        allow_superfluous_columns=True,
+    )
 
     # --- Process each (experiment_name, fold_id) group ---------------------------------------
     groups = (
@@ -568,7 +573,16 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
             (pl.col("experiment_name") == exp_name) & (pl.col("fold_id") == fold_id)
         )
 
-        per_series_metrics = compute_metrics(group_df, actuals_lf, metadata_df)
+        # Delta stores partition columns as String; cast back to Categorical so the frame
+        # conforms to PowerForecast before calling compute_metrics.
+        group_forecasts = PowerForecast.validate(
+            group_df.with_columns(
+                experiment_name=pl.col("experiment_name").cast(pl.Categorical),
+                fold_id=pl.col("fold_id").cast(pl.Categorical),
+            ),
+            allow_superfluous_columns=True,
+        )
+        per_series_metrics = compute_metrics(group_forecasts, actuals_lf, metadata_df)
 
         # Resolve evaluation-window bounds.
         if config.evaluation_scope == "leaderboard":

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -672,7 +672,10 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     settings.forecast_metrics_data_path.parent.mkdir(parents=True, exist_ok=True)
     now = datetime.now(timezone.utc)
     total_rows = 0
-    # Accumulate per-fold metric dicts per experiment for parent-run aggregation.
+    # Accumulates per-fold metric values for parent-run aggregation (leaderboard scope only).
+    # Structure: {experiment_name: {mlflow_metric_key: [value_per_fold, ...]}}
+    # e.g. {"xgboost_baseline": {"rmse__all": [0.42, 0.39], "rmse__pv": [0.31, 0.28]}}
+    # After the loop, each list is averaged and logged to the experiment's MLflow parent run.
     experiment_fold_metrics: dict[str, dict[str, list[float]]] = {}
 
     for exp_name, fold_id in groups:

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -502,9 +502,12 @@ class PopulationFilter(Config):
         """Return ``scan`` with all non-``None`` filter fields applied as Polars predicates.
 
         Args:
-            scan: Lazy scan of the ``power_forecasts`` Delta table. The raw Delta scan has
-                Categorical columns stored as ``String``, so the frame does not yet conform to
-                ``PowerForecast`` — this method filters at the string level before any casting.
+            scan: Lazy scan of the ``power_forecasts`` Delta table. Conceptually this is
+                ``PowerForecast`` data, but delta-rs stores all Categorical columns as plain
+                ``String`` on disk, so the scan does not yet conform to
+                ``pt.LazyFrame[PowerForecast]``. The caller casts Categorical columns back to
+                their declared dtypes immediately after ``.collect()``; this method operates on
+                the raw pre-cast scan.
 
         Returns:
             The same lazy scan with each non-``None`` field added as a ``.filter()`` predicate.
@@ -542,7 +545,7 @@ class MetricsConfig(Config):
 def _resolve_eval_window(
     evaluation_scope: EvalScopeType,
     fold_id: str,
-    group_df: pl.DataFrame,
+    group_df: pt.DataFrame[PowerForecast],
 ) -> tuple[datetime, datetime, str]:
     """Return ``(window_start, window_end, window_label)`` for a metrics group.
 
@@ -553,8 +556,8 @@ def _resolve_eval_window(
         evaluation_scope: ``"leaderboard"`` uses fold-config dates; ``"ad_hoc"`` uses the
             observed ``valid_time`` range of the forecast group.
         fold_id: Fold identifier; only used when ``evaluation_scope == "leaderboard"``.
-        group_df: Raw forecast rows for this ``(experiment_name, fold_id)`` group. Only
-            ``valid_time`` is accessed, and only for the ``"ad_hoc"`` branch.
+        group_df: Validated ``PowerForecast`` rows for this ``(experiment_name, fold_id)``
+            group. Only ``valid_time`` is accessed, and only for the ``"ad_hoc"`` branch.
 
     Returns:
         ``(window_start, window_end, window_label)`` — the inclusive evaluation window bounds
@@ -632,9 +635,18 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     settings = Settings()
     mlflow.set_tracking_uri(settings.mlflow_tracking_uri)
 
-    forecasts_df = config.population_filter.apply(
-        pl.scan_delta(str(settings.power_forecasts_data_path))
-    ).collect()
+    # delta-rs stores all Arrow dictionary-encoded columns (Categorical, Enum) as plain String on
+    # disk. Cast them back immediately after collecting so the rest of the asset works with a
+    # properly-typed PowerForecast frame and avoids repeating the cast inside the loop.
+    forecasts_df = (
+        config.population_filter.apply(pl.scan_delta(str(settings.power_forecasts_data_path)))
+        .collect()
+        .with_columns(
+            experiment_name=pl.col("experiment_name").cast(pl.Categorical),
+            fold_id=pl.col("fold_id").cast(pl.Categorical),
+            power_fcst_model_name=pl.col("power_fcst_model_name").cast(pl.Categorical),
+        )
+    )
     if forecasts_df.height == 0:
         context.log.warning("No forecasts matched the population filter — nothing to score.")
         context.add_output_metadata({"n_rows_written": 0, "n_groups": 0})
@@ -662,22 +674,16 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     experiment_fold_metrics: dict[str, dict[str, list[float]]] = {}
 
     for exp_name, fold_id in groups:
-        group_df = forecasts_df.filter(
-            (pl.col("experiment_name") == exp_name) & (pl.col("fold_id") == fold_id)
-        )
-        # Delta stores all Categorical columns as String; cast back before validating.
         group_forecasts = PowerForecast.validate(
-            group_df.with_columns(
-                experiment_name=pl.col("experiment_name").cast(pl.Categorical),
-                fold_id=pl.col("fold_id").cast(pl.Categorical),
-                power_fcst_model_name=pl.col("power_fcst_model_name").cast(pl.Categorical),
+            forecasts_df.filter(
+                (pl.col("experiment_name") == exp_name) & (pl.col("fold_id") == fold_id)
             ),
             allow_superfluous_columns=True,
         )
         per_series_metrics = compute_metrics(group_forecasts, actuals_lf, metadata_df)
 
         window_start, window_end, window_label = _resolve_eval_window(
-            config.evaluation_scope, fold_id, group_df
+            config.evaluation_scope, fold_id, group_forecasts
         )
         mlflow_run_id: str | None = None
         if config.evaluation_scope == "leaderboard":

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -13,7 +13,7 @@ import mlflow
 import patito as pt
 import polars as pl
 from contracts.hydra_schemas import load_cv_config
-from contracts.ml_schemas import EligibleTimeSeries, EvalScopeType
+from contracts.ml_schemas import EligibleTimeSeries, EvalScopeType, Metrics
 from contracts.power_schemas import PowerForecast, PowerTimeSeries, TimeSeriesMetadata
 from contracts.settings import Settings
 from contracts.weather_schemas import NwpInMemory, NwpOnDisk
@@ -546,7 +546,7 @@ def _resolve_eval_window(
 
 def _write_metrics_to_delta(
     path: Path,
-    enriched: pl.DataFrame,
+    enriched: pt.DataFrame[Metrics],
     exp_name: str,
     fold_id: str,
 ) -> None:

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -7,13 +7,13 @@ the logic stays fast to unit-test and the assets stay readable.
 
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Final, Literal
+from typing import Final
 
 import mlflow
 import patito as pt
 import polars as pl
 from contracts.hydra_schemas import load_cv_config
-from contracts.ml_schemas import EligibleTimeSeries
+from contracts.ml_schemas import EligibleTimeSeries, EvalScopeType
 from contracts.power_schemas import PowerForecast, PowerTimeSeries, TimeSeriesMetadata
 from contracts.settings import Settings
 from contracts.weather_schemas import NwpInMemory, NwpOnDisk
@@ -488,12 +488,30 @@ class PopulationFilter(Config):
     valid_time_max: str | None = None
     """ISO-8601 UTC timestamp; rows with ``valid_time`` after this are excluded."""
 
+    def apply(self, scan: pl.LazyFrame) -> pl.LazyFrame:
+        """Return ``scan`` with all non-``None`` filter fields applied as Polars predicates."""
+        if self.experiment_name is not None:
+            scan = scan.filter(pl.col("experiment_name") == self.experiment_name)
+        if self.fold_id is not None:
+            scan = scan.filter(pl.col("fold_id") == self.fold_id)
+        if self.valid_time_min is not None:
+            min_dt = datetime.fromisoformat(self.valid_time_min)
+            if min_dt.tzinfo is None:
+                min_dt = min_dt.replace(tzinfo=timezone.utc)
+            scan = scan.filter(pl.col("valid_time") >= min_dt)
+        if self.valid_time_max is not None:
+            max_dt = datetime.fromisoformat(self.valid_time_max)
+            if max_dt.tzinfo is None:
+                max_dt = max_dt.replace(tzinfo=timezone.utc)
+            scan = scan.filter(pl.col("valid_time") <= max_dt)
+        return scan
+
 
 class MetricsConfig(Config):
     """Run config for the ``metrics`` asset (§4.8)."""
 
     population_filter: PopulationFilter = PopulationFilter()
-    evaluation_scope: Literal["leaderboard", "ad_hoc"] = "leaderboard"
+    evaluation_scope: EvalScopeType = "leaderboard"
     """Which evaluation scope this run produces.
 
     - ``"leaderboard"``: logs per-fold + aggregate metrics to the golden leaderboard MLflow
@@ -502,27 +520,8 @@ class MetricsConfig(Config):
     """
 
 
-def _apply_population_filter(scan: pl.LazyFrame, pf: PopulationFilter) -> pl.LazyFrame:
-    """Apply a ``PopulationFilter`` to a forecast ``LazyFrame``."""
-    if pf.experiment_name is not None:
-        scan = scan.filter(pl.col("experiment_name") == pf.experiment_name)
-    if pf.fold_id is not None:
-        scan = scan.filter(pl.col("fold_id") == pf.fold_id)
-    if pf.valid_time_min is not None:
-        min_dt = datetime.fromisoformat(pf.valid_time_min)
-        if min_dt.tzinfo is None:
-            min_dt = min_dt.replace(tzinfo=timezone.utc)
-        scan = scan.filter(pl.col("valid_time") >= min_dt)
-    if pf.valid_time_max is not None:
-        max_dt = datetime.fromisoformat(pf.valid_time_max)
-        if max_dt.tzinfo is None:
-            max_dt = max_dt.replace(tzinfo=timezone.utc)
-        scan = scan.filter(pl.col("valid_time") <= max_dt)
-    return scan
-
-
 def _resolve_eval_window(
-    evaluation_scope: str,
+    evaluation_scope: EvalScopeType,
     fold_id: str,
     group_df: pl.DataFrame,
 ) -> tuple[datetime, datetime, str]:
@@ -590,9 +589,8 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     settings = Settings()
     mlflow.set_tracking_uri(settings.mlflow_tracking_uri)
 
-    forecasts_df = _apply_population_filter(
-        pl.scan_delta(str(settings.power_forecasts_data_path)),
-        config.population_filter,
+    forecasts_df = config.population_filter.apply(
+        pl.scan_delta(str(settings.power_forecasts_data_path))
     ).collect()
     if forecasts_df.height == 0:
         context.log.warning("No forecasts matched the population filter — nothing to score.")

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -617,6 +617,79 @@ def _write_metrics_to_delta(
     )
 
 
+def _score_forecast_group(
+    exp_name: str,
+    fold_id: str,
+    filtered_power_forecasts: pl.DataFrame,
+    actuals_lf: pt.LazyFrame[PowerTimeSeries],
+    metadata_df: pt.DataFrame[TimeSeriesMetadata],
+    evaluation_scope: EvalScopeType,
+    metrics_path: Path,
+    now: datetime,
+) -> tuple[int, dict[str, float] | None]:
+    """Score one ``(experiment_name, fold_id)`` group, write ``Metrics`` to Delta, and
+    optionally log to MLflow.
+
+    Args:
+        exp_name: Experiment name for this group.
+        fold_id: Fold identifier for this group.
+        filtered_power_forecasts: All collected forecast rows that survived the population
+            filter; this function slices the single ``(exp_name, fold_id)`` group from it.
+        actuals_lf: Lazy observed power scan (only the joined subset is collected inside
+            ``compute_metrics()``).
+        metadata_df: Substation metadata used to join ``time_series_type`` onto each metric row.
+        evaluation_scope: ``"leaderboard"`` logs per-fold metrics to MLflow; ``"ad_hoc"``
+            skips MLflow entirely.
+        metrics_path: Filesystem path to the ``forecast_metrics`` Delta table.
+        now: UTC timestamp stamped on every row as ``computed_at`` (injected so all rows in
+            one asset materialisation share the same timestamp).
+
+    Returns:
+        A ``(n_rows_written, fold_metric_dict)`` tuple where:
+
+        - ``n_rows_written`` — number of ``Metrics`` rows written to Delta for this group.
+        - ``fold_metric_dict`` — flat ``{mlflow_metric_key: mean_value}`` dict logged to the
+          fold's MLflow child run (e.g. ``{"rmse__all": 0.42, "rmse__pv": 0.31}``). ``None``
+          for ``"ad_hoc"`` scope, where no MLflow run exists.
+    """
+    group_forecasts = PowerForecast.validate(
+        filtered_power_forecasts.filter(
+            (pl.col("experiment_name") == exp_name) & (pl.col("fold_id") == fold_id)
+        ),
+        allow_superfluous_columns=True,
+    )
+    per_series_metrics = compute_metrics(group_forecasts, actuals_lf, metadata_df)
+
+    window_start, window_end, window_label = _resolve_eval_window(
+        evaluation_scope, fold_id, group_forecasts
+    )
+    mlflow_run_id: str | None = None
+    if evaluation_scope == "leaderboard":
+        experiment_id = get_or_create_experiment(exp_name)
+        parent_run_id = get_or_create_parent_run(experiment_id)
+        mlflow_run_id = get_or_create_fold_run(experiment_id, parent_run_id, fold_id)
+
+    enriched = enrich_metrics_rows(
+        per_series_metrics,
+        exp_name,
+        evaluation_scope,
+        window_start,
+        window_end,
+        window_label,
+        now,
+        mlflow_run_id,
+    )
+    _write_metrics_to_delta(metrics_path, enriched, exp_name, fold_id)
+
+    if evaluation_scope == "leaderboard":
+        fold_metric_dict = build_mlflow_aggregate_metrics(per_series_metrics)
+        with mlflow.start_run(run_id=mlflow_run_id):
+            mlflow.log_metrics(fold_metric_dict)
+        return enriched.height, fold_metric_dict
+
+    return enriched.height, None
+
+
 @asset(deps=["cv_power_forecasts"])
 def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     """Compute evaluation metrics and write to ``forecast_metrics``.
@@ -679,40 +752,18 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     experiment_fold_metrics: dict[str, dict[str, list[float]]] = {}
 
     for exp_name, fold_id in groups:
-        group_forecasts = PowerForecast.validate(
-            filtered_power_forecasts.filter(
-                (pl.col("experiment_name") == exp_name) & (pl.col("fold_id") == fold_id)
-            ),
-            allow_superfluous_columns=True,
-        )
-        per_series_metrics = compute_metrics(group_forecasts, actuals_lf, metadata_df)
-
-        window_start, window_end, window_label = _resolve_eval_window(
-            config.evaluation_scope, fold_id, group_forecasts
-        )
-        mlflow_run_id: str | None = None
-        if config.evaluation_scope == "leaderboard":
-            experiment_id = get_or_create_experiment(exp_name)
-            parent_run_id = get_or_create_parent_run(experiment_id)
-            mlflow_run_id = get_or_create_fold_run(experiment_id, parent_run_id, fold_id)
-
-        enriched = enrich_metrics_rows(
-            per_series_metrics,
+        n_rows, fold_metric_dict = _score_forecast_group(
             exp_name,
+            fold_id,
+            filtered_power_forecasts,
+            actuals_lf,
+            metadata_df,
             config.evaluation_scope,
-            window_start,
-            window_end,
-            window_label,
+            settings.forecast_metrics_data_path,
             now,
-            mlflow_run_id,
         )
-        _write_metrics_to_delta(settings.forecast_metrics_data_path, enriched, exp_name, fold_id)
-        total_rows += enriched.height
-
-        if config.evaluation_scope == "leaderboard":
-            fold_metric_dict = build_mlflow_aggregate_metrics(per_series_metrics)
-            with mlflow.start_run(run_id=mlflow_run_id):
-                mlflow.log_metrics(fold_metric_dict)
+        total_rows += n_rows
+        if fold_metric_dict is not None:
             exp_metrics = experiment_fold_metrics.setdefault(exp_name, {})
             for key, value in fold_metric_dict.items():
                 exp_metrics.setdefault(key, []).append(value)

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -641,15 +641,15 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     # delta-rs stores all Arrow dictionary-encoded columns (Categorical, Enum) as plain String on
     # disk. Cast lazily before filtering so PopulationFilter.apply receives a properly-typed
     # pt.LazyFrame[PowerForecast] and the collected frame already has the correct dtypes.
-    typed_scan = pt.LazyFrame.from_existing(
+    power_forecasts = pt.LazyFrame.from_existing(
         pl.scan_delta(str(settings.power_forecasts_data_path)).with_columns(
             experiment_name=pl.col("experiment_name").cast(pl.Categorical),
             fold_id=pl.col("fold_id").cast(pl.Categorical),
             power_fcst_model_name=pl.col("power_fcst_model_name").cast(pl.Categorical),
         )
     ).set_model(PowerForecast)
-    forecasts_df = config.population_filter.apply(typed_scan).collect()
-    if forecasts_df.height == 0:
+    filtered_power_forecasts = config.population_filter.apply(power_forecasts).collect()
+    if filtered_power_forecasts.height == 0:
         context.log.warning("No forecasts matched the population filter — nothing to score.")
         context.add_output_metadata({"n_rows_written": 0, "n_groups": 0})
         return
@@ -664,7 +664,7 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     )
 
     groups = (
-        forecasts_df.select(["experiment_name", "fold_id"])
+        filtered_power_forecasts.select(["experiment_name", "fold_id"])
         .unique()
         .sort(["experiment_name", "fold_id"])
         .rows()
@@ -677,7 +677,7 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
 
     for exp_name, fold_id in groups:
         group_forecasts = PowerForecast.validate(
-            forecasts_df.filter(
+            filtered_power_forecasts.filter(
                 (pl.col("experiment_name") == exp_name) & (pl.col("fold_id") == fold_id)
             ),
             allow_superfluous_columns=True,

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -6,14 +6,14 @@ the logic stays fast to unit-test and the assets stay readable.
 """
 
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Final, Literal
 
 import mlflow
 import patito as pt
 import polars as pl
-from contracts.common import UTC_DATETIME_DTYPE
 from contracts.hydra_schemas import load_cv_config
-from contracts.ml_schemas import EVALUATION_SCOPES, EligibleTimeSeries
+from contracts.ml_schemas import EligibleTimeSeries
 from contracts.power_schemas import PowerForecast, PowerTimeSeries, TimeSeriesMetadata
 from contracts.settings import Settings
 from contracts.weather_schemas import NwpInMemory, NwpOnDisk
@@ -30,7 +30,7 @@ from ml_core._cv_helpers import (
     eligible_time_series_ids,
     parse_cv_partition_key,
 )
-from ml_core.metrics import build_mlflow_aggregate_metrics, compute_metrics
+from ml_core.metrics import build_mlflow_aggregate_metrics, compute_metrics, enrich_metrics_rows
 from ml_core._mlflow_runs import (
     get_or_create_experiment,
     get_or_create_fold_run,
@@ -502,6 +502,78 @@ class MetricsConfig(Config):
     """
 
 
+def _apply_population_filter(scan: pl.LazyFrame, pf: PopulationFilter) -> pl.LazyFrame:
+    """Apply a ``PopulationFilter`` to a forecast ``LazyFrame``."""
+    if pf.experiment_name is not None:
+        scan = scan.filter(pl.col("experiment_name") == pf.experiment_name)
+    if pf.fold_id is not None:
+        scan = scan.filter(pl.col("fold_id") == pf.fold_id)
+    if pf.valid_time_min is not None:
+        min_dt = datetime.fromisoformat(pf.valid_time_min)
+        if min_dt.tzinfo is None:
+            min_dt = min_dt.replace(tzinfo=timezone.utc)
+        scan = scan.filter(pl.col("valid_time") >= min_dt)
+    if pf.valid_time_max is not None:
+        max_dt = datetime.fromisoformat(pf.valid_time_max)
+        if max_dt.tzinfo is None:
+            max_dt = max_dt.replace(tzinfo=timezone.utc)
+        scan = scan.filter(pl.col("valid_time") <= max_dt)
+    return scan
+
+
+def _resolve_eval_window(
+    evaluation_scope: str,
+    fold_id: str,
+    group_df: pl.DataFrame,
+) -> tuple[datetime, datetime, str]:
+    """Return ``(window_start, window_end, window_label)`` for a metrics group.
+
+    For ``"leaderboard"`` scope the bounds come from the fold config; for ``"ad_hoc"``
+    they are the observed ``valid_time`` extent of the forecast group.
+    """
+    if evaluation_scope == "leaderboard":
+        fold = _cv_config.get_fold(fold_id)
+        return (
+            date_to_utc_datetime(fold.val_start),
+            date_to_utc_datetime(fold.val_end, end_of_day=True),
+            fold_id,
+        )
+    # groups is derived from a non-empty forecasts_df, so min/max are always non-null datetimes.
+    window_start = group_df["valid_time"].min()
+    window_end = group_df["valid_time"].max()
+    assert isinstance(window_start, datetime) and isinstance(window_end, datetime)
+    return window_start, window_end, "ad_hoc"
+
+
+def _write_metrics_to_delta(
+    path: Path,
+    enriched: pl.DataFrame,
+    exp_name: str,
+    fold_id: str,
+) -> None:
+    """Write enriched Metrics rows to the ``forecast_metrics`` Delta table.
+
+    Casts all Categorical and Enum columns to ``String`` before writing — delta-rs stores
+    Arrow dictionary arrays as plain String in Parquet, so the on-disk schema is always
+    String. Re-sending Enum/Categorical data on an overwrite would cause a schema-mismatch
+    error. Performs an idempotent overwrite of the ``(experiment_name, fold_id)`` partition
+    so re-materialising the asset replaces rows rather than duplicating them.
+    """
+    cat_cols = [
+        c
+        for c, dtype in enriched.schema.items()
+        if dtype == pl.Categorical or hasattr(dtype, "categories")
+    ]
+    delta_data = enriched.with_columns(pl.col(c).cast(pl.String) for c in cat_cols).to_arrow()
+    write_deltalake(
+        table_or_uri=path,
+        data=delta_data,
+        mode="overwrite",
+        predicate=f"experiment_name = '{exp_name}' AND fold_id = '{fold_id}'",
+        partition_by=["experiment_name", "fold_id"],
+    )
+
+
 @asset(deps=["cv_power_forecasts"])
 def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     """Compute evaluation metrics and write to ``forecast_metrics``.
@@ -518,53 +590,33 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     settings = Settings()
     mlflow.set_tracking_uri(settings.mlflow_tracking_uri)
 
-    # --- Read forecasts with population filter ------------------------------------------------
-    forecasts_scan = pl.scan_delta(str(settings.power_forecasts_data_path))
-    pf = config.population_filter
-    if pf.experiment_name is not None:
-        forecasts_scan = forecasts_scan.filter(pl.col("experiment_name") == pf.experiment_name)
-    if pf.fold_id is not None:
-        forecasts_scan = forecasts_scan.filter(pl.col("fold_id") == pf.fold_id)
-    if pf.valid_time_min is not None:
-        min_dt = datetime.fromisoformat(pf.valid_time_min)
-        if min_dt.tzinfo is None:
-            min_dt = min_dt.replace(tzinfo=timezone.utc)
-        forecasts_scan = forecasts_scan.filter(pl.col("valid_time") >= min_dt)
-    if pf.valid_time_max is not None:
-        max_dt = datetime.fromisoformat(pf.valid_time_max)
-        if max_dt.tzinfo is None:
-            max_dt = max_dt.replace(tzinfo=timezone.utc)
-        forecasts_scan = forecasts_scan.filter(pl.col("valid_time") <= max_dt)
-
-    forecasts_df = forecasts_scan.collect()
+    forecasts_df = _apply_population_filter(
+        pl.scan_delta(str(settings.power_forecasts_data_path)),
+        config.population_filter,
+    ).collect()
     if forecasts_df.height == 0:
         context.log.warning("No forecasts matched the population filter — nothing to score.")
         context.add_output_metadata({"n_rows_written": 0, "n_groups": 0})
         return
 
-    # --- Read supporting data -----------------------------------------------------------------
     actuals_lf = pt.LazyFrame.from_existing(
         pl.scan_delta(str(settings.nged_data_path / "power_time_series.delta"))
     ).set_model(PowerTimeSeries)
-    # Validate metadata at the boundary; allow_superfluous_columns=True because the parquet
-    # also carries geo columns (e.g. h3_res_5) that are not part of TimeSeriesMetadata.
+    # allow_superfluous_columns because the parquet also carries h3_res_5 and other geo columns.
     metadata_df = TimeSeriesMetadata.validate(
         pl.read_parquet(settings.nged_data_path / "metadata.parquet"),
         allow_superfluous_columns=True,
     )
 
-    # --- Process each (experiment_name, fold_id) group ---------------------------------------
     groups = (
         forecasts_df.select(["experiment_name", "fold_id"])
         .unique()
         .sort(["experiment_name", "fold_id"])
         .rows()
     )
-
     settings.forecast_metrics_data_path.parent.mkdir(parents=True, exist_ok=True)
     now = datetime.now(timezone.utc)
     total_rows = 0
-
     # Accumulate per-fold metric dicts per experiment for parent-run aggregation.
     experiment_fold_metrics: dict[str, dict[str, list[float]]] = {}
 
@@ -572,62 +624,39 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
         group_df = forecasts_df.filter(
             (pl.col("experiment_name") == exp_name) & (pl.col("fold_id") == fold_id)
         )
-
-        # Delta stores partition columns as String; cast back to Categorical so the frame
-        # conforms to PowerForecast before calling compute_metrics.
+        # Delta stores all Categorical columns as String; cast back before validating.
         group_forecasts = PowerForecast.validate(
             group_df.with_columns(
                 experiment_name=pl.col("experiment_name").cast(pl.Categorical),
                 fold_id=pl.col("fold_id").cast(pl.Categorical),
+                power_fcst_model_name=pl.col("power_fcst_model_name").cast(pl.Categorical),
             ),
             allow_superfluous_columns=True,
         )
         per_series_metrics = compute_metrics(group_forecasts, actuals_lf, metadata_df)
 
-        # Resolve evaluation-window bounds.
-        if config.evaluation_scope == "leaderboard":
-            fold = _cv_config.get_fold(fold_id)
-            window_start = date_to_utc_datetime(fold.val_start)
-            window_end = date_to_utc_datetime(fold.val_end, end_of_day=True)
-            window_label = fold_id
-        else:
-            window_start = group_df["valid_time"].min()
-            window_end = group_df["valid_time"].max()
-            window_label = "ad_hoc"
-
-        # Resolve MLflow fold run id (leaderboard only).
+        window_start, window_end, window_label = _resolve_eval_window(
+            config.evaluation_scope, fold_id, group_df
+        )
         mlflow_run_id: str | None = None
         if config.evaluation_scope == "leaderboard":
             experiment_id = get_or_create_experiment(exp_name)
             parent_run_id = get_or_create_parent_run(experiment_id)
             mlflow_run_id = get_or_create_fold_run(experiment_id, parent_run_id, fold_id)
 
-        # Enrich per-series rows with scope and window provenance.
-        enriched = per_series_metrics.with_columns(
-            experiment_name=pl.lit(exp_name).cast(pl.Categorical),
-            evaluation_scope=pl.lit(config.evaluation_scope).cast(pl.Enum(EVALUATION_SCOPES)),
-            window_start=pl.lit(window_start).cast(UTC_DATETIME_DTYPE),
-            window_end=pl.lit(window_end).cast(UTC_DATETIME_DTYPE),
-            window_label=pl.lit(window_label),
-            computed_at=pl.lit(now).cast(UTC_DATETIME_DTYPE),
-            mlflow_run_id=pl.lit(mlflow_run_id),
+        enriched = enrich_metrics_rows(
+            per_series_metrics,
+            exp_name,
+            config.evaluation_scope,
+            window_start,
+            window_end,
+            window_label,
+            now,
+            mlflow_run_id,
         )
-
-        # Write to forecast_metrics Delta, idempotent overwrite per (experiment, fold) partition.
-        delta_data = enriched.with_columns(
-            experiment_name=pl.col("experiment_name").cast(pl.String),
-            fold_id=pl.col("fold_id").cast(pl.String),
-        ).to_arrow()
-        write_deltalake(
-            table_or_uri=settings.forecast_metrics_data_path,
-            data=delta_data,
-            mode="overwrite",
-            predicate=f"experiment_name = '{exp_name}' AND fold_id = '{fold_id}'",
-            partition_by=["experiment_name", "fold_id"],
-        )
+        _write_metrics_to_delta(settings.forecast_metrics_data_path, enriched, exp_name, fold_id)
         total_rows += enriched.height
 
-        # Leaderboard scope: log per-fold metrics to the fold MLflow run.
         if config.evaluation_scope == "leaderboard":
             fold_metric_dict = build_mlflow_aggregate_metrics(per_series_metrics)
             with mlflow.start_run(run_id=mlflow_run_id):
@@ -636,7 +665,6 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
             for key, value in fold_metric_dict.items():
                 exp_metrics.setdefault(key, []).append(value)
 
-    # Leaderboard scope: log mean-across-folds aggregates to each experiment's parent run.
     if config.evaluation_scope == "leaderboard":
         for exp_name, fold_metrics in experiment_fold_metrics.items():
             experiment_id = get_or_create_experiment(exp_name)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -25,6 +25,7 @@ import mlflow
 import polars as pl
 import pytest
 from contracts.ml_schemas import EligibleTimeSeries
+from contracts.power_schemas import LIST_OF_TIME_SERIES_TYPES, TimeSeriesMetadata
 from dagster import DagsterInstance, RunConfig, materialize
 from deltalake import write_deltalake
 from mlflow.tracking import MlflowClient
@@ -124,12 +125,27 @@ def _write_nwp(path: str) -> None:
 
 
 def _write_metadata(path: Path) -> None:
-    pl.DataFrame(
-        {
-            "time_series_id": pl.Series([1], dtype=pl.Int32),
-            "h3_res_5": pl.Series([_TS1_CELL], dtype=pl.UInt64),
-            "time_series_type": ["Disaggregated Demand"],
-        }
+    # Full TimeSeriesMetadata frame plus h3_res_5 (used by the NWP spatial join).
+    TimeSeriesMetadata.validate(
+        pl.DataFrame(
+            {
+                "time_series_id": pl.Series([1], dtype=pl.Int32),
+                "time_series_name": ["Test Substation"],
+                "time_series_type": pl.Series(["Disaggregated Demand"]).cast(
+                    pl.Enum(LIST_OF_TIME_SERIES_TYPES)
+                ),
+                "units": pl.Series(["MW"]).cast(pl.Enum(["MW", "MVA"])),
+                "licence_area": pl.Series(["EMids"]).cast(pl.Enum(["EMids"])),
+                "substation_number": pl.Series([1], dtype=pl.Int32),
+                "substation_type": pl.Series(["Primary"]).cast(
+                    pl.Enum(["BSP", "EHV Customer", "GSP", "HV Customer", "Primary"])
+                ),
+                "latitude": pl.Series([53.0], dtype=pl.Float32),
+                "longitude": pl.Series([-0.5], dtype=pl.Float32),
+                "h3_res_5": pl.Series([_TS1_CELL], dtype=pl.UInt64),
+            }
+        ),
+        allow_superfluous_columns=True,
     ).write_parquet(path)
 
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,438 @@
+"""Integration tests for the ``metrics`` asset.
+
+Tests at two tiers:
+
+1. **In-process integration** (file-based MLflow + temp Delta): exercises the real asset wiring
+   without a network server. Covers leaderboard loop, idempotency, and ad_hoc scope.
+
+2. **Full-stack cross-process** (real ``mlflow server`` subprocess + temp Delta): the one test
+   from §7.10 that proves the by-tag cross-process run resolution (§4.1.1) and the artifact
+   upload/download round-trip (§4.5). Runs against a real HTTP tracking server so each
+   ``materialize()`` call — like a separate Dagster process — uses a fresh MlflowClient
+   connection to resolve runs by tag.
+"""
+
+import shutil
+import socket
+import subprocess
+import time
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+import mlflow
+import polars as pl
+import pytest
+from contracts.ml_schemas import EligibleTimeSeries
+from dagster import DagsterInstance, RunConfig, materialize
+from deltalake import write_deltalake
+from mlflow.tracking import MlflowClient
+
+from nged_substation_forecast.defs.cv_assets import (
+    MetricsConfig,
+    PopulationFilter,
+    cv_power_forecasts,
+    metrics,
+    trained_cv_model,
+)
+from nged_substation_forecast.defs.jobs import RegisterExperimentConfig, register_experiment_job
+
+pytestmark = pytest.mark.integration
+
+FOLD_ID = "mid_2025_to_mid_2026"
+EXPERIMENT_NAME = "exp_metrics_smoke"
+PARTITION_KEY = f"{EXPERIMENT_NAME}__{FOLD_ID}"
+
+_TS1_CELL = 10
+# Train day inside window [2024-04-01, 2025-06-30]; val day inside [2025-07-01, 2026-06-30].
+_TRAIN_DAY = datetime(2024, 6, 1, tzinfo=timezone.utc)
+_VAL_DAY = datetime(2025, 8, 1, tzinfo=timezone.utc)
+_VAL_MEMBERS = (0, 1, 2)
+
+_NWP_CONTINUOUS_COLS = (
+    "temperature_2m",
+    "dew_point_temperature_2m",
+    "wind_speed_10m",
+    "wind_direction_10m",
+    "wind_speed_100m",
+    "wind_direction_100m",
+    "pressure_surface",
+    "pressure_reduced_to_mean_sea_level",
+    "geopotential_height_500hpa",
+    "downward_long_wave_radiation_flux_surface",
+    "downward_short_wave_radiation_flux_surface",
+    "precipitation_surface",
+)
+
+
+def _half_hours(day: datetime) -> pl.Series:
+    return pl.datetime_range(
+        day.replace(hour=6), day.replace(hour=8), interval="30m", time_zone="UTC", eager=True
+    )
+
+
+def _write_power_with_actuals(path: str) -> None:
+    """Power for ts1 in both the training window and the validation window.
+
+    The metrics asset joins forecasts to observed power, so we need actuals for the
+    validation window (the forecast valid times) as well as training-window data.
+    """
+    rows = []
+    for i, t in enumerate(_half_hours(_TRAIN_DAY)):
+        rows.append({"time_series_id": 1, "time": t, "power": 100.0 + i})
+    for i, t in enumerate(_half_hours(_VAL_DAY)):
+        rows.append({"time_series_id": 1, "time": t, "power": 80.0 + i})
+    pl.DataFrame(rows).cast(
+        {"time_series_id": pl.Int32, "time": pl.Datetime("us", "UTC"), "power": pl.Float32}
+    ).write_delta(path)
+
+
+def _nwp_records(cell: int, day: datetime, members: tuple[int, ...]) -> list[dict]:
+    records = []
+    init_time = day.replace(hour=0)
+    for member in members:
+        for valid_time in _half_hours(day):
+            record = {
+                "nwp_model_id": "ECMWF_ENS_0_25_degree",
+                "init_time": init_time,
+                "valid_time": valid_time,
+                "ensemble_member": member,
+                "h3_index": cell,
+                "categorical_precipitation_type_surface": None,
+            }
+            record.update({col: 2000 for col in _NWP_CONTINUOUS_COLS})
+            records.append(record)
+    return records
+
+
+def _write_nwp(path: str) -> None:
+    records = _nwp_records(_TS1_CELL, _TRAIN_DAY, (0,)) + _nwp_records(
+        _TS1_CELL, _VAL_DAY, _VAL_MEMBERS
+    )
+    df = pl.DataFrame(records).cast(
+        {
+            "init_time": pl.Datetime("us", "UTC"),
+            "valid_time": pl.Datetime("us", "UTC"),
+            "ensemble_member": pl.UInt8,
+            "h3_index": pl.UInt64,
+            "categorical_precipitation_type_surface": pl.UInt8,
+            **{col: pl.Int16 for col in _NWP_CONTINUOUS_COLS},
+        }
+    )
+    write_deltalake(table_or_uri=path, data=df.to_arrow())
+
+
+def _write_metadata(path: Path) -> None:
+    pl.DataFrame(
+        {
+            "time_series_id": pl.Series([1], dtype=pl.Int32),
+            "h3_res_5": pl.Series([_TS1_CELL], dtype=pl.UInt64),
+            "time_series_type": ["Disaggregated Demand"],
+        }
+    ).write_parquet(path)
+
+
+def _write_eligible(path: str) -> None:
+    eligible = EligibleTimeSeries.validate(
+        pl.DataFrame(
+            {
+                "fold_id": pl.Series([FOLD_ID], dtype=pl.String),
+                "time_series_id": pl.Series([1], dtype=pl.Int32),
+            }
+        )
+    )
+    write_deltalake(table_or_uri=path, data=eligible.to_arrow(), partition_by=["fold_id"])
+
+
+def _base_env(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, tracking_uri: str
+) -> dict[str, Path]:
+    """Set up environment variables and write synthetic fixtures.
+
+    Returns a dict of paths that tests use for assertions.
+    """
+    nged_path = tmp_path / "NGED"
+    nged_path.mkdir()
+    forecasts_path = tmp_path / "power_forecasts"
+    metrics_path = tmp_path / "forecast_metrics"
+    cache_path = tmp_path / "cache"
+
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", tracking_uri)
+    monkeypatch.setenv("NGED_S3_BUCKET_URL", "https://example.com")
+    monkeypatch.setenv("NGED_S3_BUCKET_ACCESS_KEY", "dummy")
+    monkeypatch.setenv("NGED_S3_BUCKET_SECRET", "dummy")
+    monkeypatch.setenv("NGED_DATA_PATH", str(nged_path))
+    monkeypatch.setenv("NWP_DATA_PATH", str(tmp_path / "NWP"))
+    monkeypatch.setenv("ELIGIBLE_TIME_SERIES_DATA_PATH", str(tmp_path / "eligible"))
+    monkeypatch.setenv("MODEL_CACHE_BASE_PATH", str(cache_path))
+    monkeypatch.setenv("POWER_FORECASTS_DATA_PATH", str(forecasts_path))
+    monkeypatch.setenv("FORECAST_METRICS_DATA_PATH", str(metrics_path))
+
+    _write_power_with_actuals(str(nged_path / "power_time_series.delta"))
+    _write_nwp(str(tmp_path / "NWP"))
+    _write_metadata(nged_path / "metadata.parquet")
+    _write_eligible(str(tmp_path / "eligible"))
+
+    return {"forecasts": forecasts_path, "metrics": metrics_path, "cache": cache_path}
+
+
+def _register(instance: DagsterInstance) -> None:
+    result = register_experiment_job.execute_in_process(
+        run_config=RunConfig(
+            ops={
+                "register_experiment": RegisterExperimentConfig(
+                    experiment_name=EXPERIMENT_NAME,
+                    base_model_config="conf/model/xgboost.yaml",
+                    config_overrides={"selected_features": ["temperature_2m"], "n_estimators": 5},
+                    run_mode="full_cv",
+                )
+            }
+        ),
+        instance=instance,
+    )
+    assert result.success
+
+
+def _metrics_run_config(scope: str = "leaderboard") -> RunConfig:
+    return RunConfig(
+        ops={
+            "metrics": MetricsConfig(
+                population_filter=PopulationFilter(
+                    experiment_name=EXPERIMENT_NAME,
+                    fold_id=FOLD_ID,
+                ),
+                evaluation_scope=scope,
+            )
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# In-process integration tests (file-based MLflow)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def file_mlflow_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> dict[str, Path]:
+    tracking_uri = f"file://{tmp_path / 'mlruns'}"
+    monkeypatch.setenv("MLFLOW_ALLOW_FILE_STORE", "true")
+    mlflow.set_tracking_uri(tracking_uri)
+    return _base_env(tmp_path, monkeypatch, tracking_uri)
+
+
+def _run_cv_pipeline(instance: DagsterInstance) -> None:
+    """Register, train, and predict for the leaderboard fold."""
+    _register(instance)
+    assert materialize([trained_cv_model], partition_key=PARTITION_KEY, instance=instance).success
+    assert materialize([cv_power_forecasts], partition_key=PARTITION_KEY, instance=instance).success
+
+
+def test_metrics_leaderboard_writes_forecast_metrics_delta(
+    file_mlflow_env: dict[str, Path],
+) -> None:
+    instance = DagsterInstance.ephemeral()
+    _run_cv_pipeline(instance)
+    assert materialize(
+        [metrics], run_config=_metrics_run_config("leaderboard"), instance=instance
+    ).success
+
+    fm = pl.read_delta(str(file_mlflow_env["metrics"]))
+    assert fm.height > 0
+
+    # Every row carries the correct scope, fold, and experiment.
+    assert (fm["evaluation_scope"] == "leaderboard").all()
+    assert (fm["fold_id"] == FOLD_ID).all()
+    assert (fm["experiment_name"] == EXPERIMENT_NAME).all()
+
+    # Window columns are populated.
+    assert fm["window_start"].is_not_null().all()
+    assert fm["window_end"].is_not_null().all()
+    assert (fm["window_label"] == FOLD_ID).all()
+    assert fm["computed_at"].is_not_null().all()
+
+    # time_series_type is populated from metadata.
+    assert (fm["time_series_type"] == "Disaggregated Demand").all()
+
+    # mlflow_run_id links back to the fold run.
+    assert fm["mlflow_run_id"].is_not_null().all()
+
+
+def test_metrics_leaderboard_logs_to_mlflow(
+    file_mlflow_env: dict[str, Path],
+) -> None:
+    instance = DagsterInstance.ephemeral()
+    _run_cv_pipeline(instance)
+    assert materialize(
+        [metrics], run_config=_metrics_run_config("leaderboard"), instance=instance
+    ).success
+
+    experiment = mlflow.get_experiment_by_name(EXPERIMENT_NAME)
+    assert experiment is not None
+    client = MlflowClient()
+
+    # Fold run has per-type + overall metrics.
+    fold_runs = client.search_runs(
+        experiment_ids=[experiment.experiment_id],
+        filter_string=f"tags.cv_role = 'fold' and tags.fold_id = '{FOLD_ID}'",
+    )
+    assert len(fold_runs) == 1
+    fold_metrics = fold_runs[0].data.metrics
+    assert "rmse__all" in fold_metrics
+    assert "rmse__disaggregated_demand" in fold_metrics
+
+    # Parent run has aggregate metrics (mean across folds — one fold here, so same values).
+    parent_runs = client.search_runs(
+        experiment_ids=[experiment.experiment_id],
+        filter_string="tags.cv_role = 'parent'",
+    )
+    assert len(parent_runs) == 1
+    parent_metrics = parent_runs[0].data.metrics
+    assert "rmse__all" in parent_metrics
+
+
+def test_metrics_is_idempotent(file_mlflow_env: dict[str, Path]) -> None:
+    instance = DagsterInstance.ephemeral()
+    _run_cv_pipeline(instance)
+
+    assert materialize(
+        [metrics], run_config=_metrics_run_config("leaderboard"), instance=instance
+    ).success
+    first_height = pl.read_delta(str(file_mlflow_env["metrics"])).height
+
+    # Re-materialising overwrites the partition rather than appending.
+    assert materialize(
+        [metrics], run_config=_metrics_run_config("leaderboard"), instance=instance
+    ).success
+    assert pl.read_delta(str(file_mlflow_env["metrics"])).height == first_height
+
+
+def test_metrics_ad_hoc_no_mlflow_logging(file_mlflow_env: dict[str, Path]) -> None:
+    instance = DagsterInstance.ephemeral()
+    _run_cv_pipeline(instance)
+    assert materialize(
+        [metrics], run_config=_metrics_run_config("ad_hoc"), instance=instance
+    ).success
+
+    # Delta rows written.
+    fm = pl.read_delta(str(file_mlflow_env["metrics"]))
+    assert fm.height > 0
+    assert (fm["evaluation_scope"] == "ad_hoc").all()
+    assert fm["mlflow_run_id"].is_null().all()
+    assert (fm["window_label"] == "ad_hoc").all()
+
+    # No MLflow metrics logged (fold run was never created; parent run has no metrics).
+    experiment = mlflow.get_experiment_by_name(EXPERIMENT_NAME)
+    assert experiment is not None
+    client = MlflowClient()
+    fold_runs = client.search_runs(
+        experiment_ids=[experiment.experiment_id],
+        filter_string=f"tags.cv_role = 'fold' and tags.fold_id = '{FOLD_ID}'",
+    )
+    # The fold run exists (created by trained_cv_model), but has no rmse metrics from metrics asset.
+    for run in fold_runs:
+        assert "rmse__all" not in run.data.metrics
+
+
+# ---------------------------------------------------------------------------
+# Full-stack cross-process test (real mlflow server)
+# ---------------------------------------------------------------------------
+
+
+def _find_free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _wait_for_mlflow_server(url: str, timeout_s: float = 30.0) -> None:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        try:
+            urllib.request.urlopen(url, timeout=1)
+            return
+        except urllib.error.URLError, OSError:
+            time.sleep(0.5)
+    pytest.fail(f"MLflow server at {url} did not become ready within {timeout_s}s")
+
+
+def test_full_stack_real_mlflow_server(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Full-stack test: real HTTP MLflow server + artifact round-trip + tag resolution.
+
+    Proves §4.1.1 (cross-call tag resolution) and §4.5 (artifact upload/download).
+    Each ``materialize()`` call starts with a fresh ``mlflow.set_tracking_uri`` inside
+    the asset body — simulating what happens when assets run in separate Dagster processes.
+    The artifact round-trip is proved by deleting the local model cache between
+    ``trained_cv_model`` and ``cv_power_forecasts``.
+    """
+    port = _find_free_port()
+    mlflow_proc = subprocess.Popen(
+        [
+            "mlflow",
+            "server",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            str(port),
+            "--backend-store-uri",
+            str(tmp_path / "mlruns"),
+            "--default-artifact-root",
+            str(tmp_path / "artifacts"),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    try:
+        tracking_uri = f"http://127.0.0.1:{port}"
+        _wait_for_mlflow_server(f"{tracking_uri}/health")
+        mlflow.set_tracking_uri(tracking_uri)
+
+        paths = _base_env(tmp_path, monkeypatch, tracking_uri)
+        instance = DagsterInstance.ephemeral()
+        _register(instance)
+
+        # Train — uploads model artifacts to the real server.
+        assert materialize(
+            [trained_cv_model], partition_key=PARTITION_KEY, instance=instance
+        ).success
+
+        # Delete local cache to force artifact re-download on the next step (§4.5 cache miss).
+        shutil.rmtree(paths["cache"], ignore_errors=True)
+
+        # Predict — downloads artifacts from the real server on cache miss.
+        assert materialize(
+            [cv_power_forecasts], partition_key=PARTITION_KEY, instance=instance
+        ).success
+
+        # Score — proves tag-based run resolution: the asset calls get_or_create_fold_run()
+        # with a fresh MlflowClient connection and finds the same run that trained_cv_model used.
+        assert materialize(
+            [metrics],
+            run_config=_metrics_run_config("leaderboard"),
+            instance=instance,
+        ).success
+
+        # Assert leaderboard metrics landed on the real server.
+        experiment = mlflow.get_experiment_by_name(EXPERIMENT_NAME)
+        assert experiment is not None
+        parent_runs = MlflowClient().search_runs(
+            experiment_ids=[experiment.experiment_id],
+            filter_string="tags.cv_role = 'parent'",
+        )
+        assert len(parent_runs) == 1
+        assert "rmse__all" in parent_runs[0].data.metrics
+
+        # Assert forecast_metrics Delta has rows.
+        fm = pl.read_delta(str(paths["metrics"]))
+        assert (
+            fm.filter(
+                (pl.col("experiment_name") == EXPERIMENT_NAME)
+                & (pl.col("fold_id") == FOLD_ID)
+                & (pl.col("evaluation_scope") == "leaderboard")
+            ).height
+            > 0
+        )
+
+    finally:
+        mlflow_proc.terminate()
+        mlflow_proc.wait(timeout=10)


### PR DESCRIPTION
## Summary

- Implements the `metrics` Dagster asset (§4.8 of `dagster_plan.md`), closing the full CV leaderboard loop milestone
- Reads `power_forecasts` Delta, joins observed power, calls `compute_metrics()`, and writes per-series rows to `forecast_metrics` Delta (partitioned by `experiment_name, fold_id`) with idempotent overwrite
- For `leaderboard` scope, logs per-fold and mean-across-folds aggregate metrics to MLflow (by-tag run resolution, cross-process safe)
- For `ad_hoc` scope, writes to Delta only — no MLflow logging
- `PopulationFilter` + `MetricsConfig` typed Dagster `Config` with `Literal["leaderboard", "ad_hoc"]` renders as a dropdown in the Dagster UI
- Extends `compute_metrics()` with `metadata: pl.DataFrame` parameter to join `time_series_type` onto every metric row
- Adds `build_mlflow_aggregate_metrics()` pure helper: `"{metric}__all"` + `"{metric}__{type_slug}"` keys
- Schema changes: adds `experiment_name` (Delta partition key, `allow_missing=True`) and relaxes `time_series_type` to `str | None` in `Metrics`

## Test plan

- [x] 13 unit tests in `packages/ml_core/tests/test_metrics.py` (MAE/NMAE/RMSE/MBE correctness, ensemble averaging, multi-fold, null type, aggregate key slugs)
- [x] `tests/test_metrics.py` in-process integration: leaderboard loop, idempotency, ad_hoc scope (file-based MLflow, `MLFLOW_ALLOW_FILE_STORE=true`)
- [x] Full-stack test with real `mlflow server` subprocess — proves cross-process tag resolution and artifact round-trip
- [x] 161 existing tests pass with no regressions
- [ ] Manual smoke via `uv run dg dev`: register → trained_cv_model → cv_power_forecasts → metrics, confirm `rmse__all` appears on the MLflow parent run

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)