### PR TITLE
Fix broken rendering of dollar amounts in live-service.md

### DIFF
--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -36,7 +36,7 @@ plan (phases 0–6.7 complete, PRs #182–#214); its final cleanup phase lives i
 - **Multi-user access** to the Dagster UI (and, later, to the dev dashboard) (rules out single-user tracking
   services).
 - AWS infrastructure with **no static AWS keys** (IAM roles throughout), basic alerting on task
-  failure (SNS → email), and cost-conscious operation (~$30–40/month target).
+  failure (SNS → email), and cost-conscious operation (~\$30–40/month target).
 
 **Post-MVP (explicitly deferred):**
 
@@ -130,7 +130,7 @@ service survives an MLflow outage), exactly as it does for CV today.
 An earlier version of this plan committed to the Level 1 ("nothing always-on") design from
 issue [#206](https://github.com/openclimatefix/nged-substation-forecast/issues/206). A
 2026-07-02 pressure-test of that decision found the #206 cost analysis substantially wrong:
-the always-on control plane it priced at ~$95–140/month actually costs ~$14–27/month (it
+the always-on control plane it priced at ~\$95–140/month actually costs ~\$14–27/month (it
 priced a 16 GB box big enough to run the *compute*, not a small control-plane box), and its
 RDS prerequisite dissolves on a single machine (Postgres-in-Docker, or SQLite on a real local
 filesystem). Two requirements also firmed up that Level 1 does not serve:
@@ -155,13 +155,13 @@ fold, plus `metrics`; single leaderboard fold), rising to ~15–20 under the fut
 multi-yearly-fold epoch.
 
 Fargate compute (eu-west-2, prices from the AWS price-list API, 2026-07-02): x86
-$0.04656/vCPU-hr + $0.00511/GB-hr; **ARM 20% cheaper** ($0.03725 + $0.00409) and
+\$0.04656/vCPU-hr + \$0.00511/GB-hr; **ARM 20% cheaper** (\$0.03725 + \$0.00409) and
 polars/XGBoost run fine on arm64. A right-sized 4 vCPU / 16 GB ARM task (measured inference
-peak ~9 GB) is $0.21/hr → 4 × 15-min live runs/day ≈ **$7/month**; hourly empty polling
-wake-ups add ~$2.50/month; a 2-hour 8 vCPU / 32 GB ARM backtest ≈ **$0.86/run**. (The old
-$15–25/month anchor assumed 8 vCPU / 32 GB x86.)
+peak ~9 GB) is \$0.21/hr → 4 × 15-min live runs/day ≈ **\$7/month**; hourly empty polling
+wake-ups add ~\$2.50/month; a 2-hour 8 vCPU / 32 GB ARM backtest ≈ **\$0.86/run**. (The old
+\$15–25/month anchor assumed 8 vCPU / 32 GB x86.)
 
-### Option A — Level 1: nothing always-on — ~$11–25/month
+### Option A — Level 1: nothing always-on — ~\$11–25/month
 
 Hourly EventBridge Scheduler → one-shot Fargate task → `dagster job execute` against a
 throwaway local `DAGSTER_HOME` → exit. Freshness check is the first op (latest Dynamical init
@@ -174,15 +174,15 @@ Dynamical availability, never Dagster's records (they evaporate with the throwaw
   needed by B/C/D anyway.
 - **Cons:** fails both new requirements — no run history, hand-rolled backfills (issue #208
   replay), backtests stay on the workstation, and the Marimo dashboard needs a separate
-  always-on home (+$8/month Fargate service) anyway.
+  always-on home (+\$8/month Fargate service) anyway.
 
-### Option B — small EC2 control-plane box + `EcsRunLauncher` — ~$29–42/month ← recommended
+### Option B — small EC2 control-plane box + `EcsRunLauncher` — ~\$29–42/month ← recommended
 
-A `t4g.medium` (2 vCPU / 4 GB; **$27.45/month on-demand, $17.30/month 1-yr no-upfront
+A `t4g.medium` (2 vCPU / 4 GB; **\$27.45/month on-demand, \$17.30/month 1-yr no-upfront
 reserved**) runs the Dagster daemon + webserver + code-location server + Postgres-in-Docker +
 **the Marimo dashboard**, behind Tailscale (no ALB). Every run — live schedules *and*
 UI-launched backtests — is dispatched by `EcsRunLauncher` to an ephemeral Fargate task sized
-to the job. Add ~$2.40 EBS, $7–9/month live Fargate, ~$1/backtest.
+to the job. Add ~\$2.40 EBS, \$7–9/month live Fargate, ~\$1/backtest.
 
 - **Pros:** Dagster properly (history, UI backfills, sensors, concurrency pools enforced
   centrally); backtests get big ephemeral compute; dashboard rides free; EC2 IAM instance
@@ -191,13 +191,13 @@ to the job. Add ~$2.40 EBS, $7–9/month live Fargate, ~$1/backtest.
   policies + the monitoring plan's "no fresh forecast" alarm); dagster.yaml/run-launcher
   config work; 4 GB is comfortable but not roomy (watch Marimo's Delta scans).
 - Cost trims: t4g.small (2 GB) is **free-trial (750 hrs/month) until 31 Dec 2026** and
-  $13.72/$8.69 after, if everything squeezes into 2 GB — likely too tight with Marimo.
+  \$13.72/\$8.69 after, if everything squeezes into 2 GB — likely too tight with Marimo.
 
-### Option C — one big box, everything on it (the OCF pattern) — ~$70–110/month
+### Option C — one big box, everything on it (the OCF pattern) — ~\$70–110/month
 
 Dagster + Postgres + Marimo + *all compute* (inference peaks ~9 GB → 16 GB box): EC2
-`t4g.xlarge` $109.79 on-demand / $69.28 reserved-1yr; Lightsail 16 GB $82.40 (4 vCPU, 40% CPU
-baseline); Lightsail memory-optimised 16 GB $72.61 (2 vCPU). This is #206's "Level 3" and how
+`t4g.xlarge` \$109.79 on-demand / \$69.28 reserved-1yr; Lightsail 16 GB \$82.40 (4 vCPU, 40% CPU
+baseline); Lightsail memory-optimised 16 GB \$72.61 (2 vCPU). This is #206's "Level 3" and how
 OCF runs everything else (with Airflow).
 
 - **Pros:** simplest architecture possible — no Fargate/ECR-per-run/EventBridge/run-launcher;
@@ -205,28 +205,28 @@ OCF runs everything else (with Airflow).
 - **Cons:** priciest; backtests capped at 2–4 vCPU (slower than the workstation); Lightsail
   variants mean static AWS keys and burst-credit accounting; biggest pet.
 
-### Option D — serverless control plane (no pets) — ~$50–55/month
+### Option D — serverless control plane (no pets) — ~\$50–55/month
 
-Daemon + webserver as one always-on 0.5 vCPU / 2 GB ARM Fargate service ($19.60), RDS
-`db.t4g.micro` Postgres ($13–16, approximate — the one unverified price), Marimo as its own
-tiny Fargate service (approx $8.30), runs on ephemeral Fargate.
+Daemon + webserver as one always-on 0.5 vCPU / 2 GB ARM Fargate service (\$19.60), RDS
+`db.t4g.micro` Postgres (\$13–16, approximate — the one unverified price), Marimo as its own
+tiny Fargate service (approx \$8.30), runs on ephemeral Fargate.
 
 - **Pros:** full Dagster with zero servers to patch; IAM-native throughout.
 - **Cons:** RDS is the tax (no local disk → no Postgres-in-Docker); webserver access needs an
-  ALB (+~$22/month) or a Tailscale-sidecar hack; the most Terraform. Cleaner on paper than in
+  ALB (+~\$22/month) or a Tailscale-sidecar hack; the most Terraform. Cleaner on paper than in
   practice.
 
-### Option E — Dagster+ Solo, Hybrid — ~$45–55/month typical
+### Option E — Dagster+ Solo, Hybrid — ~\$45–55/month typical
 
-$10/month base + $0.040/credit (1 credit = 1 materialisation or op execution; May 2026
-pricing). Live cadence ≈ 395 credits ≈ $16/month; backtests $0.20–0.70 each (a heavy
-50-experiment month adds $10–35). Plus a stateless Hybrid agent (~$9 tiny Fargate service) and
-Marimo hosting (~$5–8), and the same per-run Fargate compute. Hybrid incurs no serverless
-charge; sensor evaluations are free (an hourly freshness *op* would cost +$29/month — on
+\$10/month base + \$0.040/credit (1 credit = 1 materialisation or op execution; May 2026
+pricing). Live cadence ≈ 395 credits ≈ \$16/month; backtests \$0.20–0.70 each (a heavy
+50-experiment month adds \$10–35). Plus a stateless Hybrid agent (~\$9 tiny Fargate service) and
+Marimo hosting (~\$5–8), and the same per-run Fargate compute. Hybrid incurs no serverless
+charge; sensor evaluations are free (an hourly freshness *op* would cost +\$29/month — on
 Dagster+ you use sensors, the better design anyway).
 
 - **Pros:** managed UI/daemon/alerting/backfills with nothing of ours to keep alive.
-- **Cons:** **Solo is 1 user** — collaborators can't log in (Starter is $100/month base);
+- **Cons:** **Solo is 1 user** — collaborators can't log in (Starter is \$100/month base);
   metering shapes design decisions; vendor dependency. The 1-user cap is likely disqualifying
   for an OCF collaboration.
 
@@ -234,17 +234,17 @@ Dagster+ you use sensors, the better design anyway).
 
 | | A: Level 1 | B: small box + Fargate | C: one big box | D: serverless CP | E: Dagster+ Solo |
 |---|---|---|---|---|---|
-| $/month | 11–25 | **29–42** | 70–110 | ~50–55 (+ALB) | 45–55 |
+| \$/month | 11–25 | **29–42** | 70–110 | ~50–55 (+ALB) | 45–55 |
 | Run history + UI backfills | ✗ | ✓ | ✓ | ✓ | ✓ |
 | Backtests in AWS | ✗ | ✓ big ephemeral compute | ✓ but 2–4 vCPU | ✓ | ✓ (credits) |
-| Marimo dashboard | +$8 add-on | ✓ free on box | ✓ free on box | +$8 service | +$5–8 |
+| Marimo dashboard | +\$8 add-on | ✓ free on box | ✓ free on box | +\$8 service | +\$5–8 |
 | Servers to patch | 0 | 1 | 1 | 0 | 0 |
 | No static AWS keys | ✓ | ✓ | ✓ EC2 / ✗ Lightsail | ✓ | ✓ |
 | Multi-user UI | n/a | ✓ (Tailscale) | ✓ | ✓ | ✗ (1 user) |
 
 **Recommendation: Option B** — the only shape giving full Dagster *and* workstation-beating
-backtest compute *and* a free dashboard home, for ~$15–25/month over Level 1. Option C is the
-fallback if operational simplicity trumps backtest speed and ~$40/month. D pays an RDS+ALB
+backtest compute *and* a free dashboard home, for ~\$15–25/month over Level 1. Option C is the
+fallback if operational simplicity trumps backtest speed and ~\$40/month. D pays an RDS+ALB
 tax for purism; E's 1-user cap rules it out.
 
 **Future work (not MVP):** once an always-on control-plane box exists (Option B or later), it's


### PR DESCRIPTION
## Summary
- `mkdocs.yml` enables `pymdownx.arithmatex` (generic MathJax mode), which treats any `$...$` pair as inline LaTeX math.
- The cost-estimate prose in `docs/roadmap/live-service.md` (Workload model, AWS architecture options A–E, cost comparison table) used plain `$` for currency amounts. Paragraphs with an even count of literal `$` were accidentally parsed as math, producing garbled output like `∗∗0.86/run∗∗` instead of `**$0.86/run**` (see reported screenshot).
- Escaped every currency `$` to `\$` throughout the affected sections. Left `docs/roadmap/capacity-estimation.md` and `docs/techniques/differentiable-physics.md` untouched — their `$`/`$$` usage is genuine intentional math. Also left the one `$(git rev-parse HEAD)` inside an inline code span alone (arithmatex doesn't parse inside code spans).

## Test plan
- [x] `uv run pymarkdown scan -r docs README.md CLAUDE.md metadata/README.md packages/*/README.md` passes
- [x] `uv run mkdocs build --strict` succeeds
- [x] Verified rendered HTML: escaped `\$` produces plain `$` text (no `arithmatex` span) in `live-service.md`, while `capacity-estimation.md` and `differentiable-physics.md` still render their genuine math via `arithmatex` spans (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)