### PR TITLE
Add probabilistic-forecasting technique explainer and the Phase D quantile-ensemble plan

### DIFF
--- a/docs/ml_experimentation/cross-validation-folds.md
+++ b/docs/ml_experimentation/cross-validation-folds.md
@@ -29,12 +29,12 @@ folds).
 
 ---
 
-## Current state: a single MVP fold ✅
+## Current state: a single fold ✅
 
 Honest forecast-skill validation needs **real forecast NWP (ECMWF ENS) for both training and
 validation**. Our ECMWF ENS archive only reaches back to **2024-04-01** (Dynamical.org are
 back-filling earlier years, but slowly), so the entire usable window is ~2024-04 to mid-2026 —
-only enough for roughly **one** seasonally-complete fold. We therefore run a single MVP fold:
+only enough for roughly **one** seasonally-complete fold. We therefore run a single fold:
 
 | `fold_id` | Train | Validate | Weather source |
 |---|---|---|---|
@@ -102,7 +102,8 @@ Expanding training, but validate on the **next 3 months, non-overlapping**:
 Because the validation windows do not overlap, the folds are **genuinely independent**
 measurements, and the set covers all four seasons (so you see seasonal skill variation, then report
 per-season and the mean). This is the statistically sound version of what monthly CV reaches for.
-We deferred it to keep the MVP minimal; it is the recommended next step if we want multiple folds
+We deferred it to keep the initial CV setup minimal; it is the recommended next step if we want
+multiple folds
 *before* the ECMWF back-fill enables the full yearly protocol.
 
 ### Yearly folds backed by CERRA — rejected for validation

--- a/docs/ml_experimentation/index.md
+++ b/docs/ml_experimentation/index.md
@@ -13,5 +13,5 @@ roadmap.
 - [Model configuration](model-configuration.md) — how to set hyperparameters and choose
   features; the full feature vocabulary and the lookahead-bias guardrails.
 - [Cross-validation folds](cross-validation-folds.md) — the expanding-window CV protocol, the
-  current single MVP fold and why the data constrains us to it, the target multiple-yearly-fold
+  current single fold and why the data constrains us to it, the target multiple-yearly-fold
   protocol, and the fold-design alternatives we considered.

--- a/docs/roadmap/capacity-estimation.md
+++ b/docs/roadmap/capacity-estimation.md
@@ -21,7 +21,7 @@ soil and degrade (or are cleaned and replaced), arrays are extended. A static na
 introduces large downstream errors. The v0.7 deliverable is a **time-varying effective-capacity
 series per metered generator**, feeding the
 [`effective_capacity`](delivery-tables.md#table-4-effective_capacity) delivery table. Because
-this turns the MVP's single scalar-per-series capacity into a time-varying series, the metrics
+this turns v0.1's single scalar-per-series capacity into a time-varying series, the metrics
 pipeline must also swap its `time_series_id`-only NMAE-denominator join for a temporal as-of
 join — see
 [Normalising NMAE by `effective_capacity`](metrics-and-leaderboard.md#normalising-nmae-by-effective_capacity).

--- a/docs/roadmap/delivery-tables.md
+++ b/docs/roadmap/delivery-tables.md
@@ -33,10 +33,10 @@ There are **five** tables. This table tracks where each one stands today:
 
 | # | Table | Status | Where the schema lives |
 |---|---|---|---|
-| 1 | `power_forecast` | ✅ Implemented (deterministic-ensemble flavour only) | `contracts.power_schemas.PowerForecast` |
-| 2 | `power_forecast_warnings` | 🚧 Planned (partial in MVP) | not yet in code |
+| 1 | `power_forecast` | ✅ Deterministic-ensemble flavour implemented (v0.1); percentile flavours planned for v0.5 | `contracts.power_schemas.PowerForecast` |
+| 2 | `power_forecast_warnings` | 🚧 Planned (partial at first; complete by v1.0) | not yet in code |
 | 3 | `asset_health_history` | 🚧 Planned | not yet in code |
-| 4 | `effective_capacity` | ✅ MVP implemented (static P99 estimate); DP upgrade planned for v0.7 | `contracts.power_schemas.EffectiveCapacity` |
+| 4 | `effective_capacity` | ✅ Implemented in v0.1 (static P99 estimate); time-varying upgrade planned for v0.7 | `contracts.power_schemas.EffectiveCapacity` |
 | 5 | `substation_switching` | 🚧 Planned (v0.6) | not yet in code |
 
 > **Naming note.** The Milestone 1 report drafted these tables with the column name `timeseries_id`,
@@ -48,8 +48,8 @@ There are **five** tables. This table tracks where each one stands today:
 ## Table 1 — `power_forecast`
 
 > **Status: ✅ Implemented** as `contracts.power_schemas.PowerForecast`, but only the
-> **deterministic-ensemble** representation of uncertainty (below). The two percentile-based
-> representations are 🚧 planned.
+> **deterministic-ensemble** representation of uncertainty (below; v0.1). The two
+> percentile-based representations are 🚧 planned for v0.5.
 
 Stores OCF's probabilistic power forecasts. The table extends ~14 days **forwards** in time (the
 forecast horizon) and **backwards** to the start of the backtesting period.
@@ -57,10 +57,10 @@ forecast horizon) and **backwards** to the start of the backtesting period.
 The Milestone 1 report describes **three** ways of expressing uncertainty. We may deliver one or
 several of these:
 
-1. **Ensemble of deterministic forecasts** — one row per NWP ensemble member. ✅ **Implemented** and
-   the likely MVP representation.
-2. **Percentiles** — one row per `valid_time`, with a column per percentile. 🚧 Planned.
-3. **Ensemble of percentile forecasts** — per-member *and* per-percentile. 🚧 Planned.
+1. **Ensemble of deterministic forecasts** — one row per NWP ensemble member.
+   ✅ **Implemented in v0.1**.
+2. **Percentiles** — one row per `valid_time`, with a column per percentile. 🚧 Planned (v0.5).
+3. **Ensemble of percentile forecasts** — per-member *and* per-percentile. 🚧 Planned (v0.5).
 
 Representations 2 and 3 are two stages of one pipeline, not independent options:
 Representation 3 (per-member conditional quantiles) is produced by the model, and
@@ -134,8 +134,8 @@ delivered for power users who want the weather-scenario structure:
 ## Table 2 — `power_forecast_warnings` 🚧
 
 > **Status: 🚧 Planned.** Some warning types depend on switching-event detection and effective-capacity
-> estimation, which do not exist yet — so this table will be **partial in the MVP** and complete by
-> v1.0.
+> estimation, which do not exist yet — so this table will be **partial when it first ships** and
+> complete by v1.0.
 
 Tells NGED whenever we detect abnormal behaviour in the **most recent meter reading** for a
 `time_series_id`. Such abnormality means the asset's actual performance may deviate from the
@@ -204,7 +204,7 @@ Notes on specific flags:
 
 ## Table 4 — `effective_capacity`
 
-> **Status: ✅ MVP implemented** — the `effective_capacity` Dagster asset writes P99 of observed
+> **Status: ✅ Implemented (v0.1)** — the `effective_capacity` Dagster asset writes P99 of observed
 > power as a static capacity proxy.
 > Schema lives in `contracts.power_schemas.EffectiveCapacity`.
 > **Planned upgrade in v0.7**
@@ -216,13 +216,13 @@ OCF's estimate of each generator's or substation's **effective capacity** at eve
 timestep of the historical time series data. This table is **backward-looking only** — it does
 not cover the forecast period.
 
-**MVP approach (v0.1):** one row per `time_series_id`, `effective_capacity_mw` = P99 of
+**v0.1 approach:** one row per `time_series_id`, `effective_capacity_mw` = P99 of
 `|power|` over the full available observation history. This is a static scalar per series — a
 robust capacity proxy that is less sensitive to outlier spikes than the maximum, and more
 capacity-representative than the mean (which is dragged down by zero-output periods for PV/wind).
 It is also the denominator used to normalise NMAE in the `forecast_metrics` table — see
 [Normalising NMAE by `effective_capacity`](metrics-and-leaderboard.md#normalising-nmae-by-effective_capacity)
-for why the MVP stores one scalar row per series (rather than repeating the value at every half-hour)
+for why v0.1 stores one scalar row per series (rather than repeating the value at every half-hour)
 and how the metrics join evolves for the v0.7 upgrade.
 
 **v0.7 upgrade:** replace the static P99 with a time-varying estimate from the winning
@@ -246,7 +246,7 @@ its `time_series_id`-only capacity join for a temporal as-of join (see
 | Field | Data type | Notes |
 |---|---|---|
 | `time_series_id` | `int32` | NGED's time-series ID. |
-| `time` | `datetime` (UTC), every half hour | The half-hourly timestep this estimate applies to. In the MVP, set to the end of the available observation history for that series. |
+| `time` | `datetime` (UTC), every half hour | The half-hourly timestep this estimate applies to. In v0.1, set to the end of the available observation history for that series. |
 | `effective_capacity_mw` | `float32` | OCF's estimate of the effective capacity (MW) at this timestep. |
 
 ---

--- a/docs/roadmap/delivery-tables.md
+++ b/docs/roadmap/delivery-tables.md
@@ -60,7 +60,15 @@ several of these:
 1. **Ensemble of deterministic forecasts** — one row per NWP ensemble member. ✅ **Implemented** and
    the likely MVP representation.
 2. **Percentiles** — one row per `valid_time`, with a column per percentile. 🚧 Planned.
-3. **Ensemble of percentile forecasts** — per-member *and* per-percentile. 🔬 Research.
+3. **Ensemble of percentile forecasts** — per-member *and* per-percentile. 🚧 Planned.
+
+Representations 2 and 3 are two stages of one pipeline, not independent options:
+Representation 3 (per-member conditional quantiles) is produced by the model, and
+Representation 2 is **derived from it** by linear-pool mixing — see
+[Probabilistic forecasting from NWP ensembles](../techniques/probabilistic-forecasting.md) for
+the theory and
+[Phase D of the probabilistic evaluation plan](metrics-and-leaderboard.md#phase-d-ensemble-of-quantile-forecasts-representation-3-pooled-representation-2)
+for the implementation plan.
 
 ### Fields common to all three representations
 
@@ -97,15 +105,24 @@ filter on `fold_id` to select the population you need. See
 
 ### Representation 2 — percentiles 🚧
 
-One row per `valid_time`, with one column per percentile:
+One row per `valid_time`, with one column per percentile. This is the primary NGED-facing
+probabilistic representation, derived from
+[Representation 3](#representation-3-ensemble-of-percentile-forecasts) by pooling the
+per-member quantiles (the equal-weight mixture — *not* per-level averaging, which would discard
+the between-member spread; see
+[the explainer](../techniques/probabilistic-forecasting.md#the-tempting-shortcut-that-doesnt-work-averaging-the-quantiles)):
 
 | Fields | Data type | Notes |
 |---|---|---|
 | `p1, p2, p5, p10, p20, p35, p50, p65, p80, p90, p95, p98, p99` | `float32` | The power forecast at each percentile. NGED is far more interested in the **tails** than the shoulders. Read `p50` as "50% chance the true power flow is below this value", `p99` as "99% chance below", etc. (Scaled to [−1, +1] once normalisation lands.) |
 
-### Representation 3 — ensemble of percentile forecasts 🔬
+### Representation 3 — ensemble of percentile forecasts 🚧
 
-Each ensemble member is itself a percentile forecast:
+Each ensemble member is itself a percentile forecast — "given this member's weather, power will
+land in this range with this shape" — produced by a quantile-objective model (see
+[Phase D](metrics-and-leaderboard.md#phase-d-ensemble-of-quantile-forecasts-representation-3-pooled-representation-2)).
+Primarily an *internal* stage that Representation 2 is pooled from, but it may also be
+delivered for power users who want the weather-scenario structure:
 
 | Fields | Data type | Notes |
 |---|---|---|

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -149,6 +149,13 @@ Establish a strong XGBoost baseline before investing in capacity estimation and 
 
 The full experiment backlog — fifteen ideas across four effort tiers, ordered best
 bang-for-the-buck within each tier — is in [XGBoost improvements](xgboost-improvements.md).
+This milestone also carries the **quantile-ensemble pipeline** (per-member quantile forecasts
+pooled into delivered percentiles — Phase D of
+[Delivering the probabilistic metrics](metrics-and-leaderboard.md#delivering-the-probabilistic-metrics);
+theory in
+[Probabilistic forecasting from NWP ensembles](../techniques/probabilistic-forecasting.md)),
+which builds directly on the lead-time-feature and ensemble-member-training wins in that
+backlog.
 
 **Automated experimentation ("auto-research")**:
 

--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -49,7 +49,7 @@ plan (phases 0–6.7 complete, PRs #182–#214); its final cleanup phase lives i
 - Telemetry to Sentry.io
   ([#63](https://github.com/openclimatefix/nged-substation-forecast/issues/63)) — CloudWatch +
   SNS cover alerting first.
-- An **MLflow tracking server** and a separate **development dashboard**, both hosted on the
+- An **MLflow tracking server** (issue [#235](https://github.com/openclimatefix/nged-substation-forecast/issues/235)) and a separate **development dashboard** ([#236](https://github.com/openclimatefix/nged-substation-forecast/issues/236)), both hosted on the
   always-on control-plane box once it exists — see the [note below](#aws-architecture).
 - [Production monitoring](#production-monitoring): score live forecasts over trailing 24h/7d
   windows, logged to a dedicated MLflow experiment, with a manual, auditable way to retire

--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -18,7 +18,7 @@ plan (phases 0–6.7 complete, PRs #182–#214); its final cleanup phase lives i
 
 ## Requirements
 
-**MVP (v0.1 — get a live forecast running on AWS):**
+**v0.1 (get a live forecast running on AWS):**
 
 - Deploy the naive forecast so it runs live on AWS, 6-hourly, writing to `power_forecasts`
   (`fold_id="live"`) — the [`live_forecasts` asset](#the-live_forecasts-asset).
@@ -38,7 +38,7 @@ plan (phases 0–6.7 complete, PRs #182–#214); its final cleanup phase lives i
 - AWS infrastructure with **no static AWS keys** (IAM roles throughout), basic alerting on task
   failure (SNS → email), and cost-conscious operation (~\$30–40/month target).
 
-**Post-MVP (explicitly deferred):**
+**Post-v0.1 (explicitly deferred):**
 
 - Forecast quality/science work —
   [baselines](metrics-and-leaderboard.md#baseline-forecasters),
@@ -253,7 +253,7 @@ backtest compute *and* a free dashboard home, for ~\$15–25/month over Level 1.
 fallback if operational simplicity trumps backtest speed and ~\$40/month. D pays an RDS+ALB
 tax for purism; E's 1-user cap rules it out.
 
-**Future work (not MVP):** once an always-on control-plane box exists (Option B or later), it's also
+**Future work (post-v0.1):** once an always-on control-plane box exists (Option B or later), it's also
 a natural home for an **MLflow tracking server** (network-reachable, persistent — replacing the
 local file-store) and a **"development dashboard"** (a Marimo app for researchers). Neither is
 needed to ship v0.1; revisit once the box exists.

--- a/docs/roadmap/metrics-and-leaderboard.md
+++ b/docs/roadmap/metrics-and-leaderboard.md
@@ -209,7 +209,7 @@ machinery instead of writing any new time-series logic:
   (`power_schemas.py:242`); confirm `cv_power_forecasts` tolerates it end-to-end.
 - **Ensemble members:** for the *deterministic* baselines (persistence, climatology) the CV
   predict path feeds all ~51 members and they produce identical forecasts per member — wasteful
-  but harmless (the ensemble mean is unchanged); MVP accepts it. `nged_incumbent` is different:
+  but harmless (the ensemble mean is unchanged); v0.3 accepts it. `nged_incumbent` is different:
   it emits its own 13-member ensemble, so broadcasting it across the 51 NWP members would be wrong,
   not merely wasteful. A per-forecaster `uses_nwp_ensemble` class flag (default `True`) that
   `cv_power_forecasts` honours — restricting deterministic baselines to member 0 and letting
@@ -248,7 +248,7 @@ mistake the P95 bias for a bug.
 
 The cross-validation protocol is **implemented**, so it has moved to its permanent home:
 [ML Experimentation → Cross-validation folds](../ml_experimentation/cross-validation-folds.md).
-That page covers the expanding-window protocol, the current single MVP fold (and why the available
+That page covers the expanding-window protocol, the current single fold (and why the available
 weather data constrains us to it), the target multiple-yearly-fold protocol, and the fold-design
 alternatives we considered.
 
@@ -377,26 +377,26 @@ The denominator comes from the [`effective_capacity`](delivery-tables.md#table-4
 Delta table (schema `contracts.power_schemas.EffectiveCapacity`), consumed by `compute_metrics`
 (`ml_core.metrics`).
 
-**MVP representation (v0.1): one scalar row per series.** The `effective_capacity` asset writes one
+**v0.1 representation: one scalar row per series.** The `effective_capacity` asset writes one
 row per `time_series_id` — `effective_capacity_mw` = P99 of `|power|` over the whole observation
 history, `time` = the latest observed timestep. `compute_metrics` joins it onto the per-series
 metrics **on `time_series_id` alone** and divides.
 
-**Why the MVP is a single row per series, not the value repeated at every half-hour.** The
+**Why v0.1 is a single row per series, not the value repeated at every half-hour.** The
 v0.7 upgrade below *will* store one row per `(time_series_id, time)` half-hour — but with a
-genuinely *time-varying* value. In the MVP the value is a single constant per series, so repeating it
+genuinely *time-varying* value. In v0.1 the value is a single constant per series, so repeating it
 across every half-hour would just be a denormalised encoding of one number: at V2 scale (~2,500
 series × ~4 years × 17,520 half-hours/yr ≈ 175M rows) that is hundreds of millions of rows to
 express ~2,500 scalars, for zero extra information. It would also *not* buy forward-compatibility,
-because the real MVP→DP interface change is not the data shape but **the join** (below). The
+because the real v0.1→v0.7 interface change is not the data shape but **the join** (below). The
 `EffectiveCapacity` schema — `(time_series_id, time, effective_capacity_mw)` — already accommodates
-both the one-row-per-series MVP and the one-row-per-half-hour DP shape; that is the
-forward-compatibility we want. (The DP upgrade does widen the *columns* — the value becomes a
+both the one-row-per-series v0.1 shape and the one-row-per-half-hour v0.7 shape; that is the
+forward-compatibility we want. (The v0.7 upgrade does widen the *columns* — the value becomes a
 mean + std pair,
 [#247](https://github.com/openclimatefix/nged-substation-forecast/issues/247) — but the row shape
 and the join are unaffected by that.)
 
-**DP upgrade (v0.7): time-varying, and the join changes.** The
+**v0.7 upgrade: time-varying, and the join changes.** The
 [differentiable-physics](capacity-estimation.md) capacity model produces a value that changes over
 time (panel degradation, inverter trips, seasonal derating). At that point two things change, and
 nothing else:
@@ -468,7 +468,7 @@ widths are an implementation-time choice.
 **A subtlety to document now but _not_ model yet.** The shape of the Christmas run-up depends not
 just on the number of days before Christmas but also on **which weekday Christmas falls on** — the
 run-up demand pattern shifts year to year with that day-of-week alignment. We record it here as a
-known effect; the MVP tricky-days *flag* ignores it (it simply marks the window), and we defer any
+known effect; the v0.3 tricky-days *flag* ignores it (it simply marks the window), and we defer any
 explicit day-of-week-aware modelling of the run-up until there is evidence it moves the leaderboard.
 
 #### Implementation details — tricky days (deleted when this ships)

--- a/docs/roadmap/metrics-and-leaderboard.md
+++ b/docs/roadmap/metrics-and-leaderboard.md
@@ -521,8 +521,15 @@ deterministic mean (`packages/ml_core/src/ml_core/metrics.py:84-90`) and scores 
 RMSE/MBE on the `"all"` horizon slice (`metrics.py:51`). We pay 51× inference cost and score
 only the mean.
 
-Fix in three phases, each an independent PR. Phases A and B are pure evaluation (no model
-changes) and should land before any further MAE-driven experimentation.
+The theory behind this diagnosis — the three-term uncertainty decomposition, why a
+deterministic model driven by an NWP ensemble captures only the weather term, and what the
+principled fix looks like — is the durable explainer
+[Probabilistic forecasting from NWP ensembles](../techniques/probabilistic-forecasting.md).
+This section is the *plan* that applies it.
+
+Fix in four phases, each an independent PR (Phase D is itself several PRs). Phases A and B are
+pure evaluation (no model changes) and should land before any further MAE-driven
+experimentation.
 
 ### Phase A — horizon-sliced metrics
 
@@ -563,18 +570,47 @@ Compute member-aware metrics *before* the ensemble-mean collapse in `compute_met
 
 ### Phase C — cheap calibration (after B proves the diagnosis)
 
-Decide based on Phase B's spread-skill numbers; recommended order:
+Decide based on Phase B's spread-skill numbers. **Post-hoc spread inflation** (EMOS-lite): per
+horizon slice, fit a scalar `s` on the *training* window so that inflating members around the
+ensemble mean (`mean + s·(member − mean)`) makes spread match error. Zero schema change, zero
+new model — implementable as an optional step in `predict` or as a wrapper forecaster. Fit on
+train, apply on validation (no tuning on the fold being scored).
 
-1. **Post-hoc spread inflation** (EMOS-lite): per horizon slice, fit a scalar `s` on the
-   *training* window so that inflating members around the ensemble mean
-   (`mean + s·(member − mean)`) makes spread match error. Zero schema change, zero new model —
-   implementable as an optional step in `predict` or as a wrapper forecaster. Fit on train,
-   apply on validation (no tuning on the fold being scored).
-2. **XGBoost native multi-quantile** (`objective: reg:quantileerror`, several
-   `quantile_alpha`s) as a separate experiment/model family. This gives directly calibrated
-   quantiles but requires a percentile representation in `PowerForecast` (the
-   [delivery tables](delivery-tables.md) already plan percentiles) — a bigger schema/design
-   step, so keep it as its own follow-up plan when Phase B/C1 results justify it.
+Spread inflation widens the fan but cannot reshape it (the inflated ensemble is still 51 point
+forecasts, just pushed apart). It is the stopgap the full fix below must beat to earn its
+build cost.
+
+### Phase D — ensemble of quantile forecasts (Representation 3 → pooled Representation 2)
+
+The full fix from the
+[probabilistic-forecasting explainer](../techniques/probabilistic-forecasting.md): have the
+model emit a **conditional distribution per ensemble member** (per-member quantiles —
+[Representation 3](delivery-tables.md#representation-3-ensemble-of-percentile-forecasts) in the
+delivery tables), then recombine the 51 members with the **linear-pool mixture** into one set
+of delivered percentiles
+([Representation 2](delivery-tables.md#representation-2-percentiles)). Three steps, one PR
+each:
+
+1. **Percentile representations in `PowerForecast`**
+   ([#262](https://github.com/openclimatefix/nged-substation-forecast/issues/262)) — extend the
+   contract (and the Delta write/read paths) with the Rep 2 and Rep 3 percentile columns,
+   alongside the existing deterministic-ensemble representation.
+2. **Quantile XGBoost model family**
+   ([#263](https://github.com/openclimatefix/nged-substation-forecast/issues/263)) —
+   `objective: reg:quantileerror` with several
+   `quantile_alpha`s, as a separate experiment/model family emitting Rep 3. Sort each member's
+   quantiles at predict time (monotonic rearrangement fixes quantile crossing). The lead-time
+   feature and training on multiple members
+   ([xgboost-improvements](xgboost-improvements.md) items 1 and 14) are the double-counting
+   mitigations discussed in the explainer — land them first or measure without them
+   consciously.
+3. **Linear-pool combining step**
+   ([#264](https://github.com/openclimatefix/nged-substation-forecast/issues/264)) — pool the
+   per-member quantiles into delivered Rep 2
+   percentiles (the pseudo-sample recipe in the explainer), with a per-horizon affine
+   recalibration hook (fit on train) applied only if the pooled spread-skill/PICP numbers
+   demand it. Scored with pinball/PICP/CRPS head-to-head against the Phase-C inflated
+   deterministic champion.
 
 ### Implementation details — probabilistic metrics (deleted when they ship)
 

--- a/docs/roadmap/xgboost-improvements.md
+++ b/docs/roadmap/xgboost-improvements.md
@@ -277,6 +277,10 @@ the control member is an increasingly unrepresentative sample of the ensemble, s
 this item concentrates precisely in the primary user band — worth remembering when deciding
 how soon to invest in item 13. Ensemble *calibration* itself belongs to
 [probabilistic evaluation](metrics-and-leaderboard.md#delivering-the-probabilistic-metrics).
+Member training is also one of the
+[double-counting mitigations](../techniques/probabilistic-forecasting.md#caveat-double-counting-weather-uncertainty)
+for the Phase-D quantile-ensemble pipeline — a second reason to land it, alongside this item
+and item 1 (the lead-time feature), before or with the quantile model family.
 
 ### 15. Global model per `time_series_type`
 

--- a/docs/techniques/index.md
+++ b/docs/techniques/index.md
@@ -15,6 +15,14 @@ docstrings) as the work that applies them ships.
   the edge-flow estimator on the
   [switching-events roadmap page](../roadmap/switching-events.md), and the convex candidate in
   the [v0.7 capacity head-to-head](../roadmap/capacity-estimation.md).
+- [Probabilistic forecasting from NWP ensembles](probabilistic-forecasting.md) — why pushing an
+  NWP ensemble through a deterministic power model is systematically overconfident
+  (under-dispersed), the three-term uncertainty decomposition, the fix (per-member conditional
+  quantile forecasts recombined by the linear-pool mixture), the pooling recipe, why
+  quantile-averaging (Vincentization) re-creates the under-dispersion, and the double-counting
+  caveat. Applied by the
+  [probabilistic evaluation & calibration plan](../roadmap/metrics-and-leaderboard.md#delivering-the-probabilistic-metrics)
+  and the [delivery tables](../roadmap/delivery-tables.md#table-1-power_forecast).
 - [Differentiable physics](differentiable-physics.md) — inversion through differentiable forward
   models: the single-site solar plant and the aggregate fleet node. Applied by the
   [capacity-estimation](../roadmap/capacity-estimation.md) and

--- a/docs/techniques/probabilistic-forecasting.md
+++ b/docs/techniques/probabilistic-forecasting.md
@@ -152,12 +152,12 @@ horizons, where NWP error is large, the pooled distribution can come out **over*
 
 Mitigations, in order of practicality:
 
-- **Give the model the lead time as a feature** (`nwp_lead_time_hours`), so the learned
+- **Give the model the lead time as a feature** (`nwp_lead_time_hours`, planned in [#230](https://github.com/openclimatefix/nged-substation-forecast/issues/230)), so the learned
   conditional spread can be narrow when the weather input is trustworthy and wide when it
   isn't, rather than one horizon-averaged width.
-- **Train on many ensemble members, not just the control** — the model then sees "one plausible
+- **Train on many ensemble members, not just the control** (planned in [#148](https://github.com/openclimatefix/nged-substation-forecast/issues/148)) — the model then sees "one plausible
   scenario" as its actual input distribution, which is what a member is at inference time.
-- **Measure, then correct**: check the spread-skill ratio and PICP of the *pooled* forecast per
+- **Measure, then correct**: check the spread-skill ratio and PICP (planned in [#225](https://github.com/openclimatefix/nged-substation-forecast/issues/225)) of the *pooled* forecast per
   horizon slice, and apply a per-horizon affine recalibration of the pooled quantiles (fit on
   the training window) only if the numbers demand it.
 
@@ -170,9 +170,9 @@ over-stated risk) is a far safer failure mode than the under-dispersion it repla
 - **Diagnose first**: the spread-skill / PICP / pinball / CRPS metrics that quantify all of the
   above are Phases A–B of the
   [probabilistic evaluation plan](../roadmap/metrics-and-leaderboard.md#delivering-the-probabilistic-metrics).
-- **Cheap stopgap**: post-hoc spread inflation of the existing deterministic ensemble (Phase C
-  there) buys calibration without any of this machinery — the full mixture pipeline must beat
+- **Cheap stopgap**: post-hoc spread inflation of the existing deterministic ensemble ([Phase C
+  of the probabilistic evaluation plan](../roadmap/metrics-and-leaderboard.md#phase-c-cheap-calibration-after-b-proves-the-diagnosis)) buys calibration without any of this machinery — the full mixture pipeline must beat
   it to earn its keep.
-- **The full pipeline** (Phase D there): a quantile-objective XGBoost emits Representation 3;
+- **The full pipeline** ([Phase D of the probabilistic evaluation plan](../roadmap/metrics-and-leaderboard.md#phase-d-ensemble-of-quantile-forecasts-representation-3-pooled-representation-2)): a quantile-objective XGBoost emits Representation 3;
   the pooling recipe above derives Representation 2 for
   [delivery](../roadmap/delivery-tables.md#table-1-power_forecast).

--- a/docs/techniques/probabilistic-forecasting.md
+++ b/docs/techniques/probabilistic-forecasting.md
@@ -1,0 +1,178 @@
+# Probabilistic Forecasting from NWP Ensembles
+
+> **Status: durable method explainer.** This page explains how to turn an ensemble of weather
+> forecasts into an honest probability distribution over power — why the obvious approach is
+> systematically overconfident, what the principled fix looks like, and the one tempting
+> shortcut to avoid. It is applied by the
+> [probabilistic evaluation & calibration plan](../roadmap/metrics-and-leaderboard.md#delivering-the-probabilistic-metrics)
+> and shapes the percentile representations in the
+> [delivery tables](../roadmap/delivery-tables.md#table-1-power_forecast).
+
+## The intuitive sketch
+
+Start with what we do today. ECMWF gives us **51 plausible weather futures** (ensemble members)
+— 51 equally believable stories about next week's weather. We feed each story through our power
+model and get 51 power curves. Where the curves fan out wide, we claim to be uncertain; where
+they bunch together, we claim to be confident.
+
+The problem: each of those 51 curves is the model's **single best guess** given that weather
+story. The model is asked "what will power be if the weather does *this*?" and answers with one
+number — as if, once the weather is known, it could predict power perfectly. It can't. Two of
+the three reasons a forecast misses have been silently dropped, and the fan is too narrow: all
+51 curves can miss reality *on the same side*.
+
+The failure is worst exactly where it is most embarrassing. For tomorrow, the 51 weather
+stories barely differ — weather models only diverge over days — so the fan collapses to nearly
+a single line. The forecast claims near-certainty at the horizon where anyone can see we still
+make errors:
+
+```text
+ the fan we produce today                 an honest forecast band
+ (spread from weather only)               (weather + model error + noise)
+
+ power                                    power
+   │            ____.--~~                   │         ░░░░░░░░░░░░
+   │      ═════      ~~--__                 │     ░░░░▒▒▒▒▒▒▒▒░░░░░░
+   │ ═════x    ¯¯--__                       │ ▒▒▒▒x▒▒▒▒▒▒▒▒▒▒▒▒▒▒░░░░
+   │            x        x                  │     ▒▒▒▒x▒▒▒▒▒▒▒▒x▒▒▒░░
+   │                                        │         ░░░░░░░░░░░░░░
+   └────────────────────────▶ time          └──────────────────────▶ time
+    day 1      day 4      day 7              day 1    day 4     day 7
+
+    x = what actually happened. On day 1 the members haven't diverged yet,
+    so the fan is a confident thin line — and reality falls outside it.
+```
+
+The fix, in one sentence: instead of asking the model for one number per weather story, ask it
+for a **range** per weather story — "given this weather, power will most likely land between
+here and here, with this shape" — and then **overlay all 51 fuzzy bands on top of each other**.
+Where many bands pile up, the combined forecast is confident; the outermost edges of the pile
+are the tails. Reading percentiles off that pile gives one honest distribution that contains
+*both* kinds of spread: the weather stories disagreeing with each other, *and* each story's own
+admission that weather doesn't fully determine power.
+
+The rest of this page makes that sketch precise.
+
+## Where forecast uncertainty actually comes from
+
+Total predictive uncertainty decomposes into three terms:
+
+1. **Weather uncertainty** — we don't know what the weather will do. This is what the 51 NWP
+   members sample: their divergence *is* the weather uncertainty, growing with lead time.
+2. **Weather→power model error** — even given the true weather, our model's mapping from
+   weather to power is imperfect (finite training data, missing features, wrong functional
+   form).
+3. **Intrinsic noise** — even a perfect model given perfect weather couldn't predict power
+   exactly: meter noise, occupant behaviour, unmodelled local events. Irreducible randomness.
+
+A deterministic model (XGBoost trained with squared error learns the **conditional mean**)
+pushed through 51 members captures term 1 *only*. Terms 2 and 3 are dropped entirely. The
+resulting ensemble is **under-dispersed** — systematically overconfident — and worst at short
+horizons, where term 1 shrinks toward zero while terms 2 and 3 do not. The
+[spread-skill ratio](../roadmap/metrics-and-leaderboard.md#evaluation-metrics) is the metric
+that catches this: spread ÷ error ≪ 1 means the fan is too thin.
+
+This matters commercially, not just statistically: flexibility procurement keys off the
+**tails** (P90+ peaks), and under-dispersion is precisely the error that makes tails look safer
+than they are.
+
+## The fix, formally: a mixture of conditional distributions
+
+Ask the model for a full conditional distribution per member — "the distribution of power
+*given* weather scenario $m$", written $F_m(y) = P(\text{power} \le y \mid \text{weather}_m)$.
+In practice $F_m$ arrives as a set of quantiles (e.g. p1…p99 from a quantile-regression model);
+that per-member quantile set is exactly
+[Representation 3](../roadmap/delivery-tables.md#representation-3-ensemble-of-percentile-forecasts)
+in the delivery tables. Each conditional distribution carries terms 2 and 3; the *disagreement
+between* members carries term 1.
+
+Combining them is the law of total probability. The members are designed to be equiprobable, so
+the total predictive distribution is the equal-weight **mixture** — in the forecast-combination
+literature, the **linear (opinion) pool**:
+
+$$
+F(y) \;=\; \frac{1}{51} \sum_{m=1}^{51} F_m(y)
+$$
+
+Read it as: *the probability that power lands below $y$ is the average, over the 51 weather
+stories, of the probability of landing below $y$ within each story.* Nothing deeper than that —
+but it is the decomposition that guarantees both kinds of spread survive into the final
+distribution. This pooled distribution, expressed as percentile columns with one row per
+`valid_time`, is
+[Representation 2](../roadmap/delivery-tables.md#representation-2-percentiles) — i.e.
+Representation 2 is *derived from* Representation 3 by pooling.
+
+## Turning 51 quantile sets into one: the pooling recipe
+
+Inverting the mixture CDF sounds like numerical work, but with quantile forecasts there is a
+trick that makes it three lines of Polars:
+
+1. **Sort each member's quantiles.** Quantile-regression models fit each quantile level
+   independently, so a member's p80 can come out *below* its p65 ("quantile crossing").
+   Sorting the values within each member — "monotonic rearrangement" — is the standard,
+   theoretically sound fix.
+2. **Treat every quantile value as an equiprobable pseudo-sample.** A member's quantiles at
+   equally-spaced levels are, by construction, equally likely places for power to land within
+   that weather story. So pool all 51 × K values (51 members × K quantile levels) for a given
+   `(time_series_id, valid_time)` into one bag.
+3. **Take empirical percentiles of the bag.** The bag's p95 *is* the p95 of the mixture — this
+   recipe is exactly the inverse of the averaged CDF above (a `group_by` + `pl.quantile`).
+
+One practical note on step 2: the recipe is exact when the K levels are equally spaced. Our
+delivery levels are deliberately tail-heavy (p1, p2, p5, …, p98, p99), so either have the model
+emit a denser equally-spaced set internally and reduce to the delivery levels at the end, or
+weight the pseudo-samples by the probability gap each one represents.
+
+## The tempting shortcut that doesn't work: averaging the quantiles
+
+The "obvious" way to combine 51 percentile forecasts is to average them level by level: the
+combined p90 is the mean of the 51 members' p90s (this has a name: **Vincentization**). It
+looks harmless and is subtly wrong for our purpose.
+
+Averaging quantile-by-quantile averages the *locations* of the 51 distributions and keeps
+roughly their *individual* widths — the disagreement **between** members (term 1, the weather
+uncertainty!) is discarded rather than added. Picture 51 narrow bands scattered up and down the
+power axis: the mixture says "the truth is somewhere in this whole scattered pile"; Vincent
+averaging says "the truth is in one narrow band at the pile's centre". Vincentization is a
+respectable combiner in settings where the members are near-identical copies shifted slightly —
+but here it would *re-create the exact under-dispersion this whole design exists to fix*. Use
+the mixture.
+
+(A useful mnemonic: the mixture **adds** the between-member spread to the within-member spread;
+Vincentization **averages it away**. For fattening tails, you want addition.)
+
+## Caveat: double-counting weather uncertainty
+
+There is one way the mixture can overshoot. The conditional models are trained against
+*forecast* weather (a member's trajectory), not the weather that actually happened. So the
+spread each model learns — "given this weather input, how uncertain is power?" — already
+includes some weather-forecast error, because at training time the weather input itself was
+wrong by some amount. Mixing over 51 members then adds weather spread *again*. At long
+horizons, where NWP error is large, the pooled distribution can come out **over**-dispersed.
+
+Mitigations, in order of practicality:
+
+- **Give the model the lead time as a feature** (`nwp_lead_time_hours`), so the learned
+  conditional spread can be narrow when the weather input is trustworthy and wide when it
+  isn't, rather than one horizon-averaged width.
+- **Train on many ensemble members, not just the control** — the model then sees "one plausible
+  scenario" as its actual input distribution, which is what a member is at inference time.
+- **Measure, then correct**: check the spread-skill ratio and PICP of the *pooled* forecast per
+  horizon slice, and apply a per-horizon affine recalibration of the pooled quantiles (fit on
+  the training window) only if the numbers demand it.
+
+Keep the asymmetry in mind: for a tails-driven product, mild **over**-dispersion (slightly
+over-stated risk) is a far safer failure mode than the under-dispersion it replaces
+(under-stated risk). Fix double-counting if measured, but don't fear it more than the disease.
+
+## How this maps onto the project
+
+- **Diagnose first**: the spread-skill / PICP / pinball / CRPS metrics that quantify all of the
+  above are Phases A–B of the
+  [probabilistic evaluation plan](../roadmap/metrics-and-leaderboard.md#delivering-the-probabilistic-metrics).
+- **Cheap stopgap**: post-hoc spread inflation of the existing deterministic ensemble (Phase C
+  there) buys calibration without any of this machinery — the full mixture pipeline must beat
+  it to earn its keep.
+- **The full pipeline** (Phase D there): a quantile-objective XGBoost emits Representation 3;
+  the pooling recipe above derives Representation 2 for
+  [delivery](../roadmap/delivery-tables.md#table-1-power_forecast).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
   - Techniques:
       - Overview: techniques/index.md
       - Convex Optimisation: techniques/convex-optimisation.md
+      - Probabilistic Forecasting: techniques/probabilistic-forecasting.md
       - Differentiable Physics: techniques/differentiable-physics.md
       - Encoders: techniques/encoders.md
       - Disaggregation Evaluation: techniques/disaggregation-evaluation.md

--- a/packages/contracts/src/contracts/power_schemas.py
+++ b/packages/contracts/src/contracts/power_schemas.py
@@ -308,7 +308,7 @@ class EffectiveCapacity(pt.Model):
     Delivered to NGED as ``effective_capacity`` Delta table (Table 4 in the Milestone 1 report).
     This table is backward-looking only — it does not cover the forecast period.
 
-    **MVP implementation (v0.1):** one row per ``time_series_id``, ``time`` set to the end of
+    **v0.1 implementation:** one row per ``time_series_id``, ``time`` set to the end of
     the available observation history, ``effective_capacity_mw`` = P99 of ``abs(power)`` over
     the full observed history. This is a static scalar per series.
 
@@ -318,7 +318,7 @@ class EffectiveCapacity(pt.Model):
     giving one row per ``(time_series_id, time)`` half-hourly timestep. This schema is unchanged;
     the ``effective_capacity`` asset body changes and the ``metrics`` pipeline swaps its
     ``time_series_id``-only NMAE-denominator join for a temporal as-of join. Do **not** pre-densify
-    the MVP scalar into one row per half-hour — densifying a constant buys nothing, and the as-of
+    the v0.1 scalar into one row per half-hour — densifying a constant buys nothing, and the as-of
     join handles sparse capacity rows naturally.
     """
 
@@ -328,7 +328,7 @@ class EffectiveCapacity(pt.Model):
         dtype=UTC_DATETIME_DTYPE,
         description=(
             "The half-hourly timestep this capacity estimate applies to. "
-            "In the MVP, this is the end of the available observation history for that series."
+            "In v0.1, this is the end of the available observation history for that series."
         ),
     )
 

--- a/packages/contracts/src/contracts/settings.py
+++ b/packages/contracts/src/contracts/settings.py
@@ -115,7 +115,7 @@ class Settings(BaseSettings):
     effective_capacity_data_path: Path = Field(
         default=PROJECT_ROOT / "data" / "effective_capacity",
         description=(
-            "Delta table of per-series effective capacity (MVP: full-history P99 of |power|),"
+            "Delta table of per-series effective capacity (v0.1: full-history P99 of |power|),"
             " written by the effective_capacity asset and read by the metrics asset as the NMAE"
             " denominator."
         ),

--- a/packages/ml_core/src/ml_core/metrics.py
+++ b/packages/ml_core/src/ml_core/metrics.py
@@ -43,7 +43,7 @@ def compute_metrics(
     NMAE is normalised by the pre-computed full-history ``effective_capacity_mw`` (joined per
     ``time_series_id`` from ``capacity``) — a capacity-like denominator, computed over the full
     history so it stays stable across folds. This ``time_series_id``-only join is correct while
-    ``capacity`` is one scalar row per series (the MVP). When the v0.7
+    ``capacity`` is one scalar row per series (the v0.1 shape). When the v0.7
     upgrade makes capacity time-varying (one row per ``(time_series_id,
     time)``), this join must become a temporal as-of join on ``(time_series_id, valid_time)``.
 

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -156,18 +156,18 @@ def eligible_time_series(context: AssetExecutionContext) -> None:
 def _compute_effective_capacity(
     power_lf: pt.LazyFrame[PowerTimeSeries],
 ) -> pt.DataFrame[EffectiveCapacity]:
-    """Compute the MVP effective capacity (full-history P99 of ``|power|``) per time series.
+    """Compute the v0.1 effective capacity (full-history P99 of ``|power|``) per time series.
 
     One row per ``time_series_id``: ``effective_capacity_mw`` is the 99th percentile of
     ``abs(power)`` over all non-null observations. Series whose P99 is null or non-positive (e.g.
     all-null or all-zero power) are dropped, since ``EffectiveCapacity`` requires
     ``effective_capacity_mw > 0``.
 
-    ``time`` is set to that series' **latest** observed timestep (``time.max()``). The MVP capacity
+    ``time`` is set to that series' **latest** observed timestep (``time.max()``). The v0.1 capacity
     is a single scalar per series, so ``time`` is really an "as of" marker — it stamps the estimate
     as current to the end of the observed history — rather than a timestep the value varies over. The
     v0.7 upgrade makes capacity genuinely time-varying (one row per ``(time_series_id,
-    time)``), and only then does ``time`` carry per-row meaning. The MVP stays one scalar row per
+    time)``), and only then does ``time`` carry per-row meaning. v0.1 stays one scalar row per
     series rather than the value repeated at every half-hour: densifying a constant adds rows
     without information, and the metrics join is by ``time_series_id`` alone until capacity varies.
 
@@ -190,7 +190,7 @@ def _compute_effective_capacity(
 
 @asset(deps=["power_time_series_and_metadata"])
 def effective_capacity(context: AssetExecutionContext) -> None:
-    """Compute and persist each series' MVP effective capacity (full-history P99 of ``|power|``).
+    """Compute and persist each series' v0.1 effective capacity (full-history P99 of ``|power|``).
 
     Reads the full ``power_time_series`` Delta and writes one row per ``time_series_id`` to the
     ``effective_capacity`` Delta table (``Settings.effective_capacity_data_path``): the 99th
@@ -198,7 +198,7 @@ def effective_capacity(context: AssetExecutionContext) -> None:
     latest observed timestep. This full-history capacity is the NMAE denominator used by the
     ``metrics`` asset, replacing the validation-window P99 that would otherwise vary fold to fold.
 
-    The whole (small — one row per series) table is overwritten on each materialisation. The MVP is
+    The whole (small — one row per series) table is overwritten on each materialisation. v0.1 is
     deliberately one scalar row per series, **not** the value repeated at every half-hour —
     densifying a constant buys nothing.
 


### PR DESCRIPTION
## What

**New durable technique page — [Probabilistic forecasting from NWP ensembles](https://openclimatefix.github.io/nged-substation-forecast/techniques/probabilistic-forecasting/)** — a gentle, intuition-first explainer of:

- why pushing the 51-member NWP ensemble through a deterministic power model yields a systematically **under-dispersed** (overconfident) forecast — worst at short horizons, and worst exactly in the tails NGED cares about;
- the three-term uncertainty decomposition (weather / model error / intrinsic noise);
- the fix: per-member conditional quantile forecasts, recombined by the **linear-pool mixture** (law of total probability over equiprobable members);
- the three-line pooling recipe (sort → pool as equiprobable pseudo-samples → empirical percentiles), and why the tempting alternative — per-level quantile averaging (Vincentization) — silently discards the between-member spread and re-creates the under-dispersion;
- the double-counting caveat and its mitigations (lead-time feature, member training, measure-then-recalibrate).

**Roadmap pages updated to apply it:**

- [Metrics & leaderboard](https://openclimatefix.github.io/nged-substation-forecast/roadmap/metrics-and-leaderboard/#delivering-the-probabilistic-metrics): the old Phase C item 2 (one paragraph on native multi-quantile) is expanded into a full **Phase D — ensemble of quantile forecasts**, three steps / three PRs, now tracked as #262 → #263 → #264 (sub-issues of epic #145, ordered after #148; #263 is also blocked by #225).
- [Delivery tables](https://openclimatefix.github.io/nged-substation-forecast/roadmap/delivery-tables/#table-1-power_forecast): Representation 3 promoted 🔬 → 🚧, and the derivation recorded — Representation 2 is *derived from* Representation 3 by pooling, not an independent option.
- [XGBoost improvements](https://openclimatefix.github.io/nged-substation-forecast/roadmap/xgboost-improvements/) item 14 and the [roadmap index](https://openclimatefix.github.io/nged-substation-forecast/roadmap/#v05-xgboost-upgrades-quick-wins) v0.5 blurb: cross-links tying member training and the lead-time feature to the quantile pipeline.

## Why

Discussion (2026-07-04): the deterministic-ensemble representation captures weather uncertainty only, so its spread understates risk precisely where flexibility procurement looks (P90+ peaks). The theory needed a permanent, docstring-linkable home; the implementation path needed tracked, ordered issues.



## Also in this PR

- **"MVP" → concrete version numbers** across docs and docstrings: the deterministic-ensemble representation and static-P99 `effective_capacity` are labelled **v0.1**, the percentile representations **v0.5**, baseline-forecaster/tricky-days notes **v0.3**, and the capacity "MVP→DP" pairing is now **v0.1→v0.7**. The roadmap index's `v0.1 — "Naive" MVP` heading is kept deliberately (it defines the term); the CV pages' "single MVP fold" meant "minimal", not a milestone, and is now "a single fold".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CciN9WC6Wq2sFCTCzgSq7h
