### PR TITLE
Add markdown linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,3 +25,14 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+      - id: pymarkdown
+        name: pymarkdown (markdown files)
+        entry: uv run pymarkdown scan
+        language: system
+        types: [markdown]
+        exclude: ^plans/
+      - id: lint-docstring-markdown
+        name: pymarkdown (Python docstrings)
+        entry: uv run python scripts/lint_docstring_markdown.py
+        language: system
+        types: [python]

--- a/.pymarkdown-docstrings.json
+++ b/.pymarkdown-docstrings.json
@@ -1,0 +1,6 @@
+{
+  "plugins": {
+    "md041": { "enabled": false },
+    "md047": { "enabled": false }
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ uv run ruff check .            # check
 uv run ruff check . --fix      # fix
 uv run ruff format .           # format
 uv run ty check                # type checking
+uv run pymarkdown scan -r docs README.md CLAUDE.md metadata/README.md packages/*/README.md  # markdown lint
 
 # Testing
 uv run pytest                                # all tests
@@ -24,6 +25,11 @@ uv run dg dev                  # open http://localhost:3000
 # Marimo notebooks
 uv run marimo edit packages/notebooks/some_notebook.py
 ```
+
+Markdown (README.md files, docs/*.md, and Python docstrings) is linted automatically by the
+pre-commit hook, but when developing code or docs it's a good idea to run the markdown lint
+command above yourself before committing, for faster feedback than waiting on the commit-time
+hook.
 
 ## Architecture
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,7 @@ This is a `uv` workspace monorepo. The root `src/nged_substation_forecast/` is t
 ### Dagster Assets (`src/nged_substation_forecast/defs/assets.py`)
 
 Three main assets:
+
 - `power_time_series_and_metadata` — pulls NGED telemetry from S3, appends to Delta Lake, upserts metadata parquet
 - `h3_grid_weights` — computes fractional H3 cell overlap with the GB boundary for spatial NWP aggregation
 - `ecmwf_ens` — daily-partitioned asset that downloads ECMWF ENS NWP, scales to `Int16`, writes to Delta Lake
@@ -66,6 +67,7 @@ All tabular data flowing through the system is validated with **Patito** models.
 **Critical design invariant — no lookahead bias:** `power_fcst_init_time` (when we make the forecast) is distinct from `nwp_init_time` (when the NWP model ran). Power lag features are nullified via `_nullify_leaky_lags()` when the lag is shorter than or equal to the forecast lead time. Weather lags use a dual-strategy join: same NWP run for future target times, freshest NWP run for past target times.
 
 Two operating modes:
+
 - **Bulk training and multi-run backtesting** (recommended for most callers): `power_fcst_init_time` is `None`; it is derived per-row as `nwp_init_time + nwp_publication_delay_hours`.
 - **Single-run inference or backfilling**: `power_fcst_init_time` is provided; NWP is joined on `(time_series_id, valid_time, nwp_init_time)` for the one matching NWP run.
 
@@ -92,6 +94,7 @@ Each `BaseForecaster` also carries a `feature_engineer: ClassVar[FeatureEngineer
   is encouraged — e.g. a docstring pointing at a page in `docs/architecture/`.
 - **MkDocs-compatible constant docs** — document module-level constants with a string literal
   immediately after the assignment, not with Sphinx-style `#:` comments. This is correct:
+
   ```python
   MY_CONST: Final[str] = "value"
   """One-line summary.
@@ -99,6 +102,7 @@ Each `BaseForecaster` also carries a `feature_engineer: ClassVar[FeatureEngineer
   Optional further detail.
   """
   ```
+
 - `snake_case` for variables/functions, `PascalCase` for classes, `UPPER_SNAKE_CASE` for constants.
 - All function signatures must have complete type hints including return types.
 - All consts must be marked with the maximally "constant" type.
@@ -119,6 +123,7 @@ These rules are all about making Polars code easy to read.
 
 - **`Literal` type aliases — use a `Type` suffix** to distinguish them from the runtime tuples
   that drive Polars `Enum` declarations. Example:
+
   ```python
   EVALUATION_SCOPES: Final[tuple[str, ...]] = ("leaderboard", "production_monitoring", "ad_hoc")
   """Runtime tuple — used as pl.Enum(EVALUATION_SCOPES)."""
@@ -126,6 +131,7 @@ These rules are all about making Polars code easy to read.
   EvalScopeType = Literal["leaderboard", "ad_hoc"]
   """Type annotation — currently-implemented subset; update when adding a new scope."""
   ```
+
   The `Type`-suffixed alias is what goes in function signatures; the `UPPER_SNAKE_CASE` tuple is
   what goes into `pl.Enum(...)`. They serve different purposes and should both exist.
 

--- a/README.md
+++ b/README.md
@@ -25,12 +25,15 @@ This repo is a `uv` [workspace](https://docs.astral.sh/uv/concepts/projects/work
 3. **Install pre-commit hooks**: `uv run pre-commit install`
 
 To run Dagster:
+
 1. `uv run dg dev`
-2. Open http://localhost:3000 in your browser to see the project.
+2. Open `http://localhost:3000` in your browser to see the project.
 
 Optional: To allow Dagster to remember its state after you shut it down:
+
 1. `mkdir ~/dagster_home/`
 2. Put the following into `~/dagster_home/dagster.yaml`:
+
     ```yaml
     storage:
       sqlite:
@@ -45,6 +48,7 @@ Optional: To allow Dagster to remember its state after you shut it down:
         - nged_data
       python_log_level: DEBUG
     ```
+
 3. Add `export DAGSTER_HOME=<dagster_home_path>` to your `.bashrc` file, and restart your terminal.
 
 ### Linting & Formatting
@@ -62,14 +66,14 @@ Optional: To allow Dagster to remember its state after you shut it down:
 ### Development
 
 - **Run Dagster UI**: `uv run dagster dev`
-- Open http://localhost:3000 in your browser to see the project.
+- Open `http://localhost:3000` in your browser to see the project.
 - **Run Marimo notebooks**: `uv run marimo edit packages/notebooks/some_notebook.py`
 
 ### Documentation
 
 The docs are built with [MkDocs](https://www.mkdocs.org/) (Material theme). The tooling is part of the `dev` dependency group, so `uv sync` installs it.
 
-- **Serve docs locally with live reload**: `uv run mkdocs serve`, then open http://localhost:8000. The site rebuilds automatically as you edit files in `docs/`.
+- **Serve docs locally with live reload**: `uv run mkdocs serve`, then open `http://localhost:8000`. The site rebuilds automatically as you edit files in `docs/`.
 - **Build the static site**: `uv run mkdocs build` — renders the docs into the `site/` directory.
 
 ---

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ Optional: To allow Dagster to remember its state after you shut it down:
 - **Fix linting**: `uv run ruff check . --fix`
 - **Format code**: `uv run ruff format .`
 - **Type checking**: `uv run ty check`
+- **Markdown linting**: `uv run pymarkdown scan -r docs README.md CLAUDE.md metadata/README.md packages/*/README.md`
+
+Markdown (README.md files, docs/*.md, and Python docstrings) is linted automatically by the
+pre-commit hook, but when developing code or docs it's a good idea to run the markdown lint
+command above yourself before committing, for faster feedback than waiting on the commit-time
+hook.
 
 ### Testing
 

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -3,4 +3,5 @@
 This section contains the auto-generated API documentation for the project.
 
 ## Main Application
+
 ::: nged_substation_forecast

--- a/docs/architecture/code-style.md
+++ b/docs/architecture/code-style.md
@@ -3,6 +3,7 @@
 (This is mostly written for LLM coding agents!)
 
 ## General Principles
+
 - **Python Version**: Use Python 3.14+.
 - **Type Hints**: All function signatures **must** use expressive type hints for all arguments and return types. Use `typing` and `collections.abc` as needed.
 - **Modularity**: Keep logic in small, focused packages under `packages/`. The main app in `src/` should primarily handle orchestration.
@@ -12,16 +13,18 @@
 - **Tests**: Unit tests should each be a short, simple function. For each function in the main code, there should be at least one test function that tests the "happy path", and one test function for each of the main "unhappy" paths. Never relax an existing test just to get it to pass!
 
 ## Formatting & Linting (Ruff)
+
 - **Line Length**: 100 characters.
 - **Quotes**: Use **double quotes** (`"`) for strings.
 - **Docstrings**: Use **Google convention** for docstrings.
 - **Imports**: Sorted automatically by `ruff` (isort rules).
 - **Naming**:
-    - Variables/Functions: `snake_case`
-    - Classes: `PascalCase`
-    - Constants: `UPPER_SNAKE_CASE`
+  - Variables/Functions: `snake_case`
+  - Classes: `PascalCase`
+  - Constants: `UPPER_SNAKE_CASE`
 
 ## Data Handling
+
 - **Tabular Data**: Use **Polars** (`import polars as pl`) for dataframes. Pandas is strictly forbidden. Use Polars for all tabular data.
 - **Lazy evaluation**: Use `pl.LazyFrame` throughout the pipeline. **Do not call `.collect()` before the model boundary.** See [Lazy Evaluation Strategy](overview.md#lazy-evaluation-strategy) for the full contract.
 - **Gridded/NWP Data**: Use **Xarray** and **Zarr**.
@@ -29,12 +32,14 @@
 - **Persistence**: Prefer partitioned Parquet files for tabular data.
 
 ## Machine Learning (PyTorch)
+
 - Use **PyTorch** for differentiable physics models.
 - Use **PyTorch Geometric** for GNN implementations.
 - Use **MLFlow** for tracking experiments.
 - Follow the "test-harness" pattern: separate research logic from production orchestration but ensure they use the same data contracts.
 
 ## Error Handling
+
 - Use specific exceptions.
 - Leverage Sentry for observability in production-like code.
 - Validate data at boundaries using data contracts.

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -12,7 +12,7 @@ The system is designed as a modular monorepo using [uv workspaces](https://docs.
 
 * **Environment & Modularity**: `uv` workspace (Monorepo). Python 3.14. Individual components must be pip-installable with expressive type hints.
 * **Data Processing**: **Polars**. Chosen for extreme speed and its native `join_asof` functionality to guarantee no future-data leakage during feature engineering.
-    * **Centralized Data Preparation**: All data entering ML models passes through a centralized preparation step to enforce strict data contracts, handle missing entities, and ensure consistency between training and inference.
+  * **Centralized Data Preparation**: All data entering ML models passes through a centralized preparation step to enforce strict data contracts, handle missing entities, and ensure consistency between training and inference.
 * **Storage**: **Delta Lake** on cloud object storage for both power data and NWP weather data. Delta Lake provides ACID transactions, time-travel, and efficient partitioning. NWP data is quantised to 12-bit precision and stored as `Int16` (roughly halving the size versus `float32`), with `zstd` level-14 compression — compressing the full ECMWF ENS dataset for Great Britain to approximately 40 GB per year. A single day's NWP data takes about one minute to download and convert.
 * **Orchestration**: **Dagster**. Manages the pipeline via Software-Defined Assets (SDAs). Partitioned by NWP init time, not substation, allowing models to train globally across all substations (if they want to). Dagster is responsible for detecting bad data.
 * **Configuration Management**: **Hydra** combined with `pydantic-settings`. Dagster passes string overrides (e.g., model=xgboost_global) to trigger Hydra's Config Groups, swapping massive architectural parameter trees. The resolved YAML is logged to MLflow.
@@ -25,7 +25,7 @@ The system is designed as a modular monorepo using [uv workspaces](https://docs.
 
 The entire feature-engineering pipeline operates on Polars `LazyFrame`s. No code between reading from storage and calling `BaseForecaster.train()` or `predict()` is allowed to call `.collect()`. The pipeline is:
 
-```
+```text
 NwpOnDisk.scan_delta(path)               # lazy scan
   → NwpOnDisk.to_nwp_in_memory()        # lazy expression; no collect
   → FeatureEngineer.engineer()           # spatial join + feature pipeline;
@@ -35,9 +35,9 @@ NwpOnDisk.scan_delta(path)               # lazy scan
 
 **Why it matters:**
 
-- **Memory**: Polars only materialises the data at the last moment, at the model boundary. Intermediate representations (individual join outputs, lag columns before filtering) are never written to RAM.
-- **Query optimisation**: Polars can see the full plan end-to-end and push down filters (e.g. date ranges, `time_series_id` subsets) into the Delta Lake scan before any data crosses the wire.
-- **Clean boundaries**: The materialisation site is the model boundary — the one place where a third-party library (XGBoost, PyTorch, …) needs a concrete in-memory array. Keeping it there makes the boundary explicit and easy to find.
+* **Memory**: Polars only materialises the data at the last moment, at the model boundary. Intermediate representations (individual join outputs, lag columns before filtering) are never written to RAM.
+* **Query optimisation**: Polars can see the full plan end-to-end and push down filters (e.g. date ranges, `time_series_id` subsets) into the Delta Lake scan before any data crosses the wire.
+* **Clean boundaries**: The materialisation site is the model boundary — the one place where a third-party library (XGBoost, PyTorch, …) needs a concrete in-memory array. Keeping it there makes the boundary explicit and easy to find.
 
 **The one exception** is a `limit(1).collect()` guard in `_build_historical_weather` (inside `ml_core`) that cheaply checks for the NWP control member before building the lazy plan, so the pipeline fails loudly instead of silently returning an empty frame.
 
@@ -76,8 +76,8 @@ Prediction is bounded by chunking on **`init_time`** (`_PREDICT_INIT_CHUNK`, 14 
 
 All forecasting models subclass `BaseForecaster` (defined in `ml_core`), which provides a common `train` / `predict` / `save` / `load` interface. The model wrapper encapsulates the model weights and all translation logic, keeping Dagster assets completely agnostic to the underlying implementation. Each subclass of `BaseForecaster` is responsible for defining:
 
-- _Feature engineering_: Each subclass carries a `feature_engineer: ClassVar[FeatureEngineer]` strategy (composition, not inheritance) that owns the full preparation pipeline — from raw inputs (observed power, gridded NWP, time-series metadata) to an `AllFeatures` frame. The default `TabularFeatureEngineer` does the nearest-cell NWP spatial join then runs the tabular feature pipeline. A future model that needs a different data view (e.g. a CNN wanting a spatial NWP crop per time series) overrides `feature_engineer` with a different `FeatureEngineer` subclass without touching `BaseForecaster` or any other model. `FeatureEngineer` and `TabularFeatureEngineer` live in `packages/ml_core/src/ml_core/features/`.
-- _Input translation_: Transforms the canonical `AllFeatures` Polars LazyFrame into the required model shape.
-- _Output translation_: Converts native model outputs into the strict `PowerForecast` schema.
-- _Persistence_: Each subclass owns its own save/load format. `XGBoostForecaster` writes one `.ubj` file per `time_series_id` plus a `meta.json` containing the full serialised `XGBoostConfig`. (This may change later. We may switch to saving models using native MLflow flavors (e.g., `mlflow.xgboost.log_model`), which serialize the raw model object directly.)
-- _Identity_: Model name, version, and optional MLflow experiment ID travel with the config, so every `PowerForecast` row is self-describing.
+* _Feature engineering_: Each subclass carries a `feature_engineer: ClassVar[FeatureEngineer]` strategy (composition, not inheritance) that owns the full preparation pipeline — from raw inputs (observed power, gridded NWP, time-series metadata) to an `AllFeatures` frame. The default `TabularFeatureEngineer` does the nearest-cell NWP spatial join then runs the tabular feature pipeline. A future model that needs a different data view (e.g. a CNN wanting a spatial NWP crop per time series) overrides `feature_engineer` with a different `FeatureEngineer` subclass without touching `BaseForecaster` or any other model. `FeatureEngineer` and `TabularFeatureEngineer` live in `packages/ml_core/src/ml_core/features/`.
+* _Input translation_: Transforms the canonical `AllFeatures` Polars LazyFrame into the required model shape.
+* _Output translation_: Converts native model outputs into the strict `PowerForecast` schema.
+* _Persistence_: Each subclass owns its own save/load format. `XGBoostForecaster` writes one `.ubj` file per `time_series_id` plus a `meta.json` containing the full serialised `XGBoostConfig`. (This may change later. We may switch to saving models using native MLflow flavors (e.g., `mlflow.xgboost.log_model`), which serialize the raw model object directly.)
+* _Identity_: Model name, version, and optional MLflow experiment ID travel with the config, so every `PowerForecast` row is self-describing.

--- a/docs/background/data-quality.md
+++ b/docs/background/data-quality.md
@@ -3,26 +3,33 @@
 NGED's distribution-level data is considerably messier than transmission-level data. Key issues observed in the trial area:
 
 ## NGED Data Availability
+
 Availability of the data for the 32 time series in the trial area:
 
 ![Availability of the data for the 32 time series in the trial area](assets/NGED_data_availability_periods.png)
 
 ## Early ramp-up period
+
 The first couple of months after a meter is installed tend to have poor data quality. This is handled by simply dropping the first two months of each time series. ![Bad data for the first few months for 3 substations](assets/bad_data_for_first_months.png)
 
 ## False zeros
+
 Substation time series occasionally report zero when the true value is non-zero. These are identifiable because they are isolated amongst non-zero values. ![Example plot of a time series (Boston BSP) having some one-off falls to zero](assets/false_zeros_in_Boston_BSP.png). ![Distributions for Boston BSP and Sleaford primary showing abnormal amount of zeros, especially when Sleaford doesn’t experience any near-zero values](assets/histograms_showing_false_zeros.png)
 
 ## Stuck values
+
 Some time series go "stuck" for hours or days (standard deviation near zero over a 24-hour window).
 
 ## Missing data
+
 Gaps range from a few half-hours to months. Solar farms frequently have no data overnight (expected), but also have unexplained daytime gaps. ![Examples of missing data in streams from solar farms: Manor Farm and Canopus Solar Farm. Canopus has a known analogue issue.](assets/missing_data.png)
 
 ## Apparent power (MVA) metering
+
 Some substations only have MVA meters, which report the *absolute value* of power flow — they cannot detect direction. When generation exceeds demand and power flows "backwards", the MVA reading increases rather than going negative. This "bouncing off zero" behaviour looks like a demand increase but is actually reverse power flow. The following figure shows power flow for Stickney primary and Leverton Solar Park; note the absence of peaks at Stickney primary on May 3rd and 4th when Leverton experienced lower generation: ![Power flow for Stickney primary and Leverton Solar Park; note the absence of peaks at Stickney on May 3rd and 4th, when Leverton experienced lower generation](assets/MVA_metering_bounce_at_Stickney_primary.png)
 
 ## Switching events
+
 Power is periodically diverted from one substation to another during maintenance or in response to faults ("abnormal running arrangement"). Each substation spends roughly 10% of its operating time in an abnormal arrangement. This severely biases lagged-power features (the single most informative feature for demand forecasting) if not detected and handled. Recovering the demand that *would* have been metered under the normal running arrangement is described in [Switching Events](switching-events.md); the staged solution plan is in the [roadmap](../roadmap/switching-events.md) (v0.6 detector → v2 mixture models).
 
 See the ["Data sources" section of our Milestone 1 report](https://docs.google.com/document/d/1UF-mjfSdQfQxefAunDqEOr_GyYTjSlGk4EeuiNoXAxk/edit?tab=t.0#heading=h.etqoj9ahy92h) for a more detailed discussion, and plenty of graphs!

--- a/docs/background/requirements.md
+++ b/docs/background/requirements.md
@@ -23,5 +23,5 @@
 
 OCF delivers forecasts as **Delta Lake tables on AWS S3**, updated every 6 hours. Delta Lake provides ACID transactions, meaning NGED never reads an incomplete forecast. The tables are designed as "building blocks" that NGED can combine to construct:
 
-- A **Normal Operation Forecast** (MW or MVA): the [−1, +1] forecast multiplied by the site's nominal capacity. Assumes the grid is in a normal running arrangement with all generators at full unconstrained capacity.
-- A **Prevailing Conditions Forecast** (MW or MVA): the [−1, +1] forecast multiplied by the most recently observed effective capacity, reflecting current switching state and any reduced generator capacity.
+* A **Normal Operation Forecast** (MW or MVA): the [−1, +1] forecast multiplied by the site's nominal capacity. Assumes the grid is in a normal running arrangement with all generators at full unconstrained capacity.
+* A **Prevailing Conditions Forecast** (MW or MVA): the [−1, +1] forecast multiplied by the most recently observed effective capacity, reflecting current switching state and any reduced generator capacity.

--- a/docs/background/switching-events.md
+++ b/docs/background/switching-events.md
@@ -20,7 +20,7 @@ This matters enormously, and it is the crux of everything below:
 
 The picture below contrasts the *physical* mesh (all paths exist) with the *operated* radial state (some switches held open, marked `/`, so power flows in a tree). `[A]`–`[D]` are primary substations; `===` is an energised circuit; `/` is a normally-open switch; `·` marks the load tapped along each circuit.
 
-```
+```text
    PHYSICAL MESH (all paths exist)          OPERATED RADIALLY (open switches break loops)
 
         [A]=====·=====[B]                        [A]=====·=====[B]
@@ -65,7 +65,7 @@ NGED have confirmed two things that shape the entire problem:
 
 The diagram shows why "how much moved?" has no clean answer. The load `·` is spread along the circuit between `[A]` and `[B]`; the cut point (open switch `/`) can sit anywhere, and wherever it sits determines how much load each end keeps.
 
-```
+```text
    Circuit between two substations, load tapped continuously along it:
 
    [A]==·==·==·==·==·==·==·== / ==·==·==[B]

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,11 +10,11 @@ Each forecast is:
 
 - **Probabilistic** — expressed as an ensemble of 51 members (one per ECMWF ENS member), or as percentiles
 - **14-day horizon**, half-hourly temporal resolution
-- **Updated every 6 hours**
+- Refreshed **every 6 hours**
 - **Scaled to [−1, +1]** — a normalised value that NGED multiplies by the site's capacity to get MW/MVA
-- **Sign convention**:
-    - *Substations*: positive = power flowing towards end-users; negative = excess generation flowing back into the grid
-    - *Customer meters (generators)*: positive = generator sending power to NGED's grid; negative = customer consuming power
+- **Sign convention** depends on the time series type:
+  - *Substations*: positive = power flowing towards end-users; negative = excess generation flowing back into the grid
+  - *Customer meters (generators)*: positive = generator sending power to NGED's grid; negative = customer consuming power
 
 ## Scope
 

--- a/docs/ml_experimentation/dagster-workflow.md
+++ b/docs/ml_experimentation/dagster-workflow.md
@@ -111,7 +111,7 @@ MLflow experiment and partition keys rather than creating duplicates.
 
 The MLflow run structure after training looks like this:
 
-```
+```text
 Experiment "xgboost_smoke_test"
 └── cv_summary (parent run)   tags={cv_role: parent}
     │   params: n_estimators=100, learning_rate=0.05, …
@@ -210,7 +210,7 @@ in the run config dialog before launching.
 
 After step 8, the MLflow run structure looks like this:
 
-```
+```text
 Experiment "xgboost_smoke_test"
 └── cv_summary (parent run)   tags={cv_role: parent}
     │   params: n_estimators=100, learning_rate=0.05, …

--- a/docs/ml_experimentation/index.md
+++ b/docs/ml_experimentation/index.md
@@ -5,7 +5,6 @@ How we run and evaluate ML forecasting experiments. Unlike the [roadmap](../road
 is **implemented** and in use — the durable home for ML experimentation docs once they leave the
 roadmap.
 
-
 ## Documents
 
 - [Running an ML experiment end-to-end](dagster-workflow.md) — step-by-step recipe for going

--- a/docs/roadmap/differentiable-physics.md
+++ b/docs/roadmap/differentiable-physics.md
@@ -15,7 +15,7 @@ It is the deep-dive behind two of the "innovative and unique" capabilities highl
 Milestone 1 report: estimating the **dynamically changing effective capacity** of generators, and
 natively handling **apparent-power (MVA) metering** and **unmetered generation**.
 
-### How to read this document
+## How to read this document
 
 The sections build up from the problem statement to the full system, roughly in roadmap order:
 
@@ -74,16 +74,16 @@ learn basic physical invariants and are prone to overfitting or hallucinating no
 behaviour. We inject a **Differentiable Physics (DP)** layer directly into our computational graph
 for three core reasons:
 
-* **Data and sample efficiency:** The model does not have to spend capacity re-learning solar
+- **Data and sample efficiency:** The model does not have to spend capacity re-learning solar
   geometry (where the sun is) or the shape of a turbine power curve (roughly cubic in wind speed
   between cut-in and rated, then flat to rated power, then zero beyond cut-out). The physics engine
   supplies these constraints for free, letting the ML components focus entirely on atmospheric and
   behavioural nuances.
-* **True invertibility (inputs as parameters):** Because every operation in our physics engine
+- **True invertibility (inputs as parameters):** Because every operation in our physics engine
   preserves gradients, we can backpropagate errors all the way to the *inputs*. This lets us treat
   unobserved variables (like local irradiance) or system configurations as parameters that can be
   solved via gradient descent.
-* **Interpretability:** Instead of inspecting uninterpretable latent layers, our system updates
+- **Interpretability:** Instead of inspecting uninterpretable latent layers, our system updates
   explicit physical parameters like tilt, azimuth, or capacity. This lets engineers immediately
   audit the model's assumptions.
 
@@ -115,7 +115,7 @@ synchronised-peak regime (precisely the regime NGED cares about most) is the har
 The fundamental insight is to treat the meter reading as the output of a **forward model** that
 takes latent demand and DER generation as inputs:
 
-```
+```text
 observed_power(t) = latent_demand(t) − pv_generation(t) − wind_generation(t) − battery_net(t) + losses(t)
 ```
 
@@ -141,7 +141,7 @@ solar PV farms, large wind farms, grid-scale batteries — while a long tail of 
 (and, strictly, EV chargers and heat pumps on the demand side). Written out in full, the forward
 model is closer to:
 
-```
+```text
 observed = latent_demand
            − (pv_metered + pv_unmetered)
            − (wind_metered + wind_unmetered)
@@ -191,20 +191,20 @@ to estimate their physical parameters — most importantly the effective capacit
 down over time as a result of maintenance, faults, and build-out — feeding the
 [`effective_capacity`](delivery-tables.md#table-4-effective_capacity) delivery table.
 
-* **The problem:** A generator's effective capacity drifts over time — turbines fail, inverters drop
+- **The problem:** A generator's effective capacity drifts over time — turbines fail, inverters drop
   out, panels soil and degrade (or are cleaned and replaced). A static nameplate value introduces
   large downstream errors.
-* **The solution:** With the site's coordinates locked and live weather passed through the DP
+- **The solution:** With the site's coordinates locked and live weather passed through the DP
   module, any residual between expected and actual power is backpropagated to update the
   **effective-capacity parameter** ($\mu_{\text{capacity}}$) on a rolling basis. This doubles as a
   real-time health and availability monitor.
-* **What effective capacity must exclude:** ANM curtailment is a deliberate, network-driven
+- **What effective capacity must exclude:** ANM curtailment is a deliberate, network-driven
   reduction, not a loss of physical capability. We identify curtailed periods from NGED's
   curtailment/ANM feed and model them as a separate [curtailment gate](#8-scaling-to-the-full-grid-a-graph-structured-dp-engine), so the capacity estimate reflects only
   the asset's true availability. Folding curtailment into capacity would corrupt exactly the signal
   NGED needs — and [capacity regularisation](#5-estimating-capacity-with-dp) covers how we further stop the capacity parameter from absorbing unexplained
   noise.
-* **How capacity feeds the forecast:** as described in the roadmap, this is a **two-pass** approach —
+- **How capacity feeds the forecast:** as described in the roadmap, this is a **two-pass** approach —
   the first pass estimates effective capacity (here), and the second normalises each generator's time
   series by its effective capacity before the power-forecast model trains on it. XGBoost continues to
   do the actual power forecasting in v1; DP is responsible only for *estimating capacity* of
@@ -453,7 +453,7 @@ class UniversalFleetNode(nn.Module):
 
 ## 7. Combining differentiable physics with the weather encoder
 
-```
+```text
 +-------------------+
 | Learnt parameters |
 |     per site:     |
@@ -481,7 +481,6 @@ class UniversalFleetNode(nn.Module):
 - **Systematic / local anomalies** (the "unknown unknowns") are handled by the **retrieval / alignment** module: "on days that looked exactly like this in the past, the physics model consistently over-predicted the evening ramp-down by 5% because of that one tree on the horizon" (residual correction).
 
 `pvlib-pytorch` is a planned Open Climate Fix open-source library — a differentiable, PyTorch-native port of [pvlib](https://pvlib-python.readthedocs.io/) — that we intend to spin out of this project. It would generalise the hand-rolled transposition and panel geometry in the [single-site](#4-the-core-building-block-differentiablesolarplant) and [fleet](#6-scaling-to-aggregate-fleets-fleetsolarnode) sketches into a reusable, tested component; treat those sketches as the prototype it grows from.
-
 
 ---
 

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -50,19 +50,22 @@ The timeline below shows the order in which this work is planned.
 **Goal**: A simple XGBoost forecast that lets us test infrastructure end-to-end and establish a baseline. Intentionally does not detect switching events or estimate effective capacity — hence "naive" (assumes the grid is always in perfect health).
 
 **Data engineering**:
+
 - Download ECMWF ENS NWP from Dynamical.org; convert to Delta Lake with H3 spatial indexes on S3 ✓
 - Download NGED data from S3; convert to Delta Lake with H3 spatial indexes ✓
 - Automatic data cleaning:
-    - Remove isolated zeros in non-zero time series
-    - Remove values more than N standard deviations from the mean
-    - Remove "stuck" values (std dev near zero over a 24-hour rolling window)
-    - Drop first ~2 months of each time series (poor quality during meter ramp-up)
+  - Remove isolated zeros in non-zero time series
+  - Remove values more than N standard deviations from the mean
+  - Remove "stuck" values (std dev near zero over a 24-hour rolling window)
+  - Drop first ~2 months of each time series (poor quality during meter ramp-up)
 
 **Software engineering**:
+
 - Universal model interface (`BaseForecaster`) for all ML models ✓
 - Orchestrate everything with Dagster: data ingestion, model training, inference, backtesting ✓
 
 **ML model**:
+
 - Separate XGBoost model per `time_series_id` ✓
 - Train on the ECMWF control ensemble member; run inference on all 51 members ✓
 - Features: ECMWF ENS NWP variables, derived weather features (e.g. wind chill), lagged power (7 and 14 days ago), datetime features (`hour_of_day`, `day_of_week`, `day_of_month`, `day_of_year`, `is_weekend`, `is_bank_holiday`, `is_christmas`, `is_easter`, `utc_offset`, `forecast_horizon`)
@@ -70,6 +73,7 @@ The timeline below shows the order in which this work is planned.
 - Static capacity estimate: 99th percentile of observed power as a simple proxy
 
 **Outputs** (Delta tables on S3):
+
 - `power_forecast`
 - `power_forecast_warnings`
 - `asset_health_history`
@@ -125,32 +129,36 @@ The ML-assets architecture is designed to support this from day one (programmati
 *Internal only for first month, then shared with NGED.*
 
 **Switching events**:
+
 - Detect "abnormal running arrangement" events from the power time series alone, using statistical methods
 - Use the detected switching events to clean training data: train XGBoost only on "normal arrangement" periods
 - Populate the `substation_switching` Delta table
 
 **Dynamic effective capacity estimation for *metered* generators ([differentiable physics](differentiable-physics.md))**:
+
 - Implement a basic [differentiable physics (DP)](differentiable-physics.md) model for the *metered* wind and solar PV generators to estimate their physical parameters — most importantly effective capacity at each half-hourly timestep, which bumps up and down with maintenance, faults and build-out (this is **Phase 1** of the DP plan). The "clever" latent-demand and abnormal-running-arrangement inversion is explicitly **not** in scope here — that is v2 research.
 - Two-pass approach: first pass estimates effective capacity; second pass normalises the time series by effective capacity before training the power forecast model
 - Ingest additional weather datasets needed for capacity estimation:
-    - **CERRA** (Copernicus regional reanalysis) — high-resolution historical weather, useful for pre-training and for estimating historical generator capacity
-    - **CM SAF** (Satellite Application Facility on Climate Monitoring) — high-resolution satellite-derived irradiance, used to estimate solar PV capacity
+  - **CERRA** (Copernicus regional reanalysis) — high-resolution historical weather, useful for pre-training and for estimating historical generator capacity
+  - **CM SAF** (Satellite Application Facility on Climate Monitoring) — high-resolution satellite-derived irradiance, used to estimate solar PV capacity
 - Populate the `effective_capacity` Delta table
 
 **Dynamic effective capacity estimation for substations**:
+
 - For now, while we're forecasting substations top-down, just use the 99th percentile per year as
   the effective capacity. Later, in v2, the system should already capture everything we need to
   know about substation capacity, as a function of all the things that drive the substation's
   behaviour.
 
 **"Prevailing conditions" building block**:
+
 - Produce example Python code for NGED to construct a "prevailing conditions" forecast from OCF's building blocks
 
 ---
 
 ## v1.0 — Stable Live Service for NGED's Trial Area
 
-**Target: January 2027**
+Target: **January 2027**
 
 - All features listed above (v0.1–v0.7), plus fixes discovered during live running
 - 32 time series in the NGED trial area: 16 primary substations, 6 solar PV farms, 3 wind farms, 2 GSPs, 2 BSPs, 1 biofuel generator, 1 BESS, 1 reciprocating gas generator

--- a/docs/roadmap/switching-events.md
+++ b/docs/roadmap/switching-events.md
@@ -23,7 +23,6 @@ In short: the graph tells us *who can connect to whom*; the simple statistics an
 
 > **A note on differentiable physics.** Only the v2.6 stage uses *differentiable physics*: physics-based forward models (e.g. irradiance → PV power) implemented so their latent parameters — capacity, panel orientation, and so on — can be recovered by gradient-based **inversion** (running the forward model backwards to fit observed power). The v0.6 detector and the v2.5 mixture model do not use it. The full treatment lives in [Differentiable Physics](differentiable-physics.md), which is the single source of truth for that machinery; we do not re-derive it here.
 
-
 ---
 
 ## Part 2 — The staged roadmap
@@ -32,7 +31,7 @@ Version numbers are aligned with the main codebase: **v0.6**, then **v2.5**, the
 
 ### Overview of the ladder
 
-```
+```text
 v0.6  ── Unsupervised statistical detector on power data.
   │       Flags/masks switching events; VALIDATED against the 32-series logs.
   │       Produces the detection sensitivity floor (a quantified, honest limit).
@@ -70,7 +69,7 @@ For each substation, form an expected-power baseline that is a function of **exo
 
 A level shift at one substation could be many things (fault, new connection, meter error). What makes it a *switching event* is the conservation fingerprint: coincident, opposite-sign shifts at neighbours that *collectively balance*. Because transfers fan out to 2–3 neighbours, **do not match pairwise.** Instead, for each candidate drop of magnitude `Δ` at substation `i` at time `t`, solve a small constrained attribution: *which subset of `i`'s neighbours show coincident rises (≈ `t`) that sum to ≈ `Δ`?* With a handful of neighbours per primary this is cheap — enumerate subsets, or run a small non-negative least-squares of neighbour rises against the source drop. That candidate neighbour set is a fixed lookup from the network graph (the adjacency of who-can-exchange-load), with no learning over the graph — it is what keeps the search to a handful of substations rather than all `N`. Score by timing coincidence × magnitude-balance agreement. High score → switching event with an identified donor set; low score → "anomaly, unknown cause."
 
-```
+```text
 residuals around time t (observed - expected), one row per substation:
 
  source  i :   ‾‾‾‾‾‾|____________   drop of Δ = 9 MW at t
@@ -134,7 +133,7 @@ This is a histogram (step magnitude vs. hour-of-day), not a fitted model — del
 
 **Method.** Each substation `i` has a latent normal-demand signal `d_i(t)`. Observed power is a time-varying mixture over the neighbourhood:
 
-```
+```text
 observed_i(t) = α_ii(t)·d_i(t) + Σ_{j ∈ neighbours(i)} α_ij(t)·d_j(t)
 ```
 
@@ -147,15 +146,18 @@ observed_i(t) = α_ii(t)·d_i(t) + Σ_{j ∈ neighbours(i)} α_ij(t)·d_j(t)
 **Why "arbitrary continuous slice" is handled natively.** `α_ij(t)` is a continuous fraction, so "some load, cut anywhere, moved to several donors" is exactly representable. The continuous-fraction form — which earlier looked like a limitation — is in fact *fidelity* to a network where the transferred amount is genuinely continuous and the cut point is free.
 
 **What it adds over v0.6.**
+
 - Produces the actual latent NRA demand signal, not just event flags.
 - Models routing continuously rather than detecting it after the fact.
 - Accommodates multi-donor partial transfer through the summed mixture + node-level balance.
 
 **What it misses / cons.**
+
 - A fractional mixture `α_ij·d_j` moves a *scaled copy of neighbour j's whole aggregate demand*. The slice that really moved may have a *different shape* (e.g. unusually PV-heavy). v2.5 can match the step magnitude but carries the wrong shape with it. **Important nuance:** because there is *no stable sub-unit* with a "true" recoverable shape (movable cut points), this is largely **not a fixable limitation** — v2.5's approximation is about as good as the data structurally permits for the *demand* total. v2.6 only partially improves it, and only for the DER component.
 - DERs are folded implicitly into `d_i` (no explicit PV/wind separation yet).
 
 **Pros.**
+
 - Well-posed, identifiable, far easier to fit than any sub-primary model.
 - No sub-primary modelling whatsoever; fully unsupervised; scales.
 - Degrades gracefully; faithful to continuous, multi-donor, partial transfer.
@@ -171,7 +173,7 @@ observed_i(t) = α_ii(t)·d_i(t) + Σ_{j ∈ neighbours(i)} α_ij(t)·d_j(t)
 
 **Method.** Decompose each substation into typed components, each from its own differentiable forward module:
 
-```
+```text
 d_i(t) = gross_demand_i(t)
        − pv_metered_i(t)   − pv_unmetered_i(t)
        − wind_metered_i(t) − wind_unmetered_i(t)
@@ -184,7 +186,7 @@ d_i(t) = gross_demand_i(t)
 
 Mixing operates **per component-type**, each with its own routing weights:
 
-```
+```text
 observed_i(t) = Σ_j [ α^dem_ij(t)·gross_demand_j(t)
                     − α^pv_ij(t)·pv_j(t)
                     − α^wind_ij(t)·wind_j(t) ]
@@ -193,20 +195,24 @@ observed_i(t) = Σ_j [ α^dem_ij(t)·gross_demand_j(t)
 Each substation is now a small *bundle* of typed nodes rather than one node, and routing happens per type. But the graph stays a plain **data structure**, exactly as in the earlier stages: when the i→j boundary is active, each *type* moves with its own weight — structure-plus-arithmetic, with no message-passing network trained.
 
 **Prior structure.**
+
 1. **Coupled switching, separate composition.** A reconfiguration is one electrical action — the types do not switch at unrelated times. Introduce one latent **switching indicator per ordered pair**, `s_ij(t) ∈ {0,1}`, piecewise-constant and sparse, governing *whether* the i→j boundary is active; the **type composition** (what fraction of demand/PV/wind rides along) applies only when `s_ij(t)=1`. Types switch *together*; the moved slice can still be disproportionately one type.
 2. **Per-pair composition prior — DOWNGRADED.** An earlier design proposed a *learnable per-boundary* prior `θ_ij` ("the i→j boundary is usually 90% PV"), treating it as a stable feeder fingerprint. **This is downgraded to at most a weak, shared empirical prior, or dropped entirely.** Reason: movable cut points mean a boundary has *no stable composition* — what crosses depends on where the switch was opened this time — and `θ_ij` could not be fitted at scale anyway, since that requires labels we won't have. Do **not** rely on per-boundary learned composition.
 3. **Multi-donor (one-to-many).** As in v2.5, several `s_ij(t)` may be active for one source at once; conservation is node-level flow balance across the donor set, not pairwise.
 
 **What it adds over v2.5.**
+
 - Captures disproportionate-*type* transfer (more PV than load can move).
 - Differentiable modules give separately-shaped PV/wind/demand signals, so a step can be attributed to the right type by its temporal signature (midday irradiance-shaped → PV; evening temperature-tracking → load).
 - Cleans DERs from the demand estimate generally, not just during switching.
 
 **What it misses / cons.**
+
 - Still moves a *scaled fraction of neighbour j's total PV/wind/demand*, not the specific moved slice's profile. Fixes wrong *type-mix*; does **not** fix wrong *within-type shape*. Given movable cut points, the within-type shape is not stably recoverable anyway, so this residual is largely irreducible and almost certainly second-order for forecasting.
 - Larger latent space (three routing matrices): risk the optimiser trades PV- vs wind- vs demand-transfer to fit one step. **Mitigation:** the three types have distinct observable temporal signatures and cannot masquerade as each other if priors lean on irradiance/wind/temperature covariates; regularise each routing weight toward identity and piecewise-constant. When genuinely confounded (a windless, overcast event), accept non-identifiability and let uncertainty reflect it.
 
 **Pros.**
+
 - Physically grounded; the extra freedom is tied to physics, not invented structure.
 - Still only primary-level objects; no sub-primary modelling; unsupervised; scales.
 - Produces interpretable DER estimates as a by-product.

--- a/metadata/README.md
+++ b/metadata/README.md
@@ -1,3 +1,5 @@
+# Metadata
+
 ## Files in this directory
 
 - `nwp_metadata.csv`: Hand-written. Conforms to the `NwpMetaData` data contract.

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -1,4 +1,4 @@
-## Contracts
+# Contracts
 
 Defines the "data contracts": the schemas defining the precise shape of each data source and its semantics.
 

--- a/packages/contracts/src/contracts/ml_schemas.py
+++ b/packages/contracts/src/contracts/ml_schemas.py
@@ -118,6 +118,7 @@ class AllFeatures(pt.Model):
 
         This custom validation step is crucial for preventing weather forecast leakage
         and ensuring data integrity. We enforce uniqueness on the combination of:
+
         - `time_series_id`: Identifies the specific substation/time series.
         - `power_fcst_init_time`: The initialization time of the power forecast.
         - `valid_time`: The target time for which the forecast is made.

--- a/packages/contracts/src/contracts/settings.py
+++ b/packages/contracts/src/contracts/settings.py
@@ -15,6 +15,7 @@ class DataQualitySettings(BaseSettings):
     """Settings for data quality thresholds in substation flow processing.
 
     These thresholds are used to identify problematic telemetry data:
+
     - `stuck_std_threshold`: When the rolling standard deviation falls below this value
       (across `stuck_window_periods`), the sensor is likely stuck. We replace such
       values with null to preserve the temporal grid. A value of 0.01 MW was chosen

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -1,0 +1,3 @@
+# Dashboard
+
+Marimo web app for visualising power forecasts, telemetry, and evaluation metrics.

--- a/packages/dynamical_data/README.md
+++ b/packages/dynamical_data/README.md
@@ -16,17 +16,18 @@ As a comparison: Saving a single ECMWF ENS run using `float32`, and `zstd` compr
 level) results in Parquet files ranging between about 205 MB to 240 MB.
 
 The conclusion is to:
+
 - sort by "init_time", "lead_time", "ensemble_member", "h3_index"
 - Compress using: compression="zstd", compression_level=14
 - Minimal size = save as UInt8 = 51 MB
 - But we're worried that UInt8 might lose too much info. So we're scaling to `[0, 2¹²)` and saving a
   Int16 in Delta Lake, which roughly halves the size from 240 MB for `float32` down to 120 MB.
 
+### Test different sort orders
 
-### Test different sort orders:
 (After scaling to `[0, 255]` and saving as `UInt8`, and compressing using zstd with the default level)
 
-```
+```text
 "init_time", "lead_time", "ensemble_member", "h3_index" = 54 MB (BEST YET)
 "init_time", "ensemble_member", "lead_time", "h3_index" = 56 MB
 "init_time", "lead_time", "h3_index", "ensemble_member" = 59 MB
@@ -35,10 +36,11 @@ The conclusion is to:
 ```
 
 ### Test compression algorithm
+
 (after sorting by "init_time", "lead_time", "ensemble_member", "h3_index", and scaling to `[0, 255]`
 and saving as `UInt8`)
 
-```
+```text
 compression="zstd", compression_level=12 = 54 MB
 compression="zstd", compression_level=13 = 53 MB
 compression="zstd", compression_level=14 = 51 MB, 2.26s (BEST MIX OF SPEED & COMPRESSION RATIO)
@@ -57,9 +59,10 @@ compression="brotli", compression_level=11 = 48 MB, 17.75s!
 ```
 
 ### Testing different dtypes
+
 (after sorting by "init_time", "lead_time", "ensemble_member", "h3_index", and compressing using zstd level 14)
 
-```
+```text
 Scale to 2¹⁶ - 1, and save as UInt16 = 145 MB
 Scale to 2¹² - 1, and save as UInt16 = 117 MB
 Scale to 2¹⁰ - 1, and save as UInt16 =  79 MB
@@ -67,4 +70,3 @@ Scale to 2⁹  - 1, and save as UInt16 =  62 MB
 Scale to 2⁸  - 1, and save as UInt16 =  51 MB
 Scale to 2⁸  - 1, and save as UInt8  =  51 MB
 ```
-

--- a/packages/geo/README.md
+++ b/packages/geo/README.md
@@ -4,9 +4,8 @@ This package contains generic geospatial logic and data for the NGED substation 
 
 ## Map of Great Britain using H3 resolution 5 hexagons
 
-![](assets/map-of-Great-Britain-H3-resolution-5.png)
+![Map of Great Britain using H3 resolution 5 hexagons](assets/map-of-Great-Britain-H3-resolution-5.png)
 
 ## Purpose
 
 The `geo` package is designed to decouple generic geospatial operations from dataset-specific ingestion logic (e.g., ECMWF data processing in `dynamical_data`). This ensures that any package in the workspace can perform spatial transformations, such as mapping latitude/longitude grids to H3 hexagons, without depending on heavy or unrelated packages.
-

--- a/packages/geo/src/geo/great_britain/README.md
+++ b/packages/geo/src/geo/great_britain/README.md
@@ -1,3 +1,5 @@
+# Great Britain
+
 ## Files
 
 - `england_scotland_wales.geojson`: The source GeoJSON used to generate the H3 grid.

--- a/packages/ml_core/src/ml_core/features/_parsed_features.py
+++ b/packages/ml_core/src/ml_core/features/_parsed_features.py
@@ -231,6 +231,7 @@ class ParsedFeatures:
         """Determine if the requested features require weather (NWP) data.
 
         This checks:
+
         1. If any lookback features (lags or rolling means) are based on weather variables.
         2. If any static features (like windchill) require weather variables.
         3. If any raw weather features are requested directly.

--- a/packages/ml_core/tests/test_features.py
+++ b/packages/ml_core/tests/test_features.py
@@ -613,7 +613,7 @@ def test_parsed_features_forbids_valid_time_index():
 def test_engineer_features_multi_run_backtest_uses_bulk_mode():
     """Multi-run backtesting must use power_fcst_init_time=None (bulk training mode).
 
-    Passing power_fcst_init_time=<scalar> with multi-run data stamps the same constant
+    Passing a scalar `power_fcst_init_time` with multi-run data stamps the same constant
     nwp_init_time on every row, so the NWP join matches only one run and leaves everything
     else null. This test verifies that bulk mode (power_fcst_init_time=None) correctly
     generates one row per (nwp_init_time, valid_time) combination, which is what a

--- a/packages/notebooks/README.md
+++ b/packages/notebooks/README.md
@@ -1,0 +1,3 @@
+# Notebooks
+
+Marimo notebooks for exploratory data analysis and ad-hoc experimentation.

--- a/packages/xgboost_forecaster/README.md
+++ b/packages/xgboost_forecaster/README.md
@@ -11,6 +11,7 @@ One `xgb.Booster` is trained per `time_series_id`, so each substation's model ca
 ## Save format
 
 `XGBoostForecaster.save(path)` writes:
+
 - `{time_series_id}.ubj` — one XGBoost native binary model per trained substation
 - `meta.json` — the full `XGBoostConfig` serialised via Pydantic, so `load()` is completely self-contained
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,3 +111,11 @@ norecursedirs = [".venv", "venv", ".git", "__pycache__"]
 markers = [
     "integration: tests that exercise real wiring (Dagster + file-based MLflow + temp Delta)",
 ]
+
+[tool.pymarkdown]
+# Line length: prose isn't hard-wrapped in this repo's docs, and ruff's default lint
+# selection doesn't enforce E501 either, so there's no existing precedent to match.
+plugins.md013.enabled = false
+# Duplicate heading: only flag duplicates under the same parent heading, not across
+# the whole file (e.g. "Usage" appearing under two different top-level sections).
+plugins.md024.siblings_only = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ dev = [
     "mkdocs-material>=9.7.6",
     "mkdocstrings[python]>=1.0.3",
     "mkdocs-include-markdown-plugin>=7.2.2",
+    "pymarkdownlnt>=0.9.13",
 ]
 
 [project.urls]

--- a/scripts/lint_docstring_markdown.py
+++ b/scripts/lint_docstring_markdown.py
@@ -1,0 +1,113 @@
+"""Lint the markdown embedded in Python docstrings.
+
+`mkdocstrings` renders every module/class/function docstring as markdown in the published API
+docs (`docs/api/`), so a docstring with e.g. a list missing its blank line renders badly there
+just like it would in a `.md` file. This script extracts each docstring via `ast` and pipes it
+through `pymarkdown scan-stdin`, the same linter used on `README.md`/`docs/*.md`.
+"""
+
+import ast
+import subprocess
+import sys
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Final
+
+PYMARKDOWN_CONFIG: Final[str] = ".pymarkdown-docstrings.json"
+"""Config overrides layered on top of `pyproject.toml`'s `[tool.pymarkdown]` for docstring text.
+
+Disables rules that only make sense for a whole document (e.g. requiring the first line to be a
+heading), since a docstring is a prose fragment, not a document.
+"""
+
+
+def _dedent_docstring(raw: str) -> str:
+    """Dedent a raw (`clean=False`) docstring while preserving its exact line count.
+
+    Mirrors `inspect.cleandoc`'s dedenting logic but skips its leading/trailing blank-line
+    stripping, so line ``i`` of the result always corresponds to ``docstring_start_line + i`` in
+    the original source. That mapping is what lets violations be reported against real file:line
+    locations; `ast.get_docstring(node, clean=True)` would break it by also removing blank lines.
+    """
+    lines = raw.expandtabs().split("\n")
+    margin = sys.maxsize
+    for line in lines[1:]:
+        stripped = line.lstrip()
+        if stripped:
+            margin = min(margin, len(line) - len(stripped))
+    lines[0] = lines[0].lstrip()
+    if margin < sys.maxsize:
+        lines[1:] = [line[margin:] for line in lines[1:]]
+    return "\n".join(lines)
+
+
+def _iter_docstrings(source: str, path: Path) -> Iterator[tuple[int, str]]:
+    """Yield ``(source_start_line, dedented_text)`` for every docstring in `path`.
+
+    Covers module, class, function, and async function docstrings (`ast.walk` naturally reaches
+    methods and nested definitions too). Attribute-level docstrings (a bare string literal
+    following an assignment, e.g. a `ClassVar` docstring) aren't picked up by `ast.get_docstring`
+    and are out of scope here.
+    """
+    tree = ast.parse(source, filename=str(path))
+    docstring_nodes: list[ast.Module | ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef] = [
+        tree,
+        *(
+            node
+            for node in ast.walk(tree)
+            if isinstance(node, ast.ClassDef | ast.FunctionDef | ast.AsyncFunctionDef)
+        ),
+    ]
+    for node in docstring_nodes:
+        raw = ast.get_docstring(node, clean=False)
+        if raw is None:
+            continue
+        yield node.body[0].lineno, _dedent_docstring(raw)
+
+
+def _scan_docstring(text: str) -> tuple[str, str, int]:
+    """Run `pymarkdown scan-stdin` against `text`, returning stdout, stderr, and the return code."""
+    result = subprocess.run(
+        ["uv", "run", "pymarkdown", "--config", PYMARKDOWN_CONFIG, "scan-stdin"],
+        input=text,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout, result.stderr, result.returncode
+
+
+def _remap_violation(line: str, path: Path, start_line: int) -> str:
+    """Rewrite a `pymarkdown scan-stdin` violation's pseudo `stdin:line:col:...` to `path:line:col:...`."""
+    _pseudo_file, _, rest = line.partition(":")
+    docstring_line_str, _, remainder = rest.partition(":")
+    source_line = start_line + int(docstring_line_str) - 1
+    return f"{path}:{source_line}:{remainder}"
+
+
+def _lint_file(path: Path) -> list[str]:
+    """Return remapped violation lines for every docstring in `path`."""
+    violations: list[str] = []
+    source = path.read_text()
+    for start_line, text in _iter_docstrings(source, path):
+        stdout, stderr, returncode = _scan_docstring(text)
+        if returncode not in (0, 1):
+            violations.append(
+                f"{path}:{start_line}: pymarkdown scan-stdin failed: {stderr.strip()}"
+            )
+            continue
+        violations.extend(
+            _remap_violation(line, path, start_line) for line in stdout.splitlines() if line.strip()
+        )
+    return violations
+
+
+def main(argv: list[str]) -> int:
+    """Lint docstring markdown in each `.py` file path in `argv`; return the process exit code."""
+    violations = [violation for arg in argv for violation in _lint_file(Path(arg))]
+    for violation in violations:
+        print(violation)
+    return 1 if violations else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/src/nged_substation_forecast/utils.py
+++ b/src/nged_substation_forecast/utils.py
@@ -19,6 +19,7 @@ def create_dagster_type_from_patito_model(model: Type[pt.Model]) -> DagsterType:
     This factory function takes a Patito model and returns a DagsterType.
     The returned DagsterType uses a `type_check_fn` to validate the output
     DataFrame against the model's schema. We handle both DataFrame and LazyFrame:
+
     - For eager DataFrames, we validate the actual data.
     - For LazyFrames, we only validate the schema (using an empty dummy DataFrame)
       to avoid triggering expensive computations during type checking.

--- a/uv.lock
+++ b/uv.lock
@@ -102,6 +102,34 @@ wheels = [
 ]
 
 [[package]]
+name = "application-file-scanner"
+version = "0.6.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-walk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ea/22/e872546d298103527380955f51191ff87cd178e6aac62bb87de73c3e074f/application_file_scanner-0.6.4.tar.gz", hash = "sha256:581c48c5017345747be7f49507da84fec36d1f7b4f67003e9fbaf2f0bc6a3f66", size = 28540, upload-time = "2026-01-19T23:32:15.695Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/83/e9a5a14c1b6c20ad44abcdb7bb2f34d860aa4f4ee64c526247066b6c42fb/application_file_scanner-0.6.4-py3-none-any.whl", hash = "sha256:49c211c60f1932812477facc38701d58037b07b031fdb6a6061fdee3fd53e35f", size = 15445, upload-time = "2026-01-19T23:32:14.4Z" },
+]
+
+[[package]]
+name = "application-properties"
+version = "0.9.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyjson5" },
+    { name = "pyyaml" },
+    { name = "tomli" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/bb/321da0e373416080801d05b8dd9c0a8da77fe305c697adf8c025470ce170/application_properties-0.9.3.tar.gz", hash = "sha256:7dc7d8f23d11e539427e7b8e3afa70353e159c16f703bad6dd082cc6cdfeeaa8", size = 43304, upload-time = "2026-06-02T03:52:07.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/72/3ac1bda73e9c95444b1e13a0de73e847048a776e5ac5b3977c37f04167f9/application_properties-0.9.3-py3-none-any.whl", hash = "sha256:32dbd62b3fb657ec1c7fdc352590463c2ffd14950ffd258a5c091e8798d8aec0", size = 24595, upload-time = "2026-06-02T03:52:06.416Z" },
+]
+
+[[package]]
 name = "arro3-compute"
 version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
@@ -423,6 +451,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/84/1b/1ecdd371fa68839cfbda15cc671d0f6c92d2c42688df995a9bf6e36f3511/coloredlogs-14.0.tar.gz", hash = "sha256:a1fab193d2053aa6c0a97608c4342d031f1f93a3d1218432c59322441d31a505", size = 275863, upload-time = "2020-02-16T20:51:12.172Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5c/2f/12747be360d6dea432e7b5dfae3419132cb008535cfe614af73b9ce2643b/coloredlogs-14.0-py2.py3-none-any.whl", hash = "sha256:346f58aad6afd48444c2468618623638dadab76e4e70d5e10822676f2d32226a", size = 43888, upload-time = "2020-02-16T20:51:09.712Z" },
+]
+
+[[package]]
+name = "columnar"
+version = "1.4.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "toolz" },
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/0d/a0b2fd781050d29c9df64ac6df30b5f18b775724b79779f56fc5a8298fe9/Columnar-1.4.1.tar.gz", hash = "sha256:c3cb57273333b2ff9cfaafc86f09307419330c97faa88dcfe23df05e6fbb9c72", size = 11386, upload-time = "2021-12-27T21:58:56.123Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/00/a17a5657bf090b9dffdb310ac273c553a38f9252f60224da9fe62d9b60e9/Columnar-1.4.1-py3-none-any.whl", hash = "sha256:8efb692a7e6ca07dcc8f4ea889960421331a5dffa8e5af81f0a67ad8ea1fc798", size = 11845, upload-time = "2021-12-27T21:58:54.388Z" },
 ]
 
 [[package]]
@@ -2076,6 +2117,7 @@ dev = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "pre-commit" },
+    { name = "pymarkdownlnt" },
     { name = "pytest" },
     { name = "ruff" },
     { name = "ty" },
@@ -2111,6 +2153,7 @@ dev = [
     { name = "mkdocs-material", specifier = ">=9.7.6" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.3" },
     { name = "pre-commit", specifier = ">=4.5.1" },
+    { name = "pymarkdownlnt", specifier = ">=0.9.13" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "ruff", specifier = ">=0.14.13" },
     { name = "ty", specifier = ">=0.0.16" },
@@ -2631,6 +2674,18 @@ wheels = [
 ]
 
 [[package]]
+name = "py-walk"
+version = "0.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sly" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/b5/e2f3fab1e11d4089b1c3dfd72175fdb2408ff8028e01bdb0d308923609bb/py_walk-0.3.3.tar.gz", hash = "sha256:a1b28d6079f27203fa3098b69a98572675b3ff5bd02286c43e6dacd66615f879", size = 1815727, upload-time = "2024-10-26T14:30:39.421Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/38/56b67abdbf6797475dfe2f62d391b4a6ead851c76acbaf07e118e53651b6/py_walk-0.3.3-py3-none-any.whl", hash = "sha256:238fc018165138021ce0bfd9c351cdc473d3120ccc5534df35611b92608c94d5", size = 14537, upload-time = "2024-10-26T14:30:38.06Z" },
+]
+
+[[package]]
 name = "pyarrow"
 version = "24.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2762,6 +2817,54 @@ wheels = [
 ]
 
 [[package]]
+name = "pyjson5"
+version = "2.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/9a/3db19560e968d6e85b2a4ddf4b949c6ebf9dd1dcfb5a9f37736f8adeb927/pyjson5-2.0.1.tar.gz", hash = "sha256:a5b0e322e847b198a50d8a1ef16d6b2b19129644dc018d76773e81ef1487ca39", size = 352242, upload-time = "2026-05-15T16:12:54.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/41/70aa1cb1fb0a3ac4c9b8cd405c0c85ba935c53fdfae6271b8eae364b92d1/pyjson5-2.0.1-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:573fecd7cad4e24d232053f9ebf331c80fe1b0ed6e2064f7614797a7f691e7ca", size = 303706, upload-time = "2026-05-15T16:10:35.163Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/d9/caf44bf3d33b9502dc4b8ed5d0c7a8af8fbe33001e82414c0407f39f18bd/pyjson5-2.0.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:a8ade508a046a5407a322c098e3b7e6033216b158a7746eb8962b7a4cdbf9248", size = 158915, upload-time = "2026-05-15T16:10:36.496Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/94/f2bab1ce2eac8f77e16dcd0a1ba39de20733a84b9961c3504af0dd68bceb/pyjson5-2.0.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4635e349bb1d1f1e854dc790f14be31b6cb198d6453848e8d86818104074f805", size = 154199, upload-time = "2026-05-15T16:10:37.902Z" },
+    { url = "https://files.pythonhosted.org/packages/82/c4/d94573ca37486af3d6a72f2582844d7d490d8e55639e0cfba371ce91442f/pyjson5-2.0.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3d274697f81f143abac12ce256a06b61635c30d0f8cc11eefae7182655dac9a5", size = 186060, upload-time = "2026-05-15T16:10:39.603Z" },
+    { url = "https://files.pythonhosted.org/packages/03/cc/c42e697def319b286fdcb912939c044cc94bd1cfc7338b6dbb566f817f29/pyjson5-2.0.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:be4e2242e55a2651fd8696cfd67ec8e04f54f4ed6c089cceea2b63763a7516d8", size = 165796, upload-time = "2026-05-15T16:10:40.967Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/dd/f22a5f0e619ef22b8e32520a91bd92f815d50f9ec2d67cfe5974eab9476c/pyjson5-2.0.1-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:af855c680feaa39cae4a44914ee2863eeae1549f37ce58069c747b3d4803999a", size = 165262, upload-time = "2026-05-15T16:10:42.391Z" },
+    { url = "https://files.pythonhosted.org/packages/99/8b/90e22ecb12d51ccdc68325b6b051002e6103cc4600a335d9ed13828acdd9/pyjson5-2.0.1-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:bb769d90516da904e6cf0ba58f3d5830f4a5804486b5e85c5ca42ba3146d187a", size = 181608, upload-time = "2026-05-15T16:10:43.914Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ab/237f9036eed73e08cf8861466d3d1182ef1c88506bd29955740dcadb24ff/pyjson5-2.0.1-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6484c14e07aa46abeb3cb2ff0204a765260763ad7cf3f87f601f26b20ed607f3", size = 189582, upload-time = "2026-05-15T16:10:45.367Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3d/3df8d5f003910a9291e5f04fa178f626e3c8553a5986dc62589ca74195ff/pyjson5-2.0.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cc03673adb544324500d79b2acfe2ced038998b2aceb564d335de9cc238cbdb0", size = 176321, upload-time = "2026-05-15T16:10:47.134Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d9/a458a54f780bafec1b44ee3c27cb3007a83fb7bd4f1c17ac6bf519fd6151/pyjson5-2.0.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:5d714daf784bec2e14fc06c0c26e4a373a6157eaeddaed2d5a7b7b6ae2aabc33", size = 171956, upload-time = "2026-05-15T16:10:49.174Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d8/1010e0147c8862dc0881cf3656364d3d87a5e336d290fe4cb0b92223e14c/pyjson5-2.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:5cf3ded356730e08b5941a16db6525efc0de26f35468ab09ad573056c4efc6e5", size = 1147679, upload-time = "2026-05-15T16:10:51.005Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2f/91c8d8cdb4a2e4bbe8f14b9b57d717988e14830f2ed4a4f08d503cb5edde/pyjson5-2.0.1-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:cc00d4669fb4170c28b2c9ed3cd1c2af9f21727c55d6866030cc154f31f68747", size = 1008216, upload-time = "2026-05-15T16:10:53.252Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/d7/25c3f8693660a35be7bb4eb71b0d10d9a6981e986723a4881d607f0c6462/pyjson5-2.0.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a77a91c2e019476345c03cde105da44100daaabc3fa56f82f2bd9eb2ebbcb698", size = 1323856, upload-time = "2026-05-15T16:10:55.517Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/25/82f0f83556ff68ec0ca1129ba9afeb14149cd421dc74823cdf10c209c95c/pyjson5-2.0.1-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:9ae54e5d717982cb7a082c700ab1f7f965c6aedea6fcb003ec4bdeac4f02bf52", size = 1241860, upload-time = "2026-05-15T16:10:57.635Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/01/2c4695fc06a0f3f29041a875d3bb24f904c9ae7b3d8dbfa1f8db17ce995c/pyjson5-2.0.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:ce4f5b67b3a6fab623a31d83416b51a5b2c97cb172194f214078484bbb4783a6", size = 1178443, upload-time = "2026-05-15T16:10:59.398Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/ae/c10f534037b096aca21b90017ac9d41f791572dc3ec31fcd92db8ddcd256/pyjson5-2.0.1-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f8d2e61f7bed0b40cfe5f62375581bf56d7b5b9707c9d74747b5931149d7d376", size = 1357739, upload-time = "2026-05-15T16:11:01.189Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/f0/655224f78ede087aa6a295c4745423e0104dd31f67928675b1a4cea72a0a/pyjson5-2.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2930140edd1a64eb42689993c5ae317bca2e6bc785b5dc5053bd5e9d184c98ad", size = 1209542, upload-time = "2026-05-15T16:11:03.364Z" },
+    { url = "https://files.pythonhosted.org/packages/73/52/a7b2a26625136fcd0f92e17beaaae51e04923cc2e28502db354d4de061b4/pyjson5-2.0.1-cp314-cp314-win32.whl", hash = "sha256:51733f91dda897239ca10928f363ce6f4b5eadaf797e74477f6c1c3222c185a7", size = 118342, upload-time = "2026-05-15T16:11:40.009Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8e/79db426fff3a41610076989d4060cc18a6508ebd3c7877155f6709eea102/pyjson5-2.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:698c73aacff49ea35bbbf7f700a97785626201ea7aa2e1f1e0a4fe23788c3be2", size = 138408, upload-time = "2026-05-15T16:11:41.757Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/1b/385da14c05412bca15e86551dde91959686c8bddf7e78722bdc627fa6815/pyjson5-2.0.1-cp314-cp314-win_arm64.whl", hash = "sha256:d447e2e5756f89abfd0ad82d1438075bcbc701c1cc9279b43d24825aaac67356", size = 120905, upload-time = "2026-05-15T16:11:43.146Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/04/cd69739556d304d3ea48064ea7d47e5ff7321b0032d7ad78864bceaa0cae/pyjson5-2.0.1-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:5603be4f0cb9685d7c2cbd408ddec21b33f415252bee00ac7969f20b5789a1d1", size = 321150, upload-time = "2026-05-15T16:11:05.07Z" },
+    { url = "https://files.pythonhosted.org/packages/84/d4/6d98268ed07a2cac1e79634fcd3dc280d2503ade5f3c465f7aa095951444/pyjson5-2.0.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:87267520a256b3f2dba7f2995b745e8b3f2dd72bbf8436010a5191f7809f8ab6", size = 167540, upload-time = "2026-05-15T16:11:06.822Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c6/8855a9462bdbc8306cba62793e23cc2952dfcbcbcab8e0413f570c891361/pyjson5-2.0.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:77e58307b74019d90aff9f2781bcffbbea3315b15fc814f8fa9b8d334b956ff4", size = 162533, upload-time = "2026-05-15T16:11:08.218Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/a3/1092f68538ee71ed8027393ab5e71aa9c4a114e493e30a55e46e34c2ffb9/pyjson5-2.0.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:dd1712038837342dea73ed526883e53c6e85a158242b6f574b9ad9cdd3199c7f", size = 184165, upload-time = "2026-05-15T16:11:09.639Z" },
+    { url = "https://files.pythonhosted.org/packages/46/63/bb9f42a4047284ea59064c134c88dfac3b7f5273e40fe548d6a086cea452/pyjson5-2.0.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1dba36677c77aed5d680827c65478933705ca156a34838f1250ea191ffc27662", size = 170075, upload-time = "2026-05-15T16:11:11.105Z" },
+    { url = "https://files.pythonhosted.org/packages/55/2a/0379aa5184e986d0f9af2919712c148d81928ce7d2d7950407e271b1df3b/pyjson5-2.0.1-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:04356d0c09e58907f60675d33859f269473479b90add5026231ef2fadba5207e", size = 164100, upload-time = "2026-05-15T16:11:12.909Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d5/2087af69695c28c7fe796afc73dec7f0b0b9bc123ec329e45928d58d4705/pyjson5-2.0.1-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b331a0fbe2ae26f4ccb88045ebaecc00aeeeab23ff858f9a2223cedd969ec6d6", size = 184674, upload-time = "2026-05-15T16:11:14.448Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/06/cf1b2744e07f1689cb0ac663e162a060b81cd358474754fe9f3bf02d5398/pyjson5-2.0.1-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5ca55878d923ba5764254ad1c020c22b33e6161b3555d1f457b8060f2b3c6c17", size = 193047, upload-time = "2026-05-15T16:11:15.969Z" },
+    { url = "https://files.pythonhosted.org/packages/54/e6/a6b0deb6a3f393907c6d9115a7ac8e27557109204b56b05d3b57c51fc2ca/pyjson5-2.0.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:35e18d11e4c2034b78a664affe18c153a8efbf8872cf6bed7f12dc4fb819d440", size = 178712, upload-time = "2026-05-15T16:11:17.364Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/48/9e5c16daba56dfdb481baab85d1197e14ae3f403902fc23cdca14d14351b/pyjson5-2.0.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b710a7489b6e134890eaa1fdb285e9644a1e730c1cfcf1cd90a87859b87a84a9", size = 175642, upload-time = "2026-05-15T16:11:18.781Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/32/f07d4dbd8cf733f9e3f3e9c9abedfbc23da1e5cfa7fed46aebae07ca6f25/pyjson5-2.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:08920c0dd6aba3fb6bc6c849e6f05731c5fb2716cd651de424ff60cdd12eae65", size = 1152219, upload-time = "2026-05-15T16:11:20.54Z" },
+    { url = "https://files.pythonhosted.org/packages/01/9d/0ddbb89d381bc27f3740850d5d664c1f6f76620ad879ff5eb2506a4dfd6c/pyjson5-2.0.1-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:e166dadb3275025cff5ee8602131372a3ea171c6727b3fc6e44697348e3972c5", size = 1013305, upload-time = "2026-05-15T16:11:22.702Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/93/0f44886391dd2249ad9cf98c2deb3f26d1a115dd5a215629af7455765968/pyjson5-2.0.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:ea3c2b4e7b8e209e7f59bd6a925d79b69cd0a4ffa12f2df0c6af55514c8b2227", size = 1322840, upload-time = "2026-05-15T16:11:24.918Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/29/c478dc24dfcfc07e407ff8669df265ecc51fed5e7d47e51a01f17fd1c53f/pyjson5-2.0.1-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:b710fc8ce00c984c8865131f05a8536163e1d3caffb9d081647879eca7424670", size = 1245221, upload-time = "2026-05-15T16:11:26.873Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/f0/5fef8c47c5b7052da79af6425a021040402a9a09b37c5687d91f98696a27/pyjson5-2.0.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a9784d79275d1b06d95f2920c3f260ce5d3f6671f65a1fae1464f83fbfc834a0", size = 1182991, upload-time = "2026-05-15T16:11:29.258Z" },
+    { url = "https://files.pythonhosted.org/packages/90/33/4d3a9d3159cdff1f1886d39f1991e6c8d5927f9b606cfc9743b5bef98c2a/pyjson5-2.0.1-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0ef86c53d0e14991b5b0fe58f225e3d8faec437aa0a70da4762525b6bc2fca10", size = 1359104, upload-time = "2026-05-15T16:11:31.651Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/04/20eb16c52453aea0af68a697f4058378c9ff871bd2f0bea28eb76ffe12f8/pyjson5-2.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:1d9faccf5a9e86f14104eec31c13428ef8baeb867182ce107e0c68fcc5c62477", size = 1212847, upload-time = "2026-05-15T16:11:33.767Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/a3/69bbe93275eafb7802a5b29230cc5c28f9b924c68d15b3ab2d43cfe19825/pyjson5-2.0.1-cp314-cp314t-win32.whl", hash = "sha256:2df497af7ab03cf82d9278a4707a83d0ae4e6d727f919a883b5ccec3f7d92650", size = 139137, upload-time = "2026-05-15T16:11:35.487Z" },
+    { url = "https://files.pythonhosted.org/packages/48/45/b865ca6e0ae6887bc2b6b17cd123470ae43ac0fa04a2362d77d4b9f5bd43/pyjson5-2.0.1-cp314-cp314t-win_amd64.whl", hash = "sha256:3b31cf4f4a4f01800812865af3b02f6700cefb9377e4d9a9c6b78fdcf41fd973", size = 169412, upload-time = "2026-05-15T16:11:36.887Z" },
+    { url = "https://files.pythonhosted.org/packages/68/55/02c734459fef0a955ab3e7e745df415d5f9fc873a4c288765f60f22fbc13/pyjson5-2.0.1-cp314-cp314t-win_arm64.whl", hash = "sha256:15f0d8baea89d35c6c01c60b944c778a79cac10f77f71b727f1b244e2c7a8ccb", size = 129061, upload-time = "2026-05-15T16:11:38.712Z" },
+]
+
+[[package]]
 name = "pyjwt"
 version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2773,6 +2876,22 @@ wheels = [
 [package.optional-dependencies]
 crypto = [
     { name = "cryptography" },
+]
+
+[[package]]
+name = "pymarkdownlnt"
+version = "0.9.38"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "application-file-scanner" },
+    { name = "application-properties" },
+    { name = "columnar" },
+    { name = "py-walk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/98/c4ef7b1bac73ebc90418c29a89c3c81b2d4595e50683d7a85bc6a6513fe3/pymarkdownlnt-0.9.38.tar.gz", hash = "sha256:bd79a2cef3a90652135672272b20aabb8f5db8dd870983ee8710f7daf64a74a7", size = 442175, upload-time = "2026-06-11T03:28:31.693Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/d1/eee0e6d73cf9b4d20af1ec42583999fd5af4952fdc32276734ad9fbbb737/pymarkdownlnt-0.9.38-py3-none-any.whl", hash = "sha256:37eda39c2ba0d5be10abe0d1150e4564b08cd26a3570b1575a972db5a423aa39", size = 515479, upload-time = "2026-06-11T03:28:30.03Z" },
 ]
 
 [[package]]
@@ -3232,6 +3351,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sly"
+version = "0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/8a/59e943f7b27904c7756a7b565ffbd55f3841f5cd3d2da2b2b0713c49e488/sly-0.5.tar.gz", hash = "sha256:251d42015e8507158aec2164f06035df4a82b0314ce6450f457d7125e7649024", size = 66702, upload-time = "2022-10-25T14:35:30.592Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/4d/c96d807295183f2360329cd8d8bf5e8072c53d664125b3858c04153f026e/sly-0.5-py3-none-any.whl", hash = "sha256:20485483259eec7f6ba85ff4d2e96a4e50c6621902667fc2695cc8bc2a3e5133", size = 28864, upload-time = "2022-10-25T14:35:28.054Z" },
+]
+
+[[package]]
 name = "smmap"
 version = "5.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3363,6 +3491,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b1/09/a439bec5888f00a54b8b9f05fa94d7f901d6735ef4e55dcec9bc37b5d8fa/tomlkit-0.13.2.tar.gz", hash = "sha256:fff5fe59a87295b278abd31bec92c15d9bc4a06885ab12bcea52c71119392e79", size = 192885, upload-time = "2024-08-14T08:19:41.488Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/b6/a447b5e4ec71e13871be01ba81f5dfc9d0af7e473da256ff46bc0e24026f/tomlkit-0.13.2-py3-none-any.whl", hash = "sha256:7a974427f6e119197f670fbbbeae7bef749a6c14e793db934baefc1b5f03efde", size = 37955, upload-time = "2024-08-14T08:19:40.05Z" },
+]
+
+[[package]]
+name = "toolz"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/11/d6/114b492226588d6ff54579d95847662fc69196bdeec318eb45393b24c192/toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b", size = 52613, upload-time = "2025-10-17T04:03:21.661Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fb/12/5911ae3eeec47800503a238d971e51722ccea5feb8569b735184d5fcdbc0/toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8", size = 58093, upload-time = "2025-10-17T04:03:20.435Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add `pymarkdownlnt` as a pre-commit hook to lint `README.md` files and `docs/*.md` (catches structural issues like missing blank lines before lists, via markdownlint-compatible rule IDs MD001-MD048).
- Add a custom script (`scripts/lint_docstring_markdown.py`) that extracts markdown from Python docstrings via `ast` and lints it too, since `mkdocstrings` renders docstrings as markdown in the published API docs.
- Fix pre-existing markdown violations surfaced by the new linter (blank lines around lists/fences/headings, missing H1s, unlabeled fenced code blocks, bare URLs, missing image alt text, two empty package READMEs, and a handful of docstrings).
- Pre-commit only in this PR — no CI changes.

## Config choices
- `MD013` (line-length) disabled: docs here aren't hard-wrapped, and ruff doesn't enforce `E501` either, so there's no existing precedent for it.
- `MD024` set to `siblings_only`: only flags duplicate headings under the same parent.
- Docstring pass additionally disables `MD041` (first-line-heading) and `MD047` (single-trailing-newline), since a docstring is a prose fragment, not a whole document.

## Test plan
- [x] Deliberately introduced a malformed markdown list and confirmed the `pymarkdown` hook blocks the commit with the expected MD032 message
- [x] Deliberately introduced a malformed docstring and confirmed `lint-docstring-markdown` blocks the commit with a correctly remapped `file.py:line`
- [x] `uv run pre-commit run --all-files` passes clean
- [x] `uv run pytest` passes for all touched packages (114 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)