### PR TITLE
Delete the map table; move status/issue links onto each roadmap page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,8 +82,9 @@ must also:
    `docs/ml_experimentation/`, …).
 2. Delete the item's "Implementation details" section (and any `plans/` file), pasting it (or
    a summary) into the PR body. When a roadmap page's last 🚧 item ships, delete the page
-   (nav entry, map-table row, inbound doc links).
-3. Close the GitHub issue; update the map table and status emoji in `docs/roadmap/index.md`.
+   (nav entry, inbound doc links).
+3. Close the GitHub issue; update the status banner on the roadmap page (and the milestone
+   section in `docs/roadmap/index.md` if the arc changed).
 
 ## Architecture
 

--- a/docs/roadmap/capacity-estimation.md
+++ b/docs/roadmap/capacity-estimation.md
@@ -1,6 +1,7 @@
 # Effective-capacity estimation
 
-> **Status: 🚧 Planned (Phase 1, v0.6 / v0.7) · 🔬 Research (Phase 2, v2).** This page is the
+> **Status: 🚧 Planned (Phase 1, v0.6 / v0.7) · 🔬 Research (Phase 2, v2).** Epic:
+> [#141](https://github.com/openclimatefix/nged-substation-forecast/issues/141). This page is the
 > *plan* for applying [differentiable physics](../techniques/differentiable-physics.md) (DP) to
 > capacity estimation; the method itself — the forward models, variational machinery, and the
 > graph-structured engine — is explained on that techniques page. See the

--- a/docs/roadmap/engineering-health.md
+++ b/docs/roadmap/engineering-health.md
@@ -2,8 +2,14 @@
 
 > **Status: 🚧 Planned.** Tooling, reproducibility, and rigour improvements from the 2026-07
 > codebase review that don't change forecast behaviour. Each section is an independent,
-> roughly one-PR piece of work; sections are deleted as they ship. Task ordering lives in the
-> GitHub Project board (see the [map](index.md#map-of-substantial-work)).
+> roughly one-PR piece of work; sections are deleted as they ship. Mostly the v0.2 epic
+> [#138](https://github.com/openclimatefix/nged-substation-forecast/issues/138):
+> CI [#9](https://github.com/openclimatefix/nged-substation-forecast/issues/9) ·
+> reproducibility stamping [#227](https://github.com/openclimatefix/nged-substation-forecast/issues/227) ·
+> NWP clip logging [#161](https://github.com/openclimatefix/nged-substation-forecast/issues/161) ·
+> Hydra removal [#228](https://github.com/openclimatefix/nged-substation-forecast/issues/228) ·
+> rigor tests [#229](https://github.com/openclimatefix/nged-substation-forecast/issues/229).
+> Task ordering lives in the GitHub Project board.
 
 ## CI: run lint, types, and tests on every PR
 

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -79,30 +79,6 @@ apply them.
   estimating latent demand under the normal running arrangement: the v0.6 unsupervised statistical
   detector and the v2 mixture models (the graph is a data structure, not a GNN).
 
-## Map of substantial work
-
-The 2026-07 codebase review produced a set of substantial work items. This table maps each to its
-milestone, design doc, and tracking issue. **It is a map, not a queue** — the complete, current
-task ordering lives in the GitHub Project board, and row order here carries no commitment.
-
-| Work | Milestone | Design | GitHub | Notes |
-|---|---|---|---|---|
-| Live inference asset (`live_forecasts`: live/replay NWP semantics, all 51 members, `fold_id="live"`) | v0.1 | [Live service](live-service.md) | [#221](https://github.com/openclimatefix/nged-substation-forecast/issues/221) | Built before its container, so the container has something to run; [#208](https://github.com/openclimatefix/nged-substation-forecast/issues/208) is its verification step |
-| Champion-model container (model baked into the Docker image, loaded via plain `save`/`load` — no MLflow at runtime) | v0.1 | [Live service](live-service.md) | [#222](https://github.com/openclimatefix/nged-substation-forecast/issues/222) | Depends on the live inference asset |
-| AWS deployment (S3-capable data paths, production job + freshness check, Fargate + IAM infra, alerting) | v0.1 | [Live service](live-service.md) | [#206](https://github.com/openclimatefix/nged-substation-forecast/issues/206), [#121](https://github.com/openclimatefix/nged-substation-forecast/issues/121), [#50](https://github.com/openclimatefix/nged-substation-forecast/issues/50) | Depends on the container; five architecture options costed 2026-07-02, leaning small EC2 control plane + `EcsRunLauncher` |
-| NWP quantisation clip logging | v0.2 | [Engineering health](engineering-health.md) | [#161](https://github.com/openclimatefix/nged-substation-forecast/issues/161) | Int16 quantisation currently clips silently; not v0.1-gating (triaged 2026-07-02) |
-| CI safety net (ruff + ty + pytest on every PR) | v0.2 | [Engineering health](engineering-health.md) | [#9](https://github.com/openclimatefix/nged-substation-forecast/issues/9) | Root pytest collection currently broken by duplicate test basenames |
-| Reproducibility stamping (git SHA + Delta table versions on every MLflow run) | v0.2 | [Engineering health](engineering-health.md) | [#227](https://github.com/openclimatefix/nged-substation-forecast/issues/227) | Cheap; improves every later experiment |
-| Drop Hydra (plain YAML + importlib + pydantic) | v0.2 | [Engineering health](engineering-health.md) | [#228](https://github.com/openclimatefix/nged-substation-forecast/issues/228) | Hydra's composition/sweep value is unused |
-| Scientific-rigor tests & cleanup (no-lookahead, leaderboard-fairness, determinism tests; split `cv_assets.py`) | v0.2 | [Engineering health](engineering-health.md) | [#229](https://github.com/openclimatefix/nged-substation-forecast/issues/229) | Relates to [#62](https://github.com/openclimatefix/nged-substation-forecast/issues/62) (test coverage) |
-| Baseline forecasters (persistence + climatology) | v0.3 | [Metrics & leaderboard](metrics-and-leaderboard.md) | [#147](https://github.com/openclimatefix/nged-substation-forecast/issues/147) | Leaderboard scores aren't interpretable without them |
-| Probabilistic evaluation (horizon slices, PICP, spread-skill, CRPS → then calibration) | v0.3 | [Metrics & leaderboard](metrics-and-leaderboard.md) | [#225](https://github.com/openclimatefix/nged-substation-forecast/issues/225) | The ensemble is likely underdispersed and nothing measures it yet |
-| Leaderboard fold hygiene (held-out final-test window) | v0.3 | [Metrics & leaderboard](metrics-and-leaderboard.md) | [#226](https://github.com/openclimatefix/nged-substation-forecast/issues/226) | The single fold currently serves both model selection and reported skill |
-| Production monitoring (`production_monitoring` metrics scope, `monitoring_sensor`, `retire_experiment_job`) | v0.3 | [Live service](live-service.md) | [#224](https://github.com/openclimatefix/nged-substation-forecast/issues/224) | Starts once live forecasts are accumulating |
-| XGBoost quick wins (lead-time feature, early stopping, holidays, physics features, global models, …) | v0.5 | [XGBoost improvements](xgboost-improvements.md) | [#145](https://github.com/openclimatefix/nged-substation-forecast/issues/145) (epic), [#230](https://github.com/openclimatefix/nged-substation-forecast/issues/230) (Tier 1) | Best bang-for-the-buck first: the model currently never sees the forecast horizon |
-| Capacity estimation (differentiable physics, Phase 1) | v0.6/0.7 | [Capacity estimation](capacity-estimation.md) | [#141](https://github.com/openclimatefix/nged-substation-forecast/issues/141) | |
-| Switching-event detection (unsupervised statistical detector) | v0.6/0.7 | [Switching events](switching-events.md) | [#151](https://github.com/openclimatefix/nged-substation-forecast/issues/151) | |
-
 ## Milestones
 
 The milestone sections below show the order in which this work is planned. Each maps 1:1 to a
@@ -115,46 +91,11 @@ GitHub epic issue.
 *Epic: [#137](https://github.com/openclimatefix/nged-substation-forecast/issues/137) — deploy the
 naive forecast on AWS. **This is the current focus.***
 
-**Goal**: A simple XGBoost forecast that lets us test infrastructure end-to-end and establish a baseline. Intentionally does not detect switching events or estimate effective capacity — hence "naive" (assumes the grid is always in perfect health).
-
-**Data engineering**:
-
-- Download ECMWF ENS NWP from Dynamical.org; convert to Delta Lake with H3 spatial indexes on S3 ✓
-- Download NGED data from S3; convert to Delta Lake with H3 spatial indexes ✓
-- Automatic data cleaning:
-  - Remove isolated zeros in non-zero time series
-  - Remove values more than N standard deviations from the mean
-  - Remove "stuck" values (std dev near zero over a 24-hour rolling window)
-  - Drop first ~2 months of each time series (poor quality during meter ramp-up)
-
-**Software engineering**:
-
-- Universal model interface (`BaseForecaster`) for all ML models ✓
-- Orchestrate everything with Dagster: data ingestion, model training, inference, backtesting ✓
-
-**ML model**:
-
-- Separate XGBoost model per `time_series_id` ✓
-- Train on the ECMWF control ensemble member; run inference on all 51 members ✓
-- Features: ECMWF ENS NWP variables, derived weather features (e.g. wind chill), lagged power (7 and 14 days ago), datetime features (`hour_of_day`, `day_of_week`, `day_of_month`, `day_of_year`, `is_weekend`, `is_bank_holiday`, `is_christmas`, `is_easter`, `utc_offset`, `forecast_horizon`)
-- Output: ensemble of 51 half-hourly power forecasts per `time_series_id`, scaled to [−1, +1], on a 14-day horizon
-- Static capacity estimate: 99th percentile of observed power as a simple proxy
-
-**Deployment** (the remaining v0.1 work — see the [map](#map-of-substantial-work) above):
-
-- `live_forecasts` production inference asset: single-run feature engineering across all 51
-  ensemble members every 6 hours, with explicit live/replay NWP-availability semantics
-- Champion model baked directly into the Docker image and loaded via a plain `save`/`load` —
-  no MLflow client, run ID, or cache lookup on the runtime path at all
-- AWS infrastructure: S3-capable data paths, scheduled Fargate runs, IAM roles, and alerting
-  (Sentry) — five architecture options costed 2026-07-02, leaning a small always-on EC2
-  control-plane box + `EcsRunLauncher`
-
-**Outputs** (Delta tables on S3):
-
-- `power_forecast`
-- `power_forecast_warnings`
-- `asset_health_history`
+**Goal**: A simple XGBoost forecast that lets us test infrastructure end-to-end and establish a
+baseline. Intentionally does not detect switching events or estimate effective capacity — hence
+"naive" (assumes the grid is always in perfect health). The data pipeline, per-series XGBoost
+models, and CV leaderboard are already built; the remaining work is deployment — see
+[Live service](live-service.md).
 
 ![v0.1 Naive forecast](assets/v0.1_naive_forecast_flow_diagram.png)
 

--- a/docs/roadmap/metrics-and-leaderboard.md
+++ b/docs/roadmap/metrics-and-leaderboard.md
@@ -7,6 +7,11 @@ How OCF measures the skill of its forecasts and compares forecasting approaches.
 > implemented. The interactive leaderboard visualisation and probabilistic metrics are 🚧 planned.
 > The implemented [cross-validation protocol](../ml_experimentation/cross-validation-folds.md) has
 > moved out of the roadmap. See the [roadmap index](index.md) for status conventions.
+> The 🚧 items are tracked under the v0.3 epic
+> [#6](https://github.com/openclimatefix/nged-substation-forecast/issues/6):
+> baseline forecasters [#147](https://github.com/openclimatefix/nged-substation-forecast/issues/147) ·
+> probabilistic evaluation [#225](https://github.com/openclimatefix/nged-substation-forecast/issues/225) ·
+> fold hygiene [#226](https://github.com/openclimatefix/nged-substation-forecast/issues/226).
 
 ---
 

--- a/docs/roadmap/switching-events.md
+++ b/docs/roadmap/switching-events.md
@@ -2,7 +2,9 @@
 
 **Scope.** How to estimate, for each NGED primary substation, its *latent demand under the normal running arrangement* — the demand that would be metered if the network were never reconfigured — given that the network is in fact reconfigured roughly 10% of the time by switching events. Background on what switching events are and why they are hard is at [**Switching Events**](../background/switching-events.md). This document defines the staged modelling plan (v0.6 → v2.5 → v2.6).
 
-> **Status: 🔬 Research / 🚧 Planned.** None of this is implemented yet. The v0.6 unsupervised
+> **Status: 🔬 Research / 🚧 Planned.** Epic:
+> [#151](https://github.com/openclimatefix/nged-substation-forecast/issues/151) (the v0.6
+> detector). None of this is implemented yet. The v0.6 unsupervised
 > statistical detector is the nearest-term piece (it feeds the
 > [`substation_switching`](delivery-tables.md#table-5-substation_switching) table and the
 > training-data mask); the v2.5 / v2.6 mixture models are later research. The post-v2.0 roadmap is

--- a/docs/roadmap/xgboost-improvements.md
+++ b/docs/roadmap/xgboost-improvements.md
@@ -1,8 +1,10 @@
 # XGBoost improvements ("quick wins")
 
 > **Status: 🚧 Planned (v0.5) — deferred until v0.1 is live on AWS.** Epic:
-> [#145](https://github.com/openclimatefix/nged-substation-forecast/issues/145). Getting *any*
-> forecast live ([Live service](live-service.md)) takes priority over forecast quality.
+> [#145](https://github.com/openclimatefix/nged-substation-forecast/issues/145); the Tier-1
+> quick wins are [#230](https://github.com/openclimatefix/nged-substation-forecast/issues/230).
+> Getting *any* forecast live ([Live service](live-service.md)) takes priority over forecast
+> quality.
 
 Quick wins to make XGBoost a strong baseline before the advanced approaches land — explicitly
 *not* deep ML work ("little point in spending ages on the ML model before we have good capacity

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,14 +1,6 @@
 # Temporary implementation plans
 
-This directory holds **at most one** plan at a time: the mechanical checklist for the PR (or
-short PR sequence) currently in flight. It is deleted when that work merges — paste the plan
-(or a summary) into the PR body first. This directory is usually empty; that is the intended
-state.
-
-Everything durable belongs elsewhere (see the use-case table in `docs/roadmap/index.md`):
-design and dependencies go in `docs/roadmap/` pages (step-by-step mechanics under an
-"Implementation details (deleted when this ships)" section); methods go in `docs/techniques/`;
-the complete ordered task list is the GitHub Project.
-
-Never reference files in this directory from code or from `docs/` — they are deleted on merge,
-so any such reference rots.
+This directory holds **at most one** file — the mechanical checklist for the PR currently in
+flight — deleted when that work merges (paste the plan, or a summary, into the PR body first),
+so the directory is usually empty. Everything durable belongs elsewhere, and nothing may link
+here from code or `docs/`: see "How planning works" in `docs/roadmap/index.md`.


### PR DESCRIPTION
Applies the "content must earn its place" pass agreed today:

- **`docs/roadmap/index.md`** — the "Map of substantial work" table is deleted. It was a third copy of a mapping GitHub now owns (epics encode milestone; issue bodies link design pages), and it drifted twice on the same day it was completed. The v0.1 milestone section shrinks to goal + epic link + design-page link (+ flow diagram); its deleted deployment bullets are all on [live-service.md](https://openclimatefix.github.io/nged-substation-forecast/roadmap/live-service/).
- **Status banners** — every roadmap plan page now carries its epic/tracking-issue links in the banner: engineering-health (#138: #9/#227/#161/#228/#229), metrics-and-leaderboard (#6: #147/#225/#226), capacity-estimation (#141), switching-events (#151), xgboost-improvements (#145/#230). The engineering-health banner no longer points at the deleted map anchor.
- **`plans/README.md`** — shrunk to the two-sentence contract plus a pointer at index.md.
- **`CLAUDE.md`** — ship-time triage step 3 now says "update the status banner on the roadmap page" instead of "update the map table".

Verified: no dangling `#map-of-substantial-work` references, pymarkdown clean, `mkdocs build --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)