### PR TITLE
Centralise paths under configurable data_path/local_artifacts_path roots (#50)

### DIFF
--- a/packages/contracts/src/contracts/_uri.py
+++ b/packages/contracts/src/contracts/_uri.py
@@ -1,0 +1,29 @@
+"""Small URI helpers for paths that may be local filesystem paths *or* remote URIs.
+
+Settings data-location fields are plain ``str`` so they can hold either a local path
+(``/home/.../data/NWP``) or a remote URI (``s3://bucket/NWP``). ``pathlib.Path`` mangles
+the latter (``Path("s3://b/a") / "c"`` drops the scheme), so joins route through here.
+"""
+
+import posixpath
+from pathlib import Path
+from typing import Final
+
+_SCHEME_SEP: Final[str] = "://"
+
+
+def is_remote_uri(uri: str) -> bool:
+    """Return whether ``uri`` carries a URI scheme (e.g. ``s3://``) rather than a local path."""
+    return _SCHEME_SEP in uri
+
+
+def uri_join(base: str, *parts: str) -> str:
+    """Join ``parts`` onto ``base`` with local- or remote-aware semantics.
+
+    Local bases join through ``pathlib`` (yielding an absolute path string); remote,
+    scheme-bearing bases join posix-style so ``"s3://bucket/a"`` + ``"b"`` stays
+    ``"s3://bucket/a/b"`` instead of being mangled by ``Path.__truediv__``.
+    """
+    if is_remote_uri(base):
+        return posixpath.join(base.rstrip("/"), *parts)
+    return str(Path(base).joinpath(*parts))

--- a/packages/contracts/src/contracts/settings.py
+++ b/packages/contracts/src/contracts/settings.py
@@ -1,9 +1,11 @@
 from pathlib import Path
-from typing import Final
+from typing import Final, Self
 
 import obstore
-from pydantic import AnyHttpUrl, Field, TypeAdapter, field_validator
+from pydantic import AnyHttpUrl, Field, TypeAdapter, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from contracts._uri import uri_join
 
 url_adapter = TypeAdapter(AnyHttpUrl)
 
@@ -90,21 +92,48 @@ class Settings(BaseSettings):
         ),
     )
 
-    # Paths to the data we manage
-    nged_data_path: Path = PROJECT_ROOT / "data" / "NGED"
-    nwp_data_path: Path = PROJECT_ROOT / "data" / "NWP"
-    power_forecasts_data_path: Path = PROJECT_ROOT / "data" / "power_forecasts"
-    forecast_metrics_data_path: Path = PROJECT_ROOT / "data" / "forecast_metrics"
-    plots_data_path: Path = Field(
-        default=PROJECT_ROOT / "data" / "plots",
+    # --- Storage roots -------------------------------------------------------------------
+    #
+    # Two roots, because model/plot artifacts must stay on a local filesystem (XGBoost
+    # save_model/load_model, shutil, Altair) even when the data tables move to S3.
+
+    data_path: str = Field(
+        default=str(PROJECT_ROOT / "data"),
         description=(
-            "Directory where plot_power_forecast writes interactive forecast HTML files, one per"
-            " materialisation (filename derived from experiment, fold, init time, and the plotted"
-            " time_series_ids)."
+            "Root of the managed data tables (NWP, power, forecasts, metrics, …). A local path"
+            " by default; may be a remote URI (e.g. 's3://bucket/data') so the data tables live"
+            " on S3. Every *_data_path below that is left unset derives from this root."
         ),
     )
-    eligible_time_series_data_path: Path = Field(
-        default=PROJECT_ROOT / "data" / "eligible_time_series",
+    local_artifacts_path: str = Field(
+        default=str(PROJECT_ROOT / "data"),
+        description=(
+            "Root of the always-local artifacts (model cache, production model, plots). Kept"
+            " separate from data_path because these back local-filesystem-only libraries and"
+            " must stay local even when data_path is a remote URI."
+        ),
+    )
+
+    # --- Managed data tables (derive from data_path unless explicitly set) ----------------
+    #
+    # Each defaults to "" as a sentinel meaning "derive from data_path in _derive_unset_paths".
+    # Set any one explicitly (e.g. NWP_DATA_PATH=s3://other-bucket/NWP) to override just that
+    # table. After validation every field below is a concrete, non-empty path string.
+
+    nged_data_path: str = ""
+    """Directory holding the NGED power_time_series Delta table and metadata parquet."""
+    nwp_data_path: str = ""
+    """Delta table of NWP weather data."""
+    power_forecasts_data_path: str = ""
+    """Delta table of power forecasts (partitioned by experiment_name, fold_id)."""
+    forecast_metrics_data_path: str = ""
+    """Delta table of forecast evaluation metrics."""
+    power_time_series_data_path: str = ""
+    """Delta table of half-hourly power observations (under nged_data_path)."""
+    metadata_path: str = ""
+    """Parquet file of per-series substation metadata (under nged_data_path)."""
+    eligible_time_series_data_path: str = Field(
+        default="",
         description=(
             "Delta table of the canonical per-fold eligible time_series_id population, written"
             " by the eligible_time_series asset (partitioned by fold_id) and read by"
@@ -112,18 +141,29 @@ class Settings(BaseSettings):
             " identical, experiment-independent population."
         ),
     )
-    effective_capacity_data_path: Path = Field(
-        default=PROJECT_ROOT / "data" / "effective_capacity",
+    effective_capacity_data_path: str = Field(
+        default="",
         description=(
             "Delta table of per-series effective capacity (v0.1: full-history P99 of |power|),"
             " written by the effective_capacity asset and read by the metrics asset as the NMAE"
             " denominator."
         ),
     )
-    trained_ml_model_params_base_path: Path = PROJECT_ROOT / "data" / "trained_ML_model_params"
-    h3_grid_weights_path: Path = PROJECT_ROOT / "data" / "h3_grid_weights.parquet"
-    model_cache_base_path: Path = Field(
-        default=PROJECT_ROOT / "data" / "model_cache",
+    h3_grid_weights_path: str = ""
+    """Parquet file of fractional H3 cell overlap with the GB boundary."""
+
+    # --- Always-local artifacts (derive from local_artifacts_path unless explicitly set) --
+
+    plots_data_path: str = Field(
+        default="",
+        description=(
+            "Directory where plot_power_forecast writes interactive forecast HTML files, one per"
+            " materialisation (filename derived from experiment, fold, init time, and the plotted"
+            " time_series_ids)."
+        ),
+    )
+    model_cache_base_path: str = Field(
+        default="",
         description=(
             "Root of the local-disk model cache, keyed by MLflow run ID, used by"
             " BaseForecaster.load_from_mlflow. Currently only the CV pipeline"
@@ -132,8 +172,8 @@ class Settings(BaseSettings):
             " container image instead)."
         ),
     )
-    production_model_path: Path = Field(
-        default=PROJECT_ROOT / "data" / "production_model",
+    production_model_path: str = Field(
+        default="",
         description=(
             "Directory holding the current production model, written by the promoted_model"
             " asset (ml_core._production_helpers.fetch_model_artifacts) and read by"
@@ -141,6 +181,45 @@ class Settings(BaseSettings):
             " time. Later COPY'd into the container image at build time (issue #222)."
         ),
     )
+
+    @model_validator(mode="after")
+    def _derive_unset_paths(self) -> Self:
+        """Fill any unset ("") path from its root, so callers always see a concrete path.
+
+        The default layout lives here and nowhere else. A field set explicitly (e.g. via its
+        env var) keeps its value; only the "" sentinels are derived.
+        """
+        self.nged_data_path = self.nged_data_path or uri_join(self.data_path, "NGED")
+        self.nwp_data_path = self.nwp_data_path or uri_join(self.data_path, "NWP")
+        self.power_forecasts_data_path = self.power_forecasts_data_path or uri_join(
+            self.data_path, "power_forecasts"
+        )
+        self.forecast_metrics_data_path = self.forecast_metrics_data_path or uri_join(
+            self.data_path, "forecast_metrics"
+        )
+        self.eligible_time_series_data_path = self.eligible_time_series_data_path or uri_join(
+            self.data_path, "eligible_time_series"
+        )
+        self.effective_capacity_data_path = self.effective_capacity_data_path or uri_join(
+            self.data_path, "effective_capacity"
+        )
+        self.h3_grid_weights_path = self.h3_grid_weights_path or uri_join(
+            self.data_path, "h3_grid_weights.parquet"
+        )
+        # Derived from nged_data_path (itself derived above).
+        self.power_time_series_data_path = self.power_time_series_data_path or uri_join(
+            self.nged_data_path, "power_time_series.delta"
+        )
+        self.metadata_path = self.metadata_path or uri_join(self.nged_data_path, "metadata.parquet")
+        # Always-local artifacts.
+        self.plots_data_path = self.plots_data_path or uri_join(self.local_artifacts_path, "plots")
+        self.model_cache_base_path = self.model_cache_base_path or uri_join(
+            self.local_artifacts_path, "model_cache"
+        )
+        self.production_model_path = self.production_model_path or uri_join(
+            self.local_artifacts_path, "production_model"
+        )
+        return self
 
     # Tell Pydantic to override defaults with fields set in the .env file.
     model_config = SettingsConfigDict(

--- a/packages/contracts/src/contracts/settings.py
+++ b/packages/contracts/src/contracts/settings.py
@@ -91,6 +91,14 @@ class Settings(BaseSettings):
             " shared leaderboard evaluation protocol; read them from here, never hard-coded."
         ),
     )
+    nwp_metadata_csv_path: Path = Field(
+        default=PROJECT_ROOT / "metadata" / "nwp_metadata.csv",
+        description=(
+            "Static CSV of per-NWP-model metadata (H3 resolution, provider, ensemble flag),"
+            " checked into the repo and read by NwpMetaData.load. A code-relative resource"
+            " (like cv_config_path), so it stays a local Path even when data_path is a remote URI."
+        ),
+    )
 
     # --- Storage roots -------------------------------------------------------------------
     #

--- a/packages/contracts/src/contracts/weather_schemas.py
+++ b/packages/contracts/src/contracts/weather_schemas.py
@@ -2,19 +2,14 @@ from collections.abc import Sequence
 from datetime import datetime, timezone
 from enum import StrEnum, auto
 from pathlib import Path
-from typing import ClassVar, Final, Literal, Self
+from typing import ClassVar, Literal, Self
 
 import patito as pt
 import polars as pl
 
-from contracts.settings import PROJECT_ROOT, Settings
+from contracts.settings import Settings
 
 from .common import UTC_DATETIME_DTYPE
-
-# TODO: These paths should be moved to `contracts.settings`.
-_METADATA_PATH: Final[Path] = PROJECT_ROOT / "metadata"
-_NWP_METADATA_CSV_PATH: Final[Path] = _METADATA_PATH / "nwp_metadata.csv"
-
 
 SETTINGS = Settings()
 
@@ -65,7 +60,7 @@ class NwpMetaData(pt.Model):
     is_ensemble: bool = pt.Field(description="Whether this NWP model produces ensemble forecasts.")
 
     @classmethod
-    def load(cls, csv_path: Path = _NWP_METADATA_CSV_PATH) -> pt.DataFrame[Self]:
+    def load(cls, csv_path: str | Path = SETTINGS.nwp_metadata_csv_path) -> pt.DataFrame[Self]:
         """Load NWP metadata from a static CSV file."""
         df = pl.read_csv(csv_path)
         # Patito's .cast() will handle the conversion to the Enum type defined in the model

--- a/packages/contracts/src/contracts/weather_schemas.py
+++ b/packages/contracts/src/contracts/weather_schemas.py
@@ -325,7 +325,7 @@ class Nwp(pt.Model):
             )
 
     @classmethod
-    def scan_delta(cls, path: Path = SETTINGS.nwp_data_path) -> pt.LazyFrame[Self]:
+    def scan_delta(cls, path: str | Path = SETTINGS.nwp_data_path) -> pt.LazyFrame[Self]:
         """Lazily scan the NWP Delta table, typed and cast to this contract's dtypes.
 
         The table stores physical-unit `Float32` directly (see `delta_store.nwp.write_nwp`),

--- a/packages/contracts/tests/test_settings.py
+++ b/packages/contracts/tests/test_settings.py
@@ -17,3 +17,50 @@ def test_settings_validation_invalid_url():
             nged_s3_bucket_access_key="key",
             nged_s3_bucket_secret="secret",
         )
+
+
+def test_paths_derive_from_data_root():
+    """Unset data-table paths derive from data_path; nested tables sit under nged_data_path."""
+    settings = Settings(
+        data_path="/srv/data",
+        nged_s3_bucket_url="https://example.com",
+        nged_s3_bucket_access_key="key",
+        nged_s3_bucket_secret="secret",
+    )
+    assert settings.nwp_data_path == "/srv/data/NWP"
+    assert settings.nged_data_path == "/srv/data/NGED"
+    assert settings.power_time_series_data_path == "/srv/data/NGED/power_time_series.delta"
+    assert settings.metadata_path == "/srv/data/NGED/metadata.parquet"
+    assert settings.h3_grid_weights_path == "/srv/data/h3_grid_weights.parquet"
+
+
+def test_remote_data_path_keeps_artifacts_local():
+    """A remote data_path yields s3:// data tables while artifacts stay under local_artifacts_path."""
+    settings = Settings(
+        data_path="s3://bucket/data",
+        local_artifacts_path="/local/artifacts",
+        nged_s3_bucket_url="https://example.com",
+        nged_s3_bucket_access_key="key",
+        nged_s3_bucket_secret="secret",
+    )
+    assert settings.power_forecasts_data_path == "s3://bucket/data/power_forecasts"
+    assert settings.power_time_series_data_path == "s3://bucket/data/NGED/power_time_series.delta"
+    assert settings.model_cache_base_path == "/local/artifacts/model_cache"
+    assert settings.production_model_path == "/local/artifacts/production_model"
+    assert settings.plots_data_path == "/local/artifacts/plots"
+
+
+def test_explicit_path_overrides_derivation():
+    """An explicitly set path wins over derivation from its root."""
+    settings = Settings(
+        data_path="s3://bucket/data",
+        plots_data_path="s3://other-bucket/plots",
+        nwp_data_path="/mnt/fast/NWP",
+        nged_s3_bucket_url="https://example.com",
+        nged_s3_bucket_access_key="key",
+        nged_s3_bucket_secret="secret",
+    )
+    assert settings.plots_data_path == "s3://other-bucket/plots"
+    assert settings.nwp_data_path == "/mnt/fast/NWP"
+    # Siblings still derive normally.
+    assert settings.power_forecasts_data_path == "s3://bucket/data/power_forecasts"

--- a/packages/dashboard/main.py
+++ b/packages/dashboard/main.py
@@ -8,7 +8,7 @@ app = marimo.App(width="full")
 with app.setup:
     from typing import cast
 
-    from contracts.settings import PROJECT_ROOT, Settings
+    from contracts.settings import Settings
 
     settings = Settings()
 
@@ -25,12 +25,12 @@ with app.setup:
     from contracts.power_schemas import PowerTimeSeries, TimeSeriesMetadata
     from plotting.ocf_theme import BLUE
 
-    BASE_DELTA_PATH = PROJECT_ROOT / settings.nged_data_path / "power_time_series.delta"
+    BASE_DELTA_PATH = settings.power_time_series_data_path
 
 
 @app.cell
 def _():
-    metadata_path = PROJECT_ROOT / settings.nged_data_path / "metadata.parquet"
+    metadata_path = settings.metadata_path
     df = TimeSeriesMetadata.validate(pl.read_parquet(metadata_path))
     return (df,)
 

--- a/src/nged_substation_forecast/defs/assets.py
+++ b/src/nged_substation_forecast/defs/assets.py
@@ -1,6 +1,7 @@
 import ast
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any, Final, Generic, Self, TypeVar
 
 import patito as pt
@@ -55,8 +56,8 @@ def power_time_series_and_metadata(context: AssetExecutionContext) -> None:
     to just check what's available on NGED's S3 bucket and append to our local Delta table.
     """
     settings = Settings()
-    delta_path = settings.nged_data_path / "power_time_series.delta"
-    metadata_path = settings.nged_data_path / "metadata.parquet"
+    delta_path = Path(settings.power_time_series_data_path)
+    metadata_path = Path(settings.metadata_path)
 
     # Fetch new data from S3, using the existing delta table to determine what's new.
     # We are deliberately keeping the code simple for now, but may move the S3 store
@@ -126,15 +127,16 @@ def h3_grid_weights(context: AssetExecutionContext) -> None:
     )
 
     # Save to parquet
+    h3_grid_weights_path = Path(settings.h3_grid_weights_path)
     # FIXME: mkdir won't work when we're saving to S3!
-    settings.h3_grid_weights_path.parent.mkdir(parents=True, exist_ok=True)
-    weights.write_parquet(settings.h3_grid_weights_path)
+    h3_grid_weights_path.parent.mkdir(parents=True, exist_ok=True)
+    weights.write_parquet(h3_grid_weights_path)
 
     # Add metadata to Dagster context
     context.add_output_metadata(
         {
             "n_rows": len(weights),
-            "path": str(settings.h3_grid_weights_path),
+            "path": str(h3_grid_weights_path),
         }
     )
 
@@ -177,7 +179,9 @@ def ecmwf_ens(context: AssetExecutionContext) -> None:
     nwp_init_time = datetime.strptime(partition_date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
 
     # Load dependencies
-    h3_grid = pt.DataFrame(pl.read_parquet(settings.h3_grid_weights_path)).set_model(H3GridWeights)
+    h3_grid = pt.DataFrame(pl.read_parquet(Path(settings.h3_grid_weights_path))).set_model(
+        H3GridWeights
+    )
 
     # Download and convert
     try:
@@ -190,13 +194,14 @@ def ecmwf_ens(context: AssetExecutionContext) -> None:
 
     context.log.info(f"Columns: {nwp.columns}")
 
-    settings.nwp_data_path.parent.mkdir(parents=True, exist_ok=True)
-    write_nwp(nwp, settings.nwp_data_path)
+    nwp_data_path = Path(settings.nwp_data_path)
+    nwp_data_path.parent.mkdir(parents=True, exist_ok=True)
+    write_nwp(nwp, nwp_data_path)
 
     context.add_output_metadata(
         {
             "n_rows": len(nwp),
-            "path": str(settings.nwp_data_path),
+            "path": str(nwp_data_path),
             "init_time": str(nwp_init_time),
         }
     )

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -109,9 +109,8 @@ def eligible_time_series(context: AssetExecutionContext) -> None:
     fold_id = context.partition_key
     fold = _cv_config.get_fold(fold_id)
 
-    power_path = settings.nged_data_path / "power_time_series.delta"
     coverage = (
-        pl.scan_delta(str(power_path))
+        pl.scan_delta(settings.power_time_series_data_path)
         .group_by("time_series_id")
         .agg(
             first_time=pl.col("time").min(),
@@ -132,7 +131,7 @@ def eligible_time_series(context: AssetExecutionContext) -> None:
         )
     )
 
-    settings.eligible_time_series_data_path.parent.mkdir(parents=True, exist_ok=True)
+    Path(settings.eligible_time_series_data_path).parent.mkdir(parents=True, exist_ok=True)
     write_deltalake(
         table_or_uri=settings.eligible_time_series_data_path,
         data=eligible_df.to_arrow(),
@@ -210,11 +209,11 @@ def effective_capacity(context: AssetExecutionContext) -> None:
     """
     settings = Settings()
     power_lf = pt.LazyFrame.from_existing(
-        pl.scan_delta(str(settings.nged_data_path / "power_time_series.delta"))
+        pl.scan_delta(settings.power_time_series_data_path)
     ).set_model(PowerTimeSeries)
     capacity_df = _compute_effective_capacity(power_lf)
 
-    settings.effective_capacity_data_path.parent.mkdir(parents=True, exist_ok=True)
+    Path(settings.effective_capacity_data_path).parent.mkdir(parents=True, exist_ok=True)
     write_deltalake(
         table_or_uri=settings.effective_capacity_data_path,
         data=capacity_df.to_arrow(),
@@ -290,7 +289,7 @@ def _load_engineering_inputs(
         init_time_start = window_start - _MAX_NWP_LEAD
     if init_time_end is None:
         init_time_end = window_end
-    power_lf = pl.scan_delta(str(settings.nged_data_path / "power_time_series.delta")).filter(
+    power_lf = pl.scan_delta(settings.power_time_series_data_path).filter(
         pl.col("time_series_id").is_in(time_series_ids),
         pl.col("time") >= window_start,
         pl.col("time") <= window_end,
@@ -298,7 +297,7 @@ def _load_engineering_inputs(
     power_ts = pt.LazyFrame.from_existing(power_lf).set_model(PowerTimeSeries)
 
     metadata_df = pt.DataFrame(
-        pl.read_parquet(settings.nged_data_path / "metadata.parquet").filter(
+        pl.read_parquet(settings.metadata_path).filter(
             pl.col("time_series_id").is_in(time_series_ids)
         )
     ).set_model(TimeSeriesMetadata)
@@ -461,7 +460,7 @@ def cv_power_forecasts(context: AssetExecutionContext) -> None:
     parent_run_id = get_or_create_parent_run(experiment_id)
     fold_run_id = get_or_create_fold_run(experiment_id, parent_run_id, fold_id)
 
-    forecaster = forecaster_cls.load_from_mlflow(fold_run_id, settings.model_cache_base_path)
+    forecaster = forecaster_cls.load_from_mlflow(fold_run_id, Path(settings.model_cache_base_path))
     trained_ids = forecaster.trained_time_series_ids
     if not trained_ids:
         raise ValueError(
@@ -469,7 +468,7 @@ def cv_power_forecasts(context: AssetExecutionContext) -> None:
             "nothing to forecast. Re-materialise `trained_cv_model` for this fold."
         )
 
-    settings.power_forecasts_data_path.parent.mkdir(parents=True, exist_ok=True)
+    Path(settings.power_forecasts_data_path).parent.mkdir(parents=True, exist_ok=True)
     n_rows = 0
     time_series_seen: set[int] = set()
     ensemble_members_seen: set[int] = set()
@@ -822,16 +821,16 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
         return
 
     actuals_lf = pt.LazyFrame.from_existing(
-        pl.scan_delta(str(settings.nged_data_path / "power_time_series.delta"))
+        pl.scan_delta(settings.power_time_series_data_path)
     ).set_model(PowerTimeSeries)
     # allow_superfluous_columns because the parquet also carries h3_res_5 and other geo columns.
     metadata_df = TimeSeriesMetadata.validate(
-        pl.read_parquet(settings.nged_data_path / "metadata.parquet"),
+        pl.read_parquet(settings.metadata_path),
         allow_superfluous_columns=True,
     )
 
     # The full-history effective capacity is the NMAE denominator (a declared dep of this asset).
-    if not settings.effective_capacity_data_path.exists():
+    if not Path(settings.effective_capacity_data_path).exists():
         raise FileNotFoundError(
             f"effective_capacity Delta not found at {settings.effective_capacity_data_path}; "
             "materialise the effective_capacity asset before running metrics."
@@ -840,7 +839,7 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
         pl.read_delta(str(settings.effective_capacity_data_path))
     )
 
-    settings.forecast_metrics_data_path.parent.mkdir(parents=True, exist_ok=True)
+    Path(settings.forecast_metrics_data_path).parent.mkdir(parents=True, exist_ok=True)
     now = datetime.now(timezone.utc)
     total_rows = 0
     # Accumulates per-fold metric values for parent-run aggregation (leaderboard scope only).
@@ -859,7 +858,7 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
             metadata_df,
             capacity_df,
             config.evaluation_scope,
-            settings.forecast_metrics_data_path,
+            Path(settings.forecast_metrics_data_path),
             now,
         )
         total_rows += n_rows

--- a/src/nged_substation_forecast/defs/plot_jobs.py
+++ b/src/nged_substation_forecast/defs/plot_jobs.py
@@ -88,7 +88,7 @@ def plot_power_forecast(context: OpExecutionContext, config: PlotPowerForecastCo
         )
 
     ground_truth = (
-        pl.scan_delta(str(settings.nged_data_path / "power_time_series.delta"))
+        pl.scan_delta(settings.power_time_series_data_path)
         .filter(
             pl.col("time_series_id").is_in(config.time_series_ids),
             pl.col("time") >= init_time,
@@ -96,18 +96,19 @@ def plot_power_forecast(context: OpExecutionContext, config: PlotPowerForecastCo
         )
         .collect()
     )
-    metadata = pl.read_parquet(settings.nged_data_path / "metadata.parquet").filter(
+    metadata = pl.read_parquet(settings.metadata_path).filter(
         pl.col("time_series_id").is_in(config.time_series_ids)
     )
 
     chart = build_forecast_chart(forecasts, ground_truth, metadata, config.time_series_ids)
 
-    settings.plots_data_path.mkdir(parents=True, exist_ok=True)
+    plots_data_path = Path(settings.plots_data_path)
+    plots_data_path.mkdir(parents=True, exist_ok=True)
     ids_label = "-".join(str(i) for i in config.time_series_ids)
     filename = (
         f"{config.experiment_name}__{config.fold_id}__{init_time:%Y%m%dT%H%MZ}__ts-{ids_label}.html"
     )
-    out_path: Path = settings.plots_data_path / filename
+    out_path: Path = plots_data_path / filename
     chart.save(str(out_path))
 
     context.add_output_metadata(

--- a/src/nged_substation_forecast/defs/production_assets.py
+++ b/src/nged_substation_forecast/defs/production_assets.py
@@ -8,6 +8,7 @@ that reads it). Both stay thin shells over the pure/IO-light helpers in
 
 import json
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from typing import Final
 
 import mlflow
@@ -124,9 +125,10 @@ def promoted_model(context: AssetExecutionContext, config: PromotedModelConfig) 
     """
     settings = Settings()
     mlflow.set_tracking_uri(settings.mlflow_tracking_uri)
-    fetch_model_artifacts(config.mlflow_run_id, settings.production_model_path)
+    production_model_path = Path(settings.production_model_path)
+    fetch_model_artifacts(config.mlflow_run_id, production_model_path)
 
-    meta = json.loads((settings.production_model_path / "meta.json").read_text())
+    meta = json.loads((production_model_path / "meta.json").read_text())
     model_params = meta.get("model_params", {})
     context.add_output_metadata(
         {
@@ -134,7 +136,7 @@ def promoted_model(context: AssetExecutionContext, config: PromotedModelConfig) 
             "model_class": meta.get("model_class"),
             "experiment_name": model_params.get("experiment_name"),
             "n_trained_time_series": len(meta.get("trained_time_series_ids", [])),
-            "path": str(settings.production_model_path),
+            "path": str(production_model_path),
         }
     )
 
@@ -217,7 +219,7 @@ def live_forecasts(context: AssetExecutionContext, config: LiveForecastsConfig) 
     settings = Settings()
     power_fcst_init_time = context.partition_time_window.end
 
-    forecaster = load_forecaster_from_dir(settings.production_model_path)
+    forecaster = load_forecaster_from_dir(Path(settings.production_model_path))
     trained_ids = forecaster.trained_time_series_ids
     if not trained_ids:
         raise ValueError(
@@ -272,7 +274,7 @@ def live_forecasts(context: AssetExecutionContext, config: LiveForecastsConfig) 
             "NWP coverage and the model's trained population."
         )
 
-    settings.power_forecasts_data_path.parent.mkdir(parents=True, exist_ok=True)
+    Path(settings.power_forecasts_data_path).parent.mkdir(parents=True, exist_ok=True)
     write_power_forecasts(
         forecasts,
         settings.power_forecasts_data_path,


### PR DESCRIPTION
Closes #50. First half of "Deployment workstream 1 — S3-capable data paths" ([roadmap](https://openclimatefix.github.io/nged-substation-forecast/roadmap/live-service/#deployment-workstream-1-s3-capable-data-paths-the-biggest-unknown-start-first)); the S3 IO itself (#121) follows in a second PR.

## What & why

`PROJECT_ROOT` was overloaded to mean both "where the code lives" and "where the data lives", and the same sub-paths (`nged_data_path / "power_time_series.delta"` built 6×, `metadata.parquet` 5×) were reconstructed with `Path.__truediv__` all over the codebase. This centralises path definitions and prepares them for S3.

## Design

**Two roots**, because model/plot/cache artifacts must stay on a local filesystem (XGBoost `save_model`/`load_model`, `shutil`, Altair) even when the data tables move to S3 — so they can't hang off a possibly-remote root:

- `data_path` — the managed data tables; a local path by default, may be an `s3://…` URI.
- `local_artifacts_path` — model cache, production model, plots; always local.
- `PROJECT_ROOT` now only locates code-relative repo files (`conf/`, `.env`).

**Sentinel + validator.** Every managed path is a `str` field defaulting to `""` ("derive from my root"), resolved in one `_derive_unset_paths` model_validator — the single source of truth for the default layout. Most callers set only `DATA_PATH`; any single path stays individually overridable via its own env var (e.g. `PLOTS_DATA_PATH=s3://other-bucket/plots`), and consumers always see a concrete `str`.

## Changes

- New `contracts/_uri.py` (`is_remote_uri`, URI-safe `uri_join`).
- Collapsed the ~11 scattered joins into two derived fields (`power_time_series_data_path`, `metadata_path`).
- Fixed the dashboard `PROJECT_ROOT / settings.nged_data_path` double-join.
- Dropped the unused `trained_ml_model_params_base_path` field.
- Local-path consumers wrapped in `Path(...)`; `Nwp.scan_delta` accepts `str | Path`.
- Added `test_settings.py` coverage for default derivation, remote-`data_path`-keeps-artifacts-local, and per-path override.

**Behaviour is unchanged locally** — both roots default under `PROJECT_ROOT/data`, so every path resolves exactly where it did before. `ty`, `ruff`, and the full non-integration suite are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)