### PR TITLE
Add step-by-step logging to ecmwf_ens asset

### DIFF
--- a/packages/dynamical_data/src/dynamical_data/ecmwf_ens/download.py
+++ b/packages/dynamical_data/src/dynamical_data/ecmwf_ens/download.py
@@ -34,14 +34,17 @@ _ECMWF_ENS_VARS_TO_DOWNLOAD: Final[tuple[str, ...]] = (
 )
 
 
-def download_ecmwf_ens_run(
+def open_ecmwf_ens_run(
     nwp_init_time: datetime,
     h3_grid: pt.DataFrame[H3GridWeights],
 ) -> xr.Dataset:
-    """Download and process ECMWF data for a specific initialization time.
+    """Lazily open the ECMWF ENS Icechunk store and slice it to the requested run and H3 grid.
+
+    No data is downloaded: the returned dataset is still backed by lazy Dask/Zarr arrays.
+    Call :func:`download_ecmwf_ens_data` to actually fetch the data.
 
     Args:
-        nwp_init_time: The initialization time to download. Must be timezone aware.
+        nwp_init_time: The initialization time to open. Must be timezone aware.
         h3_grid: The H3 grid to use for spatial bounds.
     """
     if h3_grid.is_empty():
@@ -89,6 +92,16 @@ def download_ecmwf_ens_run(
     # This prevents downstream KeyErrors during DataFrame conversion.
     if ds_sliced.longitude.size == 0 or ds_sliced.latitude.size == 0:
         raise ValueError("No spatial overlap found between H3 grid and NWP dataset.")
+
+    return ds_sliced
+
+
+def download_ecmwf_ens_data(ds_sliced: xr.Dataset) -> xr.Dataset:
+    """Download (compute) a lazily-opened, already-sliced ECMWF ENS dataset.
+
+    Args:
+        ds_sliced: A lazy dataset as returned by :func:`open_ecmwf_ens_run`.
+    """
 
     def download_array(var_name: str) -> dict[str, xr.DataArray]:
         return {var_name: ds_sliced[var_name].compute()}

--- a/src/nged_substation_forecast/defs/assets.py
+++ b/src/nged_substation_forecast/defs/assets.py
@@ -21,7 +21,11 @@ from delta_store.nwp import write_nwp
 from dynamical_data.ecmwf_ens.convert_to_polars import (
     convert_nwp_xarray_dataset_to_polars_dataframe,
 )
-from dynamical_data.ecmwf_ens.download import NwpRunNotYetAvailable, download_ecmwf_ens_run
+from dynamical_data.ecmwf_ens.download import (
+    NwpRunNotYetAvailable,
+    download_ecmwf_ens_data,
+    open_ecmwf_ens_run,
+)
 from geo.great_britain.load import load_gb_boundary
 from geo.h3 import compute_h3_grid_weights_for_boundary
 from nged_data.read_nged_json import _H3_RESOLUTION
@@ -181,17 +185,22 @@ def ecmwf_ens(context: AssetExecutionContext) -> None:
 
     # Download and convert
     try:
-        ds = download_ecmwf_ens_run(nwp_init_time=nwp_init_time, h3_grid=h3_grid)
+        ds_lazy = open_ecmwf_ens_run(nwp_init_time=nwp_init_time, h3_grid=h3_grid)
     except NwpRunNotYetAvailable as exc:
         raise RetryRequested(
             max_retries=_ECMWF_ENS_MAX_RETRIES, seconds_to_wait=_ECMWF_ENS_RETRY_DELAY_SECONDS
         ) from exc
-    nwp = convert_nwp_xarray_dataset_to_polars_dataframe(ds=ds, h3_grid=h3_grid)
+    context.log.info("Lazily opened Icechunk store.")
 
-    context.log.info(f"Columns: {nwp.columns}")
+    ds = download_ecmwf_ens_data(ds_lazy)
+    context.log.info("Downloaded Icechunk data.")
+
+    nwp = convert_nwp_xarray_dataset_to_polars_dataframe(ds=ds, h3_grid=h3_grid)
+    context.log.info(f"Converted NWP data to Polars. Columns: {nwp.columns}")
 
     settings.nwp_data_path.parent.mkdir(parents=True, exist_ok=True)
     write_nwp(nwp, settings.nwp_data_path)
+    context.log.info(f"Saved NWP data to Delta table at {settings.nwp_data_path}.")
 
     context.add_output_metadata(
         {


### PR DESCRIPTION
## Summary

- Splits `download_ecmwf_ens_run` (in `dynamical_data.ecmwf_ens.download`) into `open_ecmwf_ens_run` (lazily opens the Icechunk store and slices to the requested run/H3 grid — no data downloaded) and `download_ecmwf_ens_data` (computes/downloads the sliced dataset).
- The `ecmwf_ens` Dagster asset now logs (`context.log.info`) after each pipeline stage completes: opening the Icechunk store, downloading the data, converting to Polars, and saving to the Delta table. This gives visibility into where time is spent for a given partition run in the Dagster UI.

Context: #276

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run ty check` (unchanged pre-existing diagnostics only, none in touched files)
- [x] `uv run pytest` — 215 passed, no regressions