### PR TITLE
Fix pytest collection abort on duplicate test-module basenames

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,10 @@ docstring-code-format = true
 docstring-code-line-length = 100
 
 [tool.pytest.ini_options]
+# importlib mode lets test modules in different directories share a basename (e.g.
+# tests/test_metrics.py and packages/ml_core/tests/test_metrics.py); the default prepend
+# mode aborts collection with an "import file mismatch" error on the duplicate name.
+addopts = "--import-mode=importlib"
 filterwarnings = [
     "ignore:codecs.open\\(\\) is deprecated:DeprecationWarning:mlflow.*",
 ]


### PR DESCRIPTION
## Problem

Bare `uv run pytest` (documented in CLAUDE.md as the way to run all tests) aborts during collection:

```text
import file mismatch:
imported module 'test_metrics' has this __file__ attribute:
  .../packages/ml_core/tests/test_metrics.py
which is not the same as the test file we want to collect:
  .../tests/test_metrics.py
```

`tests/test_metrics.py` and `packages/ml_core/tests/test_metrics.py` share a basename, and neither tests directory has an `__init__.py`, so under pytest's default `prepend` import mode both claim the module name `test_metrics`. Until now the suite only ran because directories were passed separately (or stale `__pycache__` happened not to collide).

## Fix

Add `addopts = "--import-mode=importlib"` to `[tool.pytest.ini_options]` — the import mode [pytest's docs recommend for new projects](https://docs.pytest.org/en/stable/explanation/goodpractices.html#choosing-an-import-mode), under which test modules in different directories don't compete for a global module name. No test files change.

## Verification

`uv run pytest` from the repo root: **174 passed** (previously: collection aborted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)