### PR TITLE
Cap ecmwf_ens download concurrency to fix self-inflicted stalls

### DIFF
--- a/packages/dynamical_data/src/dynamical_data/ecmwf_ens/download.py
+++ b/packages/dynamical_data/src/dynamical_data/ecmwf_ens/download.py
@@ -109,8 +109,14 @@ def download_ecmwf_ens_data(ds_sliced: xr.Dataset) -> xr.Dataset:
     # The download is I/O bound (S3 network requests). We use a ThreadPoolExecutor to parallelize
     # network latency across multiple variables. A ProcessPoolExecutor would be less efficient here
     # due to the high serialization overhead of Xarray objects between processes.
+    #
+    # max_workers is capped rather than left at the default (one thread per variable, i.e. 13).
+    # Investigation of issue #276 found that 13 concurrent chunked-zarr fetches self-contend badly
+    # (S3 rate limiting or connection-pool starvation): most variables finish in 5-20s, but a few
+    # straggle for minutes, making the whole download 600s+. Capping at 4 removed the stragglers
+    # entirely and cut a real download from 645s to 22.5s.
     data_arrays: dict[str, xr.DataArray] = {}
-    with concurrent.futures.ThreadPoolExecutor() as executor:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
         futures = [
             executor.submit(download_array, str(name)) for name in ds_sliced.data_vars.keys()
         ]

--- a/packages/dynamical_data/src/dynamical_data/ecmwf_ens/download.py
+++ b/packages/dynamical_data/src/dynamical_data/ecmwf_ens/download.py
@@ -117,7 +117,7 @@ def download_ecmwf_ens_data(ds_sliced: xr.Dataset) -> xr.Dataset:
     # entirely and cut a real download from 645s to 22.5s.
     #
     # This is a recent regression, not a pre-existing property of the download: Dagster's run
-    # history shows per-partition downloads holding a steady ~0.8-0.9 min right up to 2026-06-30
+    # history shows per-partition downloads holding a steady ~48-54s right up to 2026-06-30
     # 12:26 UTC, then every run afterwards (2026-07-01 onwards) taking 3-12 min. That boundary
     # lines up exactly with an `icechunk` 2.0.6 -> 2.1.0 bump in the same `uv.lock` update
     # (commit b46d145, 2026-06-30 12:26:50 UTC) — the leading theory is a change in icechunk's

--- a/packages/dynamical_data/src/dynamical_data/ecmwf_ens/download.py
+++ b/packages/dynamical_data/src/dynamical_data/ecmwf_ens/download.py
@@ -115,6 +115,14 @@ def download_ecmwf_ens_data(ds_sliced: xr.Dataset) -> xr.Dataset:
     # (S3 rate limiting or connection-pool starvation): most variables finish in 5-20s, but a few
     # straggle for minutes, making the whole download 600s+. Capping at 4 removed the stragglers
     # entirely and cut a real download from 645s to 22.5s.
+    #
+    # This is a recent regression, not a pre-existing property of the download: Dagster's run
+    # history shows per-partition downloads holding a steady ~0.8-0.9 min right up to 2026-06-30
+    # 12:26 UTC, then every run afterwards (2026-07-01 onwards) taking 3-12 min. That boundary
+    # lines up exactly with an `icechunk` 2.0.6 -> 2.1.0 bump in the same `uv.lock` update
+    # (commit b46d145, 2026-06-30 12:26:50 UTC) — the leading theory is a change in icechunk's
+    # underlying S3 client (connection pooling/concurrency handling) between those two versions,
+    # though this hasn't been confirmed by pinning back to 2.0.6 and re-testing.
     data_arrays: dict[str, xr.DataArray] = {}
     with concurrent.futures.ThreadPoolExecutor(max_workers=4) as executor:
         futures = [


### PR DESCRIPTION
## Summary

- `download_ecmwf_ens_data` used the default `ThreadPoolExecutor` (one thread per NWP variable,
  i.e. 13 concurrent threads). Benchmarking on a real init time showed this causes a few flows
  to stall for minutes (total download 645.2s), while capping at `max_workers=4` completes the
  same download in 22.5s with no stragglers — a ~29x speedup.
- The straggler pattern (10/13 variables finish fast, 2-3 take 200-600s) points to self-inflicted
  contention (S3 rate limiting or connection-pool starvation from too many concurrent
  chunked-zarr fetches), not pure external network flakiness.
- Full investigation, benchmark data, and reasoning: closes #276.

## Test plan

- [x] `uv run ruff check` / `uv run ruff format --check` / `uv run ty check` pass
- [x] Benchmarked against a real ECMWF ENS init time (2026-07-08T00:00Z) at `max_workers` of
      13 (current), 4, and 1 — see #276 comment for full per-variable timing table
- [ ] Monitor the next few `ecmwf_ens` Dagster runs in production to confirm the fix holds across
      different times of day

🤖 Generated with [Claude Code](https://claude.com/claude-code)