### PR TITLE
Harden the v0.6 switching-detector plan: statistical gotchas, edge-flow escalation, build order

### DIFF
--- a/docs/roadmap/switching-events.md
+++ b/docs/roadmap/switching-events.md
@@ -37,7 +37,7 @@ Version numbers are aligned with the main codebase: **v0.6**, then **v2.5**, the
 v0.6  ── Unsupervised statistical detector on power data.
   │       Flags/masks switching events; VALIDATED against the 32-series logs.
   │       Produces the detection sensitivity floor (a quantified, honest limit).
-  │       In-version escalation, only if sequential matching proves brittle:
+  │       In-version escalation (v0.6.1), only if sequential matching proves brittle:
   │       the joint edge-flow estimator (detection + attribution in one solve).
   │
 v2.5  ── Magnitude-only mixture model. The workhorse.
@@ -234,7 +234,7 @@ Issue: [#180](https://github.com/openclimatefix/nged-substation-forecast/issues/
 
 #### v0.6.1 — the joint edge-flow estimator
 
-> **Status within v0.6:** this sections documents the known next move if sequential matching
+> **Status within v0.6:** this section documents the known next move if sequential matching
 > (described above) proves brittle. The staged detect-then-match pipeline above remains the day-one
 > implementation because it fails legibly. v0.6.1 uses the same priors and the same graph but with
 > strictly better structure, and may well turn out to be the right method to get us to v1. The
@@ -332,7 +332,7 @@ staged detector fails *legibly* — every flag traces to a visible step and a na
 subset — while a joint optimiser is harder to inspect when it misbehaves. Build the transparent
 version first, keep it as the reference, and adopt the joint estimator where the head-to-head
 comparison (on logs + injections) shows it wins. A CVXPY implementation sketch lives in the
-implementation-details section at the bottom of this page.
+implementation-details section directly below.
 
 ---
 
@@ -464,6 +464,9 @@ Notes on the sketch:
   the switching logs — see the escalation section above for why.
 - **The anomaly slack `u`** carries a plain ℓ1 penalty here; if injections show partnerless steps
   are themselves step-like (a new connection is), `u` can be given its own fused penalty too.
+
+---
+
 ### v2.5 — Magnitude-only mixture model (the workhorse)
 
 **Goal.** Reconstruct a latent NRA demand `d_i(t)` per substation by modelling observed power as a time-varying mixture of each substation's own normal demand and its neighbours'.
@@ -501,6 +504,41 @@ observed_i(t) = α_ii(t)·d_i(t) + Σ_{j ∈ neighbours(i)} α_ij(t)·d_j(t)
   near zero moves almost nothing regardless of `α` — at PV-heavy substations whose net crosses
   zero, the transfer's magnitude information vanishes around the crossing. v2.6's typed
   decomposition removes this by mixing gross components instead.
+
+**Tooling: v2.5 can be built entirely with CVXPY — by alternation, with one honest caveat.** As
+written, v2.5 is *not* one convex problem: `α·d` multiplies two unknowns, which is exactly the
+kind of expression CVXPY's DCP check refuses (see
+[Convex Optimisation](../techniques/convex-optimisation.md)). But the bilinearity has a special
+structure — the problem is convex in each unknown *separately* — and that enables the classic
+**alternating** scheme, where every step is a plain CVXPY solve:
+
+- **α-step (fix `d`, solve for `α`).** With `d` treated as known data, the mixture is linear in
+  `α`, and the priors (identity-regularised, piecewise-constant in time, node-level balance as
+  linear constraints) make this the same group-fused-lasso family as the
+  [v0.6.1 edge-flow estimator](#v061-the-joint-edge-flow-estimator) — convex, with the exact
+  zeros that let jumps in `α` read directly as detected events.
+- **d-step (fix `α`, solve for `d`).** With the routing fixed, the observation model is linear in
+  `d`, and "weather/calendar backbone plus smooth residual" is a convex regression.
+
+Iterate the two steps to convergence. There is also a natural **convex warm start**: fixing `d`
+to the exogenous baseline makes the whole model one convex problem — it is essentially v0.6.1's
+shaped-flow refinement `e_ij(t) = f_ij(t)·baseline_j(t)` in mixture clothing — so solve that
+first, then let alternation release `d`. The caveat to state plainly: convexity now holds per
+*step*, not overall. Alternation converges, but to a *local* optimum of the bilinear problem — the
+certified-global-optimum promise of the pure-convex world does **not** come back just because
+each step uses CVXPY. The v0.6 initialisation (bullet above) and the convex warm start are what
+manage that risk. No part of v2.5 needs PyTorch.
+
+**Where `cvxpylayers` enters (and where it doesn't).** The bridge that embeds a convex solve as a
+differentiable layer inside a PyTorch model
+([the techniques page explains it](../techniques/convex-optimisation.md#the-bridge-welding-cvxpy-into-pytorch))
+is *not needed* for v2.5 — alternation above is CVXPY in a loop. It earns its place at **v2.6**,
+when `d_i` decomposes into physics modules (panel trigonometry, power curves, products of
+unknowns) that are genuinely non-convex and force PyTorch for the outer model. At that point the
+routing/switching estimation should *stay* a convex layer inside the PyTorch model rather than
+being re-implemented as free tensors: the layer keeps exact zeros (so "nonzero routing = detected
+event" survives) and built-in conservation, while gradients flow through the solve to train the
+physics modules end-to-end.
 
 **Why "arbitrary continuous slice" is handled natively.** `α_ij(t)` is a continuous fraction, so "some load, cut anywhere, moved to several donors" is exactly representable. The continuous-fraction form — which earlier looked like a limitation — is in fact *fidelity* to a network where the transferred amount is genuinely continuous and the cut point is free.
 
@@ -552,6 +590,18 @@ observed_i(t) = Σ_j [ α^dem_ij(t)·gross_demand_j(t)
 ```
 
 Each substation is now a small *bundle* of typed nodes rather than one node, and routing happens per type. But the graph stays a plain **data structure**, exactly as in the earlier stages: when the i→j boundary is active, each *type* moves with its own weight — structure-plus-arithmetic, with no message-passing network trained.
+
+**Tooling.** This is the stage where PyTorch becomes unavoidable: the typed forward modules are
+genuinely non-convex (see [Convex Optimisation](../techniques/convex-optimisation.md) for why),
+so the outer model lives in PyTorch per the
+[differentiable-physics](../techniques/differentiable-physics.md) plan. The per-type routing
+weights `α^type_ij(t)`, however, should **remain a differentiable convex layer** inside that
+model (via
+[`cvxpylayers`](../techniques/convex-optimisation.md#the-bridge-welding-cvxpy-into-pytorch))
+rather than becoming free tensors: the layer preserves exact zeros ("nonzero routing = detected
+event") and built-in conservation, while gradients flow through the solve to the physics modules.
+The full rationale, and the alternation-only path that gets v2.5 built without any PyTorch, is in
+the v2.5 tooling note above.
 
 **Prior structure.**
 
@@ -612,6 +662,3 @@ These apply at every stage and are the things most easily got wrong:
 - **Neighbour/adjacency structure** for the trial substations — which substations can exchange load (needed to define graph edges and the attribution search). Even approximate adjacency helps; note that because cut points move, "adjacency" means "can be electrically connected by some switching," not a fixed feeder map.
 - **Confirmed by NGED:** (a) multi-recipient transfer (2–3 donors) is the norm; (b) partial transfers (some, not all, of a substation's load) are the common and harder case; (c) no stable "feeder" unit exists; (d) switching labels exist only for the trial area, not at scale.
 - **To ask NGED:** how complete are the control-room switching logs for the trial area? (Determines whether measured detection precision is a tight bound or a loose lower bound.)
-
----
-

--- a/docs/roadmap/switching-events.md
+++ b/docs/roadmap/switching-events.md
@@ -329,7 +329,7 @@ consumes, the approximation the parameterisation makes, and how the penalty weig
   final scoring — and injection-based tuning is the only kind available at full scale, where no
   logs exist.
 
-**Which of the staged pipeline's failure modes it retires — and which it doesn't.** Several of
+**Which of the staged pipeline's failure modes it solves — and which it doesn't.** Several of
 the statistical traps that stages 1–2 must handle with explicit machinery simply cannot occur in
 this parameterisation:
 

--- a/docs/roadmap/switching-events.md
+++ b/docs/roadmap/switching-events.md
@@ -37,6 +37,8 @@ Version numbers are aligned with the main codebase: **v0.6**, then **v2.5**, the
 v0.6  ── Unsupervised statistical detector on power data.
   │       Flags/masks switching events; VALIDATED against the 32-series logs.
   │       Produces the detection sensitivity floor (a quantified, honest limit).
+  │       In-version escalation, only if sequential matching proves brittle:
+  │       the joint edge-flow estimator (detection + attribution in one solve).
   │
 v2.5  ── Magnitude-only mixture model. The workhorse.
   │       Reconstructs latent NRA demand per substation. Fully unsupervised.
@@ -65,10 +67,40 @@ For each substation, form an expected-power baseline that is a function of **exo
 
 **Why the baseline must be weather/calendar-based and *not* a lagged-power baseline.** A tempting cheap baseline is "same half-hour last week." It is unsound here, and disqualified. If last week sat in a switching event and this week is normal (or vice versa), the residual shows a step of the same magnitude and shape as a real event — but with the **sign reversed**, because the contamination is in the *reference*, not the observation. Stage 2's balance attribution would then hunt for donor rises coincident with a source drop that is a baseline artifact, manufacturing phantom events and mis-attributing them. Worse, because switching events can persist for days to months, a lag can land *inside the same ongoing event*, so there is no step at all and a real event is masked entirely. Weather and clock time are unaffected by network topology, so a baseline built only from them cannot be contaminated by switching state — the residual then isolates "power the weather and clock don't explain," which is exactly where a topology change appears, with no comparison period to poison.
 
-**Two residual-contamination routes to handle:**
+**Baseline implementation: reuse the existing XGBoost forecaster with no lag features.** The
+production forecaster already consumes exactly the covariates the baseline needs — NWP weather,
+time-of-day, day-of-week, holidays — through the existing feature pipeline. Configuring it with
+**no power-lag features** yields the switching-independent baseline with no new machinery (a lag
+feature would smuggle the lagged-power contamination above back in through the side door). Fit
+with a **quantile (median) objective**, which doubles as the robust loss required below; fitting
+additional quantiles (e.g. 10%/90%) gives a per-series, per-time spread estimate for free — used
+by the normalisation step below.
+
+**Three residual-contamination routes to handle:**
 
 - *Training-set contamination.* If the baseline is fitted on history that itself contains switching events, the fit is biased toward those contaminated periods. Fit **robustly** (quantile or Huber loss), or iteratively: fit → flag large residuals as candidate events → refit excluding them. Because events occupy only ~10% of the time, a robust fit recovers the NRA relationship and the events fall out as residuals. This closes a virtuous loop with the detector itself — detected events feed back to clean the baseline's training data.
 - *Persistent events.* A months-long ARA appears as a residual level shift that *stays* shifted, not a transient. The changepoint detector handles this (it catches the onset step), but the baseline must **not** be allowed to slowly adapt and treat the new level as normal. Keep the baseline static (weather/calendar-driven only) over the detection window so a sustained ARA remains visible as a sustained residual offset.
+- *Seasonal-maintenance confounding.* Planned switching is not uniform through the year — outages
+  cluster in maintenance seasons. A flexible time-of-year covariate fitted on contaminated history
+  can therefore absorb systematic ARA effects into "seasonality", and the robust loss does *not*
+  fix this, because the contamination is locally dense within the season even though it is only
+  ~10% overall. Keep seasonal terms low-flexibility, prefer multiple years of history, and make
+  sure the fit → flag → refit loop removes flagged periods from the seasonal fit too.
+
+**Changepoint detection must respect the residual's real statistics.** Textbook mean-shift
+detectors (PELT/BinSeg with an L2 cost, CUSUM) assume roughly independent noise with constant
+variance. Baseline residuals violate both assumptions. They are **autocorrelated**: an NWP error
+or an unmodelled local effect persists for hours to days, and a naive detector fires on that slow
+wander as if it were a step — the classic failure mode of changepoint-on-residual pipelines is
+hundreds of confident detections that are just weather-model error. And they are
+**heteroscedastic**: residual spread differs across substations by orders of magnitude and varies
+by time of day (PV-heavy substations are noisiest at midday). Two standard fixes, both required:
+(a) **normalise** — divide residuals by the baseline's own per-series, per-time spread estimate
+(the extra quantiles above), so detection runs on z-score-like series and one threshold scale
+works fleet-wide; and (b) **pre-whiten or calibrate** — either fit a low-order AR model to each
+normalised residual and detect on its innovations, or calibrate the changepoint penalty per
+series with a block bootstrap over believed-clean periods, so the false-alarm rate is controlled
+under the residual's actual autocorrelation rather than an i.i.d. fiction.
 
 #### Stage 2. **Node-level coincidence / balance attribution.**
 
@@ -89,6 +121,49 @@ residuals around time t (observed - expected), one row per substation:
                 (pairwise matching would FAIL: neither j nor k alone equals 9)
 ```
 
+**The neighbourhood-sum test (cheap, powerful corroboration).** Conservation offers a second,
+sharper statistic than "the rises sum to the drop": over the candidate set {source + donors}, the
+**summed residual should show no step at all** across the event, while every member shows one. So,
+once a candidate attribution exists, compute the set's summed residual and require it to be
+(approximately — see the tolerance note below) step-free at `t`. This discriminates exactly the
+failure mode the per-series view cannot: a **regional weather-model error** steps every nearby
+series *and their sum*; a genuine transfer steps the members but leaves the sum flat. It does not
+*replace* per-series detection — a flat sum alone cannot say which substations moved or by how
+much (it is equally consistent with "no event at all") — it corroborates an attribution after
+stage 1 has proposed the pieces. The same statistic, computed around the *logged* events, is also
+the very first diagnostic to run, before any detector code exists (see the diagnostic precursor
+below).
+
+**Calibrate the attribution score against chance.** With ~5 neighbours each carrying noisy
+candidate steps, *some* subset will approximately sum to `Δ` surprisingly often by luck alone —
+subset-sum matching on noisy data is generous. The score therefore needs an explicit null:
+estimate, by permutation (run the same subset search at randomly chosen event-free times), how
+often a balancing subset of a given quality arises by chance, and only accept attributions that
+clear that null. Without this, the event list gets padded with confident-looking coincidences.
+
+**Conservation is only approximate — set the tolerance band accordingly.** Reconfiguration
+changes feeding-path lengths, so `I²R` losses change; and load served at a slightly different
+voltage draws slightly different power (load is mildly voltage-dependent — the effect behind
+conservation voltage reduction). Expect the
+donor pickups to miss the source drop systematically by a few percent, in either direction. The
+balance and neighbourhood-sum tests need a tolerance band, not an equality — and the imbalance
+distribution observed on logged events is itself worth reporting.
+
+**Events are intervals, not onsets.** Everything downstream (the ARA mask, the delivered event
+table) needs `[start, end]`, so the reversion step must be detected and **paired** with its
+onset: an opposite-sign, magnitude-similar step on the same source/donor set. Pairing is not
+always clean — restorations can happen in stages; a network can be reconfigured directly from one
+ARA into another without passing through NRA; and a fault event has a brief total-loss interim
+(during which conservation does *not* hold — the load is simply off) before restoration
+completes. Treat unpaired onsets as open intervals (event still in force at the end of the
+record) rather than discarding them.
+
+**Filter fleet-wide artifacts before attribution.** Telemetry re-basing, unit changes, or other
+data-pipeline shifts on NGED's side produce coincident steps across *many* series at once. Any
+step time shared by a large fraction of the fleet is a data artifact, not a switching event, and
+must be excluded before the subset search runs — otherwise it manufactures spurious
+multi-substation "events".
+
 #### Stage 3. **Composition corroboration (post-attribution, per recipient).**
 
 *Aim.* Stages 1–2 tell us *that* a switching event happened, *when*, and *how much net power* moved to each donor. They do **not** tell us *what kind* of power moved. A slice of the network carries a mix of underlying demand and embedded generation (rooftop PV, small wind), and the meter only ever sees the *net* (demand minus generation). Two transferred slices with the same net magnitude can have completely different make-ups — one might be 8 MW of demand with negligible generation, another might be 11 MW of demand offset by 3 MW of PV, both netting to +8 MW at the donor. The aim of stage 3 is to get a cheap, qualitative read on that make-up: *was the moved slice demand-dominated, PV-dominated, or wind-dominated?* This is corroboration and enrichment, not detection — it does not change whether we flagged the event, but it characterises it.
@@ -103,15 +178,28 @@ residuals around time t (observed - expected), one row per substation:
 
 This is a histogram (step magnitude vs. hour-of-day), not a fitted model — deliberately cheap, matching v0.6's simple-statistics spirit.
 
+*Two preconditions the read-off needs.* First, a **duration floor**: the diurnal histogram only
+fills if the event spans several days — for shorter events there is no hour-of-day coverage to
+average over, so composition should not be reported below (say) ~3–5 days of event duration.
+Second, a **weather-realisation confound**: the histogram measures the slice's shape *under the
+weather that actually occurred* — a PV-heavy slice moved during an overcast week reads as
+demand-heavy. Both are mitigated the same way: rather than hour-of-day alone, **correlate each
+recipient's residual step against the NWP covariates we already hold** (irradiance for PV, wind
+speed for wind, temperature and time-of-week for demand). That conditions on the weather that
+actually happened instead of assuming a canonical sunny day, and it is still a regression-free
+read-off in the v0.6 spirit — a few correlations per leg.
+
 *Order matters — read composition off the recipient, never the source.* The diurnal shape must be measured on **each recipient's individual step**, *after* attribution has identified which donor took which leg. It must **not** be read off the source substation's lumped drop. The reason: a source commonly sheds *different* slices to *different* donors at once — say a PV-heavy slice to donor `j` and a demand-heavy slice to donor `k`. The source's own residual shows only the *sum* of everything it lost, which blends the two into a meaningless average that matches neither leg. Only the per-recipient steps separate cleanly into "what `j` got" vs. "what `k` got." (This is the same source-blends-everything pitfall noted for stage 1, applied to composition rather than magnitude.)
 
 #### Other notes
 
 Issue: [#180](https://github.com/openclimatefix/nged-substation-forecast/issues/180)
 
-**Validation against the 32-series logs (this is the point).** Score the unsupervised detector against the known switching events: detection precision/recall, accuracy of the recovered donor set, error in transferred magnitude, and — most importantly — the **detection sensitivity floor**: the transferred-magnitude threshold above which we reliably detect events and below which we cannot. Pair this with the forecast impact of missed small events. *The detector must not consume the logs as input — only as a scoring oracle.*
+**Validation against the 32-series logs (this is the point).** Score the unsupervised detector against the known switching events: detection precision/recall, accuracy of the recovered donor set, error in transferred magnitude, and — most importantly — the **detection sensitivity floor**. The floor is not a single MW number: it is a frontier in **transferred magnitude × event duration**, reported per series relative to that series' residual noise. The duration axis exists because changepoint segmentation has a minimum detectable event length at half-hourly sampling (an event lasting minutes to a few hours appears as a spike or one odd interval, not a step), just as residual noise sets a minimum magnitude. Pair the frontier with the forecast impact of missed small events. *The detector must not consume the logs as input — only as a scoring oracle.* One caveat to carry into the scoring: measured **precision is a lower bound** — if the control-room logs are incomplete (worth asking NGED how complete they believe them to be), some "false positives" will be real, unlogged events.
 
-**Diagnostic precursor.** Before formal changepoints, a near-trivial check: first-difference each residual (steps → spikes) and, over rolling windows, confirm that a source's negative spike coincides with the *summed* rises of a neighbour subset. If known-neighbour groups show no such coincidence, the neighbour list or baseline is wrong — fix that first.
+**Synthetic event injection (the workhorse of tuning and validation).** The logs contain only however many events the trial period happens to contain, which caps the statistical power of any sensitivity estimate. Injection removes that cap: take periods believed clean, move a synthetic slice between real neighbours (subtract a scaled, plausibly-shaped signal from one series and add it across 1–3 others), and measure detection and attribution over a controlled **magnitude × duration grid**. This maps the full sensitivity frontier with arbitrary precision, tunes every threshold and penalty in stages 1–2 *without touching the gold-standard logs*, and works at any scale — including, later, on unlabelled full-fleet data. The real logs then play their proper role: confirming that the synthetic frontier transfers to reality, rather than carrying the whole measurement burden alone.
+
+**Diagnostic precursor.** Before formal changepoints, a near-trivial check: first-difference each residual (steps → spikes) and, over rolling windows, confirm that a source's negative spike coincides with the *summed* rises of a neighbour subset. Equivalently, around each *logged* event, plot the member residuals and the neighbourhood-sum residual: members should step, the sum should stay (approximately) flat. If known-neighbour groups show no such structure, the neighbour list or baseline is wrong — fix that first.
 
 **What it delivers.** A labelled list of detected events (time, source, donor set, per-leg magnitude, rough per-leg composition, score); an ARA mask for the forecasting data; a validation set for later stages; and the quantified sensitivity floor.
 
@@ -120,7 +208,9 @@ Issue: [#180](https://github.com/openclimatefix/nged-substation-forecast/issues/
 - Misses slow/gradual reconfigurations (because changepoint detection algos assume abrupt shift).
 - Misses small partial transfers near the noise floor — but these are both the *hardest* and (per the tolerance principle) the *least important* for the forecast, so the failure mode is aligned with priorities. The sensitivity floor makes this limit explicit rather than hidden.
 - **Blind to events that straddle the start of the record.** A switching state already in force before the data begins has no observable onset — it is only detectable if and when it *ends*. This is a structural blind spot, not a fixable one, and belongs in the sensitivity-floor reporting alongside the magnitude threshold.
-- Struggles with temporally overlapping events on one neighbourhood.
+- Struggles with temporally overlapping events on one neighbourhood — the sequential
+  detect-then-match structure is the culprit; the joint edge-flow estimator below is the designed
+  escalation for exactly this.
 - Composition read-off is qualitative only.
 
 **Pros.**
@@ -129,6 +219,81 @@ Issue: [#180](https://github.com/openclimatefix/nged-substation-forecast/issues/
 - Runs unsupervised, exactly as the scale regime demands.
 - Produces the masking artifact and the honest sensitivity floor that everything downstream relies on.
 - De-risks the programme at minimal cost.
+
+#### Escalation within v0.6 — the joint edge-flow estimator
+
+The three stages above are deliberately sequential: detect steps per substation, then match them
+across substations. That sequencing is easy to build and debug, but it has a known structural
+weakness (visible in the cons list): when events **overlap in time on one neighbourhood**, or
+when several attributions are individually ambiguous, a sequential matcher must make hard early
+choices that a joint method would not have to. There is a well-understood single-model
+alternative that performs detection and attribution **simultaneously**. It is the planned
+escalation *within* v0.6 — built if, and only if, validation shows that sequential matching is
+the thing that is failing.
+
+**The idea, in plain terms.** Instead of asking "does substation `i` show a step, and can we find
+neighbours to balance it?", write one equation for the whole neighbourhood and solve it in one
+go. Introduce, for every edge `i–j` of the graph, an unknown time series `e_ij(t)`: *the power
+crossing that boundary at time `t` because of switching* (zero under NRA). Each substation's
+residual is then, by construction, the signed sum of the flows on its own edges, plus a
+per-substation anomaly term:
+
+```text
+residual_i(t) ≈ Σ_j ±e_ij(t) + u_i(t)
+```
+
+(`+` where flow enters `i`, `−` where it leaves; `u_i` is explained below.) An optimiser then
+finds the edge flows that best explain **all substations' residuals at once**, subject to two
+penalties encoding what we know about switching:
+
+1. **Most flows are zero most of the time** (events are rare) — so penalise a flow for being
+   non-zero at all (a *sparsity* penalty).
+2. **When a flow is non-zero it is flat, with abrupt jumps** (switching is a step change held for
+   the event's duration) — so penalise a flow for *changing value* between consecutive time steps
+   (a *fused*, or total-variation, penalty — which is exactly what produces piecewise-constant
+   solutions).
+
+This combination is known as a **sparse fused lasso**. The crucial property is that the whole
+problem is **convex**: it has a single global best answer, no local minima, and standard fast
+solvers — unlike the v2.5 mixture model, whose products of unknowns make it genuinely harder to
+fit. In effort terms it sits just above the staged detector and well below v2.5.
+
+**Why it is attractive.**
+
+- **Conservation is built in, not checked afterwards.** A flow on edge `i–j` automatically
+  subtracts from one end and adds to the other; the parameterisation *cannot represent* a
+  non-conserving event, so there is no separate balance test to pass.
+- **Detection = attribution = magnitude estimation.** An event is simply "edge `i–j`'s flow
+  stepped from 0 to 4 MW at `t₁` and back at `t₂`". Source, donor set, per-leg magnitude, event
+  intervals, and the ARA mask all read directly off the fitted flows.
+- **Overlapping events are handled natively.** Two simultaneous transfers on one neighbourhood
+  are just two edge flows active at once; the optimiser separates them jointly instead of a
+  matcher untangling them sequentially.
+
+**Two details that matter.**
+
+- **The per-node slack term `u_i(t)`.** Not every step has a partner — a new connection, a meter
+  fault, or genuine load growth steps one substation with nothing balancing it at neighbours.
+  Without an escape valve the optimiser would be *forced* to invent edge flows to explain such
+  steps. `u_i(t)` is a per-substation "unexplained anomaly" series with its own sparsity penalty:
+  a partnerless step lands there and is reported as "anomaly, unknown cause" (exactly as stage 2
+  would report it) instead of contaminating the flows.
+- **Piecewise-constant is still an approximation.** A real transferred slice is live load — it
+  has its own diurnal shape, so over a long event the true `e_ij(t)` is not flat. The refinement,
+  if injections show it is needed: make the *fraction* piecewise-constant rather than the MW —
+  model `e_ij(t) = f_ij(t)·baseline_j(t)` with `f_ij` piecewise-constant, which is still convex
+  because the baseline is a known input. This is precisely the stepping stone to v2.5, whose
+  `α_ij(t)·d_j(t)` is the same idea with the known baseline replaced by a jointly-inferred
+  latent.
+
+**What it reuses.** Everything upstream: the same weather/calendar baseline, the same
+normalised/whitened residuals, the same adjacency, and the same synthetic-injection harness
+(which is how its two penalty weights are tuned). It replaces only stages 1–2's detect-then-match
+logic; stage 3's composition read-off applies unchanged to its output. This is also why it is an
+escalation rather than the starting point: it shares nearly all its parts with the staged
+detector, adds solver machinery, and is harder to inspect when it misbehaves. Build the
+transparent staged version first, keep it as the reference, and adopt the joint estimator only
+where a head-to-head comparison (on logs + injections) shows it wins.
 
 ---
 
@@ -149,6 +314,26 @@ observed_i(t) = α_ii(t)·d_i(t) + Σ_{j ∈ neighbours(i)} α_ij(t)·d_j(t)
 - During an ARA: weight shifts from a source onto **one or more** neighbours. Multiple `α_ij(t)` may be active at once for a single source.
 - **Conservation = node-level flow balance:** weight leaving `i` is distributed across a subset of neighbours and must sum to the weight lost at `i` (approximately mass-preserving over the affected neighbourhood). **Do not** implement this as independent pairwise equal-and-opposite constraints — that is wrong given confirmed 2–3-way fan-out.
 - **Priors / regularisation:** `α(t)` strongly regularised toward the identity (NRA) and **piecewise-constant in time**, because switching events are rare (~10%) and abrupt. A useful by-product: jumps in `α` are directly interpretable as detected switching events.
+- **`d_i(t)` must itself be modelled, not left free.** If the latent demand were an unconstrained
+  value per timestep the model would be hopelessly underdetermined — any observation can be
+  explained by moving `d` instead of `α`. `d_i(t)` is a weather/calendar-driven model plus a
+  smooth residual; in other words, v2.5 embeds the v0.6 baseline inside itself as the latent's
+  backbone. The v0.6 work is reused, not discarded.
+- **Fitting is bilinear (non-convex) — initialise from v0.6.** The `α·d` products mean local
+  minima are a real risk. Initialise/anchor the `α` jump times from the v0.6 event list (or the
+  edge-flow estimator's fitted flows, which are the same object in additive form) so the
+  optimiser starts near the right switching structure. v0.6's output is thus a direct *input* to
+  v2.5, not just its validation set.
+- **Known degeneracies to guard.** (a) *Scale:* `α_ii·d_i` is invariant to rescaling one against
+  the other; the identity prior resolves this except for a substation observed under ARA for
+  (nearly) its whole record, where v0.6's record-straddling blind spot applies unchanged.
+  (b) *Growth vs transfer:* genuine new load at `i` and a small persistent transfer onto `i` are
+  separated only by conservation (growth has no balancing donor) — keep an explicit per-node
+  anomaly/slack term, as in the edge-flow estimator, so partnerless changes are not forced into
+  `α`. (c) *Net-zero crossing:* `α` is a fraction of **net** power, and a fraction of a signal
+  near zero moves almost nothing regardless of `α` — at PV-heavy substations whose net crosses
+  zero, the transfer's magnitude information vanishes around the crossing. v2.6's typed
+  decomposition removes this by mixing gross components instead.
 
 **Why "arbitrary continuous slice" is handled natively.** `α_ij(t)` is a continuous fraction, so "some load, cut anywhere, moved to several donors" is exactly representable. The continuous-fraction form — which earlier looked like a limitation — is in fact *fidelity* to a network where the transferred amount is genuinely continuous and the cut point is free.
 
@@ -245,7 +430,9 @@ These apply at every stage and are the things most easily got wrong:
 - **Do not fit pilot-only parameters and rely on them at scale.** Anything learned only on the 16 labelled primaries that cannot be set for the other ~1,145 is forbidden as a production dependency. The *method* generalises; a pilot lookup does not.
 - **Conservation is node-level flow balance, everywhere.** One source's lost power is absorbed by a *subset* of neighbours whose pickups sum to it. Never implement conservation as independent pairwise equal-and-opposite matches — confirmed 2–3-way fan-out makes that wrong.
 - **Composition is read from recipients, never the source.** Any per-leg composition estimate (v0.6 stage 3) must come from each recipient's individual step *after* attribution; the source's step blends all simultaneous outgoing legs.
-- **Partial transfer is the common case.** Expect arbitrary continuous transferred magnitudes down to the noise floor. Quantify the detection sensitivity floor; do not assume a clean event/no-event separation.
+- **Partial transfer is the common case.** Expect arbitrary continuous transferred magnitudes down to the noise floor. Quantify the detection sensitivity floor (a magnitude × duration frontier, per series); do not assume a clean event/no-event separation.
+- **Every detection statistic gets a null.** Changepoint penalties calibrated per series under the residual's real autocorrelation; attribution scores calibrated against chance-level subset balance by permutation. Uncalibrated thresholds are how phantom events happen.
+- **Synthetic event injection is the standard tuning instrument at every stage.** Thresholds, penalties, and sensitivity frontiers are tuned and measured on injected events; the logged events are reserved for final scoring, never for tuning.
 - **Routing/switching priors:** regularise toward the identity (NRA) and piecewise-constant in time; switching is rare and abrupt.
 - **Metered vs unmetered DER** kept as separate modules from v2.6 onward; metered tightly constrained, unmetered carrying the latent inference.
 - **Interpretability artifacts** (detected events, inferred `s_ij`, DER estimates) are deliverables in their own right for NGED validation, not just internal state.
@@ -257,3 +444,40 @@ These apply at every stage and are the things most easily got wrong:
 - **Switching logs for the 32-series trial** (held; e.g. the DINDER example). Used as the gold-standard validation set for v0.6 and beyond. **Not** available at full scale — this asymmetry drives the whole design.
 - **Neighbour/adjacency structure** for the trial substations — which substations can exchange load (needed to define graph edges and the attribution search). Even approximate adjacency helps; note that because cut points move, "adjacency" means "can be electrically connected by some switching," not a fixed feeder map.
 - **Confirmed by NGED:** (a) multi-recipient transfer (2–3 donors) is the norm; (b) partial transfers (some, not all, of a substation's load) are the common and harder case; (c) no stable "feeder" unit exists; (d) switching labels exist only for the trial area, not at scale.
+- **To ask NGED:** how complete are the control-room switching logs for the trial area? (Determines whether measured detection precision is a tight bound or a loose lower bound.)
+
+---
+
+## Implementation details (deleted when this ships)
+
+The build order for v0.6, simplest-first, each step delivering something testable before the next
+adds complexity. Steps 1–7 are the staged detector; step 8 is the in-version escalation, built
+only if the head-to-head justifies it.
+
+1. **Labelled event table + adjacency.** Parse the 32-series switching logs into a tidy table
+   (onset, end, source, donor set, magnitude where recorded); obtain the trial-area adjacency
+   list from NGED (see Part 5). Nothing downstream is testable without these.
+2. **Baseline.** Configure the existing XGBoost forecaster with weather/calendar features only
+   (**no power-lag features**), quantile objective (median + spread quantiles), per series.
+   Output: normalised residual series. Sanity-check residual autocorrelation and per-series
+   spread before proceeding.
+3. **Diagnostic precursor — the first detection result, with zero detector code.** Around each
+   *logged* event, plot the member residuals and the neighbourhood-sum residual: members should
+   step, the sum should stay flat. This validates the baseline, the adjacency list, and the
+   conservation premise in one cheap pass. If it fails, fix data before building any detector.
+4. **Synthetic-injection harness.** Inject shaped transfers between real neighbours over a
+   magnitude × duration grid into believed-clean periods. Built early because every later
+   threshold is tuned on it.
+5. **Per-series changepoint detection** on whitened/normalised residuals, penalty calibrated by
+   block bootstrap; measure the per-series magnitude × duration sensitivity frontier on
+   injections.
+6. **Attribution.** Neighbour-subset search + balance scoring with the permutation null and
+   loss-tolerance band; neighbourhood-sum corroboration; fleet-wide artifact filter;
+   onset/reversion pairing into event intervals.
+7. **Composition read-off + final validation.** Stage-3 covariate correlations (events above the
+   duration floor only); score everything against the logged events (precision reported as a
+   lower bound); deliver the event table, ARA mask, and sensitivity frontier.
+8. **Escalation (conditional): the joint edge-flow estimator.** Build only if step 6/7 validation
+   shows sequential matching is the binding error source (overlapping events, ambiguous
+   attributions). Reuses steps 1–5 wholesale; penalty weights tuned on the injection harness;
+   adopted only where it beats the staged detector head-to-head.

--- a/docs/roadmap/switching-events.md
+++ b/docs/roadmap/switching-events.md
@@ -144,7 +144,8 @@ series *and their sum*; a genuine transfer steps the members but leaves the sum 
 much (it is equally consistent with "no event at all") — it corroborates an attribution after
 stage 1 has proposed the pieces. The same statistic, computed around the *logged* events, is also
 the very first diagnostic to run, before any detector code exists (see the diagnostic precursor
-below).
+below). The [joint edge-flow estimator](#v061-the-joint-edge-flow-estimator) goes one step
+further: its parameterisation builds this test in, rather than running it as a separate check.
 
 **Calibrate the attribution score against chance.** With ~5 neighbours each carrying noisy
 candidate steps, *some* subset will approximately sum to `Δ` surprisingly often by luck alone —
@@ -320,7 +321,8 @@ consumes, the approximation the parameterisation makes, and how the penalty weig
   and stage 3's composition read-off survives unchanged (read the residual around each fitted
   block, per recipient). If injections show the flat-block error matters, the still-convex
   refinement is a piecewise-constant *fraction* of the source's baseline —
-  `e_ij(t) = f_ij(t)·baseline_j(t)` — which is also the stepping stone to v2.5, whose
+  `e_ij(t) = f_ij(t)·baseline_j(t)` — which is also the stepping stone to
+  [v2.5](#v25-magnitude-only-mixture-model-the-workhorse), whose
   `α_ij(t)·d_j(t)` is the same idea with the known baseline replaced by a jointly-inferred
   latent.
 - **The penalty weights are tuned on the synthetic-injection harness, never on the logs.** Too
@@ -351,7 +353,7 @@ this parameterisation:
   few-percent real-world imbalance (losses change with path length, load is mildly
   voltage-dependent) is absorbed by the fit term and `u`, with no hand-set band.
 
-What it does **not** retire: the dependency on well-behaved residuals (the
+What it does **not** solve: the dependency on well-behaved residuals (the
 normalised-and-whitened bullet above — phantom flows replace phantom changepoints, but only if
 that step is skipped), the sensitivity floor (noise and half-hourly sampling still impose a
 magnitude × duration limit, measured the same way on injections), the fleet-wide artifact
@@ -374,7 +376,7 @@ implementation-details section directly below.
 
 The build order for v0.6, simplest-first, each step delivering something testable before the next
 adds complexity. Steps 1–7 are the staged detector; step 8 is the joint edge-flow estimator, built
-only if steps 1-7 prove to be too fragile (or to test out convex optimisation as a warm-up for v2!)
+only if steps 1–7 prove to be too fragile (or to test out convex optimisation as a warm-up for v2!)
 
 1. **Labelled event table + adjacency.** Parse the 32-series switching logs into a tidy table
    (onset, end, source, donor set, magnitude where recorded); obtain the trial-area adjacency
@@ -555,8 +557,9 @@ structure — the problem is convex in each unknown *separately* — and that en
   `d`, and "weather/calendar backbone plus smooth residual" is a convex regression.
 
 Iterate the two steps to convergence. There is also a natural **convex warm start**: fixing `d`
-to the exogenous baseline makes the whole model one convex problem — it is essentially v0.6.1's
-shaped-flow refinement `e_ij(t) = f_ij(t)·baseline_j(t)` in mixture clothing — so solve that
+to the exogenous baseline makes the whole model one convex problem — it is essentially
+[v0.6.1's](#v061-the-joint-edge-flow-estimator) shaped-flow refinement
+`e_ij(t) = f_ij(t)·baseline_j(t)` in mixture clothing — so solve that
 first, then let alternation release `d`. The caveat to state plainly: convexity now holds per
 *step*, not overall. Alternation converges, but to a *local* optimum of the bilinear problem — the
 certified-global-optimum promise of the pure-convex world does **not** come back just because
@@ -568,11 +571,9 @@ differentiable layer inside a PyTorch model
 ([the techniques page explains it](../techniques/convex-optimisation.md#the-bridge-welding-cvxpy-into-pytorch))
 is *not needed* for v2.5 — alternation above is CVXPY in a loop. It earns its place at **v2.6**,
 when `d_i` decomposes into physics modules (panel trigonometry, power curves, products of
-unknowns) that are genuinely non-convex and force PyTorch for the outer model. At that point the
-routing/switching estimation should *stay* a convex layer inside the PyTorch model rather than
-being re-implemented as free tensors: the layer keeps exact zeros (so "nonzero routing = detected
-event" survives) and built-in conservation, while gradients flow through the solve to train the
-physics modules end-to-end.
+unknowns) that are genuinely non-convex and force PyTorch for the outer model — see the
+[v2.6 tooling paragraph](#v26-type-resolved-mixture-with-differentiable-physics-modules) for why
+the routing estimation should stay a convex layer even then.
 
 **Why "arbitrary continuous slice" is handled natively.** `α_ij(t)` is a continuous fraction, so "some load, cut anywhere, moved to several donors" is exactly representable. The continuous-fraction form — which earlier looked like a limitation — is in fact *fidelity* to a network where the transferred amount is genuinely continuous and the cut point is free.
 

--- a/docs/roadmap/switching-events.md
+++ b/docs/roadmap/switching-events.md
@@ -94,13 +94,25 @@ or an unmodelled local effect persists for hours to days, and a naive detector f
 wander as if it were a step — the classic failure mode of changepoint-on-residual pipelines is
 hundreds of confident detections that are just weather-model error. And they are
 **heteroscedastic**: residual spread differs across substations by orders of magnitude and varies
-by time of day (PV-heavy substations are noisiest at midday). Two standard fixes, both required:
-(a) **normalise** — divide residuals by the baseline's own per-series, per-time spread estimate
-(the extra quantiles above), so detection runs on z-score-like series and one threshold scale
-works fleet-wide; and (b) **pre-whiten or calibrate** — either fit a low-order AR model to each
-normalised residual and detect on its innovations, or calibrate the changepoint penalty per
-series with a block bootstrap over believed-clean periods, so the false-alarm rate is controlled
-under the residual's actual autocorrelation rather than an i.i.d. fiction.
+by time of day (PV-heavy substations are noisiest at midday). Two standard fixes, both required —
+detection runs on residuals that have been *normalised* and *whitened*:
+
+- **Normalise: measure surprise in units of each substation's usual wobble.** A 2 MW residual is
+  an earthquake at a small rural substation and background noise at a large urban one — and the
+  same substation wobbles more at midday than at 4 a.m. So divide each residual by the baseline's
+  own estimate of "how wrong am I usually, for this substation, at this kind of moment" (the
+  extra quantiles above). Detection then runs on how-unusual-is-this scores rather than raw MW,
+  and one threshold scale works fleet-wide.
+- **Whiten: subtract the predictable stickiness, keep the genuine news.** Residual errors are
+  sticky — if the weather forecast was too cold at 09:00 it is probably still too cold at 09:30 —
+  so residuals drift in slow waves rather than arriving as independent coin flips, and a naive
+  detector reads each wave as a step. Whitening removes the part of each residual that was
+  predictable from the residuals just before it (fit a low-order autoregressive model; keep only
+  its surprises, the *innovations*). A genuine switching step is not predictable from the past,
+  so it survives whitening; a slow weather-error wave does not. The alternative with the same
+  effect: keep the residuals as-is but calibrate the changepoint penalty per series with a block
+  bootstrap over believed-clean periods, so the false-alarm rate is controlled under the
+  residual's actual stickiness rather than an i.i.d. fiction.
 
 #### Stage 2. **Node-level coincidence / balance attribution.**
 
@@ -222,78 +234,104 @@ Issue: [#180](https://github.com/openclimatefix/nged-substation-forecast/issues/
 
 #### Escalation within v0.6 — the joint edge-flow estimator
 
-The three stages above are deliberately sequential: detect steps per substation, then match them
-across substations. That sequencing is easy to build and debug, but it has a known structural
-weakness (visible in the cons list): when events **overlap in time on one neighbourhood**, or
-when several attributions are individually ambiguous, a sequential matcher must make hard early
-choices that a joint method would not have to. There is a well-understood single-model
-alternative that performs detection and attribution **simultaneously**. It is the planned
-escalation *within* v0.6 — built if, and only if, validation shows that sequential matching is
-the thing that is failing.
+> **Status within v0.6:** documented as the known next move if sequential matching proves
+> brittle. The staged detect-then-match pipeline above remains the day-one implementation because
+> it fails legibly; this estimator is the same priors and the same graph with strictly better
+> structure, and may well turn out to be the right v0.6. The machinery it rests on — what a
+> solver is, why convexity matters, and why this is a CVXPY problem rather than a PyTorch one —
+> is explained for non-experts in [Convex Optimisation](../techniques/convex-optimisation.md).
 
-**The idea, in plain terms.** Instead of asking "does substation `i` show a step, and can we find
-neighbours to balance it?", write one equation for the whole neighbourhood and solve it in one
-go. Introduce, for every edge `i–j` of the graph, an unknown time series `e_ij(t)`: *the power
-crossing that boundary at time `t` because of switching* (zero under NRA). Each substation's
-residual is then, by construction, the signed sum of the flows on its own edges, plus a
-per-substation anomaly term:
+**The core idea, in plain language.** The three stages above look at each substation on its own,
+spot moments where its residual suddenly jumps or drops, and then play matchmaker afterwards:
+this substation dropped nine megawatts, those two neighbours rose by five and four, so presumably
+they belong together. Detection first, matching second.
+
+The edge-flow estimator flips what we search for. Instead of asking "which substations stepped?",
+ask "how much load is flowing across each boundary between neighbouring substations, at every
+moment?" Think of the network as a map where each pair of substations that can exchange load has
+an invisible pipe between them. Normally every pipe carries nothing. When engineers perform a
+switching operation, one or two pipes suddenly carry, say, five megawatts, for a few days, and
+then go back to nothing.
+
+Describing the world in terms of pipes rather than steps makes conservation of power automatic.
+Whatever flows out of one substation through a pipe necessarily flows into its neighbour — the
+same number appears with a minus sign on one side and a plus sign on the other. It is impossible,
+in this vocabulary, to describe nine megawatts vanishing from one substation while only eight
+appear elsewhere. The balance check that stage 2 performs as a separate verification step
+disappears: it is built into the parameterisation.
+
+The estimation question then becomes: given the residuals observed at every substation (stage 1's
+baseline is untouched by this proposal), what is the most plausible story about what all the
+pipes were carrying? "Plausible" encodes exactly the two priors stated throughout this page:
+switching is **rare**, so almost all pipes should carry exactly zero almost all the time; and it
+is **abrupt**, so when a pipe does carry something it should be a flat block — switch on, hold
+steady, switch off — rather than a gentle wiggle. We write down a score that rewards explaining
+the residuals and penalises stories with many active pipes or many changes, and find the single
+story with the best score. Because the problem is **convex**, that story is the certified best
+one, found deterministically every run — see
+[Convex Optimisation](../techniques/convex-optimisation.md) for what that promise means and why
+gradient-descent tooling cannot make it.
+
+**Everything falls out of that one answer.** Every stretch where a pipe carries something nonzero
+*is* a detected event; the pipe identifies source and donor; the level is the transferred MW; the
+stretch's endpoints are the event interval; "any incident pipe active" is the ARA mask.
+Overlapping events on one neighbourhood — a listed weakness of the sequential matcher — are
+handled natively: they are simply two pipe variables active over overlapping intervals, and the
+fit apportions each node's residual across its incident edges because the two events touch
+different node subsets. They only become confusable if they hit identical edges at identical
+times, at which point no method could separate them and the honest answer is non-identifiability,
+not a matcher bug.
+
+**Formally.** This is a **group fused lasso** on signed edge flows `e_ij(t)`, with a per-node
+anomaly slack `u_i(t)`:
 
 ```text
-residual_i(t) ≈ Σ_j ±e_ij(t) + u_i(t)
+residual_i(t) ≈ Σ_j ±e_ij(t) + u_i(t)     (+ where flow enters i, − where it leaves)
 ```
 
-(`+` where flow enters `i`, `−` where it leaves; `u_i` is explained below.) An optimiser then
-finds the edge flows that best explain **all substations' residuals at once**, subject to two
-penalties encoding what we know about switching:
-
-1. **Most flows are zero most of the time** (events are rare) — so penalise a flow for being
-   non-zero at all (a *sparsity* penalty).
-2. **When a flow is non-zero it is flat, with abrupt jumps** (switching is a step change held for
-   the event's duration) — so penalise a flow for *changing value* between consecutive time steps
-   (a *fused*, or total-variation, penalty — which is exactly what produces piecewise-constant
-   solutions).
-
-This combination is known as a **sparse fused lasso**. The crucial property is that the whole
-problem is **convex**: it has a single global best answer, no local minima, and standard fast
-solvers — unlike the v2.5 mixture model, whose products of unknowns make it genuinely harder to
-fit. In effort terms it sits just above the staged detector and well below v2.5.
-
-**Why it is attractive.**
-
-- **Conservation is built in, not checked afterwards.** A flow on edge `i–j` automatically
-  subtracts from one end and adds to the other; the parameterisation *cannot represent* a
-  non-conserving event, so there is no separate balance test to pass.
-- **Detection = attribution = magnitude estimation.** An event is simply "edge `i–j`'s flow
-  stepped from 0 to 4 MW at `t₁` and back at `t₂`". Source, donor set, per-leg magnitude, event
-  intervals, and the ARA mask all read directly off the fitted flows.
-- **Overlapping events are handled natively.** Two simultaneous transfers on one neighbourhood
-  are just two edge flows active at once; the optimiser separates them jointly instead of a
-  matcher untangling them sequentially.
-
-**Two details that matter.**
-
-- **The per-node slack term `u_i(t)`.** Not every step has a partner — a new connection, a meter
-  fault, or genuine load growth steps one substation with nothing balancing it at neighbours.
-  Without an escape valve the optimiser would be *forced* to invent edge flows to explain such
-  steps. `u_i(t)` is a per-substation "unexplained anomaly" series with its own sparsity penalty:
-  a partnerless step lands there and is reported as "anomaly, unknown cause" (exactly as stage 2
-  would report it) instead of contaminating the flows.
-- **Piecewise-constant is still an approximation.** A real transferred slice is live load — it
-  has its own diurnal shape, so over a long event the true `e_ij(t)` is not flat. The refinement,
-  if injections show it is needed: make the *fraction* piecewise-constant rather than the MW —
-  model `e_ij(t) = f_ij(t)·baseline_j(t)` with `f_ij` piecewise-constant, which is still convex
-  because the baseline is a known input. This is precisely the stepping stone to v2.5, whose
+- **Fused penalty on grouped increments** → each flow is piecewise-constant with sparse changes.
+  The *group* structure ties the increments across edges at each timestep, so a fan-out event —
+  one switching action changing two or three edge flows at once — is encouraged to place all its
+  changes at one shared changepoint. (Refinement: group per node-neighbourhood rather than
+  globally, so unrelated events elsewhere on the network don't share changepoint credit.)
+- **Level (ℓ1) penalty on the flows** pulls inactive pipes to *exactly* zero — the
+  regularise-toward-NRA prior. The exactness matters: "nonzero stretch = detected event" only
+  works if inactive pipes read 0.000 MW rather than a trickle of ±0.03 MW, and producing crisp
+  zeros is precisely what convex solvers do well and gradient descent does not (see the
+  [techniques page](../techniques/convex-optimisation.md#the-corners-are-a-feature-exact-zeros)).
+- **The per-node slack `u_i(t)`** (with its own ℓ1 penalty) is the escape valve for partnerless
+  steps. A new connection, a meter fault, or genuine load growth steps one substation with
+  nothing balancing it at neighbours; without `u`, the optimiser's only vocabulary is pipes, so
+  it would be *forced* to invent flows. With it, partnerless steps land in `u` and are reported
+  as "anomaly, unknown cause" — exactly as stage 2 would classify them.
+- **It consumes stage 1's normalised, whitened residuals** (see stage 1 for the plain-language
+  version: measure surprise in units of each substation's usual wobble, after subtracting the
+  predictable stickiness of weather-model error). Feeding it raw residuals would inflate phantom
+  flows exactly as it inflates phantom changepoints.
+- **Flat blocks are an approximation — the same one stage 1 makes.** A real transferred slice is
+  live load with its own diurnal shape; a piecewise-constant flow captures its *mean level* and
+  leaves the shape in the residual. That is no worse than the mean-shift changepoint detector,
+  and stage 3's composition read-off survives unchanged (read the residual around each fitted
+  block, per recipient). If injections show the flat-block error matters, the still-convex
+  refinement is a piecewise-constant *fraction* of the source's baseline —
+  `e_ij(t) = f_ij(t)·baseline_j(t)` — which is also the stepping stone to v2.5, whose
   `α_ij(t)·d_j(t)` is the same idea with the known baseline replaced by a jointly-inferred
   latent.
+- **The penalty weights are tuned on the synthetic-injection harness, never on the logs.** Too
+  strict smooths real events away; too loose produces confetti of tiny phantom flows. Injection
+  sweeps over the magnitude × duration grid set the weights; the logged events stay reserved for
+  final scoring — and injection-based tuning is the only kind available at full scale, where no
+  logs exist.
 
-**What it reuses.** Everything upstream: the same weather/calendar baseline, the same
-normalised/whitened residuals, the same adjacency, and the same synthetic-injection harness
-(which is how its two penalty weights are tuned). It replaces only stages 1–2's detect-then-match
-logic; stage 3's composition read-off applies unchanged to its output. This is also why it is an
-escalation rather than the starting point: it shares nearly all its parts with the staged
-detector, adds solver machinery, and is harder to inspect when it misbehaves. Build the
-transparent staged version first, keep it as the reference, and adopt the joint estimator only
-where a head-to-head comparison (on logs + injections) shows it wins.
+**What it reuses, and why it is not the day-one build.** Everything upstream: the same
+weather/calendar baseline, the same normalised/whitened residuals, the same adjacency, and the
+same synthetic-injection harness. It replaces only stages 1–2's detect-then-match logic; stage 3
+applies unchanged to its output. It is an escalation rather than the starting point because the
+staged detector fails *legibly* — every flag traces to a visible step and a named neighbour
+subset — while a joint optimiser is harder to inspect when it misbehaves. Build the transparent
+version first, keep it as the reference, and adopt the joint estimator where the head-to-head
+comparison (on logs + injections) shows it wins. A CVXPY implementation sketch lives in the
+implementation-details section at the bottom of this page.
 
 ---
 
@@ -480,4 +518,99 @@ only if the head-to-head justifies it.
 8. **Escalation (conditional): the joint edge-flow estimator.** Build only if step 6/7 validation
    shows sequential matching is the binding error source (overlapping events, ambiguous
    attributions). Reuses steps 1–5 wholesale; penalty weights tuned on the injection harness;
-   adopted only where it beats the staged detector head-to-head.
+   adopted only where it beats the staged detector head-to-head. CVXPY sketch below.
+
+### Sketch of the edge-flow estimator (step 8 — untested)
+
+Illustrative sketch code, not the implementation. Background on CVXPY and why this problem is
+convex: [Convex Optimisation](../techniques/convex-optimisation.md).
+
+```python
+import cvxpy as cp
+import numpy as np
+
+
+def fit_edge_flows(R, B, lam_fused, lam_sparse, lam_anomaly, weights=None):
+    """Joint convex estimator for switching events (untested sketch).
+
+    Args:
+        R: (T, N) normalised, whitened residuals (observed − baseline) for N
+            substations over T timesteps; NaNs allowed.
+        B: (N, E) signed node–edge incidence matrix over the who-can-exchange-load
+            graph (−1/+1 at the two ends of each oriented edge).
+        lam_fused: penalty weight on grouped changes over time (events are abrupt).
+        lam_sparse: penalty weight on flow levels (regularise toward NRA).
+        lam_anomaly: penalty weight on the per-node slack (partnerless steps).
+        weights: optional (T, N) fit weights; 0 masks missing data.
+
+    Returns:
+        (T, E) fitted edge flows and (T, N) fitted per-node anomalies.
+    """
+    n_times, n_nodes = R.shape
+    n_edges = B.shape[1]
+
+    e = cp.Variable((n_times, n_edges))  # edge flows (the "pipes")
+    u = cp.Variable((n_times, n_nodes))  # per-node anomaly slack
+
+    # --- fit term: each node's residual ≈ signed sum of incident flows + anomaly ---
+    if weights is None:
+        weights = np.where(np.isnan(R), 0.0, 1.0)
+    resid = np.nan_to_num(R) - e @ B.T - u
+    fit = cp.sum_squares(cp.multiply(np.sqrt(weights), resid))
+
+    # --- group fused penalty: piecewise-constant flows whose changes share timesteps ---
+    increments = e[1:, :] - e[:-1, :]
+    fused = cp.sum(cp.norm(increments, 2, axis=1))
+
+    # --- level sparsity: pull inactive pipes to exactly zero (NRA prior) ---
+    sparse = cp.sum(cp.abs(e))
+
+    # --- anomaly slack: partnerless steps land here, not in invented flows ---
+    anomaly = cp.sum(cp.abs(u))
+
+    prob = cp.Problem(
+        cp.Minimize(fit + lam_fused * fused + lam_sparse * sparse + lam_anomaly * anomaly)
+    )
+    prob.solve(solver=cp.CLARABEL)  # or ECOS / SCS
+    return e.value, u.value
+
+
+def extract_events(edge_flows, edge_list, times, tol=1e-4):
+    """Turn fitted flows into event records: maximal nonzero runs per edge.
+
+    ``edge_list[k]`` is the oriented pair ``(a, b)`` for edge ``k``, matching the
+    incidence matrix (−1 at ``a``, +1 at ``b``): positive flow moves load from
+    ``a``'s meter to ``b``'s. ``tol`` is a numerical tolerance for solver precision,
+    not a detection threshold — the sparsity penalty does the actual thresholding
+    inside the optimisation.
+    """
+    events = []
+    for k, (a, b) in enumerate(edge_list):
+        active = np.abs(edge_flows[:, k]) > tol
+        # Walk maximal runs of `active`.
+        idx = np.flatnonzero(np.diff(np.r_[0, active.astype(int), 0]))
+        for start, stop in zip(idx[::2], idx[1::2]):
+            level = float(np.median(edge_flows[start:stop, k]))
+            source, donor = (a, b) if level > 0 else (b, a)
+            events.append({
+                "source": source,  # lost the load
+                "donor": donor,  # picked it up
+                "start": times[start],
+                "end": times[stop - 1],
+                "magnitude_mw": abs(level),
+            })
+    return events
+```
+
+Notes on the sketch:
+
+- **Scale.** At V1 scale (32 series, half-hourly, months of data) this solves in seconds to
+  minutes on a laptop. At V2 scale (~2,500 series), solve per neighbourhood cluster and/or in
+  sliding windows rather than one monolithic problem.
+- **Group structure.** The `axis=1` group norm ties changepoints across *all* edges per timestep;
+  the refinement is grouping per node-neighbourhood, so unrelated events elsewhere on the network
+  don't share changepoint credit.
+- **Tuning the `lam_*` weights** happens on the synthetic-injection harness (step 4), never on
+  the switching logs — see the escalation section above for why.
+- **The anomaly slack `u`** carries a plain ℓ1 penalty here; if injections show partnerless steps
+  are themselves step-like (a new connection is), `u` can be given its own fused penalty too.

--- a/docs/roadmap/switching-events.md
+++ b/docs/roadmap/switching-events.md
@@ -290,6 +290,11 @@ anomaly slack `u_i(t)`:
 residual_i(t) ≈ Σ_j ±e_ij(t) + u_i(t)     (+ where flow enters i, − where it leaves)
 ```
 
+Each term in that equation, and each penalty applied to it, is a deliberate design choice. The
+bullets below unpack them in turn: the two penalties that encode the switching priors, the
+anomaly slack that keeps non-switching steps out of the flows, the residuals the fit term
+consumes, the approximation the parameterisation makes, and how the penalty weights are set.
+
 - **Fused penalty on grouped increments** → each flow is piecewise-constant with sparse changes.
   The *group* structure ties the increments across edges at each timestep, so a fan-out event —
   one switching action changing two or three edge flows at once — is encouraged to place all its
@@ -323,6 +328,35 @@ residual_i(t) ≈ Σ_j ±e_ij(t) + u_i(t)     (+ where flow enters i, − where 
   sweeps over the magnitude × duration grid set the weights; the logged events stay reserved for
   final scoring — and injection-based tuning is the only kind available at full scale, where no
   logs exist.
+
+**Which of the staged pipeline's failure modes it retires — and which it doesn't.** Several of
+the statistical traps that stages 1–2 must handle with explicit machinery simply cannot occur in
+this parameterisation:
+
+- *Onset/reversion pairing disappears.* Stage 2 must detect each reversion step and pair it with
+  its onset — messy under staged restorations and ARA-to-ARA reconfigurations. Here an event is a
+  nonzero *run* of one flow variable, so its start and end are read off directly, and an
+  ARA-to-ARA move is just one flow stepping down as another steps up.
+- *Regional weather errors can't masquerade as events.* Flows are zero-sum across a neighbourhood
+  by construction, so a common-mode residual wave (an NWP bust hitting every nearby series with
+  the same sign) is *inexpressible* as edge flows — it falls into the anomaly slack instead. The
+  neighbourhood-sum test from stage 2 is not run as a separate check; the parameterisation
+  enforces it.
+- *The chance-balance null becomes a penalty competition.* Stage 2 needs an explicit permutation
+  null because some neighbour subset will approximately balance by luck. Here, for a candidate
+  event to enter the solution it must out-compete two rival explanations at once — "stay at zero"
+  (the sparsity price) and "call it an anomaly" (`u`) — evaluated jointly over the whole record.
+  That calibration is done once, by tuning the penalty weights on the injection harness.
+- *The loss/CVR tolerance band is implicit.* Exact conservation lives in the flows; the
+  few-percent real-world imbalance (losses change with path length, load is mildly
+  voltage-dependent) is absorbed by the fit term and `u`, with no hand-set band.
+
+What it does **not** retire: the dependency on well-behaved residuals (the
+normalised-and-whitened bullet above — phantom flows replace phantom changepoints, but only if
+that step is skipped), the sensitivity floor (noise and half-hourly sampling still impose a
+magnitude × duration limit, measured the same way on injections), the fleet-wide artifact
+pre-filter, and stage 3's composition preconditions (duration floor, weather-realisation
+confound).
 
 **What it reuses, and why it is not the day-one build.** Everything upstream: the same
 weather/calendar baseline, the same normalised/whitened residuals, the same adjacency, and the

--- a/docs/roadmap/switching-events.md
+++ b/docs/roadmap/switching-events.md
@@ -232,14 +232,15 @@ Issue: [#180](https://github.com/openclimatefix/nged-substation-forecast/issues/
 - Produces the masking artifact and the honest sensitivity floor that everything downstream relies on.
 - De-risks the programme at minimal cost.
 
-#### Escalation within v0.6 — the joint edge-flow estimator
+#### v0.6.1 — the joint edge-flow estimator
 
-> **Status within v0.6:** documented as the known next move if sequential matching proves
-> brittle. The staged detect-then-match pipeline above remains the day-one implementation because
-> it fails legibly; this estimator is the same priors and the same graph with strictly better
-> structure, and may well turn out to be the right v0.6. The machinery it rests on — what a
-> solver is, why convexity matters, and why this is a CVXPY problem rather than a PyTorch one —
-> is explained for non-experts in [Convex Optimisation](../techniques/convex-optimisation.md).
+> **Status within v0.6:** this sections documents the known next move if sequential matching
+> (described above) proves brittle. The staged detect-then-match pipeline above remains the day-one
+> implementation because it fails legibly. v0.6.1 uses the same priors and the same graph but with
+> strictly better structure, and may well turn out to be the right method to get us to v1. The
+> machinery it rests on — what a solver is, why convexity matters, and why this is a CVXPY problem
+> rather than a PyTorch one — is explained for non-experts in [Convex
+> Optimisation](../techniques/convex-optimisation.md).
 
 **The core idea, in plain language.** The three stages above look at each substation on its own,
 spot moments where its residual suddenly jumps or drops, and then play matchmaker afterwards:
@@ -335,6 +336,134 @@ implementation-details section at the bottom of this page.
 
 ---
 
+#### Implementation details for v0.6.x (deleted when this ships)
+
+The build order for v0.6, simplest-first, each step delivering something testable before the next
+adds complexity. Steps 1–7 are the staged detector; step 8 is the joint edge-flow estimator, built
+only if steps 1-7 prove to be too fragile (or to test out convex optimisation as a warm-up for v2!)
+
+1. **Labelled event table + adjacency.** Parse the 32-series switching logs into a tidy table
+   (onset, end, source, donor set, magnitude where recorded); obtain the trial-area adjacency
+   list from NGED (see Part 5). Nothing downstream is testable without these.
+2. **Baseline.** Configure the existing XGBoost forecaster with weather/calendar features only
+   (**no power-lag features**), quantile objective (median + spread quantiles), per series.
+   Output: normalised residual series. Sanity-check residual autocorrelation and per-series
+   spread before proceeding.
+3. **Diagnostic precursor — the first detection result, with zero detector code.** Around each
+   *logged* event, plot the member residuals and the neighbourhood-sum residual: members should
+   step, the sum should stay flat. This validates the baseline, the adjacency list, and the
+   conservation premise in one cheap pass. If it fails, fix data before building any detector.
+4. **Synthetic-injection harness.** Inject shaped transfers between real neighbours over a
+   magnitude × duration grid into believed-clean periods. Built early because every later
+   threshold is tuned on it.
+5. **Per-series changepoint detection** on whitened/normalised residuals, penalty calibrated by
+   block bootstrap; measure the per-series magnitude × duration sensitivity frontier on
+   injections.
+6. **Attribution.** Neighbour-subset search + balance scoring with the permutation null and
+   loss-tolerance band; neighbourhood-sum corroboration; fleet-wide artifact filter;
+   onset/reversion pairing into event intervals.
+7. **Composition read-off + final validation.** Stage-3 covariate correlations (events above the
+   duration floor only); score everything against the logged events (precision reported as a
+   lower bound); deliver the event table, ARA mask, and sensitivity frontier.
+8. **Escalation (conditional): the joint edge-flow estimator.** Build only if step 6/7 validation
+   shows sequential matching is the binding error source (overlapping events, ambiguous
+   attributions). Reuses steps 1–5 wholesale; penalty weights tuned on the injection harness;
+   adopted only where it beats the staged detector head-to-head. CVXPY sketch below.
+
+##### Sketch of the edge-flow estimator
+
+Illustrative, untested sketch code, not the implementation. Background on CVXPY and why this problem
+is convex: [Convex Optimisation](../techniques/convex-optimisation.md).
+
+```python
+import cvxpy as cp
+import numpy as np
+
+
+def fit_edge_flows(R, B, lam_fused, lam_sparse, lam_anomaly, weights=None):
+    """Joint convex estimator for switching events (untested sketch).
+
+    Args:
+        R: (T, N) normalised, whitened residuals (observed − baseline) for N
+            substations over T timesteps; NaNs allowed.
+        B: (N, E) signed node–edge incidence matrix over the who-can-exchange-load
+            graph (−1/+1 at the two ends of each oriented edge).
+        lam_fused: penalty weight on grouped changes over time (events are abrupt).
+        lam_sparse: penalty weight on flow levels (regularise toward NRA).
+        lam_anomaly: penalty weight on the per-node slack (partnerless steps).
+        weights: optional (T, N) fit weights; 0 masks missing data.
+
+    Returns:
+        (T, E) fitted edge flows and (T, N) fitted per-node anomalies.
+    """
+    n_times, n_nodes = R.shape
+    n_edges = B.shape[1]
+
+    e = cp.Variable((n_times, n_edges))  # edge flows (the "pipes")
+    u = cp.Variable((n_times, n_nodes))  # per-node anomaly slack
+
+    # --- fit term: each node's residual ≈ signed sum of incident flows + anomaly ---
+    if weights is None:
+        weights = np.where(np.isnan(R), 0.0, 1.0)
+    resid = np.nan_to_num(R) - e @ B.T - u
+    fit = cp.sum_squares(cp.multiply(np.sqrt(weights), resid))
+
+    # --- group fused penalty: piecewise-constant flows whose changes share timesteps ---
+    increments = e[1:, :] - e[:-1, :]
+    fused = cp.sum(cp.norm(increments, 2, axis=1))
+
+    # --- level sparsity: pull inactive pipes to exactly zero (NRA prior) ---
+    sparse = cp.sum(cp.abs(e))
+
+    # --- anomaly slack: partnerless steps land here, not in invented flows ---
+    anomaly = cp.sum(cp.abs(u))
+
+    prob = cp.Problem(
+        cp.Minimize(fit + lam_fused * fused + lam_sparse * sparse + lam_anomaly * anomaly)
+    )
+    prob.solve(solver=cp.CLARABEL)  # or ECOS / SCS
+    return e.value, u.value
+
+
+def extract_events(edge_flows, edge_list, times, tol=1e-4):
+    """Turn fitted flows into event records: maximal nonzero runs per edge.
+
+    ``edge_list[k]`` is the oriented pair ``(a, b)`` for edge ``k``, matching the
+    incidence matrix (−1 at ``a``, +1 at ``b``): positive flow moves load from
+    ``a``'s meter to ``b``'s. ``tol`` is a numerical tolerance for solver precision,
+    not a detection threshold — the sparsity penalty does the actual thresholding
+    inside the optimisation.
+    """
+    events = []
+    for k, (a, b) in enumerate(edge_list):
+        active = np.abs(edge_flows[:, k]) > tol
+        # Walk maximal runs of `active`.
+        idx = np.flatnonzero(np.diff(np.r_[0, active.astype(int), 0]))
+        for start, stop in zip(idx[::2], idx[1::2]):
+            level = float(np.median(edge_flows[start:stop, k]))
+            source, donor = (a, b) if level > 0 else (b, a)
+            events.append({
+                "source": source,  # lost the load
+                "donor": donor,  # picked it up
+                "start": times[start],
+                "end": times[stop - 1],
+                "magnitude_mw": abs(level),
+            })
+    return events
+```
+
+Notes on the sketch:
+
+- **Scale.** At V1 scale (32 series, half-hourly, months of data) this solves in seconds to
+  minutes on a laptop. At V2 scale (~2,500 series), solve per neighbourhood cluster and/or in
+  sliding windows rather than one monolithic problem.
+- **Group structure.** The `axis=1` group norm ties changepoints across *all* edges per timestep;
+  the refinement is grouping per node-neighbourhood, so unrelated events elsewhere on the network
+  don't share changepoint credit.
+- **Tuning the `lam_*` weights** happens on the synthetic-injection harness (step 4), never on
+  the switching logs — see the escalation section above for why.
+- **The anomaly slack `u`** carries a plain ℓ1 penalty here; if injections show partnerless steps
+  are themselves step-like (a new connection is), `u` can be given its own fused penalty too.
 ### v2.5 — Magnitude-only mixture model (the workhorse)
 
 **Goal.** Reconstruct a latent NRA demand `d_i(t)` per substation by modelling observed power as a time-varying mixture of each substation's own normal demand and its neighbours'.
@@ -486,131 +615,3 @@ These apply at every stage and are the things most easily got wrong:
 
 ---
 
-## Implementation details (deleted when this ships)
-
-The build order for v0.6, simplest-first, each step delivering something testable before the next
-adds complexity. Steps 1–7 are the staged detector; step 8 is the in-version escalation, built
-only if the head-to-head justifies it.
-
-1. **Labelled event table + adjacency.** Parse the 32-series switching logs into a tidy table
-   (onset, end, source, donor set, magnitude where recorded); obtain the trial-area adjacency
-   list from NGED (see Part 5). Nothing downstream is testable without these.
-2. **Baseline.** Configure the existing XGBoost forecaster with weather/calendar features only
-   (**no power-lag features**), quantile objective (median + spread quantiles), per series.
-   Output: normalised residual series. Sanity-check residual autocorrelation and per-series
-   spread before proceeding.
-3. **Diagnostic precursor — the first detection result, with zero detector code.** Around each
-   *logged* event, plot the member residuals and the neighbourhood-sum residual: members should
-   step, the sum should stay flat. This validates the baseline, the adjacency list, and the
-   conservation premise in one cheap pass. If it fails, fix data before building any detector.
-4. **Synthetic-injection harness.** Inject shaped transfers between real neighbours over a
-   magnitude × duration grid into believed-clean periods. Built early because every later
-   threshold is tuned on it.
-5. **Per-series changepoint detection** on whitened/normalised residuals, penalty calibrated by
-   block bootstrap; measure the per-series magnitude × duration sensitivity frontier on
-   injections.
-6. **Attribution.** Neighbour-subset search + balance scoring with the permutation null and
-   loss-tolerance band; neighbourhood-sum corroboration; fleet-wide artifact filter;
-   onset/reversion pairing into event intervals.
-7. **Composition read-off + final validation.** Stage-3 covariate correlations (events above the
-   duration floor only); score everything against the logged events (precision reported as a
-   lower bound); deliver the event table, ARA mask, and sensitivity frontier.
-8. **Escalation (conditional): the joint edge-flow estimator.** Build only if step 6/7 validation
-   shows sequential matching is the binding error source (overlapping events, ambiguous
-   attributions). Reuses steps 1–5 wholesale; penalty weights tuned on the injection harness;
-   adopted only where it beats the staged detector head-to-head. CVXPY sketch below.
-
-### Sketch of the edge-flow estimator (step 8 — untested)
-
-Illustrative sketch code, not the implementation. Background on CVXPY and why this problem is
-convex: [Convex Optimisation](../techniques/convex-optimisation.md).
-
-```python
-import cvxpy as cp
-import numpy as np
-
-
-def fit_edge_flows(R, B, lam_fused, lam_sparse, lam_anomaly, weights=None):
-    """Joint convex estimator for switching events (untested sketch).
-
-    Args:
-        R: (T, N) normalised, whitened residuals (observed − baseline) for N
-            substations over T timesteps; NaNs allowed.
-        B: (N, E) signed node–edge incidence matrix over the who-can-exchange-load
-            graph (−1/+1 at the two ends of each oriented edge).
-        lam_fused: penalty weight on grouped changes over time (events are abrupt).
-        lam_sparse: penalty weight on flow levels (regularise toward NRA).
-        lam_anomaly: penalty weight on the per-node slack (partnerless steps).
-        weights: optional (T, N) fit weights; 0 masks missing data.
-
-    Returns:
-        (T, E) fitted edge flows and (T, N) fitted per-node anomalies.
-    """
-    n_times, n_nodes = R.shape
-    n_edges = B.shape[1]
-
-    e = cp.Variable((n_times, n_edges))  # edge flows (the "pipes")
-    u = cp.Variable((n_times, n_nodes))  # per-node anomaly slack
-
-    # --- fit term: each node's residual ≈ signed sum of incident flows + anomaly ---
-    if weights is None:
-        weights = np.where(np.isnan(R), 0.0, 1.0)
-    resid = np.nan_to_num(R) - e @ B.T - u
-    fit = cp.sum_squares(cp.multiply(np.sqrt(weights), resid))
-
-    # --- group fused penalty: piecewise-constant flows whose changes share timesteps ---
-    increments = e[1:, :] - e[:-1, :]
-    fused = cp.sum(cp.norm(increments, 2, axis=1))
-
-    # --- level sparsity: pull inactive pipes to exactly zero (NRA prior) ---
-    sparse = cp.sum(cp.abs(e))
-
-    # --- anomaly slack: partnerless steps land here, not in invented flows ---
-    anomaly = cp.sum(cp.abs(u))
-
-    prob = cp.Problem(
-        cp.Minimize(fit + lam_fused * fused + lam_sparse * sparse + lam_anomaly * anomaly)
-    )
-    prob.solve(solver=cp.CLARABEL)  # or ECOS / SCS
-    return e.value, u.value
-
-
-def extract_events(edge_flows, edge_list, times, tol=1e-4):
-    """Turn fitted flows into event records: maximal nonzero runs per edge.
-
-    ``edge_list[k]`` is the oriented pair ``(a, b)`` for edge ``k``, matching the
-    incidence matrix (−1 at ``a``, +1 at ``b``): positive flow moves load from
-    ``a``'s meter to ``b``'s. ``tol`` is a numerical tolerance for solver precision,
-    not a detection threshold — the sparsity penalty does the actual thresholding
-    inside the optimisation.
-    """
-    events = []
-    for k, (a, b) in enumerate(edge_list):
-        active = np.abs(edge_flows[:, k]) > tol
-        # Walk maximal runs of `active`.
-        idx = np.flatnonzero(np.diff(np.r_[0, active.astype(int), 0]))
-        for start, stop in zip(idx[::2], idx[1::2]):
-            level = float(np.median(edge_flows[start:stop, k]))
-            source, donor = (a, b) if level > 0 else (b, a)
-            events.append({
-                "source": source,  # lost the load
-                "donor": donor,  # picked it up
-                "start": times[start],
-                "end": times[stop - 1],
-                "magnitude_mw": abs(level),
-            })
-    return events
-```
-
-Notes on the sketch:
-
-- **Scale.** At V1 scale (32 series, half-hourly, months of data) this solves in seconds to
-  minutes on a laptop. At V2 scale (~2,500 series), solve per neighbourhood cluster and/or in
-  sliding windows rather than one monolithic problem.
-- **Group structure.** The `axis=1` group norm ties changepoints across *all* edges per timestep;
-  the refinement is grouping per node-neighbourhood, so unrelated events elsewhere on the network
-  don't share changepoint credit.
-- **Tuning the `lam_*` weights** happens on the synthetic-injection harness (step 4), never on
-  the switching logs — see the escalation section above for why.
-- **The anomaly slack `u`** carries a plain ℓ1 penalty here; if injections show partnerless steps
-  are themselves step-like (a new connection is), `u` can be given its own fused penalty too.

--- a/docs/techniques/convex-optimisation.md
+++ b/docs/techniques/convex-optimisation.md
@@ -1,0 +1,155 @@
+# Convex Optimisation — When the Best Answer Is Guaranteed
+
+> **Status: durable method explainer.** This page explains what convex optimisation is, why a
+> convex formulation is a fundamentally better deal than gradient-descent training wherever it is
+> available, and the project's practical tooling rule — **CVXPY for convex estimation
+> subproblems, PyTorch for physics + learning**. The first planned application is the
+> [joint edge-flow estimator](../roadmap/switching-events.md#escalation-within-v06-the-joint-edge-flow-estimator)
+> for switching-event detection; further applications are expected. The Python in this document
+> is illustrative sketch code, not the implementation.
+
+## The problem class
+
+An optimisation problem has three parts: **unknowns** (numbers we want to find), a **score** (a
+function that says how bad any candidate setting of the unknowns is), and optionally
+**constraints** (rules a candidate must obey). "Solving" means finding the setting with the
+lowest score. Most estimation tasks in this project fit this shape once said out loud: *find the
+edge flows that best explain every substation's residual, preferring stories with few active
+pipes and few changes* (the switching-events estimator); *find the latent capacities that make
+the physics model reproduce the meter readings*
+([differentiable physics](differentiable-physics.md)).
+
+The two examples differ not in the question but in the **shape of the score landscape** — and
+that shape decides which tool can answer.
+
+## Convexity: the one-bowl property
+
+Picture the score as a landscape over every possible setting of the unknowns. A problem is
+**convex** when that landscape is a single bowl: pick any two points on the surface, draw the
+straight line between them, and the surface never rises above that line. The payoff: **a convex
+landscape has no false valleys.** Anywhere that looks like a bottom locally *is* the bottom
+globally. (If the score is *strictly* convex the bottom is a single point; with penalties like
+the absolute value the bottom can be a small flat face — but every point on it scores
+identically, so any answer the solver returns is a best answer.)
+
+Formally, a function `f` is convex when, for all `x`, `y` and `0 ≤ λ ≤ 1`:
+
+```text
+f(λ·x + (1−λ)·y)  ≤  λ·f(x) + (1−λ)·f(y)
+```
+
+You rarely check this by hand, because convexity has a *calculus* — a small rulebook that builds
+complicated convex functions from simple ones:
+
+- **Atoms.** Squared error `x²`; absolute value `|x|`; norms, including group norms such as the
+  ℓ2 norm of a vector of increments; `max`; the quantile/pinball loss; the Huber loss — all
+  convex.
+- **Combination rules.** A non-negative weighted sum of convex functions is convex (so
+  `fit + λ·penalty` is safe). A convex function of an *affine* expression (`A·x + b`) is convex
+  (so "residual = data − incidence-matrix × flows, then sum of squares" is safe). A pointwise max
+  of convex functions is convex.
+
+Every term in the edge-flow estimator is assembled from exactly these pieces — that is *why* it
+is convex — and the rulebook is mechanical enough for software to verify (two sections down).
+
+## What a solver is, and why convexity matters
+
+A solver is off-the-shelf software whose whole job is finding the best answer to an optimisation
+problem: hand it a scoring rule and a set of unknowns, and it returns the values that score best.
+Convex problems are the friendly kind — the score landscape is one smooth bowl with a single
+lowest point and no false valleys. The solver rolls downhill and is *guaranteed* to stop at the
+true bottom. Contrast training a neural network, where the landscape is full of dents and you
+never know whether you found the best one. Here you always do, deterministically: no learning
+rates, no convergence babysitting, no random seeds, and the identical answer every run.
+
+That last property is quietly important for this project's deliverables: an event list handed to
+NGED should not change because a fit was re-run.
+
+## The corners are a feature: exact zeros
+
+Lasso-family penalties (`|x|` and its group cousins) have a sharp corner at zero, and the corner
+is the point: it makes the optimum sit at *exactly* zero for most variables, rather than merely
+near it. Designs like the edge-flow estimator lean on this — "this pipe's stretch of nonzero
+flow" literally *is* the detected event, which only works if inactive pipes read 0.000 MW.
+
+Specialised convex solvers (proximal and interior-point methods) handle those corners exactly.
+Plain gradient descent does not: it slides around the corner and leaves every variable carrying a
+tiny residual trickle — ±0.03 MW on every pipe, everywhere — forcing a threshold to decide what
+counts as an event, and thereby reintroducing exactly the arbitrary cutoff the formulation was
+designed to remove. Fixing this in PyTorch means hand-rolling the proximal machinery that convex
+solvers provide for free.
+
+## CVXPY: the modelling language
+
+[CVXPY](https://www.cvxpy.org/) is a Python modelling language for convex problems. You write the
+score in NumPy-like syntax; CVXPY checks *at construction time* — using the compositional
+rulebook above, formalised as **disciplined convex programming (DCP)** — that the problem really
+is convex, and refuses to build it otherwise. It then compiles the problem and hands it to a
+solver backend (Clarabel, ECOS, SCS, …).
+
+```python
+import cvxpy as cp
+
+x = cp.Variable(n)
+score = cp.sum_squares(A @ x - b) + lam * cp.sum(cp.abs(x))
+problem = cp.Problem(cp.Minimize(score), [x >= 0])
+problem.solve(solver=cp.CLARABEL)  # certified global optimum in x.value
+```
+
+The construction-time check cuts both ways, and both directions are useful: it *certifies* the
+formulations it accepts, and it *refuses* the ones it cannot certify — which is a feature, not an
+obstacle, because it says honestly when a problem has left the convex world and needs the other
+toolchain.
+
+## Why not just PyTorch for the convex problems too?
+
+Because the same loss implemented in PyTorch surrenders the two properties that motivated the
+convex formulation in the first place:
+
+1. **The guarantee.** CVXPY exploits convexity to deliver the certified global optimum,
+   identically, every run. Gradient descent doesn't know the bowl is smooth and inherits all the
+   usual tuning — learning rates, schedules, stopping criteria, seeds — for a problem that
+   required none.
+2. **Exact zeros.** As above: crisp zeros come from solvers that respect the ℓ1 corner; gradient
+   descent leaves trickles and brings thresholds back.
+
+The residual attractions of PyTorch are real — one toolchain across the project, GPUs at
+~2,500-series scale, and the freedom to later make a model non-convex — but they do not outweigh
+the two properties above *for a formulation that is actually convex*. And the bridge below means
+the choice is not a wall.
+
+## Where PyTorch is the right tool
+
+For the differentiable-physics disaggregation work — estimating unmetered solar, wind, EVs and
+heat pumps, and the effective capacity of metered generators — CVXPY is not marginally wrong but
+*cannot-express-the-problem* wrong. Convexity is fragile: panel-orientation trigonometry,
+wind-turbine power curves (S-shaped ramp, cut-out), thermal heat-pump models, even multiplying
+two unknowns together (unknown capacity × unknown per-unit output) all break it, and GNN layers
+are as non-convex as it gets. CVXPY's DCP check would refuse these models at construction —
+correctly. PyTorch offers the opposite deal: write down almost anything, gradients flow through
+it, GPUs make it fast, and the dented landscape is managed with initialisation, restarts, and
+validation. The [differentiable-physics](differentiable-physics.md) plan is right to live there.
+
+**Rule of thumb:** convex estimation subproblems (the switching-events edge-flow estimator, and
+similar) → **CVXPY**, for certainty, reproducibility, and little code. Physics + learning
+(capacity estimation, disaggregation) → **PyTorch**, because nothing else can express it.
+
+## The bridge: welding CVXPY into PyTorch
+
+There is a bridge between the two worlds: **differentiable convex optimisation layers**
+([`cvxpylayers`](https://github.com/cvxgrp/cvxpylayers), from the same research group as CVXPY).
+It embeds a convex solve inside a PyTorch model as if it were another layer, with gradients
+flowing through the solve itself. Concretely for this project: the switching-event estimator need
+not remain a separate preprocessing step forever — it could eventually sit *inside* the v2.5
+mixture model, jointly trained, with the physics modules feeding it and gradients passing
+straight through. Not a day-one build — but it means choosing CVXPY for switching now does not
+wall that code off from the PyTorch future.
+
+## Applications in this project
+
+- **Switching-event detection — the
+  [joint edge-flow estimator](../roadmap/switching-events.md#escalation-within-v06-the-joint-edge-flow-estimator)**
+  (first planned application): a group fused lasso on signed edge flows; implementation sketch on
+  the roadmap page.
+- More are expected to follow. Roadmap pages that adopt a convex formulation should cite this
+  page for the rationale and tooling choice rather than re-deriving them.

--- a/docs/techniques/convex-optimisation.md
+++ b/docs/techniques/convex-optimisation.md
@@ -4,7 +4,7 @@
 > convex formulation is a fundamentally better deal than gradient-descent training wherever it is
 > available, and the project's practical tooling rule — **CVXPY for convex estimation
 > subproblems, PyTorch for physics + learning**. The first planned application is the
-> [joint edge-flow estimator](../roadmap/switching-events.md#escalation-within-v06-the-joint-edge-flow-estimator)
+> [joint edge-flow estimator](../roadmap/switching-events.md#v061-the-joint-edge-flow-estimator)
 > for switching-event detection; further applications are expected. The Python in this document
 > is illustrative sketch code, not the implementation.
 
@@ -140,16 +140,24 @@ There is a bridge between the two worlds: **differentiable convex optimisation l
 ([`cvxpylayers`](https://github.com/cvxgrp/cvxpylayers), from the same research group as CVXPY).
 It embeds a convex solve inside a PyTorch model as if it were another layer, with gradients
 flowing through the solve itself. Concretely for this project: the switching-event estimator need
-not remain a separate preprocessing step forever — it could eventually sit *inside* the v2.5
-mixture model, jointly trained, with the physics modules feeding it and gradients passing
-straight through. Not a day-one build — but it means choosing CVXPY for switching now does not
-wall that code off from the PyTorch future.
+not remain a separate preprocessing step forever — the routing/switching solve can eventually sit
+*inside* the v2.6 type-resolved model as a convex layer, with the differentiable-physics modules
+feeding it and gradients passing straight through, keeping exact zeros and built-in conservation
+where free tensors would lose both. (v2.5, by contrast, needs no PyTorch at all: it is buildable
+as alternating CVXPY solves.) When each rung earns its place is documented in the
+[v2.5 tooling note](../roadmap/switching-events.md#v25-magnitude-only-mixture-model-the-workhorse)
+on the switching-events roadmap page. Not a day-one build — but it means choosing CVXPY for
+switching now does not wall that code off from the PyTorch future.
 
 ## Applications in this project
 
 - **Switching-event detection — the
-  [joint edge-flow estimator](../roadmap/switching-events.md#escalation-within-v06-the-joint-edge-flow-estimator)**
+  [joint edge-flow estimator](../roadmap/switching-events.md#v061-the-joint-edge-flow-estimator)**
   (first planned application): a group fused lasso on signed edge flows; implementation sketch on
   the roadmap page.
+- **The v2.5 mixture model** — bilinear, so not one convex problem, but buildable entirely as
+  *alternating* CVXPY solves (each step convex; global-optimum guarantee holds per step, not
+  overall). See the
+  [v2.5 tooling note](../roadmap/switching-events.md#v25-magnitude-only-mixture-model-the-workhorse).
 - More are expected to follow. Roadmap pages that adopt a convex formulation should cite this
   page for the rationale and tooling choice rather than re-deriving them.

--- a/docs/techniques/convex-optimisation.md
+++ b/docs/techniques/convex-optimisation.md
@@ -56,9 +56,8 @@ is convex — and the rulebook is mechanical enough for software to verify (two 
 
 A solver is off-the-shelf software whose whole job is finding the best answer to an optimisation
 problem: hand it a scoring rule and a set of unknowns, and it returns the values that score best.
-Convex problems are the friendly kind — the score landscape is one smooth bowl with a single
-lowest point and no false valleys. The solver rolls downhill and is *guaranteed* to stop at the
-true bottom. Contrast training a neural network, where the landscape is full of dents and you
+Convex problems are the friendly kind — the score landscape is a single bowl with no false
+valleys. The solver rolls downhill and is *guaranteed* to stop at the true bottom. Contrast training a neural network, where the landscape is full of dents and you
 never know whether you found the best one. Here you always do, deterministically: no learning
 rates, no convergence babysitting, no random seeds, and the identical answer every run.
 
@@ -107,8 +106,8 @@ Because the same loss implemented in PyTorch surrenders the two properties that 
 convex formulation in the first place:
 
 1. **The guarantee.** CVXPY exploits convexity to deliver the certified global optimum,
-   identically, every run. Gradient descent doesn't know the bowl is smooth and inherits all the
-   usual tuning — learning rates, schedules, stopping criteria, seeds — for a problem that
+   identically, every run. Gradient descent doesn't know the landscape is one bowl and inherits
+   all the usual tuning — learning rates, schedules, stopping criteria, seeds — for a problem that
    required none.
 2. **Exact zeros.** As above: crisp zeros come from solvers that respect the ℓ1 corner; gradient
    descent leaves trickles and brings thresholds back.

--- a/docs/techniques/differentiable-physics.md
+++ b/docs/techniques/differentiable-physics.md
@@ -8,7 +8,10 @@
 > (graph-structured disaggregation of net substation power into latent demand and DER generation)
 > is [v2 research](../roadmap/index.md#v20-scale-up-future-research). Abnormal running
 > arrangements and latent-demand recovery under switching are covered in their own canonical doc,
-> [Switching events & latent demand](../roadmap/switching-events.md). The Python in this document
+> [Switching events & latent demand](../roadmap/switching-events.md). The tooling counterpart to
+> this page — which estimation problems belong in convex optimisation (CVXPY) rather than
+> PyTorch, and the `cvxpylayers` bridge between the two — is
+> [Convex Optimisation](convex-optimisation.md). The Python in this document
 > is illustrative sketch code, not the implementation. See the
 > [roadmap index](../roadmap/index.md) for status conventions.
 

--- a/docs/techniques/index.md
+++ b/docs/techniques/index.md
@@ -8,6 +8,11 @@ sections: [background](../background/network.md) describes the *problem*, the
 pages, techniques pages are permanent: they stay put (and stay linkable — including from code
 docstrings) as the work that applies them ships.
 
+- [Convex optimisation](convex-optimisation.md) — the one-bowl property, why a certified global
+  optimum beats gradient descent wherever it is available, exact zeros from ℓ1 penalties, and the
+  project tooling rule (CVXPY for convex estimation subproblems; PyTorch for physics + learning).
+  First applied by the edge-flow estimator on the
+  [switching-events roadmap page](../roadmap/switching-events.md).
 - [Differentiable physics](differentiable-physics.md) — inversion through differentiable forward
   models: the single-site solar plant, aggregate fleet nodes, the graph-structured disaggregation
   engine, and native MVA handling. Applied by the

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,6 +41,7 @@ nav:
       - Switching Events: background/switching-events.md
   - Techniques:
       - Overview: techniques/index.md
+      - Convex Optimisation: techniques/convex-optimisation.md
       - Differentiable Physics: techniques/differentiable-physics.md
       - Encoders: techniques/encoders.md
       - Disaggregation Evaluation: techniques/disaggregation-evaluation.md


### PR DESCRIPTION
Part of #151. Updates the [switching-events roadmap page](https://openclimatefix.github.io/nged-substation-forecast/roadmap/switching-events/) following a design review of the v0.6 detector and the v2.5/v2.6 mixture models, and adds a new durable techniques page, [Convex Optimisation](https://openclimatefix.github.io/nged-substation-forecast/techniques/convex-optimisation/). The staged architecture is unchanged; this PR hardens the plan against the statistical failure modes that typically sink changepoint-on-residual pipelines, fleshes out the joint edge-flow estimator as the planned in-version escalation (with a non-expert intro and a CVXPY sketch), and specifies the v0.6 build order.

## v0.6 stage 1 (baseline + changepoints)

- **Baseline implementation pinned down**: reuse the existing XGBoost forecaster with weather/calendar features only (no power-lag features), quantile objective — the median is the robust fit, extra quantiles give a per-series/per-time spread estimate for free.
- **New contamination route**: seasonal-maintenance confounding (planned switching clusters in maintenance seasons, so flexible seasonality terms can absorb ARA effects; robust loss alone doesn't fix it).
- **Residual statistics**: baseline residuals are autocorrelated and heteroscedastic, which violates the assumptions of PELT/CUSUM-style detectors and produces mass false positives if ignored. Detection runs on **normalised, whitened** residuals — both explained in plain language (surprise in units of each substation's usual wobble; subtract the predictable stickiness, keep the genuine news).

## v0.6 stage 2 (attribution)

- **Neighbourhood-sum test**: over {source + donors}, the summed residual should show *no* step while every member shows one — discriminates genuine transfers from regional weather-model error, which steps the sum too. Corroborates attribution; also the very first diagnostic to run against the logged events (build-order step 3).
- Attribution scores calibrated against a permutation null (subset-sum matching on noisy data balances by chance surprisingly often).
- Conservation is only approximate (losses change with path length; load is voltage-dependent) — tolerance band, not equality.
- Events are intervals: onset/reversion pairing, staged restorations, fault total-loss interims, open intervals.
- Fleet-wide artifact filter (coincident steps across many series are data artifacts, not events).

## v0.6 stage 3 + validation

- Composition read-off gains a duration floor (~3–5 days) and a weather-realisation caveat; correlate recipient steps against NWP covariates rather than hour-of-day alone.
- Sensitivity floor redefined as a per-series **magnitude × duration frontier** (half-hourly sampling imposes a duration floor, not just a magnitude floor).
- **Synthetic event injection** as the standard tuning/validation instrument — maps the frontier with arbitrary statistical power, keeps the logs unused until final scoring, and is the only tuning available at full scale where no logs exist.
- Measured precision documented as a lower bound (logs may be incomplete; question for NGED added to Part 5).

## Joint edge-flow estimator (in-version escalation)

Fully fleshed out with a gentle plain-language intro (the "pipes" framing): one unknown flow per graph edge, fitted jointly across all residuals as a **group fused lasso** — sparsity encodes "switching is rare", the fused penalty encodes "switching is abrupt", and the group structure lets a single fan-out switching action share one changepoint across its 2–3 edges. Conservation is built into the parameterisation; detection, attribution, magnitude, and intervals read directly off the fitted flows; overlapping events are handled natively (and the truly confounded case — identical edges, identical times — is honest non-identifiability, not a matcher bug). A per-node slack term absorbs partnerless anomalies (new connections, meter faults) so they can't force invented flows. Penalty weights are tuned on the injection harness, never the logs. Status: the staged detector remains day one because it fails legibly, but this may well turn out to be the right v0.6. An untested CVXPY sketch (`fit_edge_flows` / `extract_events`) lives in the page's implementation-details section. A closing block spells out which stage-1/2 failure modes the estimator solves structurally (onset/reversion pairing, regional weather-error masquerade, the chance-balance permutation null, the loss/CVR tolerance band) and which it does not (residual quality, the sensitivity floor, the artifact pre-filter, stage-3 preconditions).

## New techniques page: Convex Optimisation

Durable, non-expert explainer backing the estimator and future convex subproblems: what an optimisation problem and a solver are, the one-bowl property and the convexity calculus (the basis of CVXPY's DCP verification), why exact zeros from ℓ1 corners need real convex solvers rather than gradient descent, the project tooling rule (**CVXPY for convex estimation subproblems; PyTorch for physics + learning**, where convexity is unexpressible), and the `cvxpylayers` bridge that lets the estimator later sit inside the v2.5 model. Cross-linked from the differentiable-physics page and the techniques index; added to the nav.

## v2.5

- `d_i(t)` must itself be modelled (v2.5 embeds the v0.6 baseline as the latent's backbone).
- The fit is bilinear/non-convex — initialise α jump times from the v0.6 event list, making v0.6's output a direct input to v2.5.
- Degeneracies named: scale (α·d rescaling), growth-vs-transfer (needs a per-node slack), and net-zero crossing at PV-heavy substations.
- **Tooling documented**: v2.5 is *not* one convex problem (α·d is bilinear; DCP refuses it) but is buildable **entirely with CVXPY** as alternating convex solves — the α-step is the same group-fused-lasso family as the edge-flow estimator, the d-step a convex regression — with a convex warm start (d fixed to the baseline) and the honest caveat that alternation converges to a *local* optimum. `cvxpylayers` is documented as earning its place at **v2.6**, where the non-convex physics modules force PyTorch: the per-type routing weights stay a differentiable convex layer inside the PyTorch model, preserving exact zeros and built-in conservation. Cross-referenced from the techniques page (bridge section + applications list) and a v2.6 tooling note.

## Build order

New "Implementation details (deleted when this ships)" section: (1) event table + adjacency → (2) baseline → (3) neighbourhood-sum diagnostic on logged events (first detection result, zero detector code) → (4) injection harness → (5) per-series changepoints → (6) attribution → (7) composition + final validation → (8) conditional edge-flow escalation (CVXPY sketch included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011KrcruNkZzYmXj2EUsuRj1


