### PR TITLE
Fix small inconsistencies found in the final docs consistency pass

### DIFF
--- a/docs/roadmap/delivery-tables.md
+++ b/docs/roadmap/delivery-tables.md
@@ -10,8 +10,9 @@ How OCF delivers forecasts and supporting data to NGED.
 ## How forecasts are delivered
 
 For v1 of the live service, OCF delivers live forecasts (and the supporting tables below) as
-**Delta Lake** tables in an AWS S3 bucket. We are **not** building a REST API for v1 (see
-[scope changes](index.md)); an API may be added later if it brings additional benefit.
+**Delta Lake** tables in an AWS S3 bucket. We are **not** building a REST API for v1 (a REST API is a v2
+[stretch goal](index.md#v20-scale-up-future-research)); an API may be added later if it brings
+additional benefit.
 
 - **Why Delta Lake?** It is just Parquet files plus a transaction log, giving ACID guarantees on
   cheap object storage. NGED never reads a half-written forecast: each update is atomic, so the
@@ -35,7 +36,7 @@ There are **five** tables. This table tracks where each one stands today:
 | 1 | `power_forecast` | ✅ Implemented (deterministic-ensemble flavour only) | `contracts.power_schemas.PowerForecast` |
 | 2 | `power_forecast_warnings` | 🚧 Planned (partial in MVP) | not yet in code |
 | 3 | `asset_health_history` | 🚧 Planned | not yet in code |
-| 4 | `effective_capacity` | 🚧 MVP in v0.1 (P99 estimate); DP upgrade planned for v0.6 / v0.7 | `contracts.power_schemas.EffectiveCapacity` |
+| 4 | `effective_capacity` | ✅ MVP implemented (static P99 estimate); DP upgrade planned for v0.6 / v0.7 | `contracts.power_schemas.EffectiveCapacity` |
 | 5 | `substation_switching` | 🚧 Planned (v0.6 / v0.7) | not yet in code |
 
 > **Naming note.** The Milestone 1 report drafted these tables with the column name `timeseries_id`,
@@ -182,9 +183,10 @@ Notes on specific flags:
 
 ---
 
-## Table 4 — `effective_capacity` 🚧
+## Table 4 — `effective_capacity`
 
-> **Status: 🚧 MVP in v0.1** using P99 of observed power as a static capacity proxy.
+> **Status: ✅ MVP implemented** — the `effective_capacity` Dagster asset writes P99 of observed
+> power as a static capacity proxy.
 > Schema lives in `contracts.power_schemas.EffectiveCapacity`.
 > **Planned upgrade in v0.6 / v0.7** to differentiable-physics capacity estimation — see
 > [Capacity estimation](capacity-estimation.md).

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -13,13 +13,13 @@ Technical plans change as we learn more — treat this as a best-estimate, not a
 
 ## How planning works
 
-Plans live in three places with deliberately non-overlapping jobs:
+Planning content lives in four places with deliberately non-overlapping jobs:
 
 | Place | Job |
 |---|---|
 | **GitHub** ([issues](https://github.com/openclimatefix/nged-substation-forecast/issues) + the OCF Project board) | The **complete, ordered task list** — including quick tweaks and non-code tasks — plus all discussion. **Fine-grained prioritisation lives only in GitHub.** Epics map 1:1 to the milestones below; dependencies are recorded as `blocked by` issue relationships. |
-| **`docs/roadmap/` (this folder)**:| Design depth: What we plan to build and *why*. The milestone arc and inter-plan dependencies are recorded here; fine-grained task-level ordering is not. |
-| **`docs/`[techniques](../techniques/index.md), [background](../background/network.md), [architecture](../architecture/overview.md)**: |What is already build. This is where content moves to from `docs/roadmap/` after implementation.|
+| **`docs/roadmap/` (this folder)** | Design depth: What we plan to build and *why*. The milestone arc and inter-plan dependencies are recorded here; fine-grained task-level ordering is not. |
+| **`docs/`[techniques](../techniques/index.md), [background](../background/network.md), [architecture](../architecture/overview.md)** | What is already built. This is where content moves to from `docs/roadmap/` after implementation. |
 | **`plans/`** (repo root, not published) | At most **one** file: the mechanical checklist for the PR currently in flight, deleted when it merges. Usually empty. |
 
 **Relationship between `docs/roadmap/` and GitHub**: Every substantial 🚧 plan in the

--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -247,11 +247,10 @@ backtest compute *and* a free dashboard home, for ~\$15–25/month over Level 1.
 fallback if operational simplicity trumps backtest speed and ~\$40/month. D pays an RDS+ALB
 tax for purism; E's 1-user cap rules it out.
 
-**Future work (not MVP):** once an always-on control-plane box exists (Option B or later), it's
-also a natural home for an **MLflow tracking server** (network-reachable, persistent — replacing
-the local file-store) and a **"development dashboard"** (a Marimo app for researchers, distinct
-from the production dashboard already scoped above). Neither is needed to ship v0.1; revisit
-once the box exists.
+**Future work (not MVP):** once an always-on control-plane box exists (Option B or later), it's also
+a natural home for an **MLflow tracking server** (network-reachable, persistent — replacing the
+local file-store) and a **"development dashboard"** (a Marimo app for researchers). Neither is
+needed to ship v0.1; revisit once the box exists.
 
 ## Production monitoring
 

--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -250,7 +250,7 @@ tax for purism; E's 1-user cap rules it out.
 **Future work (not MVP):** once an always-on control-plane box exists (Option B or later), it's
 also a natural home for an **MLflow tracking server** (network-reachable, persistent — replacing
 the local file-store) and a **"development dashboard"** (a Marimo app for researchers, distinct
-from the production dev dashboard already scoped above). Neither is needed to ship v0.1; revisit
+from the production dashboard already scoped above). Neither is needed to ship v0.1; revisit
 once the box exists.
 
 ## Production monitoring

--- a/docs/roadmap/metrics-and-leaderboard.md
+++ b/docs/roadmap/metrics-and-leaderboard.md
@@ -234,7 +234,8 @@ nothing else:
 
 The `Metrics` schema and the rest of the metrics pipeline are untouched. Note the table is
 **backward-looking only** (it holds no future `valid_time`s): fine for historical CV folds (whose
-validation windows lie inside the observed history), but live-forecast scoring (Phase 7 / 8) must
+validation windows lie inside the observed history), but live-forecast scoring
+([production monitoring](live-service.md#production-monitoring)) must
 choose which reference time's capacity to apply rather than expecting a row at a future `valid_time`.
 
 One related distinction to keep straight: the *metric denominator* may use the full-history

--- a/docs/roadmap/switching-events.md
+++ b/docs/roadmap/switching-events.md
@@ -98,7 +98,7 @@ residuals around time t (observed - expected), one row per substation:
 - a step that is **roughly flat, or tracks the evening demand peak** → **demand-heavy**;
 - a step that is **large but uncorrelated with daylight, gusty/variable** → **wind-heavy**.
 
-This is a histogram (step magnitude vs. hour-of-day), not a fitted model — deliberately cheap, matching the spirit of v0.5.
+This is a histogram (step magnitude vs. hour-of-day), not a fitted model — deliberately cheap, matching v0.6's simple-statistics spirit.
 
 *Order matters — read composition off the recipient, never the source.* The diurnal shape must be measured on **each recipient's individual step**, *after* attribution has identified which donor took which leg. It must **not** be read off the source substation's lumped drop. The reason: a source commonly sheds *different* slices to *different* donors at once — say a PV-heavy slice to donor `j` and a demand-heavy slice to donor `k`. The source's own residual shows only the *sum* of everything it lost, which blends the two into a meaningless average that matches neither leg. Only the per-recipient steps separate cleanly into "what `j` got" vs. "what `k` got." (This is the same source-blends-everything pitfall noted for stage 1, applied to composition rather than magnitude.)
 

--- a/docs/roadmap/xgboost-improvements.md
+++ b/docs/roadmap/xgboost-improvements.md
@@ -8,8 +8,9 @@
 
 Quick wins to make XGBoost a strong baseline before the advanced approaches land — explicitly
 *not* deep ML work ("little point in spending ages on the ML model before we have good capacity
-estimation"). This page merges [#145](https://github.com/openclimatefix/nged-substation-forecast/issues/145)'s
-nine sub-issues with additional tricks from the 2026-07 codebase review, ordered **best
+estimation"). This page merges the sub-issues of
+[#145](https://github.com/openclimatefix/nged-substation-forecast/issues/145)
+with additional tricks from the 2026-07 codebase review, ordered **best
 bang-for-the-buck first** (expected skill per unit effort), grouped into effort tiers.
 
 **Measure before optimising.** Land the


### PR DESCRIPTION
Findings from a full consistency sweep of `docs/` (every roadmap page read end-to-end; all internal anchors verified against the built site; every issue number cited in docs checked open; docs-stated dependencies cross-checked against GitHub `blocked by` links; docs-cited code line references spot-checked).

Fixes in this PR:

- **roadmap/index.md** — the "which place do I use" intro said "three places" but the table has four rows; two table rows had broken formatting (stray `:` before the pipe, missing spaces) and the "What is already build" typo.
- **metrics-and-leaderboard.md** — "live-forecast scoring (Phase 7 / 8)" referenced the deleted Dagster ML-assets plan's phase numbering; now links to [production monitoring](https://openclimatefix.github.io/nged-substation-forecast/roadmap/live-service/#production-monitoring).
- **delivery-tables.md** — Table 4 (`effective_capacity`) was marked "🚧 MVP in v0.1", but the MVP asset is implemented (`cv_assets.py` — full-history P99, one scalar row per series, exactly as the page describes); flipped to ✅ with the DP upgrade still 🚧. Also retargeted the "(see [scope changes](index.md))" label — no such section exists — to the v2 stretch-goals anchor where the REST API actually lives.
- **switching-events.md** — stage 3's "matching the spirit of v0.5" → v0.6 (the detector's own simple-statistics ethos).
- **xgboost-improvements.md** — dropped the stale "nine sub-issues" count (#145 now has ten, one of which — #230 — is this page's own Tier 1).
- **live-service.md** — "the production dev dashboard" → "the production dashboard", so the name no longer collides with the future researchers' "development dashboard" in the same sentence.

Checked and found consistent (no change needed): all status banners vs epic sub-issue membership on GitHub; all five docs-stated dependencies exist as `blocked by` links (#222/#224←#221, #206←#222, #149←#225, #148←#91, #229←#224); milestone sections vs page banners; the 32-series trial-area breakdown (sums to 32 everywhere in docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)