### PR TITLE
Phase 6.7: metrics asset partition pruning + per-group scoring

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -213,6 +213,17 @@ Casting after `.collect()` also works but is later than necessary: typed helpers
 scan (e.g. a filter method) would then have to accept `pl.LazyFrame` instead of
 `pt.LazyFrame[MySchema]`.
 
+**Caveat — filter *before* the cast when the column is filtered on (especially a Delta partition
+column).** The lazy cast above is right for columns you only *read*, but a `String→Categorical`
+cast placed between `pl.scan_delta(...)` and a `.filter()` on that column **blocks predicate
+pushdown**: Polars can no longer prune Delta partitions or skip row groups, so it reads the *whole*
+table even when the filter names one partition. `experiment_name` / `fold_id` are the on-disk
+partition columns of `power_forecasts`, so when filtering on them, filter the **raw `String`
+scan first, then cast** the surviving rows per group. Confirm pushdown with `.explain()` — it
+should list only the matching `partition=value` paths. (This is the ordering `PopulationFilter.apply`
+and `_load_forecast_group` in `cv_assets.py` follow, and the reason `apply` returns a *plain*
+`pl.LazyFrame` — there is no model to attach until after the cast.)
+
 ### Patito + Polars Gotcha: `pt.LazyFrame.filter()` drops the Patito subclass
 
 Most Polars operations on a `pt.LazyFrame` return a plain `pl.LazyFrame`, including `.filter()`.

--- a/docs/ml_experimentation/dagster-workflow.md
+++ b/docs/ml_experimentation/dagster-workflow.md
@@ -196,8 +196,11 @@ in the run config dialog before launching.
 
 **What the asset does:**
 
-1. Scans `power_forecasts` Delta, applying any non-null `PopulationFilter` predicates.
-2. Groups the matched rows by `(experiment_name, fold_id)` and for each group:
+1. Scans `power_forecasts` Delta, applying any non-null `PopulationFilter` predicates. The filter
+   runs on the raw scan so its predicates push into the Delta scan: naming an experiment/fold
+   prunes to just that partition rather than reading the whole (unbounded) table.
+2. Discovers the matching `(experiment_name, fold_id)` groups, then loads and scores **one group at
+   a time** — peak memory is a single fold, not the entire matched population. For each group:
    a. Calls `compute_metrics()` — joins observed power, averages ensemble members, computes
       MAE / NMAE / RMSE / MBE per `(time_series_id, fold_id, power_fcst_model_name)`.
    b. Enriches rows with scope (`evaluation_scope`), window bounds (`window_start`, `window_end`,

--- a/plans/dagster_plan.md
+++ b/plans/dagster_plan.md
@@ -1475,7 +1475,7 @@ nullable `String`). This makes the entire `ad_hoc` metrics path broken today; th
   with `evaluation_scope="ad_hoc"` writes `forecast_metrics` rows with a null (but `String`-typed)
   `mlflow_run_id` and no MLflow logging.
 
-### 7.6.7 Phase 6.7 — `metrics` asset: only load the `power_forecasts` partitions it needs
+### 7.6.7 Phase 6.7 — `metrics` asset: only load the `power_forecasts` partitions it needs - Completed in PR #214
 
 *Deferred from the Phase 6.5 line of work to keep that PR small.*
 

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -579,22 +579,28 @@ class PopulationFilter(Config):
     valid_time_max: str | None = None
     """ISO-8601 UTC timestamp; rows with ``valid_time`` after this are excluded."""
 
-    def apply(self, scan: pt.LazyFrame[PowerForecast]) -> pt.LazyFrame[PowerForecast]:
+    def apply(self, scan: pl.LazyFrame) -> pl.LazyFrame:
         """Return ``scan`` with all non-``None`` filter fields applied as Polars predicates.
 
         Args:
-            scan: Typed lazy scan of the ``power_forecasts`` Delta table. The caller is
-                responsible for casting any ``String`` columns that ``PowerForecast`` declares as
-                ``Categorical`` before passing the scan here (delta-rs stores all
-                dictionary-encoded columns as plain ``String`` on disk; casting lazily via
-                ``.with_columns()`` before ``.collect()`` is zero-cost).
+            scan: **Raw** lazy scan of the ``power_forecasts`` Delta table, i.e. the direct
+                ``pl.scan_delta(...)`` result with ``experiment_name`` / ``fold_id`` still as
+                plain ``String`` (delta-rs stores all dictionary-encoded columns as ``String`` on
+                disk). It must **not** yet be cast to the ``Categorical`` dtypes that
+                ``PowerForecast`` declares — see the return note below for why.
 
         Returns:
-            The same lazy scan with each non-``None`` field added as a ``.filter()`` predicate.
+            A plain ``pl.LazyFrame`` — deliberately **not** a ``pt.LazyFrame[PowerForecast]``.
+            The whole point of this method is that its ``.filter()`` predicates push down into the
+            Delta scan for partition pruning (``experiment_name`` / ``fold_id`` are the on-disk
+            partition columns) and row-group skipping. A ``String → Categorical`` cast placed
+            between ``scan_delta`` and these filters would block that pushdown and force Polars to
+            read every partition, so the cast is deliberately deferred to *after* filtering — done
+            per group by ``_load_forecast_group``, which is where the frame becomes a typed
+            ``pt.DataFrame[PowerForecast]``. Returning a plain frame keeps that ordering honest:
+            there is no model to attach until the columns actually hold their declared dtypes.
         """
-        # Rebind to plain pl.LazyFrame: Polars' .filter() drops the pt.LazyFrame subclass, so
-        # accumulating filters via scan = scan.filter(...) would fail ty's assignment check.
-        # Re-wrap as pt.LazyFrame[PowerForecast] before returning (zero-copy).
+        # Polars' .filter() already returns a plain pl.LazyFrame; annotate for clarity.
         lf: pl.LazyFrame = scan
         if self.experiment_name is not None:
             lf = lf.filter(pl.col("experiment_name") == self.experiment_name)
@@ -610,7 +616,7 @@ class PopulationFilter(Config):
             if max_dt.tzinfo is None:
                 max_dt = max_dt.replace(tzinfo=timezone.utc)
             lf = lf.filter(pl.col("valid_time") <= max_dt)
-        return pt.LazyFrame.from_existing(lf).set_model(PowerForecast)
+        return lf
 
 
 class MetricsConfig(Config):
@@ -698,10 +704,42 @@ def _write_metrics_to_delta(
     )
 
 
+def _load_forecast_group(
+    pruned_scan: pl.LazyFrame, exp_name: str, fold_id: str
+) -> pt.DataFrame[PowerForecast]:
+    """Collect and validate a single ``(experiment_name, fold_id)`` group.
+
+    Narrows the already-pruned scan to one partition. Because ``pruned_scan`` is a plain
+    ``pl.LazyFrame`` (the raw String Delta scan with ``PopulationFilter`` predicates already
+    applied), this extra ``.filter()`` on the partition columns pushes down into the Delta scan, so
+    only this partition's Parquet files are read. The ``String → Categorical`` cast happens *after*
+    the filter so it never blocks that pushdown. Peak memory is therefore a single fold, regardless
+    of how many groups the population filter matched.
+
+    Args:
+        pruned_scan: Raw ``pl.LazyFrame`` returned by ``PopulationFilter.apply`` (String partition
+            columns, predicates already applied, not yet cast to ``Categorical``).
+        exp_name: Experiment name of the group to load.
+        fold_id: Fold identifier of the group to load.
+
+    Returns:
+        The validated ``PowerForecast`` rows for this one group.
+    """
+    group_scan = pruned_scan.filter(
+        (pl.col("experiment_name") == exp_name) & (pl.col("fold_id") == fold_id)
+    ).with_columns(
+        experiment_name=pl.col("experiment_name").cast(pl.Categorical),
+        fold_id=pl.col("fold_id").cast(pl.Categorical),
+        power_fcst_model_name=pl.col("power_fcst_model_name").cast(pl.Categorical),
+    )
+    collected = pt.LazyFrame.from_existing(group_scan).set_model(PowerForecast).collect()
+    return PowerForecast.validate(collected, allow_superfluous_columns=True)
+
+
 def _score_forecast_group(
     exp_name: str,
     fold_id: str,
-    filtered_power_forecasts: pl.DataFrame,
+    group_forecasts: pt.DataFrame[PowerForecast],
     actuals_lf: pt.LazyFrame[PowerTimeSeries],
     metadata_df: pt.DataFrame[TimeSeriesMetadata],
     capacity_df: pt.DataFrame[EffectiveCapacity],
@@ -715,8 +753,8 @@ def _score_forecast_group(
     Args:
         exp_name: Experiment name for this group.
         fold_id: Fold identifier for this group.
-        filtered_power_forecasts: All collected forecast rows that survived the population
-            filter; this function slices the single ``(exp_name, fold_id)`` group from it.
+        group_forecasts: The already-sliced, validated ``PowerForecast`` rows for this single
+            ``(exp_name, fold_id)`` group (loaded by ``_load_forecast_group``).
         actuals_lf: Lazy observed power scan (only the joined subset is collected inside
             ``compute_metrics()``).
         metadata_df: Substation metadata used to join ``time_series_type`` onto each metric row.
@@ -736,12 +774,6 @@ def _score_forecast_group(
           fold's MLflow child run (e.g. ``{"rmse__all": 0.42, "rmse__pv": 0.31}``). ``None``
           for ``"ad_hoc"`` scope, where no MLflow run exists.
     """
-    group_forecasts = PowerForecast.validate(
-        filtered_power_forecasts.filter(
-            (pl.col("experiment_name") == exp_name) & (pl.col("fold_id") == fold_id)
-        ),
-        allow_superfluous_columns=True,
-    )
     per_series_metrics = compute_metrics(group_forecasts, actuals_lf, metadata_df, capacity_df)
 
     window_start, window_end, window_label = _resolve_eval_window(
@@ -795,18 +827,25 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     settings = Settings()
     mlflow.set_tracking_uri(settings.mlflow_tracking_uri)
 
-    # delta-rs stores all Arrow dictionary-encoded columns (Categorical, Enum) as plain String on
-    # disk. Cast lazily before filtering so PopulationFilter.apply receives a properly-typed
-    # pt.LazyFrame[PowerForecast] and the collected frame already has the correct dtypes.
-    power_forecasts = pt.LazyFrame.from_existing(
-        pl.scan_delta(str(settings.power_forecasts_data_path)).with_columns(
-            experiment_name=pl.col("experiment_name").cast(pl.Categorical),
-            fold_id=pl.col("fold_id").cast(pl.Categorical),
-            power_fcst_model_name=pl.col("power_fcst_model_name").cast(pl.Categorical),
-        )
-    ).set_model(PowerForecast)
-    filtered_power_forecasts = config.population_filter.apply(power_forecasts).collect()
-    if filtered_power_forecasts.height == 0:
+    # Apply the population filter to the RAW String scan so its predicates push into the Delta scan
+    # (experiment_name / fold_id are the on-disk partition columns → partition pruning). The
+    # String → Categorical cast is deliberately deferred to _load_forecast_group, after filtering,
+    # because a cast between scan_delta and the filter would defeat pushdown. See
+    # PopulationFilter.apply for the full rationale.
+    raw_scan = pl.scan_delta(str(settings.power_forecasts_data_path))
+    pruned_scan = config.population_filter.apply(raw_scan)
+
+    # Discover the matching groups from the pruned scan — projecting to only the two partition
+    # columns keeps this collect cheap (partition metadata, not row data). Each group is then
+    # loaded and scored one at a time, so peak memory is a single fold.
+    groups = (
+        pruned_scan.select(["experiment_name", "fold_id"])
+        .unique()
+        .sort(["experiment_name", "fold_id"])
+        .collect()
+        .rows()
+    )
+    if not groups:
         context.log.warning("No forecasts matched the population filter — nothing to score.")
         context.add_output_metadata({"n_rows_written": 0, "n_groups": 0})
         return
@@ -830,12 +869,6 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
         pl.read_delta(str(settings.effective_capacity_data_path))
     )
 
-    groups = (
-        filtered_power_forecasts.select(["experiment_name", "fold_id"])
-        .unique()
-        .sort(["experiment_name", "fold_id"])
-        .rows()
-    )
     settings.forecast_metrics_data_path.parent.mkdir(parents=True, exist_ok=True)
     now = datetime.now(timezone.utc)
     total_rows = 0
@@ -846,10 +879,11 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     experiment_fold_metrics: dict[str, dict[str, list[float]]] = {}
 
     for exp_name, fold_id in groups:
+        group_forecasts = _load_forecast_group(pruned_scan, exp_name, fold_id)
         n_rows, fold_metric_dict = _score_forecast_group(
             exp_name,
             fold_id,
-            filtered_power_forecasts,
+            group_forecasts,
             actuals_lf,
             metadata_df,
             capacity_df,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -406,6 +406,70 @@ def test_metrics_ad_hoc_no_mlflow_logging(file_mlflow_env: dict[str, Path]) -> N
         assert "rmse__all" not in run.data.metrics
 
 
+def test_population_filter_prunes_partitions(tmp_path: Path) -> None:
+    """``PopulationFilter.apply`` pushes its predicate into the Delta scan (partition pruning).
+
+    Regression guard for Phase 6.7: casting ``experiment_name`` / ``fold_id`` *before* filtering
+    (the prior behaviour) forces Polars to read every partition. Applying the filter to the raw
+    ``String`` scan prunes to just the named partition — the explain plan lists only that
+    partition's Parquet path and never the other experiment's.
+    """
+    path = str(tmp_path / "power_forecasts")
+    valid_time = pl.Series([datetime(2025, 8, 1, 6, tzinfo=timezone.utc)] * 4).dt.cast_time_unit(
+        "us"
+    )
+    df = pl.DataFrame(
+        {
+            "experiment_name": ["expA", "expA", "expB", "expB"],
+            "fold_id": ["f1", "f1", "f1", "f1"],
+            "valid_time": valid_time,
+            "power_hat": [1.0, 2.0, 3.0, 4.0],
+        }
+    )
+    write_deltalake(
+        table_or_uri=path, data=df.to_arrow(), partition_by=["experiment_name", "fold_id"]
+    )
+
+    plan = PopulationFilter(experiment_name="expA").apply(pl.scan_delta(path)).explain()
+    assert "experiment_name=expA" in plan
+    assert "experiment_name=expB" not in plan
+
+
+def test_metrics_no_filter_scores_every_group(file_mlflow_env: dict[str, Path]) -> None:
+    """A default (no-filter) ``metrics`` run scores every ``(experiment_name, fold_id)`` group.
+
+    The pipeline produces forecasts for one experiment; we duplicate them under a second
+    experiment so two groups exist on disk, then run ``metrics`` with the default
+    ``PopulationFilter()`` (no filter) and assert both groups land in ``forecast_metrics``.
+    """
+    instance = DagsterInstance.ephemeral()
+    _run_cv_pipeline(instance)
+
+    # Duplicate the produced forecasts under a second experiment so two groups exist on disk.
+    forecasts_path = str(file_mlflow_env["forecasts"])
+    second_experiment = f"{EXPERIMENT_NAME}_2"
+    duplicate = pl.read_delta(forecasts_path).with_columns(
+        experiment_name=pl.lit(second_experiment)
+    )
+    write_deltalake(
+        table_or_uri=forecasts_path,
+        data=duplicate.to_arrow(),
+        mode="append",
+        partition_by=["experiment_name", "fold_id"],
+    )
+
+    # Default PopulationFilter() = no filter → score everything.
+    assert materialize(
+        [metrics],
+        run_config=RunConfig(ops={"metrics": MetricsConfig(evaluation_scope="ad_hoc")}),
+        instance=instance,
+    ).success
+
+    fm = pl.read_delta(str(file_mlflow_env["metrics"]))
+    scored_experiments = set(fm["experiment_name"].unique().to_list())
+    assert scored_experiments == {EXPERIMENT_NAME, second_experiment}
+
+
 # ---------------------------------------------------------------------------
 # Full-stack cross-process test (real mlflow server)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Phase 6.7 — `metrics` asset: only load the `power_forecasts` partitions it needs

Deferred from the Phase 6.5 line of work (§7.6.7 of the plan).

### Problems on `main`

1. **Partition pruning is silently defeated.** `power_forecasts` is partitioned on disk by
   `(experiment_name, fold_id)`, but `metrics` casts those columns `String → Categorical`
   *before* `PopulationFilter.apply` runs. The cast sits between `scan_delta` and the filter,
   so the partition predicates never push into the Delta scan and Polars reads **every**
   partition even when the run names one experiment/fold.
2. **The whole matched population is `.collect()`ed at once**, then re-sliced per group. The
   default `PopulationFilter()` ("score everything") pulls the entire table into RAM.

### Fix

- `PopulationFilter.apply` now operates on (and returns) a raw String `pl.LazyFrame`, so the
  filter predicates push into the Delta scan (partition pruning + row-group stats).
- The `String → Categorical` cast moves *after* the filter, into a new per-group loader.
- `metrics` discovers matching `(experiment_name, fold_id)` groups from the pruned scan and
  scores **one group at a time**, so peak memory is a single fold regardless of match count.

Metric values are unchanged — this is a pruning / memory refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)