### PR TITLE
Switch PowerForecast/Metrics identity columns from Categorical to String

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,37 +192,35 @@ result = pl.DataFrame._from_pydf(patito_df._df).cast({"foo": pl.Categorical})
 Patito use and is correct. Expression/Series casts like `pl.col("foo").cast(pl.Int8)` are always
 plain Polars and unaffected.)
 
-### Delta Lake read-path: cast `String→Categorical` lazily, before filtering
+### Delta Lake dictionary-encoded columns: declare Delta filter/partition columns as `String`
 
 delta-rs stores all Arrow dictionary-encoded columns (`Categorical`, `Enum`) as plain `String` in
-Parquet (this is the write-path gotcha documented in `_write_metrics_to_delta`). On the **read**
-path, cast them back *lazily* — in the `pl.scan_delta(...)` result — before wrapping with
-`set_model` and passing to any typed helper:
+Parquet (this is the write-path gotcha documented in `_write_metrics_to_delta`, which casts the
+remaining `Enum` columns to `String` before writing). Two consequences:
 
-```python
-# Cast lazily so the scan is typed from the start; zero-cost until .collect().
-typed_scan = pt.LazyFrame.from_existing(
-    pl.scan_delta(str(path)).with_columns(
-        experiment_name=pl.col("experiment_name").cast(pl.Categorical),
-        fold_id=pl.col("fold_id").cast(pl.Categorical),
-    )
-).set_model(MySchema)
-```
+1. **A contract column you filter or partition on in Delta should be `String`, not `Categorical`.**
+   If the schema declared it `Categorical`, every read would need a `String → Categorical` cast to
+   satisfy the model — and a cast placed between `pl.scan_delta(...)` and a `.filter()` on that
+   column **blocks predicate pushdown** (Polars can no longer prune Delta partitions or skip row
+   groups, so it reads the *whole* table even when the filter names one partition). Declaring the
+   column `String` matches what is on disk, so the scan is typed by `set_model` with no cast, the
+   filter pushes straight down, and there is no dtype tension at the write boundary either.
+   `PowerForecast.experiment_name` / `fold_id` (the `power_forecasts` partition columns) and
+   `power_fcst_model_name` are `String` for exactly this reason; `PopulationFilter.apply` therefore
+   takes and returns a typed `pt.LazyFrame[PowerForecast]`. Confirm pushdown with `.explain()` — it
+   should list only the matching `partition=value` paths.
 
-Casting after `.collect()` also works but is later than necessary: typed helpers that receive the
-scan (e.g. a filter method) would then have to accept `pl.LazyFrame` instead of
-`pt.LazyFrame[MySchema]`.
+2. **For a genuinely low-cardinality column you only *read* (never filter on), cast `String →
+   Enum`/`Categorical` lazily** — in the `pl.scan_delta(...)` result, before `set_model` — so the
+   scan is typed from the start and the cast stays zero-cost until `.collect()`:
 
-**Caveat — filter *before* the cast when the column is filtered on (especially a Delta partition
-column).** The lazy cast above is right for columns you only *read*, but a `String→Categorical`
-cast placed between `pl.scan_delta(...)` and a `.filter()` on that column **blocks predicate
-pushdown**: Polars can no longer prune Delta partitions or skip row groups, so it reads the *whole*
-table even when the filter names one partition. `experiment_name` / `fold_id` are the on-disk
-partition columns of `power_forecasts`, so when filtering on them, filter the **raw `String`
-scan first, then cast** the surviving rows per group. Confirm pushdown with `.explain()` — it
-should list only the matching `partition=value` paths. (This is the ordering `PopulationFilter.apply`
-and `_load_forecast_group` in `cv_assets.py` follow, and the reason `apply` returns a *plain*
-`pl.LazyFrame` — there is no model to attach until after the cast.)
+   ```python
+   typed_scan = pt.LazyFrame.from_existing(
+       pl.scan_delta(str(path)).with_columns(
+           metric_name=pl.col("metric_name").cast(pl.Enum(METRIC_NAMES)),
+       )
+   ).set_model(MetricsSchema)
+   ```
 
 ### Patito + Polars Gotcha: `pt.LazyFrame.filter()` drops the Patito subclass
 

--- a/docs/ml_experimentation/dagster-workflow.md
+++ b/docs/ml_experimentation/dagster-workflow.md
@@ -196,9 +196,10 @@ in the run config dialog before launching.
 
 **What the asset does:**
 
-1. Scans `power_forecasts` Delta, applying any non-null `PopulationFilter` predicates. The filter
-   runs on the raw scan so its predicates push into the Delta scan: naming an experiment/fold
-   prunes to just that partition rather than reading the whole (unbounded) table.
+1. Scans `power_forecasts` Delta, applying any non-null `PopulationFilter` predicates. The
+   partition columns (`experiment_name` / `fold_id`) are `String`, matching what delta-rs stores,
+   so the predicates push straight into the Delta scan: naming an experiment/fold prunes to just
+   that partition rather than reading the whole (unbounded) table.
 2. Discovers the matching `(experiment_name, fold_id)` groups, then loads and scores **one group at
    a time** — peak memory is a single fold, not the entire matched population. For each group:
    a. Calls `compute_metrics()` — joins observed power, averages ensemble members, computes

--- a/packages/contracts/src/contracts/ml_schemas.py
+++ b/packages/contracts/src/contracts/ml_schemas.py
@@ -254,12 +254,12 @@ class Metrics(pt.Model):
     time_series_id: int = _get_time_series_id_dtype()
 
     power_fcst_model_name: str = pt.Field(
-        dtype=pl.Categorical,
+        dtype=pl.String,
         description="Identifier for the ML-based power forecasting model family.",
     )
 
     fold_id: str = pt.Field(
-        dtype=pl.Categorical,
+        dtype=pl.String,
         description="CV fold year (e.g. '2022'), or 'live' for production forecasts. Matches PowerForecast.fold_id.",
     )
 
@@ -348,7 +348,7 @@ class Metrics(pt.Model):
     )
 
     experiment_name: str = pt.Field(
-        dtype=pl.Categorical,
+        dtype=pl.String,
         allow_missing=True,
         description=(
             "Experiment that produced these forecasts. Delta partition key alongside fold_id. "

--- a/packages/contracts/src/contracts/ml_schemas.py
+++ b/packages/contracts/src/contracts/ml_schemas.py
@@ -255,7 +255,8 @@ class Metrics(pt.Model):
 
     # String (not Categorical): fold_id/experiment_name are Delta partition columns and delta-rs
     # stores dictionary-encoded columns as String anyway; String keeps them cast-free and lets
-    # predicate pushdown work. See the "declare Delta filter/partition columns as String" gotcha.
+    # predicate pushdown work. See the "declare Delta filter/partition columns as String" gotcha:
+    # ../../../../CLAUDE.md#delta-lake-dictionary-encoded-columns-declare-delta-filterpartition-columns-as-string
     power_fcst_model_name: str = pt.Field(
         dtype=pl.String,
         description="Identifier for the ML-based power forecasting model family.",

--- a/packages/contracts/src/contracts/ml_schemas.py
+++ b/packages/contracts/src/contracts/ml_schemas.py
@@ -253,6 +253,9 @@ class Metrics(pt.Model):
 
     time_series_id: int = _get_time_series_id_dtype()
 
+    # String (not Categorical): fold_id/experiment_name are Delta partition columns and delta-rs
+    # stores dictionary-encoded columns as String anyway; String keeps them cast-free and lets
+    # predicate pushdown work. See the "declare Delta filter/partition columns as String" gotcha.
     power_fcst_model_name: str = pt.Field(
         dtype=pl.String,
         description="Identifier for the ML-based power forecasting model family.",
@@ -348,7 +351,7 @@ class Metrics(pt.Model):
     )
 
     experiment_name: str = pt.Field(
-        dtype=pl.String,
+        dtype=pl.String,  # String (not Categorical) — Delta partition column, see fold_id above.
         allow_missing=True,
         description=(
             "Experiment that produced these forecasts. Delta partition key alongside fold_id. "

--- a/packages/contracts/src/contracts/power_schemas.py
+++ b/packages/contracts/src/contracts/power_schemas.py
@@ -244,10 +244,14 @@ class PowerForecast(pt.Model):
     )
 
     power_fcst_model_name: str = pt.Field(
-        dtype=pl.String,
+        dtype=pl.String,  # String, not Categorical — see experiment_name below.
         description="Identifier for our ML-based power forecasting model. Model-family identity set by the BaseForecaster subclass (MODEL_NAME).",
     )
 
+    # String (not Categorical): experiment_name/fold_id are the Delta partition columns and delta-rs
+    # stores dictionary-encoded columns as String anyway; String keeps them cast-free and lets
+    # predicate pushdown work. See the "declare Delta filter/partition columns as String" gotcha:
+    # ../../../../CLAUDE.md#delta-lake-dictionary-encoded-columns-declare-delta-filterpartition-columns-as-string
     experiment_name: str = pt.Field(
         dtype=pl.String,
         description=(
@@ -286,7 +290,7 @@ class PowerForecast(pt.Model):
     )
 
     fold_id: FoldId = pt.Field(
-        dtype=pl.String,
+        dtype=pl.String,  # String, not Categorical — see experiment_name above.
         description=(
             "Identifies the source of this forecast row.  "
             "For cross-validation runs, the value is the fold's label from conf/cv/default.yaml "

--- a/packages/contracts/src/contracts/power_schemas.py
+++ b/packages/contracts/src/contracts/power_schemas.py
@@ -244,12 +244,12 @@ class PowerForecast(pt.Model):
     )
 
     power_fcst_model_name: str = pt.Field(
-        dtype=pl.Categorical,
+        dtype=pl.String,
         description="Identifier for our ML-based power forecasting model. Model-family identity set by the BaseForecaster subclass (MODEL_NAME).",
     )
 
     experiment_name: str = pt.Field(
-        dtype=pl.Categorical,
+        dtype=pl.String,
         description=(
             "Per-experiment key identifying the experiment that produced this forecast."
             " Distinct from `power_fcst_model_name`, which is the model-family identity"
@@ -286,7 +286,7 @@ class PowerForecast(pt.Model):
     )
 
     fold_id: FoldId = pt.Field(
-        dtype=pl.Categorical,
+        dtype=pl.String,
         description=(
             "Identifies the source of this forecast row.  "
             "For cross-validation runs, the value is the fold's label from conf/cv/default.yaml "

--- a/packages/ml_core/src/ml_core/metrics.py
+++ b/packages/ml_core/src/ml_core/metrics.py
@@ -133,8 +133,6 @@ def compute_metrics(
         .with_columns(
             horizon_slice=pl.lit("all").cast(pl.Enum(HORIZON_SLICES)),
             metric_param=pl.lit("all").cast(pl.Enum(METRIC_PARAMS)),
-            power_fcst_model_name=pl.col("power_fcst_model_name").cast(pl.Categorical),
-            fold_id=pl.col("fold_id").cast(pl.Categorical),
         )
     )
 
@@ -234,7 +232,7 @@ def enrich_metrics_rows(
     """
     return Metrics.validate(
         per_series_metrics.with_columns(
-            experiment_name=pl.lit(experiment_name).cast(pl.Categorical),
+            experiment_name=pl.lit(experiment_name, dtype=pl.String),
             evaluation_scope=pl.lit(evaluation_scope).cast(pl.Enum(EVALUATION_SCOPES)),
             window_start=pl.lit(window_start).cast(UTC_DATETIME_DTYPE),
             window_end=pl.lit(window_end).cast(UTC_DATETIME_DTYPE),

--- a/packages/ml_core/tests/test_metrics.py
+++ b/packages/ml_core/tests/test_metrics.py
@@ -52,11 +52,11 @@ def _make_cv_forecasts(
             "ensemble_member": pl.Series([0] * n, dtype=pl.Int8),
             "nwp_init_time": pl.Series([None] * n, dtype=pl.Datetime("us", "UTC")),
             "power_fcst": pl.Series(power_fcst, dtype=pl.Float32),
-            "power_fcst_model_name": pl.Series(["stub"] * n).cast(pl.Categorical),
+            "power_fcst_model_name": pl.Series(["stub"] * n, dtype=pl.String),
             "power_fcst_model_version": pl.Series([1] * n, dtype=pl.Int16),
             "ml_flow_experiment_id": pl.Series([None] * n, dtype=pl.Int32),
-            "experiment_name": pl.Series(["stub_exp"] * n).cast(pl.Categorical),
-            "fold_id": pl.Series([fold_id] * n).cast(pl.Categorical),
+            "experiment_name": pl.Series(["stub_exp"] * n, dtype=pl.String),
+            "fold_id": pl.Series([fold_id] * n, dtype=pl.String),
         }
     )
     return PowerForecast.validate(df, allow_superfluous_columns=True)
@@ -186,11 +186,11 @@ def test_compute_metrics_ensemble_averaging():
             "ensemble_member": pl.Series([0, 1], dtype=pl.Int8),
             "nwp_init_time": pl.Series([None, None], dtype=pl.Datetime("us", "UTC")),
             "power_fcst": pl.Series([8.0, 12.0], dtype=pl.Float32),
-            "power_fcst_model_name": pl.Series(["stub", "stub"]).cast(pl.Categorical),
+            "power_fcst_model_name": pl.Series(["stub", "stub"], dtype=pl.String),
             "power_fcst_model_version": pl.Series([1, 1], dtype=pl.Int16),
             "ml_flow_experiment_id": pl.Series([None, None], dtype=pl.Int32),
-            "experiment_name": pl.Series(["stub_exp", "stub_exp"]).cast(pl.Categorical),
-            "fold_id": pl.Series(["2022", "2022"]).cast(pl.Categorical),
+            "experiment_name": pl.Series(["stub_exp", "stub_exp"], dtype=pl.String),
+            "fold_id": pl.Series(["2022", "2022"], dtype=pl.String),
         }
     )
     forecasts = PowerForecast.validate(df, allow_superfluous_columns=True)

--- a/packages/xgboost_forecaster/src/xgboost_forecaster/forecaster.py
+++ b/packages/xgboost_forecaster/src/xgboost_forecaster/forecaster.py
@@ -188,20 +188,10 @@ class XGBoostForecaster(BaseForecaster):
             empty = cast(pt.DataFrame[AllFeatures], df.head(0))
             parts.append(_build_part(empty, np.empty(0, dtype=np.float32)))
 
-        # ``select``/``with_columns`` and ``pl.concat`` preserve the input's Patito ``AllFeatures``
-        # subclass, so a Patito ``.cast`` here would ignore the mapping and instead revert every
-        # column to its ``AllFeatures`` dtype (e.g. ``ensemble_member`` back to ``UInt8``) and leave
-        # the forecast-only columns untouched. Strip the Patito model so the dict-cast uses plain
-        # Polars semantics. ``_from_pydf`` reuses the same underlying frame (zero-copy).
-        combined = pl.concat(parts)
-        result = pl.DataFrame._from_pydf(combined._df).cast(
-            {
-                "power_fcst_model_name": pl.Categorical,
-                "experiment_name": pl.Categorical,
-                "fold_id": pl.Categorical,
-            }
-        )
-        return PowerForecast.validate(result)
+        # The identity columns (power_fcst_model_name / experiment_name / fold_id) are built as
+        # ``pl.lit(str)`` above, so they are already ``String`` — the dtype PowerForecast declares —
+        # and need no cast before validation.
+        return PowerForecast.validate(pl.concat(parts))
 
     def save(self, path: Path) -> None:
         """Save all Boosters as .ubj files plus a meta.json with the full config."""

--- a/packages/xgboost_forecaster/tests/test_forecaster.py
+++ b/packages/xgboost_forecaster/tests/test_forecaster.py
@@ -82,7 +82,7 @@ def test_predict_output_schema() -> None:
 
     assert len(result) == len(df)
     assert result["power_fcst"].dtype == pl.Float32
-    assert result["power_fcst_model_name"].dtype == pl.Categorical
+    assert result["power_fcst_model_name"].dtype == pl.String
     assert result["power_fcst_model_version"].dtype == pl.Int16
     # ml_flow_experiment_id=None → every row is null
     assert result["ml_flow_experiment_id"].is_null().all()
@@ -149,7 +149,7 @@ def test_predict_stamps_experiment_name() -> None:
     df = _make_df()
     lf = pt.LazyFrame.from_existing(df.lazy())
     result = _trained(df, experiment_name="my_experiment").predict(lf)
-    assert result["experiment_name"].dtype == pl.Categorical
+    assert result["experiment_name"].dtype == pl.String
     assert (result["experiment_name"] == "my_experiment").all()
 
 
@@ -164,7 +164,7 @@ def test_predict_stamps_supplied_fold_id() -> None:
     df = _make_df()
     lf = pt.LazyFrame.from_existing(df.lazy())
     result = _trained(df).predict(lf, fold_id="2024")
-    assert result["fold_id"].dtype == pl.Categorical
+    assert result["fold_id"].dtype == pl.String
     assert (result["fold_id"] == "2024").all()
 
 

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -502,12 +502,9 @@ def cv_power_forecasts(context: AssetExecutionContext) -> None:
         if forecasts.height == 0 and not is_first:
             continue
 
-        # Cast the partition columns to plain strings so Delta stores them as Hive-style string
-        # directories (delta-rs cannot partition on a dictionary-encoded Categorical column).
-        delta_data = forecasts.with_columns(
-            experiment_name=pl.col("experiment_name").cast(pl.String),
-            fold_id=pl.col("fold_id").cast(pl.String),
-        ).to_arrow()
+        # experiment_name / fold_id are String (their PowerForecast dtype), which is exactly what
+        # delta-rs needs for Hive-style partition directories — no cast required.
+        delta_data = forecasts.to_arrow()
         if is_first:
             # The first chunk overwrites the (experiment, fold) partition, clearing any prior run.
             write_deltalake(
@@ -579,28 +576,23 @@ class PopulationFilter(Config):
     valid_time_max: str | None = None
     """ISO-8601 UTC timestamp; rows with ``valid_time`` after this are excluded."""
 
-    def apply(self, scan: pl.LazyFrame) -> pl.LazyFrame:
+    def apply(self, scan: pt.LazyFrame[PowerForecast]) -> pt.LazyFrame[PowerForecast]:
         """Return ``scan`` with all non-``None`` filter fields applied as Polars predicates.
 
+        ``experiment_name`` / ``fold_id`` are ``String`` in ``PowerForecast`` (matching how
+        delta-rs stores the on-disk partition columns), so the ``pl.scan_delta`` result can be
+        typed with ``set_model(PowerForecast)`` directly and these ``.filter()`` predicates push
+        straight down into the Delta scan — partition pruning on ``experiment_name`` / ``fold_id``
+        plus row-group skipping — with no dtype cast in the way.
+
         Args:
-            scan: **Raw** lazy scan of the ``power_forecasts`` Delta table, i.e. the direct
-                ``pl.scan_delta(...)`` result with ``experiment_name`` / ``fold_id`` still as
-                plain ``String`` (delta-rs stores all dictionary-encoded columns as ``String`` on
-                disk). It must **not** yet be cast to the ``Categorical`` dtypes that
-                ``PowerForecast`` declares — see the return note below for why.
+            scan: Typed lazy scan of the ``power_forecasts`` Delta table.
 
         Returns:
-            A plain ``pl.LazyFrame`` — deliberately **not** a ``pt.LazyFrame[PowerForecast]``.
-            The whole point of this method is that its ``.filter()`` predicates push down into the
-            Delta scan for partition pruning (``experiment_name`` / ``fold_id`` are the on-disk
-            partition columns) and row-group skipping. A ``String → Categorical`` cast placed
-            between ``scan_delta`` and these filters would block that pushdown and force Polars to
-            read every partition, so the cast is deliberately deferred to *after* filtering — done
-            per group by ``_load_forecast_group``, which is where the frame becomes a typed
-            ``pt.DataFrame[PowerForecast]``. Returning a plain frame keeps that ordering honest:
-            there is no model to attach until the columns actually hold their declared dtypes.
+            The same scan with the filter predicates applied, re-wrapped as a
+            ``pt.LazyFrame[PowerForecast]`` (``.filter()`` drops the Patito subclass).
         """
-        # Polars' .filter() already returns a plain pl.LazyFrame; annotate for clarity.
+        # .filter() drops the pt subclass; accumulate on a plain LazyFrame, re-wrap on return.
         lf: pl.LazyFrame = scan
         if self.experiment_name is not None:
             lf = lf.filter(pl.col("experiment_name") == self.experiment_name)
@@ -616,7 +608,7 @@ class PopulationFilter(Config):
             if max_dt.tzinfo is None:
                 max_dt = max_dt.replace(tzinfo=timezone.utc)
             lf = lf.filter(pl.col("valid_time") <= max_dt)
-        return lf
+        return pt.LazyFrame.from_existing(lf).set_model(PowerForecast)
 
 
 class MetricsConfig(Config):
@@ -675,9 +667,9 @@ def _write_metrics_to_delta(
 ) -> None:
     """Write enriched Metrics rows to the ``forecast_metrics`` Delta table.
 
-    Casts all Categorical and Enum columns to ``String`` before writing — delta-rs stores
-    Arrow dictionary arrays as plain String in Parquet, so the on-disk schema is always
-    String. Re-sending Enum/Categorical data on an overwrite would cause a schema-mismatch
+    Casts the ``Enum`` columns (e.g. ``metric_name``, ``horizon_slice``) to ``String`` before
+    writing — delta-rs stores Arrow dictionary arrays as plain String in Parquet, so the on-disk
+    schema is always String. Re-sending Enum data on an overwrite would cause a schema-mismatch
     error. Performs an idempotent overwrite of the ``(experiment_name, fold_id)`` partition
     so re-materialising the asset replaces rows rather than duplicating them.
 
@@ -689,12 +681,8 @@ def _write_metrics_to_delta(
             replacement to this ``(experiment_name, fold_id)`` partition.
         fold_id: Fold identifier; used alongside ``exp_name`` in the predicate.
     """
-    cat_cols = [
-        c
-        for c, dtype in enriched.schema.items()
-        if dtype == pl.Categorical or hasattr(dtype, "categories")
-    ]
-    delta_data = enriched.with_columns(pl.col(c).cast(pl.String) for c in cat_cols).to_arrow()
+    enum_cols = [c for c, dtype in enriched.schema.items() if isinstance(dtype, pl.Enum)]
+    delta_data = enriched.with_columns(pl.col(c).cast(pl.String) for c in enum_cols).to_arrow()
     write_deltalake(
         table_or_uri=path,
         data=delta_data,
@@ -705,20 +693,18 @@ def _write_metrics_to_delta(
 
 
 def _load_forecast_group(
-    pruned_scan: pl.LazyFrame, exp_name: str, fold_id: str
+    pruned_scan: pt.LazyFrame[PowerForecast], exp_name: str, fold_id: str
 ) -> pt.DataFrame[PowerForecast]:
     """Collect and validate a single ``(experiment_name, fold_id)`` group.
 
-    Narrows the already-pruned scan to one partition. Because ``pruned_scan`` is a plain
-    ``pl.LazyFrame`` (the raw String Delta scan with ``PopulationFilter`` predicates already
-    applied), this extra ``.filter()`` on the partition columns pushes down into the Delta scan, so
-    only this partition's Parquet files are read. The ``String → Categorical`` cast happens *after*
-    the filter so it never blocks that pushdown. Peak memory is therefore a single fold, regardless
-    of how many groups the population filter matched.
+    Narrows the already-pruned scan to one partition. This extra ``.filter()`` on the String
+    partition columns pushes down into the Delta scan, so only this partition's Parquet files are
+    read. Peak memory is therefore a single fold, regardless of how many groups the population
+    filter matched.
 
     Args:
-        pruned_scan: Raw ``pl.LazyFrame`` returned by ``PopulationFilter.apply`` (String partition
-            columns, predicates already applied, not yet cast to ``Categorical``).
+        pruned_scan: The ``pt.LazyFrame[PowerForecast]`` returned by ``PopulationFilter.apply``
+            (partition predicates already applied).
         exp_name: Experiment name of the group to load.
         fold_id: Fold identifier of the group to load.
 
@@ -727,10 +713,6 @@ def _load_forecast_group(
     """
     group_scan = pruned_scan.filter(
         (pl.col("experiment_name") == exp_name) & (pl.col("fold_id") == fold_id)
-    ).with_columns(
-        experiment_name=pl.col("experiment_name").cast(pl.Categorical),
-        fold_id=pl.col("fold_id").cast(pl.Categorical),
-        power_fcst_model_name=pl.col("power_fcst_model_name").cast(pl.Categorical),
     )
     collected = pt.LazyFrame.from_existing(group_scan).set_model(PowerForecast).collect()
     return PowerForecast.validate(collected, allow_superfluous_columns=True)
@@ -827,13 +809,14 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     settings = Settings()
     mlflow.set_tracking_uri(settings.mlflow_tracking_uri)
 
-    # Apply the population filter to the RAW String scan so its predicates push into the Delta scan
-    # (experiment_name / fold_id are the on-disk partition columns → partition pruning). The
-    # String → Categorical cast is deliberately deferred to _load_forecast_group, after filtering,
-    # because a cast between scan_delta and the filter would defeat pushdown. See
-    # PopulationFilter.apply for the full rationale.
-    raw_scan = pl.scan_delta(str(settings.power_forecasts_data_path))
-    pruned_scan = config.population_filter.apply(raw_scan)
+    # Apply the population filter to the scan so its predicates push into the Delta scan
+    # (experiment_name / fold_id are the on-disk partition columns → partition pruning). These
+    # columns are String in PowerForecast, matching how delta-rs stores them, so no dtype cast
+    # sits between scan_delta and the filter to defeat pushdown. See PopulationFilter.apply.
+    scan = pt.LazyFrame.from_existing(
+        pl.scan_delta(str(settings.power_forecasts_data_path))
+    ).set_model(PowerForecast)
+    pruned_scan = config.population_filter.apply(scan)
 
     # Discover the matching groups from the pruned scan — projecting to only the two partition
     # columns keeps this collect cheap (partition metadata, not row data). Each group is then

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -23,10 +23,15 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 import mlflow
+import patito as pt
 import polars as pl
 import pytest
 from contracts.ml_schemas import EligibleTimeSeries
-from contracts.power_schemas import LIST_OF_TIME_SERIES_TYPES, TimeSeriesMetadata
+from contracts.power_schemas import (
+    LIST_OF_TIME_SERIES_TYPES,
+    PowerForecast,
+    TimeSeriesMetadata,
+)
 from dagster import DagsterInstance, RunConfig, materialize
 from deltalake import write_deltalake
 from mlflow.tracking import MlflowClient
@@ -409,9 +414,9 @@ def test_metrics_ad_hoc_no_mlflow_logging(file_mlflow_env: dict[str, Path]) -> N
 def test_population_filter_prunes_partitions(tmp_path: Path) -> None:
     """``PopulationFilter.apply`` pushes its predicate into the Delta scan (partition pruning).
 
-    Regression guard for Phase 6.7: casting ``experiment_name`` / ``fold_id`` *before* filtering
-    (the prior behaviour) forces Polars to read every partition. Applying the filter to the raw
-    ``String`` scan prunes to just the named partition — the explain plan lists only that
+    Regression guard for partition pruning: ``experiment_name`` / ``fold_id`` are ``String`` in
+    ``PowerForecast`` (matching how delta-rs stores them on disk), so the filter pushes straight
+    into the Delta scan with no dtype cast in the way. The explain plan lists only the named
     partition's Parquet path and never the other experiment's.
     """
     path = str(tmp_path / "power_forecasts")
@@ -430,7 +435,8 @@ def test_population_filter_prunes_partitions(tmp_path: Path) -> None:
         table_or_uri=path, data=df.to_arrow(), partition_by=["experiment_name", "fold_id"]
     )
 
-    plan = PopulationFilter(experiment_name="expA").apply(pl.scan_delta(path)).explain()
+    scan = pt.LazyFrame.from_existing(pl.scan_delta(path)).set_model(PowerForecast)
+    plan = PopulationFilter(experiment_name="expA").apply(scan).explain()
     assert "experiment_name=expA" in plan
     assert "experiment_name=expB" not in plan
 


### PR DESCRIPTION
Closes #215.

## Problem

`experiment_name`, `fold_id`, and `power_fcst_model_name` were declared as `pl.Categorical` in the `PowerForecast` and `Metrics` contracts, but they are `String` at every Delta boundary: delta-rs stores dictionary-encoded columns as plain `String` and cannot partition on a `Categorical` column. The contract/on-disk mismatch forced a `String ↔ Categorical` cast on every read and write, and the read-path cast — placed between `scan_delta` and the partition filter — defeated predicate pushdown. That is why Phase 6.7 (#214) had to drop the typed `pt.LazyFrame[PowerForecast]` signature from `PopulationFilter.apply`.

## Change

Declare the three columns `String` so the contract matches what is on disk:

- **`PopulationFilter.apply` regains its typed `pt.LazyFrame[PowerForecast]` signature** — predicates push straight into the Delta scan, so partition pruning is preserved (guarded by the existing explain-plan test).
- Removes the read-path cast in `_load_forecast_group`, the write-path casts in `cv_power_forecasts`, and reduces `_write_metrics_to_delta`'s cast list to the remaining `Enum` columns.
- Drops the `Categorical` cast + Patito-strip dance in `XGBoostForecaster.predict` (the identity columns are already `String` literals).
- Simplifies the `enrich_metrics_rows` / `compute_metrics` casts.
- Tidies the `CLAUDE.md` read-path gotcha into the durable lesson (declare Delta filter/partition columns as `String`) and updates the affected tests + `dagster-workflow.md`.

Net −24 lines.

## Trade-off

`String` costs more RAM than dictionary-encoded `Categorical` for these high-repetition columns in a large collected frame. Within a scored group they are constant, so the targeted memory fix (if needed at V2 scale) is column projection, not a Categorical contract — see the discussion on #215.

## Verification

- `uv run pytest packages/ tests/test_metrics.py` — all green, including `test_population_filter_prunes_partitions` (explain plan lists only the matching partition) and the `test_full_stack_real_mlflow_server` cross-process integration test.
- `uv run ruff check . && uv run ruff format --check . && uv run ty check && uv run pymarkdown scan -r docs CLAUDE.md` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)