### PR TITLE
Phase 6.6: fix ad_hoc mlflow_run_id null-dtype validation bug

### DIFF
--- a/packages/ml_core/src/ml_core/metrics.py
+++ b/packages/ml_core/src/ml_core/metrics.py
@@ -238,8 +238,8 @@ def enrich_metrics_rows(
             evaluation_scope=pl.lit(evaluation_scope).cast(pl.Enum(EVALUATION_SCOPES)),
             window_start=pl.lit(window_start).cast(UTC_DATETIME_DTYPE),
             window_end=pl.lit(window_end).cast(UTC_DATETIME_DTYPE),
-            window_label=pl.lit(window_label),
+            window_label=pl.lit(window_label, dtype=pl.String),
             computed_at=pl.lit(computed_at).cast(UTC_DATETIME_DTYPE),
-            mlflow_run_id=pl.lit(mlflow_run_id),
+            mlflow_run_id=pl.lit(mlflow_run_id, dtype=pl.String),
         )
     )

--- a/plans/dagster_plan.md
+++ b/plans/dagster_plan.md
@@ -1404,7 +1404,7 @@ Implements §4.10. Independent of Phases 6–8 — it works with the already-bui
   materialising the smoke-test fold + `metrics`, the MLflow parent run shows the aggregate
   leaderboard metrics and `forecast_metrics` holds the per-type/overall rows. *(Milestone.)*
 
-### 7.6.5 Phase 6.5 — MVP `effective_capacity` asset + NMAE normalisation upgrade - Underway in PR #211
+### 7.6.5 Phase 6.5 — MVP `effective_capacity` asset + NMAE normalisation upgrade - Completed in PR #211
 
 *The data contract (`EffectiveCapacity`) and the NMAE P99 change in `compute_metrics` are already
 landed. This phase adds the Dagster asset that computes and persists the capacity estimate, then
@@ -1453,7 +1453,7 @@ differentiable-physics capacity model (see `docs/roadmap/differentiable-physics.
 `EffectiveCapacity` schema, `compute_metrics` interface, and the `metrics` asset are all unchanged;
 only the `effective_capacity` asset body changes.
 
-### 7.6.6 Phase 6.6 — fix `ad_hoc` scope `mlflow_run_id` null-dtype validation bug
+### 7.6.6 Phase 6.6 — fix `ad_hoc` scope `mlflow_run_id` null-dtype validation bug - Completed
 
 *Pre-existing bug discovered during Phase 6.5 (fails on `main`, unrelated to the capacity work).
 Deferred so it lands in its own PR after the Phase 6.5 PR merges.*

--- a/plans/dagster_plan.md
+++ b/plans/dagster_plan.md
@@ -1453,7 +1453,7 @@ differentiable-physics capacity model (see `docs/roadmap/differentiable-physics.
 `EffectiveCapacity` schema, `compute_metrics` interface, and the `metrics` asset are all unchanged;
 only the `effective_capacity` asset body changes.
 
-### 7.6.6 Phase 6.6 — fix `ad_hoc` scope `mlflow_run_id` null-dtype validation bug - Completed
+### 7.6.6 Phase 6.6 — fix `ad_hoc` scope `mlflow_run_id` null-dtype validation bug - Completed in PR #212
 
 *Pre-existing bug discovered during Phase 6.5 (fails on `main`, unrelated to the capacity work).
 Deferred so it lands in its own PR after the Phase 6.5 PR merges.*


### PR DESCRIPTION
## Summary

Implements Phase 6.6 (§7.6.6 of `plans/dagster_plan.md`): a focused, pre-existing bug fix.

`enrich_metrics_rows` (`packages/ml_core/src/ml_core/metrics.py`) built the `mlflow_run_id`
column with a bare `pl.lit(mlflow_run_id)`. For the `ad_hoc` evaluation scope `mlflow_run_id`
is `None`, so Polars inferred a **`Null`-dtype** column, which then failed `Metrics.validate`
(the schema declares `mlflow_run_id` as a nullable `String`) with
`Polars dtype Null does not match model field type`. This broke the entire `ad_hoc` metrics
path on `main`.

## Change

- Pin `mlflow_run_id=pl.lit(mlflow_run_id, dtype=pl.String)` so a `None` value yields a
  `String`-typed all-null column rather than a `Null`-typed one.
- Pin `window_label=pl.lit(window_label, dtype=pl.String)` for the same class of latent issue.
- Mark Phase 6.5 (PR #211) and Phase 6.6 completed in the plan.

## Verification

- `tests/test_metrics.py::test_metrics_ad_hoc_no_mlflow_logging` now passes (previously failed).
- `packages/ml_core/tests/test_metrics.py` — all 15 pass.
- ruff / ruff format / ty all clean.

(`test_full_stack_real_mlflow_server` fails locally only because it needs a live MLflow server
process, which won't start in this environment — unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)