### PR TITLE
Make the managed data tables S3-capable (#121)

### DIFF
--- a/docs/live_service/index.md
+++ b/docs/live_service/index.md
@@ -15,6 +15,9 @@ of those candidates as the running production model and keeping live forecasts f
 
 ## Documents
 
+- [Environment & storage setup](setup.md) — where the data tables and local artifacts live, and
+  how to configure credentials for running locally, against a local MinIO, or with the data tables
+  on AWS S3.
 - [Running live forecasts end-to-end](dagster-workflow.md) — step-by-step recipe: promote a
   champion model to `promoted_model`, let the 6-hourly `live_forecasts` schedule run (or
   materialise a slot by hand), inspect a forecast, and backfill a missed slot in replay mode.

--- a/docs/live_service/setup.md
+++ b/docs/live_service/setup.md
@@ -1,0 +1,188 @@
+# Environment & storage setup
+
+Where the live service keeps its data and artifacts, and how to configure credentials for each
+environment. This is the setup you do **once per environment**, before running anything.
+
+It sits alongside two neighbours and deliberately does not repeat them:
+
+- [The repository README](https://github.com/openclimatefix/nged-substation-forecast#setup) owns
+  first-time repo setup — installing `uv`, `uv sync`, pre-commit hooks.
+- [Running live forecasts end-to-end](dagster-workflow.md) owns how to *drive* the assets once
+  the environment is configured (picking a champion, the 6-hourly schedule, backfilling), and the
+  persistent-`DAGSTER_HOME` prerequisite.
+
+This page owns the layer in between: **where the bytes live** (a local disk, or S3) and **what
+credentials reach them**.
+
+## The configuration model
+
+Everything here is driven by [`Settings`](../api/contracts/index.md) (in
+`packages/contracts/src/contracts/settings.py`), populated from a `.env` file in the repo root and
+from environment variables. Environment variables win over `.env`, which wins over the defaults;
+every field name maps to an upper-case env var (`data_path` → `DATA_PATH`).
+
+### Two storage roots
+
+The single most important idea is that there are **two** roots, not one:
+
+| Root | Env var | May be `s3://`? | Holds |
+|---|---|---|---|
+| Data tables | `DATA_PATH` | **Yes** | NWP, power observations, forecasts, metrics, metadata, H3 weights |
+| Local artifacts | `LOCAL_ARTIFACTS_PATH` | No — always local | Trained-model cache, the promoted production model, plot HTML |
+
+They are split because the artifacts back local-filesystem-only libraries — XGBoost's
+`save_model`/`load_model`, `shutil`, Altair — that cannot write to an object store. So even when the
+data tables move to S3, the model and plot paths must stay on a real filesystem. Deriving them from
+a possibly-remote `DATA_PATH` would break inference; hence two independent roots.
+
+Both default to `<repo>/data`, so out of the box everything lives under one local directory and the
+distinction is invisible. It only matters once `DATA_PATH` becomes an `s3://` URI.
+
+### The "derive from root" convention
+
+Each individual table has its own setting (`NWP_DATA_PATH`, `POWER_FORECASTS_DATA_PATH`, …), but you
+almost never set them. Each defaults to an empty string, a sentinel meaning *derive me from my
+root*: after validation, `NWP_DATA_PATH` becomes `<DATA_PATH>/NWP`, `METADATA_PATH` becomes
+`<DATA_PATH>/NGED/metadata.parquet`, and so on. The full default layout lives in
+`Settings._derive_unset_paths` and nowhere else.
+
+Set `DATA_PATH` alone and all nine data tables move together. Setting an individual table (e.g.
+`NWP_DATA_PATH=s3://other-bucket/NWP`) overrides just that one — useful for keeping one big table on
+a separate bucket, and nothing else needs to change.
+
+### The `.env` file and NGED source credentials
+
+Create a `.env` file in the repo root. The three **NGED source-bucket** credentials are always
+required, in every environment — they authenticate reads of NGED's telemetry bucket, which is a
+*different* account and bucket from our own managed data tables:
+
+```dotenv
+NGED_S3_BUCKET_URL=<nged source bucket url>
+NGED_S3_BUCKET_ACCESS_KEY=<key>
+NGED_S3_BUCKET_SECRET=<secret>
+```
+
+`.env` is git-ignored — never commit real credentials. Everything else on this page is optional and
+layers on top of these three.
+
+## Running locally
+
+The default. With only the three `NGED_S3_BUCKET_*` values in `.env` and nothing else set, both roots
+resolve to `<repo>/data`, `Settings.storage_options` is empty, and every table is a plain file on
+disk. Follow the [README setup](https://github.com/openclimatefix/nged-substation-forecast#setup),
+then [run the workflow](dagster-workflow.md). Nothing in this section is needed for that path.
+
+### Optional: rehearse S3 locally with MinIO
+
+To exercise the exact S3 read/write code paths without touching AWS, point `DATA_PATH` at a local
+[MinIO](https://min.io/) (or any S3-compatible) endpoint and supply all four `DATA_STORE_*`
+settings:
+
+```dotenv
+DATA_PATH=s3://my-bucket/data
+DATA_STORE_ENDPOINT_URL=http://localhost:9000
+DATA_STORE_ACCESS_KEY_ID=minioadmin
+DATA_STORE_SECRET_ACCESS_KEY=minioadmin
+DATA_STORE_REGION=us-east-1
+```
+
+`LOCAL_ARTIFACTS_PATH` is left unset, so models and plots stay under `<repo>/data` on your disk while
+the data tables round-trip through MinIO. Setting `DATA_STORE_ENDPOINT_URL` also allows plain HTTP,
+since dev endpoints rarely have TLS. (This is the same machinery the S3 integration test drives
+against an in-process `moto` server.)
+
+## Running on AWS (manual point-and-click)
+
+> **Scope: data tables on S3, not the full unattended deployment.** This section covers pointing the
+> **data tables** at S3 — which is all the ephemeral-compute deployment needs from the storage layer,
+> and is enough to run the stack from your laptop against an S3 `DATA_PATH` today. Running the
+> forecast itself as an unattended, scheduled **Fargate task** (the container build, ECR, EventBridge
+> scheduling) is a separate, not-yet-built roadmap item — see
+> [Live service roadmap → Production model artifacts](https://openclimatefix.github.io/nged-substation-forecast/roadmap/live-service/#production-model-artifacts)
+> ([#222](https://github.com/openclimatefix/nged-substation-forecast/issues/222)) and the
+> [AWS architecture](https://openclimatefix.github.io/nged-substation-forecast/roadmap/live-service/#aws-architecture)
+> section for that plan.
+
+### Step 1 — Create the S3 bucket
+
+In the AWS console → **S3** → **Create bucket**:
+
+1. **Region** `eu-west-2` (London) — keep every resource in one region so S3 ↔ compute transfer
+   stays free.
+2. **Name** e.g. `nged-flexpectation-data` (bucket names are globally unique; pick your own).
+3. Leave **Block all public access** **on**, and default **SSE-S3** encryption on. Nothing here is
+   public.
+4. **Versioning** is optional and not required by the app.
+
+No DynamoDB lock table is needed. The `deltalake` version we use commits via S3's native
+conditional-put, so concurrent-safe Delta writes work on plain S3 with no lock table and no
+`AWS_S3_ALLOW_UNSAFE_RENAME` flag.
+
+### Step 2 — Grant access with IAM
+
+Create an IAM policy scoped to just this bucket:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"],
+      "Resource": [
+        "arn:aws:s3:::nged-flexpectation-data",
+        "arn:aws:s3:::nged-flexpectation-data/*"
+      ]
+    }
+  ]
+}
+```
+
+Attach it to **whichever identity runs the code**:
+
+- **Compute running on AWS** (an EC2 box or Fargate task) → attach the policy to that resource's
+  **IAM role**. Nothing else is needed: delta-rs' object_store auto-discovers the role's temporary
+  credentials and region at runtime, so you leave all four `DATA_STORE_*` settings **empty**.
+- **Your laptop, against the real bucket** → attach the policy to an **IAM user**, create an access
+  key for it, and set the credentials via `DATA_STORE_*` (Step 3).
+
+### Step 3 — Point `Settings` at the bucket
+
+Set `DATA_PATH` to the bucket URI, and leave `LOCAL_ARTIFACTS_PATH` unset so models and plots stay on
+local disk. What else you set depends on Step 2:
+
+**On AWS compute (IAM role)** — credentials and region are auto-discovered, so just:
+
+```dotenv
+DATA_PATH=s3://nged-flexpectation-data/data
+```
+
+**From your laptop (IAM user access key)** — supply the key and region, but **not** an endpoint URL
+(that is only for non-AWS/MinIO endpoints, and it would wrongly allow plain HTTP):
+
+```dotenv
+DATA_PATH=s3://nged-flexpectation-data/data
+DATA_STORE_ACCESS_KEY_ID=<access key id>
+DATA_STORE_SECRET_ACCESS_KEY=<secret access key>
+DATA_STORE_REGION=eu-west-2
+```
+
+The four `DATA_STORE_*` fields map onto the shared `aws_*` object_store option keys that delta-rs,
+Polars, and obstore all understand, so this one dict feeds every read and write.
+
+### Step 4 — Verify
+
+With the above in place, materialise any data-writing asset (e.g. `power_time_series_and_metadata`)
+from the Dagster UI, then confirm the objects appear under `s3://nged-flexpectation-data/data/…` in
+the S3 console. Because `LOCAL_ARTIFACTS_PATH` stayed local, a subsequent `promoted_model`
+materialisation still writes the model to `<repo>/data/production_model/` on disk — the two roots
+behaving independently is exactly what you want to see.
+
+### At-a-glance: which settings for which environment
+
+| Environment | `DATA_PATH` | `DATA_STORE_*` |
+|---|---|---|
+| Local (default) | unset → `<repo>/data` | none |
+| Local MinIO rehearsal | `s3://…` | all four, incl. `ENDPOINT_URL` |
+| Laptop → real S3 | `s3://…` | key + secret + region (no endpoint) |
+| Compute on AWS (IAM role) | `s3://…` | none (auto-discovered) |

--- a/docs/live_service/setup.md
+++ b/docs/live_service/setup.md
@@ -30,13 +30,31 @@ The single most important idea is that there are **two** roots, not one:
 | Data tables | `DATA_PATH` | **Yes** | NWP, power observations, forecasts, metrics, metadata, H3 weights |
 | Local artifacts | `LOCAL_ARTIFACTS_PATH` | No — always local | Trained-model cache, the promoted production model, plot HTML |
 
-They are split because the artifacts back local-filesystem-only libraries — XGBoost's
-`save_model`/`load_model`, `shutil`, Altair — that cannot write to an object store. So even when the
-data tables move to S3, the model and plot paths must stay on a real filesystem. Deriving them from
-a possibly-remote `DATA_PATH` would break inference; hence two independent roots.
+They are split for an **architectural** reason, not merely because XGBoost and Altair happen to
+write to local files (a library that can't write to S3 can always be bridged — write to a tempdir,
+upload — as MLflow does internally). The real reason is that **nothing under `LOCAL_ARTIFACTS_PATH`
+is part of the S3-backed data plane**. Each item belongs to the laptop/CV workflow or to the
+container image, not to shared storage:
 
-Both default to `<repo>/data`, so out of the box everything lives under one local directory and the
-distinction is invisible. It only matters once `DATA_PATH` becomes an `s3://` URI.
+- **Trained-model cache** — a local-disk *cache* keyed by MLflow run id, filled by
+  `BaseForecaster.load_from_mlflow` to avoid re-downloading artifacts. A cache is node-local by
+  definition, and only the CV pipeline (which runs on a laptop) uses it; production inference never
+  touches it.
+- **Promoted production model** — distributed via the **container image**, not shared storage: the
+  v0.1 deployment bakes the champion into the image at build time and loads it with a plain disk
+  `load()` (see
+  [roadmap: Production model artifacts](https://openclimatefix.github.io/nged-substation-forecast/roadmap/live-service/#production-model-artifacts),
+  [#222](https://github.com/openclimatefix/nged-substation-forecast/issues/222)). This local
+  directory is the build-time staging area that gets copied into the image; on the deployed task the
+  model is read from the image's own filesystem.
+- **Plot HTML** — a **local-dev convenience** only (materialise, open in a browser); see the note
+  under [Running on AWS](#viewing-forecasts-on-aws) for why it is not the way to view forecasts in a
+  deployed service.
+
+So the deployed AWS runtime reads its model from the image, reads data from S3, and writes forecasts
+to S3 — it never uses `LOCAL_ARTIFACTS_PATH` as shared storage at all. Both roots default to
+`<repo>/data`, so out of the box everything lives under one local directory and the distinction is
+invisible; it only matters once `DATA_PATH` becomes an `s3://` URI.
 
 ### The "derive from root" convention
 
@@ -177,6 +195,18 @@ from the Dagster UI, then confirm the objects appear under `s3://nged-flexpectat
 the S3 console. Because `LOCAL_ARTIFACTS_PATH` stayed local, a subsequent `promoted_model`
 materialisation still writes the model to `<repo>/data/production_model/` on disk — the two roots
 behaving independently is exactly what you want to see.
+
+### Viewing forecasts on AWS
+
+Do **not** rely on the `plot_power_forecast` asset in a deployed service. It writes Altair HTML to
+`LOCAL_ARTIFACTS_PATH`, which on an ephemeral Fargate task is a disk that is discarded when the task
+exits — the file would never be seen. `plot_power_forecast` is a **local-development convenience**:
+materialise it on your laptop, open the HTML in a browser.
+
+The durable, S3-native way to look at forecasts is the **dashboard**
+(`packages/dashboard/main.py`), which reads the `power_forecasts` and metadata tables directly from
+`DATA_PATH` (with the same `storage_options`) and renders on demand — no plot files to persist.
+Point it at the same `Settings` and it works identically whether `DATA_PATH` is local or `s3://`.
 
 ### At-a-glance: which settings for which environment
 

--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -8,7 +8,7 @@
 > (matches #137's sub-issue order): the
 > [inference asset](#the-live_forecasts-asset) (#221, done) → the
 > [local dress rehearsal](#deployment-workstream-1-the-production-job-local-dress-rehearsal)
-> (#208) → [S3-capable data paths](#deployment-workstream-2-s3-capable-data-paths) (#121, #50)
+> (#208) → S3-capable data paths (#121, #50, done)
 > → the [champion-model container](#production-model-artifacts) (#222) → the
 > [AWS infrastructure](#aws-architecture) (#206) → smaller cleanup (#197, #63, #246) →
 > [the v0.1 version bump](#related-github-issues) (#209).
@@ -556,32 +556,6 @@ partition keys come from Dagster natively, and missed slots are backfilled from 
 idempotence insurance, and it keeps the job runnable one-shot for the local dress rehearsal
 ([#208](https://github.com/openclimatefix/nged-substation-forecast/issues/208)).
 
-### Deployment workstream 2 — S3-capable data paths
-
-Issues: [#121](https://github.com/openclimatefix/nged-substation-forecast/issues/121),
-[#50](https://github.com/openclimatefix/nged-substation-forecast/issues/50)
-
-The biggest unknown of the three workstreams, but not a blocker for workstream 1 above — start
-this once the local dress rehearsal is underway. Every data location in `Settings` is a local
-`Path` (`packages/contracts/src/contracts/settings.py:104-135`) and all IO assumes a local
-filesystem. delta-rs/Polars read and write `s3://` URIs fine, but the plumbing has to allow it:
-
-- Change the data-location fields (`nwp_data_path`, `power_forecasts_data_path`,
-  `forecast_metrics_data_path`, `eligible_time_series_data_path`,
-  `effective_capacity_data_path`, NGED power/metadata paths) from `Path` to `str` URIs
-  (local paths remain valid `str`s; dev defaults unchanged). Keep genuinely-local paths
-  (`model_cache_base_path`, `plots_data_path`, `cv_config_path`) as `Path`.
-- Audit every consumer (`scan_delta`, `write_delta`, `DeltaTable(...)`, parquet read/write)
-  for `Path`-only operations (`.exists()`, `/` joins, `mkdir`) and route them through
-  URI-safe helpers; pass `storage_options` where delta-rs needs credentials (prefer IAM
-  roles — no static keys — so `storage_options` stays empty on AWS and only dev needs any).
-- Verify **predicate pushdown / partition pruning still works over S3** (the whole memory
-  design depends on it): run the existing `.explain()`-based pruning test pattern against an
-  S3 URI.
-- Test tier: unit tests with local paths as today, plus one integration test against MinIO (or
-  a dev bucket) exercising Delta round-trip + partition-pruned scan through the changed
-  settings.
-
 ### Deployment workstream 3 — AWS infrastructure
 
 Common to all options:
@@ -629,8 +603,8 @@ order issues were opened.
 |---|---|
 | [#221 Add the `live_forecasts` Dagster asset](https://github.com/openclimatefix/nged-substation-forecast/issues/221) | [The `live_forecasts` asset](#the-live_forecasts-asset) — done |
 | [#208 Run every 6 hours locally and backfill missing runs (as a test)](https://github.com/openclimatefix/nged-substation-forecast/issues/208) | Workstream 1 + the local dress rehearsal (also exercises the replay mode) |
-| [#121 Use obstore instead of pathlib](https://github.com/openclimatefix/nged-substation-forecast/issues/121) | Workstream 2 |
-| [#50 Define all paths in Settings](https://github.com/openclimatefix/nged-substation-forecast/issues/50) | Workstream 2 |
+| [#121 Use obstore instead of pathlib](https://github.com/openclimatefix/nged-substation-forecast/issues/121) | S3-capable data paths — done ([setup guide](https://openclimatefix.github.io/nged-substation-forecast/live_service/setup/)) |
+| [#50 Define all paths in Settings](https://github.com/openclimatefix/nged-substation-forecast/issues/50) | S3-capable data paths — done |
 | [#222 Build the production Docker image](https://github.com/openclimatefix/nged-substation-forecast/issues/222) | [Production model artifacts](#production-model-artifacts) + the container-build notes above |
 | [#206 Deploy to AWS!](https://github.com/openclimatefix/nged-substation-forecast/issues/206) | This page (the options above supersede its cost analysis; the issue links back here) |
 | [#197 Make fold-run param logging re-run-safe](https://github.com/openclimatefix/nged-substation-forecast/issues/197) | Bug fix folded into the v0.1 epic (MLflow param immutability on re-runs) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
       - Evaluating new data sources: ml_experimentation/evaluating-new-data-sources.md
   - Live Service:
       - Overview: live_service/index.md
+      - Environment & storage setup: live_service/setup.md
       - Running live forecasts end-to-end: live_service/dagster-workflow.md
   - Roadmap:
       - Overview: roadmap/index.md

--- a/packages/contracts/pyproject.toml
+++ b/packages/contracts/pyproject.toml
@@ -8,6 +8,8 @@ dependencies = [
     "polars>=1.0.0",
     "pydantic-settings>=2.4.0",
     "omegaconf>=2.3.0",
+    "deltalake>=1.6.0",
+    "obstore>=0.11.0",
 ]
 
 [build-system]

--- a/packages/contracts/src/contracts/_uri.py
+++ b/packages/contracts/src/contracts/_uri.py
@@ -3,11 +3,22 @@
 Settings data-location fields are plain ``str`` so they can hold either a local path
 (``/home/.../data/NWP``) or a remote URI (``s3://bucket/NWP``). ``pathlib.Path`` mangles
 the latter (``Path("s3://b/a") / "c"`` drops the scheme), so joins route through here.
+
+The existence/parent helpers below give the asset IO layer a single local-or-remote-aware
+call for the two things it does around every Delta/parquet write: make sure the parent
+directory exists (a no-op on object stores, which have no directories) and check whether a
+table/object is already there. Remote calls go through delta-rs / obstore with the caller's
+``storage_options`` so the same code path serves both a local ``data_path`` and an ``s3://`` one.
 """
 
 import posixpath
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Final
+from urllib.parse import urlparse
+
+import obstore
+from deltalake import DeltaTable
 
 _SCHEME_SEP: Final[str] = "://"
 
@@ -27,3 +38,44 @@ def uri_join(base: str, *parts: str) -> str:
     if is_remote_uri(base):
         return posixpath.join(base.rstrip("/"), *parts)
     return str(Path(base).joinpath(*parts))
+
+
+def ensure_local_parent(uri: str) -> None:
+    """Create the parent directory of a *local* ``uri``; a no-op for a remote URI.
+
+    Local filesystems need a table/file's parent directory to exist before a write; object
+    stores (``s3://``) have no directories — a write creates the key's prefix implicitly — so
+    there is nothing to do and this returns immediately.
+    """
+    if is_remote_uri(uri):
+        return
+    Path(uri).parent.mkdir(parents=True, exist_ok=True)
+
+
+def delta_table_exists(uri: str, storage_options: Mapping[str, str] | None = None) -> bool:
+    """Return whether a Delta table already exists at ``uri`` (local path or remote URI).
+
+    Wraps ``DeltaTable.is_deltatable``, which inspects the ``_delta_log`` through delta-rs'
+    object_store and so works identically for a local path and an ``s3://`` URI given the
+    matching ``storage_options``. Replaces ``Path(uri).exists()`` at the write-guard sites,
+    which would raise on a remote URI.
+    """
+    return DeltaTable.is_deltatable(uri, storage_options=dict(storage_options or {}))
+
+
+def object_exists(uri: str, storage_options: Mapping[str, str] | None = None) -> bool:
+    """Return whether a single object/file at ``uri`` exists (local file or remote object).
+
+    For a local ``uri`` this is ``Path.exists()``; for a remote URI it issues an object-store
+    ``head`` via obstore, so it works for a plain file (e.g. a ``.parquet``) that is not a Delta
+    table. Use ``delta_table_exists`` for Delta tables.
+    """
+    if not is_remote_uri(uri):
+        return Path(uri).exists()
+    parsed = urlparse(uri)
+    store = obstore.store.S3Store(parsed.netloc, config=dict(storage_options or {}))
+    try:
+        obstore.head(store, parsed.path.lstrip("/"))
+    except FileNotFoundError:
+        return False
+    return True

--- a/packages/contracts/src/contracts/_uri.py
+++ b/packages/contracts/src/contracts/_uri.py
@@ -58,7 +58,7 @@ def uri_join(base: str, *parts: str) -> str:
     return str(Path(base).joinpath(*parts))
 
 
-def ensure_local_parent(uri: str) -> None:
+def if_local_path_then_make_parent_dir(uri: str) -> None:
     """Create the parent directory of a *local* ``uri``; a no-op for a remote URI.
 
     Local filesystems need a table/file's parent directory to exist before a write; object

--- a/packages/contracts/src/contracts/_uri.py
+++ b/packages/contracts/src/contracts/_uri.py
@@ -12,15 +12,33 @@ table/object is already there. Remote calls go through delta-rs / obstore with t
 """
 
 import posixpath
-from collections.abc import Mapping
 from pathlib import Path
-from typing import Final
+from typing import Final, TypedDict
 from urllib.parse import urlparse
 
 import obstore
 from deltalake import DeltaTable
 
+from contracts.typing_utils import typeddict_to_dict
+
 _SCHEME_SEP: Final[str] = "://"
+
+
+class ObjectStoreOptions(TypedDict, total=False):
+    """object_store options for the managed data tables — the shared ``aws_*`` aliases understood
+    by delta-rs, Polars, and obstore alike, so one value feeds every IO site.
+
+    Authored as a ``TypedDict`` (rather than a bare ``dict[str, str]``) so ``ty`` checks every key
+    where it is written — see ``Settings.storage_options``. Widen it to the plain ``dict`` the IO
+    libraries expect with ``typeddict_to_dict`` at each call boundary. Empty on AWS (object_store
+    auto-discovers the IAM-role credentials and region) and for a local ``data_path``.
+    """
+
+    aws_endpoint_url: str
+    aws_allow_http: str
+    aws_access_key_id: str
+    aws_secret_access_key: str
+    aws_region: str
 
 
 def is_remote_uri(uri: str) -> bool:
@@ -52,7 +70,7 @@ def ensure_local_parent(uri: str) -> None:
     Path(uri).parent.mkdir(parents=True, exist_ok=True)
 
 
-def delta_table_exists(uri: str, storage_options: Mapping[str, str] | None = None) -> bool:
+def delta_table_exists(uri: str, storage_options: ObjectStoreOptions | None = None) -> bool:
     """Return whether a Delta table already exists at ``uri`` (local path or remote URI).
 
     Wraps ``DeltaTable.is_deltatable``, which inspects the ``_delta_log`` through delta-rs'
@@ -60,10 +78,10 @@ def delta_table_exists(uri: str, storage_options: Mapping[str, str] | None = Non
     matching ``storage_options``. Replaces ``Path(uri).exists()`` at the write-guard sites,
     which would raise on a remote URI.
     """
-    return DeltaTable.is_deltatable(uri, storage_options=dict(storage_options or {}))
+    return DeltaTable.is_deltatable(uri, storage_options=typeddict_to_dict(storage_options) or {})
 
 
-def object_exists(uri: str, storage_options: Mapping[str, str] | None = None) -> bool:
+def object_exists(uri: str, storage_options: ObjectStoreOptions | None = None) -> bool:
     """Return whether a single object/file at ``uri`` exists (local file or remote object).
 
     For a local ``uri`` this is ``Path.exists()``; for a remote URI it issues an object-store
@@ -73,7 +91,7 @@ def object_exists(uri: str, storage_options: Mapping[str, str] | None = None) ->
     if not is_remote_uri(uri):
         return Path(uri).exists()
     parsed = urlparse(uri)
-    store = obstore.store.S3Store(parsed.netloc, config=dict(storage_options or {}))
+    store = obstore.store.S3Store(parsed.netloc, config=typeddict_to_dict(storage_options) or {})
     try:
         obstore.head(store, parsed.path.lstrip("/"))
     except FileNotFoundError:

--- a/packages/contracts/src/contracts/settings.py
+++ b/packages/contracts/src/contracts/settings.py
@@ -5,7 +5,7 @@ import obstore
 from pydantic import AnyHttpUrl, Field, TypeAdapter, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from contracts._uri import uri_join
+from contracts._uri import ObjectStoreOptions, uri_join
 
 url_adapter = TypeAdapter(AnyHttpUrl)
 
@@ -154,16 +154,18 @@ class Settings(BaseSettings):
     )
 
     @property
-    def storage_options(self) -> dict[str, str]:
+    def storage_options(self) -> ObjectStoreOptions:
         """delta-rs / polars / obstore ``storage_options`` for the managed data tables.
 
         Empty on AWS — object_store auto-discovers the Fargate task's IAM-role credentials and
         region — and empty for a local ``data_path`` (delta-rs ignores it there). Populated from
         the ``data_store_*`` settings only for a dev/MinIO/S3-compatible endpoint. The ``aws_*``
         keys are the shared object_store aliases understood by delta-rs, polars cloud IO, and
-        obstore alike, so one dict feeds every IO site.
+        obstore alike, so one value feeds every IO site. Returned as an ``ObjectStoreOptions``
+        ``TypedDict`` so ``ty`` checks each key here, where they are authored; widen it to a plain
+        ``dict`` at each IO boundary with ``typeddict_to_dict``.
         """
-        options: dict[str, str] = {}
+        options: ObjectStoreOptions = {}
         if self.data_store_endpoint_url:
             options["aws_endpoint_url"] = self.data_store_endpoint_url
             options["aws_allow_http"] = "true"

--- a/packages/contracts/src/contracts/settings.py
+++ b/packages/contracts/src/contracts/settings.py
@@ -102,8 +102,13 @@ class Settings(BaseSettings):
 
     # --- Storage roots -------------------------------------------------------------------
     #
-    # Two roots, because model/plot artifacts must stay on a local filesystem (XGBoost
-    # save_model/load_model, shutil, Altair) even when the data tables move to S3.
+    # Two roots because nothing under local_artifacts_path is part of the S3-backed data plane:
+    # the model cache is a node-local scratch cache used only by the (laptop) CV pipeline; the
+    # production model is distributed via the container image, not shared storage (this dir is its
+    # build-time staging area); and plot HTML is a local-dev convenience (the dashboard, reading
+    # power_forecasts from data_path, is the deployed way to view forecasts). So the deployed
+    # runtime reads its model from the image, data from S3, and writes forecasts to S3 — it never
+    # uses local_artifacts_path as shared storage. See docs/live_service/setup.md.
 
     data_path: str = Field(
         default=str(PROJECT_ROOT / "data"),

--- a/packages/contracts/src/contracts/settings.py
+++ b/packages/contracts/src/contracts/settings.py
@@ -102,13 +102,9 @@ class Settings(BaseSettings):
 
     # --- Storage roots -------------------------------------------------------------------
     #
-    # Two roots because nothing under local_artifacts_path is part of the S3-backed data plane:
-    # the model cache is a node-local scratch cache used only by the (laptop) CV pipeline; the
-    # production model is distributed via the container image, not shared storage (this dir is its
-    # build-time staging area); and plot HTML is a local-dev convenience (the dashboard, reading
-    # power_forecasts from data_path, is the deployed way to view forecasts). So the deployed
-    # runtime reads its model from the image, data from S3, and writes forecasts to S3 — it never
-    # uses local_artifacts_path as shared storage. See docs/live_service/setup.md.
+    # data_path holds the (S3-capable) data tables; local_artifacts_path holds the always-local
+    # model cache, production model, and plots. Why they are split, and what belongs in each:
+    # https://openclimatefix.github.io/nged-substation-forecast/live_service/setup/
 
     data_path: str = Field(
         default=str(PROJECT_ROOT / "data"),
@@ -129,11 +125,10 @@ class Settings(BaseSettings):
 
     # --- Object-store credentials for the data tables (used only when data_path is remote) --
     #
-    # All empty by default. On AWS nothing needs setting: delta-rs' object_store discovers the
-    # Fargate task's IAM-role credentials and region automatically. Populate these (via env)
-    # only for a dev / MinIO / S3-compatible endpoint that needs an explicit endpoint + keys.
-    # Separate from the nged_s3_bucket_* creds above, which authenticate reads of NGED's source
-    # bucket (a different account/bucket from our own managed data tables).
+    # All empty by default; unset on AWS (object_store auto-discovers the IAM-role credentials),
+    # set only for a dev/MinIO endpoint. The AWS/dev split, and how these differ from the
+    # nged_s3_bucket_* source-bucket creds above:
+    # https://openclimatefix.github.io/nged-substation-forecast/live_service/setup/
 
     data_store_endpoint_url: str = Field(
         default="",
@@ -179,9 +174,9 @@ class Settings(BaseSettings):
 
     # --- Managed data tables (derive from data_path unless explicitly set) ----------------
     #
-    # Each defaults to "" as a sentinel meaning "derive from data_path in _derive_unset_paths".
-    # Set any one explicitly (e.g. NWP_DATA_PATH=s3://other-bucket/NWP) to override just that
-    # table. After validation every field below is a concrete, non-empty path string.
+    # Each defaults to "" — a sentinel meaning "derive from data_path in _derive_unset_paths".
+    # The derive-from-root convention and per-table overrides:
+    # https://openclimatefix.github.io/nged-substation-forecast/live_service/setup/
 
     nged_data_path: str = ""
     """Directory holding the NGED power_time_series Delta table and metadata parquet."""

--- a/packages/contracts/src/contracts/settings.py
+++ b/packages/contracts/src/contracts/settings.py
@@ -122,6 +122,54 @@ class Settings(BaseSettings):
         ),
     )
 
+    # --- Object-store credentials for the data tables (used only when data_path is remote) --
+    #
+    # All empty by default. On AWS nothing needs setting: delta-rs' object_store discovers the
+    # Fargate task's IAM-role credentials and region automatically. Populate these (via env)
+    # only for a dev / MinIO / S3-compatible endpoint that needs an explicit endpoint + keys.
+    # Separate from the nged_s3_bucket_* creds above, which authenticate reads of NGED's source
+    # bucket (a different account/bucket from our own managed data tables).
+
+    data_store_endpoint_url: str = Field(
+        default="",
+        description=(
+            "S3-compatible endpoint URL for the data tables (e.g. a MinIO/dev endpoint). Empty on"
+            " AWS, where the endpoint is inferred. When set, the store is also allowed to use"
+            " plain HTTP (dev endpoints rarely have TLS)."
+        ),
+    )
+    data_store_access_key_id: str = Field(
+        default="", description="Access key for the data-table object store; empty on AWS (IAM)."
+    )
+    data_store_secret_access_key: str = Field(
+        default="", description="Secret key for the data-table object store; empty on AWS (IAM)."
+    )
+    data_store_region: str = Field(
+        default="", description="Region for the data-table object store; empty to auto-discover."
+    )
+
+    @property
+    def storage_options(self) -> dict[str, str]:
+        """delta-rs / polars / obstore ``storage_options`` for the managed data tables.
+
+        Empty on AWS — object_store auto-discovers the Fargate task's IAM-role credentials and
+        region — and empty for a local ``data_path`` (delta-rs ignores it there). Populated from
+        the ``data_store_*`` settings only for a dev/MinIO/S3-compatible endpoint. The ``aws_*``
+        keys are the shared object_store aliases understood by delta-rs, polars cloud IO, and
+        obstore alike, so one dict feeds every IO site.
+        """
+        options: dict[str, str] = {}
+        if self.data_store_endpoint_url:
+            options["aws_endpoint_url"] = self.data_store_endpoint_url
+            options["aws_allow_http"] = "true"
+        if self.data_store_access_key_id:
+            options["aws_access_key_id"] = self.data_store_access_key_id
+        if self.data_store_secret_access_key:
+            options["aws_secret_access_key"] = self.data_store_secret_access_key
+        if self.data_store_region:
+            options["aws_region"] = self.data_store_region
+        return options
+
     # --- Managed data tables (derive from data_path unless explicitly set) ----------------
     #
     # Each defaults to "" as a sentinel meaning "derive from data_path in _derive_unset_paths".

--- a/packages/contracts/src/contracts/typing_utils.py
+++ b/packages/contracts/src/contracts/typing_utils.py
@@ -1,0 +1,27 @@
+"""Reusable typing shims — domain-agnostic helpers that reconcile expressive in-code types
+with the plainer types third-party APIs annotate.
+
+Kept generic and separate from any one domain so they can be shared across the workspace (and
+promoted to their own package if they grow). The first inhabitant bridges the gap between a
+``TypedDict`` — which we use so ``ty`` checks every key at the point it is written — and the
+``dict[str, str]`` that libraries such as delta-rs, Polars, and obstore expect: a ``TypedDict`` is
+deliberately *not* assignable to any ``dict[..]`` type (a ``dict`` permits destructive operations
+like ``clear()``), so it has to be widened explicitly at the boundary.
+"""
+
+from collections.abc import Mapping
+from typing import cast
+
+
+def typeddict_to_dict(td: Mapping[str, object] | None) -> dict[str, str] | None:
+    """Widen a string-valued ``TypedDict`` to the plain ``dict[str, str]`` libraries expect.
+
+    Author options as a ``TypedDict`` — so ``ty`` catches a mistyped key where it is written —
+    then call this at the last moment, at the boundary to a third-party API annotated
+    ``dict[str, str]`` (or ``dict[str, Any]``). ``None`` passes straight through so a call site
+    can forward an optional value unchanged.
+
+    The widening is a zero-copy ``cast``: the caller is responsible for the ``TypedDict``'s values
+    actually being ``str`` (they are, for every current caller).
+    """
+    return None if td is None else cast("dict[str, str]", td)

--- a/packages/contracts/src/contracts/weather_schemas.py
+++ b/packages/contracts/src/contracts/weather_schemas.py
@@ -320,10 +320,26 @@ class Nwp(pt.Model):
             )
 
     @classmethod
-    def scan_delta(cls, path: str | Path = SETTINGS.nwp_data_path) -> pt.LazyFrame[Self]:
+    def scan_delta(
+        cls,
+        path: str | Path = SETTINGS.nwp_data_path,
+        storage_options: dict[str, str] | None = None,
+    ) -> pt.LazyFrame[Self]:
         """Lazily scan the NWP Delta table, typed and cast to this contract's dtypes.
 
         The table stores physical-unit `Float32` directly (see `delta_store.nwp.write_nwp`),
         so no rescale step is needed.
+
+        Args:
+            path: Path or URI of the ``nwp`` Delta table.
+            storage_options: delta-rs object-store options (credentials/endpoint) for a remote
+                ``path``. ``None`` falls back to ``Settings().storage_options``; empty for a
+                local ``path``.
         """
-        return pt.LazyFrame.from_existing(pl.scan_delta(path)).set_model(cls).cast()
+        if storage_options is None:
+            storage_options = SETTINGS.storage_options
+        return (
+            pt.LazyFrame.from_existing(pl.scan_delta(path, storage_options=storage_options))
+            .set_model(cls)
+            .cast()
+        )

--- a/packages/contracts/src/contracts/weather_schemas.py
+++ b/packages/contracts/src/contracts/weather_schemas.py
@@ -325,7 +325,7 @@ class Nwp(pt.Model):
     def scan_delta(
         cls,
         path: str | Path = SETTINGS.nwp_data_path,
-        storage_options: ObjectStoreOptions | None = None,
+        storage_options: ObjectStoreOptions = SETTINGS.storage_options,
     ) -> pt.LazyFrame[Self]:
         """Lazily scan the NWP Delta table, typed and cast to this contract's dtypes.
 
@@ -335,11 +335,9 @@ class Nwp(pt.Model):
         Args:
             path: Path or URI of the ``nwp`` Delta table.
             storage_options: delta-rs object-store options (credentials/endpoint) for a remote
-                ``path``. ``None`` falls back to ``Settings().storage_options``; empty for a
-                local ``path``.
+                ``path``; defaults to the ``SETTINGS`` singleton's options (empty for a local
+                ``path``). Read-only — never mutated here (shared mutable default).
         """
-        if storage_options is None:
-            storage_options = SETTINGS.storage_options
         return (
             pt.LazyFrame.from_existing(
                 pl.scan_delta(path, storage_options=typeddict_to_dict(storage_options))

--- a/packages/contracts/src/contracts/weather_schemas.py
+++ b/packages/contracts/src/contracts/weather_schemas.py
@@ -7,7 +7,9 @@ from typing import ClassVar, Literal, Self
 import patito as pt
 import polars as pl
 
+from contracts._uri import ObjectStoreOptions
 from contracts.settings import Settings
+from contracts.typing_utils import typeddict_to_dict
 
 from .common import UTC_DATETIME_DTYPE
 
@@ -323,7 +325,7 @@ class Nwp(pt.Model):
     def scan_delta(
         cls,
         path: str | Path = SETTINGS.nwp_data_path,
-        storage_options: dict[str, str] | None = None,
+        storage_options: ObjectStoreOptions | None = None,
     ) -> pt.LazyFrame[Self]:
         """Lazily scan the NWP Delta table, typed and cast to this contract's dtypes.
 
@@ -339,7 +341,9 @@ class Nwp(pt.Model):
         if storage_options is None:
             storage_options = SETTINGS.storage_options
         return (
-            pt.LazyFrame.from_existing(pl.scan_delta(path, storage_options=storage_options))
+            pt.LazyFrame.from_existing(
+                pl.scan_delta(path, storage_options=typeddict_to_dict(storage_options))
+            )
             .set_model(cls)
             .cast()
         )

--- a/packages/contracts/tests/test_settings.py
+++ b/packages/contracts/tests/test_settings.py
@@ -64,3 +64,35 @@ def test_explicit_path_overrides_derivation():
     assert settings.nwp_data_path == "/mnt/fast/NWP"
     # Siblings still derive normally.
     assert settings.power_forecasts_data_path == "s3://bucket/data/power_forecasts"
+
+
+def test_storage_options_empty_without_dev_credentials():
+    """With no ``data_store_*`` credentials set, ``storage_options`` is empty (the AWS default)."""
+    settings = Settings(
+        data_path="s3://bucket/data",
+        nged_s3_bucket_url="https://example.com",
+        nged_s3_bucket_access_key="key",
+        nged_s3_bucket_secret="secret",
+    )
+    assert settings.storage_options == {}
+
+
+def test_storage_options_populated_from_dev_credentials():
+    """The ``data_store_*`` settings map onto the shared ``aws_*`` object_store option keys."""
+    settings = Settings(
+        data_path="s3://bucket/data",
+        data_store_endpoint_url="http://localhost:9000",
+        data_store_access_key_id="minio",
+        data_store_secret_access_key="minio123",
+        data_store_region="us-east-1",
+        nged_s3_bucket_url="https://example.com",
+        nged_s3_bucket_access_key="key",
+        nged_s3_bucket_secret="secret",
+    )
+    assert settings.storage_options == {
+        "aws_endpoint_url": "http://localhost:9000",
+        "aws_allow_http": "true",
+        "aws_access_key_id": "minio",
+        "aws_secret_access_key": "minio123",
+        "aws_region": "us-east-1",
+    }

--- a/packages/contracts/tests/test_uri.py
+++ b/packages/contracts/tests/test_uri.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import polars as pl
 from contracts._uri import (
     delta_table_exists,
-    ensure_local_parent,
+    if_local_path_then_make_parent_dir,
     is_remote_uri,
     object_exists,
     uri_join,
@@ -32,16 +32,16 @@ def test_uri_join_local_and_remote():
     assert uri_join("/srv/data", "NWP") == "/srv/data/NWP"
 
 
-def test_ensure_local_parent_creates_local_dir(tmp_path: Path):
+def test_if_local_path_then_make_parent_dir_creates_local_dir(tmp_path: Path):
     target = tmp_path / "nested" / "dir" / "table"
     assert not target.parent.exists()
-    ensure_local_parent(str(target))
+    if_local_path_then_make_parent_dir(str(target))
     assert target.parent.is_dir()
 
 
-def test_ensure_local_parent_noop_for_remote():
+def test_if_local_path_then_make_parent_dir_noop_for_remote():
     # Must not raise or touch the filesystem for a remote URI.
-    ensure_local_parent("s3://bucket/data/table")
+    if_local_path_then_make_parent_dir("s3://bucket/data/table")
 
 
 def test_object_exists_local(tmp_path: Path):

--- a/packages/contracts/tests/test_uri.py
+++ b/packages/contracts/tests/test_uri.py
@@ -1,0 +1,58 @@
+"""Unit tests for the local-or-remote URI helpers in ``contracts._uri``.
+
+Covers the local-filesystem behaviour (the remote ``s3://`` behaviour is exercised end-to-end
+against a moto server in ``tests/test_s3_data_paths.py``).
+"""
+
+from pathlib import Path
+
+import polars as pl
+from contracts._uri import (
+    delta_table_exists,
+    ensure_local_parent,
+    is_remote_uri,
+    object_exists,
+    uri_join,
+)
+
+
+def test_is_remote_uri():
+    assert is_remote_uri("s3://bucket/key")
+    assert not is_remote_uri("/home/jack/data/NWP")
+    assert not is_remote_uri("relative/path")
+
+
+def test_uri_join_local_and_remote():
+    # Remote joins stay scheme-preserving and posix-style.
+    assert uri_join("s3://bucket/data", "NGED", "metadata.parquet") == (
+        "s3://bucket/data/NGED/metadata.parquet"
+    )
+    assert uri_join("s3://bucket/data/", "NWP") == "s3://bucket/data/NWP"
+    # Local joins go through pathlib.
+    assert uri_join("/srv/data", "NWP") == "/srv/data/NWP"
+
+
+def test_ensure_local_parent_creates_local_dir(tmp_path: Path):
+    target = tmp_path / "nested" / "dir" / "table"
+    assert not target.parent.exists()
+    ensure_local_parent(str(target))
+    assert target.parent.is_dir()
+
+
+def test_ensure_local_parent_noop_for_remote():
+    # Must not raise or touch the filesystem for a remote URI.
+    ensure_local_parent("s3://bucket/data/table")
+
+
+def test_object_exists_local(tmp_path: Path):
+    path = tmp_path / "metadata.parquet"
+    assert not object_exists(str(path))
+    pl.DataFrame({"x": [1]}).write_parquet(path)
+    assert object_exists(str(path))
+
+
+def test_delta_table_exists_local(tmp_path: Path):
+    path = str(tmp_path / "table")
+    assert not delta_table_exists(path)
+    pl.DataFrame({"x": [1, 2]}).write_delta(path)
+    assert delta_table_exists(path)

--- a/packages/dashboard/main.py
+++ b/packages/dashboard/main.py
@@ -23,6 +23,7 @@ with app.setup:
     import polars as pl
     import pyarrow
     from contracts.power_schemas import PowerTimeSeries, TimeSeriesMetadata
+    from contracts.typing_utils import typeddict_to_dict
     from plotting.ocf_theme import BLUE
 
     BASE_DELTA_PATH = settings.power_time_series_data_path
@@ -32,7 +33,7 @@ with app.setup:
 def _():
     metadata_path = settings.metadata_path
     df = TimeSeriesMetadata.validate(
-        pl.read_parquet(metadata_path, storage_options=settings.storage_options)
+        pl.read_parquet(metadata_path, storage_options=typeddict_to_dict(settings.storage_options))
     )
     return (df,)
 
@@ -94,7 +95,9 @@ def _(arrow_table):
 
 @app.cell
 def _():
-    delta_df = pl.scan_delta(BASE_DELTA_PATH, storage_options=settings.storage_options).filter(
+    delta_df = pl.scan_delta(
+        BASE_DELTA_PATH, storage_options=typeddict_to_dict(settings.storage_options)
+    ).filter(
         # Filter to only show recent data. Altair crashes if you try to show too much data.
         pl.col("time") > pl.lit(datetime(2026, 3, 1)).cast(UTC_DATETIME_DTYPE)
     )

--- a/packages/dashboard/main.py
+++ b/packages/dashboard/main.py
@@ -31,7 +31,9 @@ with app.setup:
 @app.cell
 def _():
     metadata_path = settings.metadata_path
-    df = TimeSeriesMetadata.validate(pl.read_parquet(metadata_path))
+    df = TimeSeriesMetadata.validate(
+        pl.read_parquet(metadata_path, storage_options=settings.storage_options)
+    )
     return (df,)
 
 
@@ -92,7 +94,7 @@ def _(arrow_table):
 
 @app.cell
 def _():
-    delta_df = pl.scan_delta(str(BASE_DELTA_PATH)).filter(
+    delta_df = pl.scan_delta(BASE_DELTA_PATH, storage_options=settings.storage_options).filter(
         # Filter to only show recent data. Altair crashes if you try to show too much data.
         pl.col("time") > pl.lit(datetime(2026, 3, 1)).cast(UTC_DATETIME_DTYPE)
     )

--- a/packages/delta_store/src/delta_store/nwp.py
+++ b/packages/delta_store/src/delta_store/nwp.py
@@ -23,6 +23,8 @@ from typing import Final
 
 import patito as pt
 import polars as pl
+from contracts._uri import ObjectStoreOptions
+from contracts.typing_utils import typeddict_to_dict
 from contracts.weather_schemas import Nwp
 from deltalake import WriterProperties, write_deltalake
 
@@ -56,7 +58,7 @@ that choice, which won for ``power_forecasts``, measures worse here."""
 def write_nwp(
     nwp: pt.DataFrame[Nwp],
     table_uri: str | Path,
-    storage_options: dict[str, str] | None = None,
+    storage_options: ObjectStoreOptions | None = None,
 ) -> None:
     """Append ``Nwp`` rows to the ``nwp`` Delta table in its storage format.
 
@@ -99,5 +101,5 @@ def write_nwp(
         mode="append",
         partition_by=["nwp_model_id", "init_time"],
         writer_properties=NWP_WRITER_PROPERTIES,
-        storage_options=storage_options,
+        storage_options=typeddict_to_dict(storage_options),
     )

--- a/packages/delta_store/src/delta_store/nwp.py
+++ b/packages/delta_store/src/delta_store/nwp.py
@@ -53,7 +53,11 @@ NWP_WRITER_PROPERTIES: Final[WriterProperties] = WriterProperties(
 that choice, which won for ``power_forecasts``, measures worse here."""
 
 
-def write_nwp(nwp: pt.DataFrame[Nwp], table_uri: str | Path) -> None:
+def write_nwp(
+    nwp: pt.DataFrame[Nwp],
+    table_uri: str | Path,
+    storage_options: dict[str, str] | None = None,
+) -> None:
     """Append ``Nwp`` rows to the ``nwp`` Delta table in its storage format.
 
     Rounds every continuous weather variable to ``NWP_SIGNIFICAND_BITS`` significand bits, sorts
@@ -71,6 +75,8 @@ def write_nwp(nwp: pt.DataFrame[Nwp], table_uri: str | Path) -> None:
     Args:
         nwp: Validated NWP rows for a single ``(nwp_model_id, init_time)`` partition.
         table_uri: Path or URI of the ``nwp`` Delta table.
+        storage_options: delta-rs object-store options (credentials/endpoint) for a remote
+            ``table_uri``; ``None``/empty for a local path.
     """
     continuous_vars = sorted(Nwp.continuous_var_names())
     rounded = nwp.with_columns(
@@ -93,4 +99,5 @@ def write_nwp(nwp: pt.DataFrame[Nwp], table_uri: str | Path) -> None:
         mode="append",
         partition_by=["nwp_model_id", "init_time"],
         writer_properties=NWP_WRITER_PROPERTIES,
+        storage_options=storage_options,
     )

--- a/packages/delta_store/src/delta_store/power_forecasts.py
+++ b/packages/delta_store/src/delta_store/power_forecasts.py
@@ -15,7 +15,9 @@ from typing import Final
 
 import patito as pt
 import polars as pl
+from contracts._uri import ObjectStoreOptions
 from contracts.power_schemas import PowerForecast
+from contracts.typing_utils import typeddict_to_dict
 from deltalake import ColumnProperties, WriterProperties, write_deltalake
 
 from delta_store.precision import round_to_significand_bits
@@ -79,7 +81,7 @@ def write_power_forecasts(
     *,
     replace_partition: tuple[str, str] | None = None,
     replace_predicate_extra: str | None = None,
-    storage_options: dict[str, str] | None = None,
+    storage_options: ObjectStoreOptions | None = None,
 ) -> None:
     """Write ``PowerForecast`` rows to the ``power_forecasts`` Delta table in its storage format.
 
@@ -130,7 +132,7 @@ def write_power_forecasts(
             predicate=predicate,
             partition_by=["experiment_name", "fold_id"],
             writer_properties=POWER_FORECASTS_WRITER_PROPERTIES,
-            storage_options=storage_options,
+            storage_options=typeddict_to_dict(storage_options),
         )
     else:
         write_deltalake(
@@ -139,5 +141,5 @@ def write_power_forecasts(
             mode="append",
             partition_by=["experiment_name", "fold_id"],
             writer_properties=POWER_FORECASTS_WRITER_PROPERTIES,
-            storage_options=storage_options,
+            storage_options=typeddict_to_dict(storage_options),
         )

--- a/packages/delta_store/src/delta_store/power_forecasts.py
+++ b/packages/delta_store/src/delta_store/power_forecasts.py
@@ -79,6 +79,7 @@ def write_power_forecasts(
     *,
     replace_partition: tuple[str, str] | None = None,
     replace_predicate_extra: str | None = None,
+    storage_options: dict[str, str] | None = None,
 ) -> None:
     """Write ``PowerForecast`` rows to the ``power_forecasts`` Delta table in its storage format.
 
@@ -105,6 +106,8 @@ def write_power_forecasts(
             partition. delta-rs' ``replaceWhere`` supports predicates on non-partition columns
             (confirmed empirically: a `datetime.isoformat()` literal round-trips correctly
             against a ``Timestamp`` column). Only meaningful alongside ``replace_partition``.
+        storage_options: delta-rs object-store options (credentials/endpoint) for a remote
+            ``table_uri``; ``None``/empty for a local path.
     """
     prepared = (
         forecasts.with_columns(
@@ -127,6 +130,7 @@ def write_power_forecasts(
             predicate=predicate,
             partition_by=["experiment_name", "fold_id"],
             writer_properties=POWER_FORECASTS_WRITER_PROPERTIES,
+            storage_options=storage_options,
         )
     else:
         write_deltalake(
@@ -135,4 +139,5 @@ def write_power_forecasts(
             mode="append",
             partition_by=["experiment_name", "fold_id"],
             writer_properties=POWER_FORECASTS_WRITER_PROPERTIES,
+            storage_options=storage_options,
         )

--- a/packages/nged_data/src/nged_data/storage.py
+++ b/packages/nged_data/src/nged_data/storage.py
@@ -1,10 +1,10 @@
 import logging
-from pathlib import Path
 from typing import Final, Sequence, TypedDict, overload
 
 import obstore
 import patito as pt
 import polars as pl
+from contracts._uri import delta_table_exists, object_exists
 from contracts.common import UTC_DATETIME_DTYPE, _get_time_series_id_dtype
 from contracts.power_schemas import PowerTimeSeries, TimeSeriesMetadata
 
@@ -195,7 +195,8 @@ class _MaxTimePerTimeSeriesId(pt.Model):
 @overload
 def select_new_rows(
     time_series: pt.DataFrame[PowerTimeSeries],
-    delta_path: Path,
+    delta_path: str,
+    storage_options: dict[str, str] | None = None,
 ) -> pt.DataFrame[PowerTimeSeries]: ...
 
 
@@ -204,26 +205,34 @@ def select_new_rows(
 @overload
 def select_new_rows(
     time_series: pt.DataFrame[_ProcessedFileListing],
-    delta_path: Path,
+    delta_path: str,
+    storage_options: dict[str, str] | None = None,
 ) -> pt.DataFrame[_ProcessedFileListing]: ...
 
 
 def select_new_rows(
     time_series: pt.DataFrame[PowerTimeSeries] | pt.DataFrame[_ProcessedFileListing],
-    delta_path: Path,
+    delta_path: str,
+    storage_options: dict[str, str] | None = None,
 ) -> pt.DataFrame[PowerTimeSeries] | pt.DataFrame[_ProcessedFileListing]:
     """
     Return rows in `time_series` that are more recent than the most recent
     data already in our Delta table, on a time_series_id by time_series_id basis.
+
+    `delta_path` is a local path or remote URI for the ``power_time_series`` Delta table;
+    `storage_options` carries the object-store credentials/endpoint for a remote `delta_path`.
     """
 
-    if not delta_path.exists():
+    if not delta_table_exists(delta_path, storage_options):
         log.info(f"{delta_path=} does not exist yet.")
         return time_series
 
     # Scan the existing delta table and find the most recent time per time_series_id
     max_times = (
-        pl.scan_delta(delta_path).group_by("time_series_id").agg(max_time=pl.max("time")).collect()
+        pl.scan_delta(delta_path, storage_options=storage_options)
+        .group_by("time_series_id")
+        .agg(max_time=pl.max("time"))
+        .collect()
     )
 
     log.info(
@@ -269,7 +278,9 @@ class UpsertMetadataStats(TypedDict, total=False):
 
 
 def upsert_metadata(
-    new_metadata: pt.DataFrame[TimeSeriesMetadata], metadata_path: Path
+    new_metadata: pt.DataFrame[TimeSeriesMetadata],
+    metadata_path: str,
+    storage_options: dict[str, str] | None = None,
 ) -> UpsertMetadataStats:
     """
     Upserts metadata to a Parquet file.
@@ -284,8 +295,10 @@ def upsert_metadata(
 
     Args:
         new_metadata: The new metadata DataFrame.
-        metadata_path: The path to the Parquet file where we store our local version of the
-            metadata.
+        metadata_path: Local path or remote URI of the Parquet file where we store our version
+            of the metadata.
+        storage_options: Object-store credentials/endpoint for a remote `metadata_path`;
+            ``None``/empty for a local path.
 
     Returns stats about new metadata
     """
@@ -293,17 +306,18 @@ def upsert_metadata(
 
     new_metadata = TimeSeriesMetadata.validate(new_metadata.sort("time_series_id"))
 
-    # FIXME: `path.exists()` won't work when metadata_path is on S3!
-    if not metadata_path.exists():
+    if not object_exists(metadata_path, storage_options):
         log.info(f"Metadata file not found at {metadata_path}. Creating new file.")
-        new_metadata.write_parquet(metadata_path, compression=COMPRESSION)
+        new_metadata.write_parquet(
+            metadata_path, compression=COMPRESSION, storage_options=storage_options
+        )
         return UpsertMetadataStats(
             metadata_n_new_TimeSeriesIDs=new_metadata.height,
             metadata_n_updated_TimeSeriesIDs=0,
         )
 
     # Read existing metadata
-    existing_metadata = pl.read_parquet(metadata_path)
+    existing_metadata = pl.read_parquet(metadata_path, storage_options=storage_options)
     TimeSeriesMetadata.validate(existing_metadata)
 
     # Compare metadata. `metadata_diff` contains all rows in `new_metadata` that do not have an
@@ -334,7 +348,9 @@ def upsert_metadata(
 
     TimeSeriesMetadata.validate(merged_metadata)
 
-    merged_metadata.write_parquet(metadata_path, compression=COMPRESSION)
+    merged_metadata.write_parquet(
+        metadata_path, compression=COMPRESSION, storage_options=storage_options
+    )
 
     # Compute stats
     new_ids = set(new_metadata["time_series_id"]) - set(existing_metadata["time_series_id"])

--- a/packages/nged_data/src/nged_data/storage.py
+++ b/packages/nged_data/src/nged_data/storage.py
@@ -4,9 +4,10 @@ from typing import Final, Sequence, TypedDict, overload
 import obstore
 import patito as pt
 import polars as pl
-from contracts._uri import delta_table_exists, object_exists
+from contracts._uri import ObjectStoreOptions, delta_table_exists, object_exists
 from contracts.common import UTC_DATETIME_DTYPE, _get_time_series_id_dtype
 from contracts.power_schemas import PowerTimeSeries, TimeSeriesMetadata
+from contracts.typing_utils import typeddict_to_dict
 
 from nged_data.read_nged_json import (
     _extract_power_time_series,
@@ -196,7 +197,7 @@ class _MaxTimePerTimeSeriesId(pt.Model):
 def select_new_rows(
     time_series: pt.DataFrame[PowerTimeSeries],
     delta_path: str,
-    storage_options: dict[str, str] | None = None,
+    storage_options: ObjectStoreOptions | None = None,
 ) -> pt.DataFrame[PowerTimeSeries]: ...
 
 
@@ -206,14 +207,14 @@ def select_new_rows(
 def select_new_rows(
     time_series: pt.DataFrame[_ProcessedFileListing],
     delta_path: str,
-    storage_options: dict[str, str] | None = None,
+    storage_options: ObjectStoreOptions | None = None,
 ) -> pt.DataFrame[_ProcessedFileListing]: ...
 
 
 def select_new_rows(
     time_series: pt.DataFrame[PowerTimeSeries] | pt.DataFrame[_ProcessedFileListing],
     delta_path: str,
-    storage_options: dict[str, str] | None = None,
+    storage_options: ObjectStoreOptions | None = None,
 ) -> pt.DataFrame[PowerTimeSeries] | pt.DataFrame[_ProcessedFileListing]:
     """
     Return rows in `time_series` that are more recent than the most recent
@@ -229,7 +230,7 @@ def select_new_rows(
 
     # Scan the existing delta table and find the most recent time per time_series_id
     max_times = (
-        pl.scan_delta(delta_path, storage_options=storage_options)
+        pl.scan_delta(delta_path, storage_options=typeddict_to_dict(storage_options))
         .group_by("time_series_id")
         .agg(max_time=pl.max("time"))
         .collect()
@@ -280,7 +281,7 @@ class UpsertMetadataStats(TypedDict, total=False):
 def upsert_metadata(
     new_metadata: pt.DataFrame[TimeSeriesMetadata],
     metadata_path: str,
-    storage_options: dict[str, str] | None = None,
+    storage_options: ObjectStoreOptions | None = None,
 ) -> UpsertMetadataStats:
     """
     Upserts metadata to a Parquet file.
@@ -309,7 +310,9 @@ def upsert_metadata(
     if not object_exists(metadata_path, storage_options):
         log.info(f"Metadata file not found at {metadata_path}. Creating new file.")
         new_metadata.write_parquet(
-            metadata_path, compression=COMPRESSION, storage_options=storage_options
+            metadata_path,
+            compression=COMPRESSION,
+            storage_options=typeddict_to_dict(storage_options),
         )
         return UpsertMetadataStats(
             metadata_n_new_TimeSeriesIDs=new_metadata.height,
@@ -317,7 +320,9 @@ def upsert_metadata(
         )
 
     # Read existing metadata
-    existing_metadata = pl.read_parquet(metadata_path, storage_options=storage_options)
+    existing_metadata = pl.read_parquet(
+        metadata_path, storage_options=typeddict_to_dict(storage_options)
+    )
     TimeSeriesMetadata.validate(existing_metadata)
 
     # Compare metadata. `metadata_diff` contains all rows in `new_metadata` that do not have an
@@ -349,7 +354,7 @@ def upsert_metadata(
     TimeSeriesMetadata.validate(merged_metadata)
 
     merged_metadata.write_parquet(
-        metadata_path, compression=COMPRESSION, storage_options=storage_options
+        metadata_path, compression=COMPRESSION, storage_options=typeddict_to_dict(storage_options)
     )
 
     # Compute stats

--- a/packages/nged_data/tests/test_storage.py
+++ b/packages/nged_data/tests/test_storage.py
@@ -41,7 +41,7 @@ def test_upsert_metadata_new_file(tmp_path: Path):
         .validate()
     )
 
-    upsert_metadata(metadata, metadata_path)
+    upsert_metadata(metadata, str(metadata_path))
 
     assert metadata_path.exists()
 
@@ -102,7 +102,7 @@ def test_upsert_metadata_merge(tmp_path: Path):
         .validate()
     )
 
-    upsert_metadata(new_metadata, metadata_path)
+    upsert_metadata(new_metadata, str(metadata_path))
 
     # Read back and verify
     read_metadata = pl.read_parquet(metadata_path)
@@ -188,7 +188,7 @@ def test_upsert_metadata_returns_diff(tmp_path: Path):
     new_metadata = pt.DataFrame(new_data).set_model(TimeSeriesMetadata).cast().validate()
 
     # 3. Call upsert_metadata
-    stats = upsert_metadata(new_metadata, metadata_path)
+    stats = upsert_metadata(new_metadata, str(metadata_path))
 
     # 4. Assertions
     assert stats["metadata_n_new_TimeSeriesIDs"] == 1
@@ -271,7 +271,7 @@ def test_select_new_rows_file_listing(tmp_path: Path):
     )
     file_listing = pt.DataFrame(raw).set_model(_ProcessedFileListing).validate()
 
-    result = select_new_rows(file_listing, delta_path)
+    result = select_new_rows(file_listing, str(delta_path))
 
     assert result.height == 2
     assert set(result["path"].to_list()) == {"new_ts1.json", "new_ts2.json"}
@@ -304,7 +304,7 @@ def test_select_new_rows_power_time_series(tmp_path: Path):
         )
     )
 
-    result = select_new_rows(input_power, delta_path)
+    result = select_new_rows(input_power, str(delta_path))
 
     assert result.height == 1
     assert result["time"][0] == datetime(2026, 1, 1, 12, 30, tzinfo=UTC)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ dev = [
     "mkdocs-include-markdown-plugin>=7.2.2",
     "pymarkdownlnt>=0.9.13",
     "mlflow>=3.14.0",
+    "moto[server]>=5.0.0",
 ]
 
 [project.urls]

--- a/src/nged_substation_forecast/defs/assets.py
+++ b/src/nged_substation_forecast/defs/assets.py
@@ -1,11 +1,11 @@
 import ast
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Any, Final, Generic, Self, TypeVar
 
 import patito as pt
 import polars as pl
+from contracts._uri import ensure_local_parent
 from contracts.geo_schemas import H3GridWeights
 from contracts.power_schemas import PowerTimeSeries
 from contracts.settings import Settings
@@ -60,8 +60,9 @@ def power_time_series_and_metadata(context: AssetExecutionContext) -> None:
     to just check what's available on NGED's S3 bucket and append to our local Delta table.
     """
     settings = Settings()
-    delta_path = Path(settings.power_time_series_data_path)
-    metadata_path = Path(settings.metadata_path)
+    delta_path = settings.power_time_series_data_path
+    metadata_path = settings.metadata_path
+    storage_options = settings.storage_options
 
     # Fetch new data from S3, using the existing delta table to determine what's new.
     # We are deliberately keeping the code simple for now, but may move the S3 store
@@ -69,7 +70,7 @@ def power_time_series_and_metadata(context: AssetExecutionContext) -> None:
     store = settings.get_nged_s3_store()
     list_of_all_json_files = list_timeseries_json_files(store)
     list_of_large_json_files = remove_small_files_from_listing(list_of_all_json_files)
-    list_of_new_json_files = select_new_rows(list_of_large_json_files, delta_path)
+    list_of_new_json_files = select_new_rows(list_of_large_json_files, delta_path, storage_options)
 
     # Log statistics to be shown in Dagster's UI.
     context.add_output_metadata(
@@ -92,16 +93,18 @@ def power_time_series_and_metadata(context: AssetExecutionContext) -> None:
         return
 
     # Save TimeSeriesMetadata:
-    upsert_metadata_stats = upsert_metadata(new_metadata, metadata_path)
+    upsert_metadata_stats = upsert_metadata(new_metadata, metadata_path, storage_options)
     context.add_output_metadata(upsert_metadata_stats)
 
     # Save PowerTimeSeries:
-    new_power_ts_deduped = select_new_rows(new_power_ts, delta_path)
+    new_power_ts_deduped = select_new_rows(new_power_ts, delta_path, storage_options)
     if not new_power_ts_deduped.is_empty():
-        # FIXME: mkdir won't work when delta_path is on S3!
-        delta_path.parent.mkdir(parents=True, exist_ok=True)
+        ensure_local_parent(delta_path)
         new_power_ts_deduped.write_delta(
-            delta_path, mode="append", delta_write_options={"partition_by": "time_series_id"}
+            delta_path,
+            mode="append",
+            storage_options=storage_options,
+            delta_write_options={"partition_by": "time_series_id"},
         )
 
     # Log statistics to be shown in Dagster's UI.
@@ -131,16 +134,15 @@ def h3_grid_weights(context: AssetExecutionContext) -> None:
     )
 
     # Save to parquet
-    h3_grid_weights_path = Path(settings.h3_grid_weights_path)
-    # FIXME: mkdir won't work when we're saving to S3!
-    h3_grid_weights_path.parent.mkdir(parents=True, exist_ok=True)
-    weights.write_parquet(h3_grid_weights_path)
+    h3_grid_weights_path = settings.h3_grid_weights_path
+    ensure_local_parent(h3_grid_weights_path)
+    weights.write_parquet(h3_grid_weights_path, storage_options=settings.storage_options)
 
     # Add metadata to Dagster context
     context.add_output_metadata(
         {
             "n_rows": len(weights),
-            "path": str(h3_grid_weights_path),
+            "path": h3_grid_weights_path,
         }
     )
 
@@ -179,13 +181,14 @@ def ecmwf_ens(context: AssetExecutionContext) -> None:
     ``delta_store.nwp.write_nwp`` (Float32, significand-rounded).
     """
     settings = Settings()
+    storage_options = settings.storage_options
     partition_date_str = context.partition_key
     nwp_init_time = datetime.strptime(partition_date_str, "%Y-%m-%d").replace(tzinfo=timezone.utc)
 
     # Load dependencies
-    h3_grid = pt.DataFrame(pl.read_parquet(Path(settings.h3_grid_weights_path))).set_model(
-        H3GridWeights
-    )
+    h3_grid = pt.DataFrame(
+        pl.read_parquet(settings.h3_grid_weights_path, storage_options=storage_options)
+    ).set_model(H3GridWeights)
 
     # Download and convert
     try:
@@ -202,15 +205,15 @@ def ecmwf_ens(context: AssetExecutionContext) -> None:
     nwp = convert_nwp_xarray_dataset_to_polars_dataframe(ds=ds, h3_grid=h3_grid)
     context.log.info(f"Converted NWP data to Polars. Columns: {nwp.columns}")
 
-    nwp_data_path = Path(settings.nwp_data_path)
-    nwp_data_path.parent.mkdir(parents=True, exist_ok=True)
-    write_nwp(nwp, nwp_data_path)
+    nwp_data_path = settings.nwp_data_path
+    ensure_local_parent(nwp_data_path)
+    write_nwp(nwp, nwp_data_path, storage_options)
     context.log.info(f"Saved NWP data to Delta table at {nwp_data_path}.")
 
     context.add_output_metadata(
         {
             "n_rows": len(nwp),
-            "path": str(nwp_data_path),
+            "path": nwp_data_path,
             "init_time": str(nwp_init_time),
         }
     )

--- a/src/nged_substation_forecast/defs/assets.py
+++ b/src/nged_substation_forecast/defs/assets.py
@@ -5,7 +5,7 @@ from typing import Any, Final, Generic, Self, TypeVar
 
 import patito as pt
 import polars as pl
-from contracts._uri import ensure_local_parent
+from contracts._uri import if_local_path_then_make_parent_dir
 from contracts.geo_schemas import H3GridWeights
 from contracts.power_schemas import PowerTimeSeries
 from contracts.settings import Settings
@@ -100,7 +100,7 @@ def power_time_series_and_metadata(context: AssetExecutionContext) -> None:
     # Save PowerTimeSeries:
     new_power_ts_deduped = select_new_rows(new_power_ts, delta_path, storage_options)
     if not new_power_ts_deduped.is_empty():
-        ensure_local_parent(delta_path)
+        if_local_path_then_make_parent_dir(delta_path)
         new_power_ts_deduped.write_delta(
             delta_path,
             mode="append",
@@ -136,7 +136,7 @@ def h3_grid_weights(context: AssetExecutionContext) -> None:
 
     # Save to parquet
     h3_grid_weights_path = settings.h3_grid_weights_path
-    ensure_local_parent(h3_grid_weights_path)
+    if_local_path_then_make_parent_dir(h3_grid_weights_path)
     weights.write_parquet(
         h3_grid_weights_path, storage_options=typeddict_to_dict(settings.storage_options)
     )
@@ -211,7 +211,7 @@ def ecmwf_ens(context: AssetExecutionContext) -> None:
     context.log.info(f"Converted NWP data to Polars. Columns: {nwp.columns}")
 
     nwp_data_path = settings.nwp_data_path
-    ensure_local_parent(nwp_data_path)
+    if_local_path_then_make_parent_dir(nwp_data_path)
     write_nwp(nwp, nwp_data_path, storage_options)
     context.log.info(f"Saved NWP data to Delta table at {nwp_data_path}.")
 

--- a/src/nged_substation_forecast/defs/assets.py
+++ b/src/nged_substation_forecast/defs/assets.py
@@ -9,6 +9,7 @@ from contracts._uri import ensure_local_parent
 from contracts.geo_schemas import H3GridWeights
 from contracts.power_schemas import PowerTimeSeries
 from contracts.settings import Settings
+from contracts.typing_utils import typeddict_to_dict
 from dagster import (
     AssetExecutionContext,
     DailyPartitionsDefinition,
@@ -103,7 +104,7 @@ def power_time_series_and_metadata(context: AssetExecutionContext) -> None:
         new_power_ts_deduped.write_delta(
             delta_path,
             mode="append",
-            storage_options=storage_options,
+            storage_options=typeddict_to_dict(storage_options),
             delta_write_options={"partition_by": "time_series_id"},
         )
 
@@ -136,7 +137,9 @@ def h3_grid_weights(context: AssetExecutionContext) -> None:
     # Save to parquet
     h3_grid_weights_path = settings.h3_grid_weights_path
     ensure_local_parent(h3_grid_weights_path)
-    weights.write_parquet(h3_grid_weights_path, storage_options=settings.storage_options)
+    weights.write_parquet(
+        h3_grid_weights_path, storage_options=typeddict_to_dict(settings.storage_options)
+    )
 
     # Add metadata to Dagster context
     context.add_output_metadata(
@@ -187,7 +190,9 @@ def ecmwf_ens(context: AssetExecutionContext) -> None:
 
     # Load dependencies
     h3_grid = pt.DataFrame(
-        pl.read_parquet(settings.h3_grid_weights_path, storage_options=storage_options)
+        pl.read_parquet(
+            settings.h3_grid_weights_path, storage_options=typeddict_to_dict(storage_options)
+        )
     ).set_model(H3GridWeights)
 
     # Download and convert

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -12,7 +12,7 @@ from typing import Final
 import mlflow
 import patito as pt
 import polars as pl
-from contracts._uri import delta_table_exists, ensure_local_parent
+from contracts._uri import ObjectStoreOptions, delta_table_exists, ensure_local_parent
 from contracts.hydra_schemas import load_cv_config
 from contracts.ml_schemas import EligibleTimeSeries, EvalScopeType, Metrics
 from contracts.power_schemas import (
@@ -22,6 +22,7 @@ from contracts.power_schemas import (
     TimeSeriesMetadata,
 )
 from contracts.settings import Settings
+from contracts.typing_utils import typeddict_to_dict
 from contracts.weather_schemas import Nwp
 from dagster import (
     AssetExecutionContext,
@@ -112,7 +113,9 @@ def eligible_time_series(context: AssetExecutionContext) -> None:
     fold = _cv_config.get_fold(fold_id)
 
     coverage = (
-        pl.scan_delta(settings.power_time_series_data_path, storage_options=storage_options)
+        pl.scan_delta(
+            settings.power_time_series_data_path, storage_options=typeddict_to_dict(storage_options)
+        )
         .group_by("time_series_id")
         .agg(
             first_time=pl.col("time").min(),
@@ -140,7 +143,7 @@ def eligible_time_series(context: AssetExecutionContext) -> None:
         mode="overwrite",
         predicate=f"fold_id = '{fold_id}'",
         partition_by=["fold_id"],
-        storage_options=storage_options,
+        storage_options=typeddict_to_dict(storage_options),
     )
 
     context.add_output_metadata(
@@ -213,7 +216,9 @@ def effective_capacity(context: AssetExecutionContext) -> None:
     settings = Settings()
     storage_options = settings.storage_options
     power_lf = pt.LazyFrame.from_existing(
-        pl.scan_delta(settings.power_time_series_data_path, storage_options=storage_options)
+        pl.scan_delta(
+            settings.power_time_series_data_path, storage_options=typeddict_to_dict(storage_options)
+        )
     ).set_model(PowerTimeSeries)
     capacity_df = _compute_effective_capacity(power_lf)
 
@@ -222,7 +227,7 @@ def effective_capacity(context: AssetExecutionContext) -> None:
         table_or_uri=settings.effective_capacity_data_path,
         data=capacity_df.to_arrow(),
         mode="overwrite",
-        storage_options=storage_options,
+        storage_options=typeddict_to_dict(storage_options),
     )
 
     context.add_output_metadata(
@@ -296,7 +301,7 @@ def _load_engineering_inputs(
         init_time_end = window_end
     storage_options = settings.storage_options
     power_lf = pl.scan_delta(
-        settings.power_time_series_data_path, storage_options=storage_options
+        settings.power_time_series_data_path, storage_options=typeddict_to_dict(storage_options)
     ).filter(
         pl.col("time_series_id").is_in(time_series_ids),
         pl.col("time") >= window_start,
@@ -305,9 +310,9 @@ def _load_engineering_inputs(
     power_ts = pt.LazyFrame.from_existing(power_lf).set_model(PowerTimeSeries)
 
     metadata_df = pt.DataFrame(
-        pl.read_parquet(settings.metadata_path, storage_options=storage_options).filter(
-            pl.col("time_series_id").is_in(time_series_ids)
-        )
+        pl.read_parquet(
+            settings.metadata_path, storage_options=typeddict_to_dict(storage_options)
+        ).filter(pl.col("time_series_id").is_in(time_series_ids))
     ).set_model(TimeSeriesMetadata)
 
     # The H3 cells the requested series sit in (many series may share one cell).
@@ -359,7 +364,8 @@ def trained_cv_model(context: AssetExecutionContext) -> None:
 
     eligible_ids = (
         pl.scan_delta(
-            settings.eligible_time_series_data_path, storage_options=settings.storage_options
+            settings.eligible_time_series_data_path,
+            storage_options=typeddict_to_dict(settings.storage_options),
         )
         .filter(pl.col("fold_id") == fold_id)
         .select("time_series_id")
@@ -662,7 +668,7 @@ def _write_metrics_to_delta(
     enriched: pt.DataFrame[Metrics],
     exp_name: str,
     fold_id: str,
-    storage_options: dict[str, str] | None = None,
+    storage_options: ObjectStoreOptions | None = None,
 ) -> None:
     """Write enriched Metrics rows to the ``forecast_metrics`` Delta table.
 
@@ -689,7 +695,7 @@ def _write_metrics_to_delta(
         mode="overwrite",
         predicate=f"experiment_name = '{exp_name}' AND fold_id = '{fold_id}'",
         partition_by=["experiment_name", "fold_id"],
-        storage_options=storage_options,
+        storage_options=typeddict_to_dict(storage_options),
     )
 
 
@@ -729,7 +735,7 @@ def _score_forecast_group(
     evaluation_scope: EvalScopeType,
     metrics_path: str,
     now: datetime,
-    storage_options: dict[str, str] | None = None,
+    storage_options: ObjectStoreOptions | None = None,
 ) -> tuple[int, dict[str, float] | None]:
     """Score one ``(experiment_name, fold_id)`` group, write ``Metrics`` to Delta, and
     optionally log to MLflow.
@@ -819,7 +825,9 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     # columns are String in PowerForecast, matching how delta-rs stores them, so no dtype cast
     # sits between scan_delta and the filter to defeat pushdown. See PopulationFilter.apply.
     scan = pt.LazyFrame.from_existing(
-        pl.scan_delta(settings.power_forecasts_data_path, storage_options=storage_options)
+        pl.scan_delta(
+            settings.power_forecasts_data_path, storage_options=typeddict_to_dict(storage_options)
+        )
     ).set_model(PowerForecast)
     pruned_scan = config.population_filter.apply(scan)
 
@@ -839,11 +847,13 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
         return
 
     actuals_lf = pt.LazyFrame.from_existing(
-        pl.scan_delta(settings.power_time_series_data_path, storage_options=storage_options)
+        pl.scan_delta(
+            settings.power_time_series_data_path, storage_options=typeddict_to_dict(storage_options)
+        )
     ).set_model(PowerTimeSeries)
     # allow_superfluous_columns because the parquet also carries h3_res_5 and other geo columns.
     metadata_df = TimeSeriesMetadata.validate(
-        pl.read_parquet(settings.metadata_path, storage_options=storage_options),
+        pl.read_parquet(settings.metadata_path, storage_options=typeddict_to_dict(storage_options)),
         allow_superfluous_columns=True,
     )
 
@@ -854,7 +864,10 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
             "materialise the effective_capacity asset before running metrics."
         )
     capacity_df = EffectiveCapacity.validate(
-        pl.read_delta(settings.effective_capacity_data_path, storage_options=storage_options)
+        pl.read_delta(
+            settings.effective_capacity_data_path,
+            storage_options=typeddict_to_dict(storage_options),
+        )
     )
 
     ensure_local_parent(settings.forecast_metrics_data_path)

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -12,6 +12,7 @@ from typing import Final
 import mlflow
 import patito as pt
 import polars as pl
+from contracts._uri import delta_table_exists, ensure_local_parent
 from contracts.hydra_schemas import load_cv_config
 from contracts.ml_schemas import EligibleTimeSeries, EvalScopeType, Metrics
 from contracts.power_schemas import (
@@ -106,11 +107,12 @@ def eligible_time_series(context: AssetExecutionContext) -> None:
     rows rather than duplicating them.
     """
     settings = Settings()
+    storage_options = settings.storage_options
     fold_id = context.partition_key
     fold = _cv_config.get_fold(fold_id)
 
     coverage = (
-        pl.scan_delta(settings.power_time_series_data_path)
+        pl.scan_delta(settings.power_time_series_data_path, storage_options=storage_options)
         .group_by("time_series_id")
         .agg(
             first_time=pl.col("time").min(),
@@ -131,13 +133,14 @@ def eligible_time_series(context: AssetExecutionContext) -> None:
         )
     )
 
-    Path(settings.eligible_time_series_data_path).parent.mkdir(parents=True, exist_ok=True)
+    ensure_local_parent(settings.eligible_time_series_data_path)
     write_deltalake(
         table_or_uri=settings.eligible_time_series_data_path,
         data=eligible_df.to_arrow(),
         mode="overwrite",
         predicate=f"fold_id = '{fold_id}'",
         partition_by=["fold_id"],
+        storage_options=storage_options,
     )
 
     context.add_output_metadata(
@@ -208,16 +211,18 @@ def effective_capacity(context: AssetExecutionContext) -> None:
     ``time_series_id`` alone (same doc section).
     """
     settings = Settings()
+    storage_options = settings.storage_options
     power_lf = pt.LazyFrame.from_existing(
-        pl.scan_delta(settings.power_time_series_data_path)
+        pl.scan_delta(settings.power_time_series_data_path, storage_options=storage_options)
     ).set_model(PowerTimeSeries)
     capacity_df = _compute_effective_capacity(power_lf)
 
-    Path(settings.effective_capacity_data_path).parent.mkdir(parents=True, exist_ok=True)
+    ensure_local_parent(settings.effective_capacity_data_path)
     write_deltalake(
         table_or_uri=settings.effective_capacity_data_path,
         data=capacity_df.to_arrow(),
         mode="overwrite",
+        storage_options=storage_options,
     )
 
     context.add_output_metadata(
@@ -289,7 +294,10 @@ def _load_engineering_inputs(
         init_time_start = window_start - _MAX_NWP_LEAD
     if init_time_end is None:
         init_time_end = window_end
-    power_lf = pl.scan_delta(settings.power_time_series_data_path).filter(
+    storage_options = settings.storage_options
+    power_lf = pl.scan_delta(
+        settings.power_time_series_data_path, storage_options=storage_options
+    ).filter(
         pl.col("time_series_id").is_in(time_series_ids),
         pl.col("time") >= window_start,
         pl.col("time") <= window_end,
@@ -297,7 +305,7 @@ def _load_engineering_inputs(
     power_ts = pt.LazyFrame.from_existing(power_lf).set_model(PowerTimeSeries)
 
     metadata_df = pt.DataFrame(
-        pl.read_parquet(settings.metadata_path).filter(
+        pl.read_parquet(settings.metadata_path, storage_options=storage_options).filter(
             pl.col("time_series_id").is_in(time_series_ids)
         )
     ).set_model(TimeSeriesMetadata)
@@ -305,7 +313,7 @@ def _load_engineering_inputs(
     # The H3 cells the requested series sit in (many series may share one cell).
     cells = metadata_df["h3_res_5"].unique().to_list()
 
-    nwp_scan = Nwp.scan_delta(settings.nwp_data_path).filter(
+    nwp_scan = Nwp.scan_delta(settings.nwp_data_path, storage_options=storage_options).filter(
         # init_time is the partition key — this prunes whole partitions, not just row groups.
         pl.col("init_time") >= init_time_start,
         pl.col("init_time") <= init_time_end,
@@ -350,7 +358,9 @@ def trained_cv_model(context: AssetExecutionContext) -> None:
     train_end = date_to_utc_datetime(fold.train_end, end_of_day=True)
 
     eligible_ids = (
-        pl.scan_delta(str(settings.eligible_time_series_data_path))
+        pl.scan_delta(
+            settings.eligible_time_series_data_path, storage_options=settings.storage_options
+        )
         .filter(pl.col("fold_id") == fold_id)
         .select("time_series_id")
         .collect()["time_series_id"]
@@ -468,7 +478,7 @@ def cv_power_forecasts(context: AssetExecutionContext) -> None:
             "nothing to forecast. Re-materialise `trained_cv_model` for this fold."
         )
 
-    Path(settings.power_forecasts_data_path).parent.mkdir(parents=True, exist_ok=True)
+    ensure_local_parent(settings.power_forecasts_data_path)
     n_rows = 0
     time_series_seen: set[int] = set()
     ensemble_members_seen: set[int] = set()
@@ -508,6 +518,7 @@ def cv_power_forecasts(context: AssetExecutionContext) -> None:
             forecasts,
             settings.power_forecasts_data_path,
             replace_partition=(experiment_name, fold_id) if is_first else None,
+            storage_options=settings.storage_options,
         )
         is_first = False
         n_rows += forecasts.height
@@ -647,10 +658,11 @@ def _resolve_eval_window(
 
 
 def _write_metrics_to_delta(
-    path: Path,
+    path: str,
     enriched: pt.DataFrame[Metrics],
     exp_name: str,
     fold_id: str,
+    storage_options: dict[str, str] | None = None,
 ) -> None:
     """Write enriched Metrics rows to the ``forecast_metrics`` Delta table.
 
@@ -661,12 +673,13 @@ def _write_metrics_to_delta(
     so re-materialising the asset replaces rows rather than duplicating them.
 
     Args:
-        path: Filesystem path to the ``forecast_metrics`` Delta table.
+        path: Local path or remote URI of the ``forecast_metrics`` Delta table.
         enriched: Fully populated ``Metrics`` rows, with all provenance columns set by
             ``enrich_metrics_rows()``.
         exp_name: Experiment name; used in the Delta overwrite predicate to scope the
             replacement to this ``(experiment_name, fold_id)`` partition.
         fold_id: Fold identifier; used alongside ``exp_name`` in the predicate.
+        storage_options: Object-store options for a remote ``path``; ``None``/empty for local.
     """
     enum_cols = [c for c, dtype in enriched.schema.items() if isinstance(dtype, pl.Enum)]
     delta_data = enriched.with_columns(pl.col(c).cast(pl.String) for c in enum_cols).to_arrow()
@@ -676,6 +689,7 @@ def _write_metrics_to_delta(
         mode="overwrite",
         predicate=f"experiment_name = '{exp_name}' AND fold_id = '{fold_id}'",
         partition_by=["experiment_name", "fold_id"],
+        storage_options=storage_options,
     )
 
 
@@ -713,8 +727,9 @@ def _score_forecast_group(
     metadata_df: pt.DataFrame[TimeSeriesMetadata],
     capacity_df: pt.DataFrame[EffectiveCapacity],
     evaluation_scope: EvalScopeType,
-    metrics_path: Path,
+    metrics_path: str,
     now: datetime,
+    storage_options: dict[str, str] | None = None,
 ) -> tuple[int, dict[str, float] | None]:
     """Score one ``(experiment_name, fold_id)`` group, write ``Metrics`` to Delta, and
     optionally log to MLflow.
@@ -731,9 +746,11 @@ def _score_forecast_group(
             ``compute_metrics()``; must cover every scored series.
         evaluation_scope: ``"leaderboard"`` logs per-fold metrics to MLflow; ``"ad_hoc"``
             skips MLflow entirely.
-        metrics_path: Filesystem path to the ``forecast_metrics`` Delta table.
+        metrics_path: Local path or remote URI of the ``forecast_metrics`` Delta table.
         now: UTC timestamp stamped on every row as ``computed_at`` (injected so all rows in
             one asset materialisation share the same timestamp).
+        storage_options: Object-store options for a remote ``metrics_path``; ``None``/empty
+            for local.
 
     Returns:
         A ``(n_rows_written, fold_metric_dict)`` tuple where:
@@ -764,7 +781,7 @@ def _score_forecast_group(
         now,
         mlflow_run_id,
     )
-    _write_metrics_to_delta(metrics_path, enriched, exp_name, fold_id)
+    _write_metrics_to_delta(metrics_path, enriched, exp_name, fold_id, storage_options)
 
     if evaluation_scope == "leaderboard":
         fold_metric_dict = build_mlflow_aggregate_metrics(per_series_metrics)
@@ -794,6 +811,7 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
             no filter and ``"leaderboard"`` scope.
     """
     settings = Settings()
+    storage_options = settings.storage_options
     mlflow.set_tracking_uri(settings.mlflow_tracking_uri)
 
     # Apply the population filter to the scan so its predicates push into the Delta scan
@@ -801,7 +819,7 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     # columns are String in PowerForecast, matching how delta-rs stores them, so no dtype cast
     # sits between scan_delta and the filter to defeat pushdown. See PopulationFilter.apply.
     scan = pt.LazyFrame.from_existing(
-        pl.scan_delta(str(settings.power_forecasts_data_path))
+        pl.scan_delta(settings.power_forecasts_data_path, storage_options=storage_options)
     ).set_model(PowerForecast)
     pruned_scan = config.population_filter.apply(scan)
 
@@ -821,25 +839,25 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
         return
 
     actuals_lf = pt.LazyFrame.from_existing(
-        pl.scan_delta(settings.power_time_series_data_path)
+        pl.scan_delta(settings.power_time_series_data_path, storage_options=storage_options)
     ).set_model(PowerTimeSeries)
     # allow_superfluous_columns because the parquet also carries h3_res_5 and other geo columns.
     metadata_df = TimeSeriesMetadata.validate(
-        pl.read_parquet(settings.metadata_path),
+        pl.read_parquet(settings.metadata_path, storage_options=storage_options),
         allow_superfluous_columns=True,
     )
 
     # The full-history effective capacity is the NMAE denominator (a declared dep of this asset).
-    if not Path(settings.effective_capacity_data_path).exists():
+    if not delta_table_exists(settings.effective_capacity_data_path, storage_options):
         raise FileNotFoundError(
             f"effective_capacity Delta not found at {settings.effective_capacity_data_path}; "
             "materialise the effective_capacity asset before running metrics."
         )
     capacity_df = EffectiveCapacity.validate(
-        pl.read_delta(str(settings.effective_capacity_data_path))
+        pl.read_delta(settings.effective_capacity_data_path, storage_options=storage_options)
     )
 
-    Path(settings.forecast_metrics_data_path).parent.mkdir(parents=True, exist_ok=True)
+    ensure_local_parent(settings.forecast_metrics_data_path)
     now = datetime.now(timezone.utc)
     total_rows = 0
     # Accumulates per-fold metric values for parent-run aggregation (leaderboard scope only).
@@ -858,8 +876,9 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
             metadata_df,
             capacity_df,
             config.evaluation_scope,
-            Path(settings.forecast_metrics_data_path),
+            settings.forecast_metrics_data_path,
             now,
+            storage_options,
         )
         total_rows += n_rows
         if fold_metric_dict is not None:

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -12,7 +12,11 @@ from typing import Final
 import mlflow
 import patito as pt
 import polars as pl
-from contracts._uri import ObjectStoreOptions, delta_table_exists, ensure_local_parent
+from contracts._uri import (
+    ObjectStoreOptions,
+    delta_table_exists,
+    if_local_path_then_make_parent_dir,
+)
 from contracts.hydra_schemas import load_cv_config
 from contracts.ml_schemas import EligibleTimeSeries, EvalScopeType, Metrics
 from contracts.power_schemas import (
@@ -136,7 +140,7 @@ def eligible_time_series(context: AssetExecutionContext) -> None:
         )
     )
 
-    ensure_local_parent(settings.eligible_time_series_data_path)
+    if_local_path_then_make_parent_dir(settings.eligible_time_series_data_path)
     write_deltalake(
         table_or_uri=settings.eligible_time_series_data_path,
         data=eligible_df.to_arrow(),
@@ -222,7 +226,7 @@ def effective_capacity(context: AssetExecutionContext) -> None:
     ).set_model(PowerTimeSeries)
     capacity_df = _compute_effective_capacity(power_lf)
 
-    ensure_local_parent(settings.effective_capacity_data_path)
+    if_local_path_then_make_parent_dir(settings.effective_capacity_data_path)
     write_deltalake(
         table_or_uri=settings.effective_capacity_data_path,
         data=capacity_df.to_arrow(),
@@ -484,7 +488,7 @@ def cv_power_forecasts(context: AssetExecutionContext) -> None:
             "nothing to forecast. Re-materialise `trained_cv_model` for this fold."
         )
 
-    ensure_local_parent(settings.power_forecasts_data_path)
+    if_local_path_then_make_parent_dir(settings.power_forecasts_data_path)
     n_rows = 0
     time_series_seen: set[int] = set()
     ensemble_members_seen: set[int] = set()
@@ -870,7 +874,7 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
         )
     )
 
-    ensure_local_parent(settings.forecast_metrics_data_path)
+    if_local_path_then_make_parent_dir(settings.forecast_metrics_data_path)
     now = datetime.now(timezone.utc)
     total_rows = 0
     # Accumulates per-fold metric values for parent-run aggregation (leaderboard scope only).

--- a/src/nged_substation_forecast/defs/plot_jobs.py
+++ b/src/nged_substation_forecast/defs/plot_jobs.py
@@ -14,6 +14,7 @@ from typing import Final
 
 import polars as pl
 from contracts.settings import Settings
+from contracts.typing_utils import typeddict_to_dict
 from dagster import Config, MetadataValue, OpExecutionContext, job, op
 from plotting.forecast_chart import build_forecast_chart
 from pydantic import Field
@@ -70,7 +71,9 @@ def plot_power_forecast(context: OpExecutionContext, config: PlotPowerForecastCo
     window_end = init_time + FORECAST_HORIZON
 
     forecasts = (
-        pl.scan_delta(settings.power_forecasts_data_path, storage_options=storage_options)
+        pl.scan_delta(
+            settings.power_forecasts_data_path, storage_options=typeddict_to_dict(storage_options)
+        )
         .filter(
             pl.col("experiment_name") == config.experiment_name,
             pl.col("fold_id") == config.fold_id,
@@ -89,7 +92,9 @@ def plot_power_forecast(context: OpExecutionContext, config: PlotPowerForecastCo
         )
 
     ground_truth = (
-        pl.scan_delta(settings.power_time_series_data_path, storage_options=storage_options)
+        pl.scan_delta(
+            settings.power_time_series_data_path, storage_options=typeddict_to_dict(storage_options)
+        )
         .filter(
             pl.col("time_series_id").is_in(config.time_series_ids),
             pl.col("time") >= init_time,
@@ -97,9 +102,9 @@ def plot_power_forecast(context: OpExecutionContext, config: PlotPowerForecastCo
         )
         .collect()
     )
-    metadata = pl.read_parquet(settings.metadata_path, storage_options=storage_options).filter(
-        pl.col("time_series_id").is_in(config.time_series_ids)
-    )
+    metadata = pl.read_parquet(
+        settings.metadata_path, storage_options=typeddict_to_dict(storage_options)
+    ).filter(pl.col("time_series_id").is_in(config.time_series_ids))
 
     chart = build_forecast_chart(forecasts, ground_truth, metadata, config.time_series_ids)
 

--- a/src/nged_substation_forecast/defs/plot_jobs.py
+++ b/src/nged_substation_forecast/defs/plot_jobs.py
@@ -63,13 +63,14 @@ def plot_power_forecast(context: OpExecutionContext, config: PlotPowerForecastCo
     directly, so it plots whatever forecasts already exist on disk.
     """
     settings = Settings()
+    storage_options = settings.storage_options
     init_time = datetime.fromisoformat(config.power_fcst_init_time)
     if init_time.tzinfo is None:
         init_time = init_time.replace(tzinfo=UTC)
     window_end = init_time + FORECAST_HORIZON
 
     forecasts = (
-        pl.scan_delta(str(settings.power_forecasts_data_path))
+        pl.scan_delta(settings.power_forecasts_data_path, storage_options=storage_options)
         .filter(
             pl.col("experiment_name") == config.experiment_name,
             pl.col("fold_id") == config.fold_id,
@@ -88,7 +89,7 @@ def plot_power_forecast(context: OpExecutionContext, config: PlotPowerForecastCo
         )
 
     ground_truth = (
-        pl.scan_delta(settings.power_time_series_data_path)
+        pl.scan_delta(settings.power_time_series_data_path, storage_options=storage_options)
         .filter(
             pl.col("time_series_id").is_in(config.time_series_ids),
             pl.col("time") >= init_time,
@@ -96,7 +97,7 @@ def plot_power_forecast(context: OpExecutionContext, config: PlotPowerForecastCo
         )
         .collect()
     )
-    metadata = pl.read_parquet(settings.metadata_path).filter(
+    metadata = pl.read_parquet(settings.metadata_path, storage_options=storage_options).filter(
         pl.col("time_series_id").is_in(config.time_series_ids)
     )
 

--- a/src/nged_substation_forecast/defs/production_assets.py
+++ b/src/nged_substation_forecast/defs/production_assets.py
@@ -14,6 +14,7 @@ from typing import Final
 import mlflow
 import patito as pt
 import polars as pl
+from contracts._uri import ensure_local_parent
 from contracts.ml_schemas import AllFeatures
 from contracts.settings import Settings
 from dagster import (
@@ -148,7 +149,7 @@ def _available_nwp_init_times(settings: Settings) -> list[datetime]:
     the ``init_time`` partition values — naive ``"YYYY-MM-DD HH:MM:SS.ffffff"`` strings on disk —
     into tz-aware UTC datetimes.
     """
-    delta_table = DeltaTable(str(settings.nwp_data_path))
+    delta_table = DeltaTable(settings.nwp_data_path, storage_options=settings.storage_options)
     raw_values = {partition["init_time"] for partition in delta_table.partitions()}
     return [
         datetime.strptime(value, "%Y-%m-%d %H:%M:%S.%f").replace(tzinfo=timezone.utc)
@@ -274,12 +275,13 @@ def live_forecasts(context: AssetExecutionContext, config: LiveForecastsConfig) 
             "NWP coverage and the model's trained population."
         )
 
-    Path(settings.power_forecasts_data_path).parent.mkdir(parents=True, exist_ok=True)
+    ensure_local_parent(settings.power_forecasts_data_path)
     write_power_forecasts(
         forecasts,
         settings.power_forecasts_data_path,
         replace_partition=(forecaster.model_params.experiment_name, "live"),
         replace_predicate_extra=f"power_fcst_init_time = '{power_fcst_init_time.isoformat()}'",
+        storage_options=settings.storage_options,
     )
 
     context.add_output_metadata(

--- a/src/nged_substation_forecast/defs/production_assets.py
+++ b/src/nged_substation_forecast/defs/production_assets.py
@@ -17,6 +17,7 @@ import polars as pl
 from contracts._uri import ensure_local_parent
 from contracts.ml_schemas import AllFeatures
 from contracts.settings import Settings
+from contracts.typing_utils import typeddict_to_dict
 from dagster import (
     AssetDep,
     AssetExecutionContext,
@@ -149,7 +150,9 @@ def _available_nwp_init_times(settings: Settings) -> list[datetime]:
     the ``init_time`` partition values — naive ``"YYYY-MM-DD HH:MM:SS.ffffff"`` strings on disk —
     into tz-aware UTC datetimes.
     """
-    delta_table = DeltaTable(settings.nwp_data_path, storage_options=settings.storage_options)
+    delta_table = DeltaTable(
+        settings.nwp_data_path, storage_options=typeddict_to_dict(settings.storage_options)
+    )
     raw_values = {partition["init_time"] for partition in delta_table.partitions()}
     return [
         datetime.strptime(value, "%Y-%m-%d %H:%M:%S.%f").replace(tzinfo=timezone.utc)

--- a/src/nged_substation_forecast/defs/production_assets.py
+++ b/src/nged_substation_forecast/defs/production_assets.py
@@ -14,7 +14,7 @@ from typing import Final
 import mlflow
 import patito as pt
 import polars as pl
-from contracts._uri import ensure_local_parent
+from contracts._uri import if_local_path_then_make_parent_dir
 from contracts.ml_schemas import AllFeatures
 from contracts.settings import Settings
 from contracts.typing_utils import typeddict_to_dict
@@ -278,7 +278,7 @@ def live_forecasts(context: AssetExecutionContext, config: LiveForecastsConfig) 
             "NWP coverage and the model's trained population."
         )
 
-    ensure_local_parent(settings.power_forecasts_data_path)
+    if_local_path_then_make_parent_dir(settings.power_forecasts_data_path)
     write_power_forecasts(
         forecasts,
         settings.power_forecasts_data_path,

--- a/tests/test_s3_data_paths.py
+++ b/tests/test_s3_data_paths.py
@@ -30,6 +30,7 @@ import patito as pt
 import polars as pl
 import pytest
 from contracts._uri import object_exists
+from contracts.typing_utils import typeddict_to_dict
 from contracts.power_schemas import PowerForecast, TimeSeriesMetadata
 from contracts.settings import Settings
 from contracts.weather_schemas import Nwp
@@ -186,14 +187,14 @@ def test_power_forecasts_round_trip_and_pruning_over_s3(s3_endpoint: str) -> Non
         storage_options=opts,
     )
 
-    both = pl.read_delta(uri, storage_options=opts)
+    both = pl.read_delta(uri, storage_options=typeddict_to_dict(opts))
     assert set(both["experiment_name"].unique()) == {"expA", "expB"}
     assert both.height == 8
 
     # Partition pruning must survive over S3: the explain plan lists only expA's path.
-    scan = pt.LazyFrame.from_existing(pl.scan_delta(uri, storage_options=opts)).set_model(
-        PowerForecast
-    )
+    scan = pt.LazyFrame.from_existing(
+        pl.scan_delta(uri, storage_options=typeddict_to_dict(opts))
+    ).set_model(PowerForecast)
     plan = PopulationFilter(experiment_name="expA").apply(scan).explain()
     assert "experiment_name=expA" in plan
     assert "experiment_name=expB" not in plan
@@ -225,7 +226,7 @@ def test_metadata_parquet_round_trip_over_s3(s3_endpoint: str) -> None:
     assert stats["metadata_n_new_TimeSeriesIDs"] == 3
 
     assert object_exists(uri, opts)
-    back = pl.read_parquet(uri, storage_options=opts)
+    back = pl.read_parquet(uri, storage_options=typeddict_to_dict(opts))
     assert back.height == 3
 
     # A second upsert of identical rows is a no-op (exercises the read-existing S3 path).

--- a/tests/test_s3_data_paths.py
+++ b/tests/test_s3_data_paths.py
@@ -1,0 +1,233 @@
+"""S3 integration tests for the managed data tables (issue #121).
+
+Exercises the data-table IO layer against a real S3 endpoint — an in-process ``moto`` server, so
+no Docker or network — driven entirely through ``Settings`` pointed at an ``s3://`` ``data_path``.
+Proves the two things the S3 migration must guarantee and that the local test suite cannot:
+
+1. Delta and parquet tables round-trip over ``s3://`` through the production write/read helpers
+   (``write_power_forecasts`` / ``write_nwp`` / ``Nwp.scan_delta`` / ``upsert_metadata``) using
+   only ``Settings.storage_options``.
+2. **Partition pruning survives over S3** — the ``.explain()`` plan for a filter on the
+   ``experiment_name`` partition column lists only the matching partition's path. The whole
+   memory-bounding design (single fold in RAM) depends on this holding on the object store too.
+
+The coverage here goes through the functional ``write_deltalake`` + polars
+``scan_delta``/``read_delta`` + obstore paths that production uses for the hot IO. It deliberately
+does **not** drive the ``deltalake.DeltaTable`` *class* client (``delta_table_exists`` /
+``DeltaTable(...).partitions()``): that client's connection handling hangs against moto's in-process
+dev server (an emulator limitation — it is the standard API and works on real S3/MinIO), so
+exercising it here would only add a 3-minute stall, not real signal.
+
+Marked ``integration``; skipped automatically if ``moto`` is not installed.
+"""
+
+import socket
+import urllib.request
+from collections.abc import Iterator
+from datetime import datetime, timedelta, timezone
+
+import patito as pt
+import polars as pl
+import pytest
+from contracts._uri import object_exists
+from contracts.power_schemas import PowerForecast, TimeSeriesMetadata
+from contracts.settings import Settings
+from contracts.weather_schemas import Nwp
+from delta_store.nwp import write_nwp
+from delta_store.power_forecasts import write_power_forecasts
+from nged_data.storage import upsert_metadata
+
+from nged_substation_forecast.defs.cv_assets import PopulationFilter
+
+pytestmark = pytest.mark.integration
+
+ThreadedMotoServer = pytest.importorskip("moto.server").ThreadedMotoServer
+
+_T0 = datetime(2025, 7, 1, tzinfo=timezone.utc)
+_BUCKET = "nged-test-bucket"
+
+_CONTINUOUS_BASE_VALUES = {
+    "temperature_2m": 15.7031,
+    "dew_point_temperature_2m": 9.1234,
+    "wind_speed_10m": 5.6789,
+    "wind_direction_10m": 123.456,
+    "wind_speed_100m": 8.9101,
+    "wind_direction_100m": 234.567,
+    "pressure_surface": 101_234.5,
+    "pressure_reduced_to_mean_sea_level": 101_567.8,
+    "geopotential_height_500hpa": 5_432.1,
+    "downward_long_wave_radiation_flux_surface": 312.34,
+    "downward_short_wave_radiation_flux_surface": 456.78,
+    "precipitation_surface": 0.00123,
+}
+
+
+def _free_port() -> int:
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+@pytest.fixture(scope="module")
+def s3_endpoint() -> Iterator[str]:
+    """Start an in-process moto S3 server and create the test bucket (no boto3, no Docker)."""
+    port = _free_port()
+    server = ThreadedMotoServer(port=port)
+    server.start()
+    endpoint = f"http://127.0.0.1:{port}"
+    # Create the bucket with a bare HTTP PUT — object_store never creates buckets itself.
+    urllib.request.urlopen(urllib.request.Request(f"{endpoint}/{_BUCKET}", method="PUT")).close()
+    try:
+        yield endpoint
+    finally:
+        server.stop()
+
+
+def _s3_settings(endpoint: str, prefix: str) -> Settings:
+    """A ``Settings`` whose data tables live under ``s3://{_BUCKET}/{prefix}`` on the moto server.
+
+    Only ``data_path`` and the ``data_store_*`` credentials are set; every ``*_data_path`` derives
+    from ``data_path`` through the normal validator, so the test drives the real derivation +
+    ``storage_options`` chain rather than hand-built URIs.
+    """
+    return Settings(
+        data_path=f"s3://{_BUCKET}/{prefix}",
+        data_store_endpoint_url=endpoint,
+        data_store_access_key_id="test",
+        data_store_secret_access_key="test",
+        data_store_region="us-east-1",
+        nged_s3_bucket_url="https://example.com",
+        nged_s3_bucket_access_key="key",
+        nged_s3_bucket_secret="secret",
+    )
+
+
+def _make_forecasts(experiment_name: str, power_fcst: list[float]) -> pt.DataFrame[PowerForecast]:
+    n = len(power_fcst)
+    return (
+        PowerForecast.DataFrame(
+            {
+                "valid_time": [_T0 + timedelta(hours=i) for i in range(n)],
+                "time_series_id": list(range(1, n + 1)),
+                "ensemble_member": [i % 3 for i in range(n)],
+                "ml_flow_experiment_id": [None] * n,
+                "nwp_init_time": [_T0] * n,
+                "power_fcst_model_name": ["xgboost"] * n,
+                "experiment_name": [experiment_name] * n,
+                "power_fcst_model_version": [1] * n,
+                "power_fcst_init_time": [_T0] * n,
+                "power_fcst": power_fcst,
+                "fold_id": ["s3_test"] * n,
+            }
+        )
+        .cast()
+        .validate()
+    )
+
+
+def _make_nwp(n: int = 6) -> pt.DataFrame[Nwp]:
+    return (
+        Nwp.DataFrame(
+            {
+                "nwp_model_id": ["ECMWF_ENS_0_25_degree"] * n,
+                "init_time": [_T0] * n,
+                "valid_time": [_T0 + timedelta(hours=(i % 3) + 1) for i in range(n)],
+                "ensemble_member": list(range(n - 1, -1, -1)),
+                "h3_index": [100 + i for i in range(n)],
+                "categorical_precipitation_type_surface": [1] * n,
+                **{
+                    var: [base * (1 + 0.003 * i) for i in range(n)]
+                    for var, base in _CONTINUOUS_BASE_VALUES.items()
+                },
+            }
+        )
+        .cast()
+        .validate()
+    )
+
+
+def _make_metadata() -> pt.DataFrame[TimeSeriesMetadata]:
+    rows = [
+        {
+            "time_series_id": ts_id,
+            "time_series_name": f"Test Substation {ts_id}",
+            "time_series_type": "Disaggregated Demand",
+            "units": "MW",
+            "licence_area": "EMids",
+            "substation_number": ts_id,
+            "substation_type": "Primary",
+            "latitude": 52.0,
+            "longitude": -1.0,
+            "h3_res_5": 599423199024775167,
+        }
+        for ts_id in (1, 2, 3)
+    ]
+    return pt.DataFrame(rows).set_model(TimeSeriesMetadata).cast().validate()
+
+
+def test_power_forecasts_round_trip_and_pruning_over_s3(s3_endpoint: str) -> None:
+    """``write_power_forecasts`` writes to S3 and the filtered scan prunes partitions over S3."""
+    settings = _s3_settings(s3_endpoint, "forecasts")
+    uri = settings.power_forecasts_data_path
+    opts = settings.storage_options
+    assert uri.startswith("s3://")
+
+    # Two experiments = two on-disk partitions.
+    write_power_forecasts(
+        _make_forecasts("expA", [1.0, 2.0, 3.0, 4.0]),
+        uri,
+        replace_partition=("expA", "s3_test"),
+        storage_options=opts,
+    )
+    write_power_forecasts(
+        _make_forecasts("expB", [5.0, 6.0, 7.0, 8.0]),
+        uri,
+        replace_partition=("expB", "s3_test"),
+        storage_options=opts,
+    )
+
+    both = pl.read_delta(uri, storage_options=opts)
+    assert set(both["experiment_name"].unique()) == {"expA", "expB"}
+    assert both.height == 8
+
+    # Partition pruning must survive over S3: the explain plan lists only expA's path.
+    scan = pt.LazyFrame.from_existing(pl.scan_delta(uri, storage_options=opts)).set_model(
+        PowerForecast
+    )
+    plan = PopulationFilter(experiment_name="expA").apply(scan).explain()
+    assert "experiment_name=expA" in plan
+    assert "experiment_name=expB" not in plan
+
+
+def test_nwp_round_trip_over_s3(s3_endpoint: str) -> None:
+    """``write_nwp`` writes to S3 and ``Nwp.scan_delta`` reads it back with the same storage opts."""
+    settings = _s3_settings(s3_endpoint, "nwp")
+    uri = settings.nwp_data_path
+    opts = settings.storage_options
+
+    write_nwp(_make_nwp(), uri, opts)
+
+    back = Nwp.scan_delta(uri, storage_options=opts).collect()
+    assert back.height == 6
+    assert set(back["ensemble_member"]) == set(range(6))
+
+
+def test_metadata_parquet_round_trip_over_s3(s3_endpoint: str) -> None:
+    """``upsert_metadata`` creates then reads a parquet file on S3 (object_exists + parquet IO)."""
+    settings = _s3_settings(s3_endpoint, "meta")
+    uri = settings.metadata_path
+    opts = settings.storage_options
+
+    assert not object_exists(uri, opts)
+
+    metadata = _make_metadata()
+    stats = upsert_metadata(metadata, uri, opts)
+    assert stats["metadata_n_new_TimeSeriesIDs"] == 3
+
+    assert object_exists(uri, opts)
+    back = pl.read_parquet(uri, storage_options=opts)
+    assert back.height == 3
+
+    # A second upsert of identical rows is a no-op (exercises the read-existing S3 path).
+    stats2 = upsert_metadata(metadata, uri, opts)
+    assert stats2["metadata_n_new_TimeSeriesIDs"] == 0

--- a/uv.lock
+++ b/uv.lock
@@ -334,6 +334,34 @@ wheels = [
 ]
 
 [[package]]
+name = "aws-sam-translator"
+version = "1.111.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "jsonschema" },
+    { name = "pydantic" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/31/4e6d6f0b9d4ead8eaa1c13a14d86834e7691acf5726fb49de98f8e195028/aws_sam_translator-1.111.0.tar.gz", hash = "sha256:6884d94e28dc20384e5e0396e9386a456fe59303d706924deb2646329b4d97d3", size = 374368, upload-time = "2026-07-02T00:31:39.601Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/e3/505c9db9c4a4270ad12bac621f370cb02eabb224886c1b81960c658d9baa/aws_sam_translator-1.111.0-py3-none-any.whl", hash = "sha256:510d0ad8cd40b245a62004f2dc974ddbb6ff0d496bdec0bc7d9cd209b46d5fad", size = 440579, upload-time = "2026-07-02T00:31:38.077Z" },
+]
+
+[[package]]
+name = "aws-xray-sdk"
+version = "2.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/14/25/0cbd7a440080def5e6f063720c3b190a25f8aa2938c1e34415dc18241596/aws_xray_sdk-2.15.0.tar.gz", hash = "sha256:794381b96e835314345068ae1dd3b9120bd8b4e21295066c37e8814dbb341365", size = 76315, upload-time = "2025-10-29T20:59:45Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/c3/f30a7a63e664acc7c2545ca0491b6ce8264536e0e5cad3965f1d1b91e960/aws_xray_sdk-2.15.0-py2.py3-none-any.whl", hash = "sha256:422d62ad7d52e373eebb90b642eb1bb24657afe03b22a8df4a8b2e5108e278a3", size = 103228, upload-time = "2025-10-29T21:00:24.12Z" },
+]
+
+[[package]]
 name = "babel"
 version = "2.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -371,6 +399,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/21/28/9b3f50ce0e048515135495f198351908d99540d69bfdc8c1d15b73dc55ce/blinker-1.9.0.tar.gz", hash = "sha256:b4ce2265a7abece45e7cc896e98dbebe6cead56bcf805a3d23136d145f5445bf", size = 22460, upload-time = "2024-11-08T17:25:47.436Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/cb/f2ad4230dc2eb1a74edf38f1a38b9b52277f75bef262d8908e60d957e13c/blinker-1.9.0-py3-none-any.whl", hash = "sha256:ba0efaa9080b619ff2f3459d1d500c57bddea4a6b424b60a91141db6fd2f08bc", size = 8458, upload-time = "2024-11-08T17:25:46.184Z" },
+]
+
+[[package]]
+name = "boto3"
+version = "1.43.42"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/21/1e/4b6b2bd7ad9173e72fd5aef5ec1187847e06ff5497b66c2051b387827d56/boto3-1.43.42.tar.gz", hash = "sha256:f5a7fa503fd902dbd305d52a4571971149acb2c19f02508188f283e244e121e4", size = 112671, upload-time = "2026-07-07T19:35:53.709Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/53/ccb197ae4659300370b2538fa8a73bde1dcb4118319f0e9a865a975ea2a7/boto3-1.43.42-py3-none-any.whl", hash = "sha256:c34a36c9181998dd9b663095b0b0f5f5bc97f3b6846d6a63b31529462091047a", size = 140032, upload-time = "2026-07-07T19:35:51.513Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.42"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/de/c264abcfb6b371d05c7c1ffbd10d666bf517b6a259390d3e49c921f2a1c5/botocore-1.43.42.tar.gz", hash = "sha256:d813d5d5707db5f1c73b5d65f6b172c49f38375b23b30c593966fef56f8b5e40", size = 15680498, upload-time = "2026-07-07T19:35:41.747Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/c5/ca819ae7489a233b03241d20458518b0de150bddc6b87c20192de3eaff7e/botocore-1.43.42-py3-none-any.whl", hash = "sha256:62aa017eb5bb9791b1bc655571fa1548611e508f35e13e636d3939e1be3745f0", size = 15367131, upload-time = "2026-07-07T19:35:36.881Z" },
 ]
 
 [[package]]
@@ -466,6 +522,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "cfn-lint"
+version = "1.52.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aws-sam-translator" },
+    { name = "jsonpatch" },
+    { name = "networkx" },
+    { name = "pyyaml" },
+    { name = "regex" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ed/67/6e8416db23ac67854c66123dd97d1758d2dd0ff2603653a97d9dd872bed5/cfn_lint-1.52.1.tar.gz", hash = "sha256:696cf93fc3c20c257eb7c5ce4622621bc8f5b0823cb5e0ea2d042e1eb0c2cd0c", size = 4487553, upload-time = "2026-06-29T18:39:29.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/4b/25a9e8a09083d03ee7ee8701428e514c08029c000f34707cc7665980f4ae/cfn_lint-1.52.1-py3-none-any.whl", hash = "sha256:26222d5891f7893c53a97020ed1b390063fec440da941e6eb9d12d3a741c2ac4", size = 5012567, upload-time = "2026-06-29T18:39:26.57Z" },
 ]
 
 [[package]]
@@ -617,6 +691,8 @@ name = "contracts"
 version = "0.0.1"
 source = { editable = "packages/contracts" }
 dependencies = [
+    { name = "deltalake" },
+    { name = "obstore" },
     { name = "omegaconf" },
     { name = "patito" },
     { name = "polars" },
@@ -625,6 +701,8 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "deltalake", specifier = ">=1.6.0" },
+    { name = "obstore", specifier = ">=0.11.0" },
     { name = "omegaconf", specifier = ">=2.3.0" },
     { name = "patito", specifier = ">=0.8.0" },
     { name = "polars", specifier = ">=1.0.0" },
@@ -1848,12 +1926,63 @@ wheels = [
 ]
 
 [[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
+]
+
+[[package]]
 name = "joblib"
 version = "1.5.3"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
+name = "joserfc"
+version = "1.7.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d4/c6/b1cac0280f8efc57626ea8804866b37099f23cae11b1485a42b213245e31/joserfc-1.7.3.tar.gz", hash = "sha256:116955c2587139dba20621fd0bd7fc9255fa960c9fe7f43c43ebef2e801dcfcf", size = 233821, upload-time = "2026-07-08T12:41:42.66Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7d/f5/650b59d1b74f5befb7a7a7e7d7c92a26b94256df3541e2b4914152cd177a/joserfc-1.7.3-py3-none-any.whl", hash = "sha256:7c39f3f2c943dbc03122747fa8ebbd8e156e54904cf25651b452f4d2634a6075", size = 70982, upload-time = "2026-07-08T12:41:41.521Z" },
+]
+
+[[package]]
+name = "jsonpatch"
+version = "1.33"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonpointer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/42/78/18813351fe5d63acad16aec57f94ec2b70a09e53ca98145589e185423873/jsonpatch-1.33.tar.gz", hash = "sha256:9fcd4009c41e6d12348b4a0ff2563ba56a2923a7dfee731d004e212e1ee5030c", size = 21699, upload-time = "2023-06-26T12:07:29.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/07/02e16ed01e04a374e644b575638ec7987ae846d25ad97bcc9945a3ee4b0e/jsonpatch-1.33-py2.py3-none-any.whl", hash = "sha256:0ae28c0cd062bbd8b8ecc26d7d164fbbea9652a1a3693f3b956c1eae5145dade", size = 12898, upload-time = "2023-06-16T21:01:28.466Z" },
+]
+
+[[package]]
+name = "jsonpath-ng"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/58/250751940d75c8019659e15482d548a4aa3b6ce122c515102a4bfdac50e3/jsonpath_ng-1.8.0.tar.gz", hash = "sha256:54252968134b5e549ea5b872f1df1168bd7defe1a52fed5a358c194e1943ddc3", size = 74513, upload-time = "2026-02-24T14:42:06.182Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/99/33c7d78a3fb70d545fd5411ac67a651c81602cc09c9cf0df383733f068c5/jsonpath_ng-1.8.0-py3-none-any.whl", hash = "sha256:b8dde192f8af58d646fc031fac9c99fe4d00326afc4148f1f043c601a8cfe138", size = 67844, upload-time = "2026-02-28T00:53:19.637Z" },
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
 ]
 
 [[package]]
@@ -1869,6 +1998,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-path"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "pathable" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/39/79/cd02a4df6d9270efdc7d3feefe6edd730b0820c39eeaa107a2faee8322d5/jsonschema_path-0.5.0.tar.gz", hash = "sha256:493b156ba895c97602655b620a8456caa2ce08c1aa389f5a7addec065e6e855c", size = 19597, upload-time = "2026-05-19T20:45:00.971Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/2c/9e69d73c4297508be9e3b64a970ea3971b3eb8db64ffc5802d40bd25981f/jsonschema_path-0.5.0-py3-none-any.whl", hash = "sha256:2790a070bc7abb08ea3dbe4d340ece4efadf639223001f020c7503229ba068e2", size = 24077, upload-time = "2026-05-19T20:44:59.225Z" },
 ]
 
 [[package]]
@@ -1928,6 +2072,20 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/18/43a5f24608d8c313dd189cf838c8e68d75b115567c6279de7796197cfb6a/kiwisolver-1.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:e7a116ae737f0000343218c4edf5bd45893bfeaff0993c0b215d7124c9f77646", size = 2394403, upload-time = "2026-03-09T13:15:31.517Z" },
     { url = "https://files.pythonhosted.org/packages/3b/b5/98222136d839b8afabcaa943b09bd05888c2d36355b7e448550211d1fca4/kiwisolver-1.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:1dd9b0b119a350976a6d781e7278ec7aca0b201e1a9e2d23d9804afecb6ca681", size = 79687, upload-time = "2026-03-09T13:15:33.204Z" },
     { url = "https://files.pythonhosted.org/packages/99/a2/ca7dc962848040befed12732dff6acae7fb3c4f6fc4272b3f6c9a30b8713/kiwisolver-1.5.0-cp314-cp314t-win_arm64.whl", hash = "sha256:58f812017cd2985c21fbffb4864d59174d4903dd66fa23815e74bbc7a0e2dd57", size = 70032, upload-time = "2026-03-09T13:15:34.411Z" },
+]
+
+[[package]]
+name = "lazy-object-proxy"
+version = "1.12.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/a2/69df9c6ba6d316cfd81fe2381e464db3e6de5db45f8c43c6a23504abf8cb/lazy_object_proxy-1.12.0.tar.gz", hash = "sha256:1f5a462d92fd0cfb82f1fab28b51bfb209fabbe6aabf7f0d51472c0c124c0c61", size = 43681, upload-time = "2025-08-22T13:50:06.783Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/3a/277857b51ae419a1574557c0b12e0d06bf327b758ba94cafc664cb1e2f66/lazy_object_proxy-1.12.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c9defba70ab943f1df98a656247966d7729da2fe9c2d5d85346464bf320820a3", size = 26582, upload-time = "2025-08-22T13:49:49.366Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b6/c5e0fa43535bb9c87880e0ba037cdb1c50e01850b0831e80eb4f4762f270/lazy_object_proxy-1.12.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6763941dbf97eea6b90f5b06eb4da9418cc088fce0e3883f5816090f9afcde4a", size = 71059, upload-time = "2025-08-22T13:49:50.488Z" },
+    { url = "https://files.pythonhosted.org/packages/06/8a/7dcad19c685963c652624702f1a968ff10220b16bfcc442257038216bf55/lazy_object_proxy-1.12.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fdc70d81235fc586b9e3d1aeef7d1553259b62ecaae9db2167a5d2550dcc391a", size = 71034, upload-time = "2025-08-22T13:49:54.224Z" },
+    { url = "https://files.pythonhosted.org/packages/12/ac/34cbfb433a10e28c7fd830f91c5a348462ba748413cbb950c7f259e67aa7/lazy_object_proxy-1.12.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0a83c6f7a6b2bfc11ef3ed67f8cbe99f8ff500b05655d8e7df9aab993a6abc95", size = 69529, upload-time = "2025-08-22T13:49:55.29Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/6a/11ad7e349307c3ca4c0175db7a77d60ce42a41c60bcb11800aabd6a8acb8/lazy_object_proxy-1.12.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:256262384ebd2a77b023ad02fbcc9326282bcfd16484d5531154b02bc304f4c5", size = 70391, upload-time = "2025-08-22T13:49:56.35Z" },
+    { url = "https://files.pythonhosted.org/packages/59/97/9b410ed8fbc6e79c1ee8b13f8777a80137d4bc189caf2c6202358e66192c/lazy_object_proxy-1.12.0-cp314-cp314-win_amd64.whl", hash = "sha256:7601ec171c7e8584f8ff3f4e440aa2eebf93e854f04639263875b8c2971f819f", size = 26988, upload-time = "2025-08-22T13:49:57.302Z" },
 ]
 
 [[package]]
@@ -2420,6 +2578,51 @@ wheels = [
 ]
 
 [[package]]
+name = "moto"
+version = "5.2.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "boto3" },
+    { name = "botocore" },
+    { name = "cryptography" },
+    { name = "requests" },
+    { name = "responses" },
+    { name = "werkzeug" },
+    { name = "xmltodict" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/63/d944f387582cc53f53febbff2b3fa36a6d2ed7c1feef8990bf646cfa9cba/moto-5.2.2.tar.gz", hash = "sha256:aac8023a429e125e91c91f8f4730a67b54f518cda587352f7e67252fe3168f75", size = 8678761, upload-time = "2026-06-06T18:57:54.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/45/13cff46f4f617a6e97e1d497d75abd913e250bb4c823a4985668c6e593e4/moto-5.2.2-py3-none-any.whl", hash = "sha256:3817f1e39721ca833579b921e53e3b68547ace6a34d848c9486fbb5905808de9", size = 6698689, upload-time = "2026-06-06T18:57:51.435Z" },
+]
+
+[package.optional-dependencies]
+server = [
+    { name = "antlr4-python3-runtime" },
+    { name = "aws-xray-sdk" },
+    { name = "cfn-lint" },
+    { name = "docker" },
+    { name = "flask" },
+    { name = "flask-cors" },
+    { name = "graphql-core" },
+    { name = "joserfc" },
+    { name = "jsonpath-ng" },
+    { name = "openapi-spec-validator" },
+    { name = "py-partiql-parser" },
+    { name = "pyparsing" },
+    { name = "pyyaml" },
+    { name = "setuptools" },
+]
+
+[[package]]
+name = "mpmath"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e0/47/dd32fa426cc72114383ac549964eecb20ecfd886d1e5ccf5340b55b02f57/mpmath-1.3.0.tar.gz", hash = "sha256:7a28eb2a9774d00c7bc92411c19a89209d5da7c4c9a9e227be8330a23a25b91f", size = 508106, upload-time = "2023-03-07T16:47:11.061Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/43/e3/7d92a15f894aa0c9c4b49b8ee9ac9850d6e63b03c9c32c0367a13ae62209/mpmath-1.3.0-py3-none-any.whl", hash = "sha256:a0b2b9fe80bbcd81a6647ff13108738cfb482d481d826cc0e02f5b35e5c88d2c", size = 536198, upload-time = "2023-03-07T16:47:09.197Z" },
+]
+
+[[package]]
 name = "msgspec"
 version = "0.21.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2498,6 +2701,15 @@ wheels = [
 ]
 
 [[package]]
+name = "networkx"
+version = "3.6.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/c9/b2622292ea83fbb4ec318f5b9ab867d0a28ab43c5717bb85b0a5f6b3b0a4/networkx-3.6.1-py3-none-any.whl", hash = "sha256:d47fbf302e7d9cbbb9e2555a0d267983d2aa476bac30e90dfbe5669bd57f3762", size = 2068504, upload-time = "2025-12-08T17:02:38.159Z" },
+]
+
+[[package]]
 name = "nged-data"
 version = "0.0.1"
 source = { editable = "packages/nged_data" }
@@ -2549,6 +2761,7 @@ dev = [
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "mlflow" },
+    { name = "moto", extra = ["server"] },
     { name = "numpy" },
     { name = "pre-commit" },
     { name = "pymarkdownlnt" },
@@ -2588,6 +2801,7 @@ dev = [
     { name = "mkdocs-material", specifier = ">=9.7.6" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.3" },
     { name = "mlflow", specifier = ">=3.14.0" },
+    { name = "moto", extras = ["server"], specifier = ">=5.0.0" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "pre-commit", specifier = ">=4.5.1" },
     { name = "pymarkdownlnt", specifier = ">=0.9.13" },
@@ -2736,6 +2950,40 @@ wheels = [
 ]
 
 [[package]]
+name = "openapi-schema-validator"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "jsonschema-specifications" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "referencing" },
+    { name = "rfc3339-validator" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/98/e8/ab3f27dbca54ec645f7fab714b640907d5d36c2ebb07e87eebd30bd5c81b/openapi_schema_validator-0.9.0.tar.gz", hash = "sha256:b72db64315b89d21834cd3ffef37e3e6893bc876327be2d366e8424b1029afd3", size = 24686, upload-time = "2026-04-27T17:31:27.606Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/c0/5467967d95378b2cfce312e09cbd0c9ab64354a0922379b734f793edd04f/openapi_schema_validator-0.9.0-py3-none-any.whl", hash = "sha256:faa3bbe7c3aa8ca2087ad83f709dc3b7d920283153a570c03e24ea182558aa25", size = 19980, upload-time = "2026-04-27T17:31:25.965Z" },
+]
+
+[[package]]
+name = "openapi-spec-validator"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema" },
+    { name = "jsonschema-path" },
+    { name = "lazy-object-proxy" },
+    { name = "openapi-schema-validator" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8f/d2/640b5149cd5688bc0ad1fdbb4df6a2f7b84a093c8d787c27d566132f8b8b/openapi_spec_validator-0.9.0.tar.gz", hash = "sha256:6d648cff6490ebb799dcfe273792f2941c050158854c721f086599d845da78b8", size = 1756839, upload-time = "2026-05-20T09:23:18.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/d8/321ff889330acca2e3097f3d4f80a40bcc41b6d34d302978ab32c449520b/openapi_spec_validator-0.9.0-py3-none-any.whl", hash = "sha256:222fecffc7714f6d0a6ad62c0e4b66cc2b7dbfafb7b93acfc6c308abbdb51af8", size = 50328, upload-time = "2026-05-20T09:23:17.017Z" },
+]
+
+[[package]]
 name = "opentelemetry-api"
 version = "1.43.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2847,6 +3095,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/30/4b/90c937815137d43ce71ba043cd3566221e9df6b9c805f24b5d138c9d40a7/parso-0.8.7.tar.gz", hash = "sha256:eaaac4c9fdd5e9e8852dc778d2d7405897ec510f2a298071453e5e3a07914bb1", size = 401824, upload-time = "2026-05-01T23:13:02.138Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/99/5d/8268b644392ee874ee82a635cd0df1773de230bde356c38de28e298392cc/parso-0.8.7-py2.py3-none-any.whl", hash = "sha256:a8926eb2a1b915486941fdbd31e86a4baf88fe8c210f25f2f35ecec5b574ca1c", size = 107025, upload-time = "2026-05-01T23:12:58.867Z" },
+]
+
+[[package]]
+name = "pathable"
+version = "0.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/f3/5a20387de9bcd0607871bfc2198ee0e15836da7baa4592ccd7f24c27c986/pathable-0.6.0.tar.gz", hash = "sha256:6404b8b82aef5ff0fd478934137128b99b12212ba35afdde5525ca4f8388ea58", size = 18970, upload-time = "2026-05-19T18:15:11.911Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/e8/6d75ffd9784bce2e93d1ae4415649427e39a53bb172d4672b2b59c6f0a7b/pathable-0.6.0-py3-none-any.whl", hash = "sha256:82c4ca6c98c502ad12e0d4e9779b6210afee93c38990988c8c5d1b49bdcdf566", size = 18983, upload-time = "2026-05-19T18:15:10.728Z" },
 ]
 
 [[package]]
@@ -3168,6 +3425,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cd/05/0a34433a064256a578f1783a10da6df098ceaa4a57bbeaa96a6c0352786b/pure_eval-0.2.3.tar.gz", hash = "sha256:5f4e983f40564c576c7c8635ae88db5956bb2229d7e9237d03b3c0b0190eaf42", size = 19752, upload-time = "2024-07-21T12:58:21.801Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8e/37/efad0257dc6e593a18957422533ff0f87ede7c9c6ea010a2177d738fb82f/pure_eval-0.2.3-py3-none-any.whl", hash = "sha256:1db8e35b67b3d218d818ae653e27f06c3aa420901fa7b081ca98cbedc874e0d0", size = 11842, upload-time = "2024-07-21T12:58:20.04Z" },
+]
+
+[[package]]
+name = "py-partiql-parser"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/56/7a/a0f6bda783eb4df8e3dfd55973a1ac6d368a89178c300e1b5b91cd181e5e/py_partiql_parser-0.6.3.tar.gz", hash = "sha256:09cecf916ce6e3da2c050f0cb6106166de42c33d34a078ec2eb19377ea70389a", size = 17456, upload-time = "2025-10-18T13:56:13.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/33/a7cbfccc39056a5cf8126b7aab4c8bafbedd4f0ca68ae40ecb627a2d2cd3/py_partiql_parser-0.6.3-py2.py3-none-any.whl", hash = "sha256:deb0769c3346179d2f590dcbde556f708cdb929059fb654bad75f4cf6e07f582", size = 23752, upload-time = "2025-10-18T13:56:12.256Z" },
 ]
 
 [[package]]
@@ -3641,6 +3907,46 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.6.28"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/05/e4f219230e11e774a6c9987d2ab0d0c6b8573e13a17e143d0015bee710ef/regex-2026.6.28.tar.gz", hash = "sha256:3cb4b6c5cb3060cc31efdc1fbb27c25fb9b29044afd87e40601a1c4d9db54342", size = 416101, upload-time = "2026-06-28T19:56:55.302Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/fb/fad3b810a5bb1e09b9e5d6913fc6ba88cab738fdf283196827a3c59a4c10/regex-2026.6.28-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:f7c032b0c8a73739ff8ff1aaf30c281fa19c17bf7f1543256c8507390db7807c", size = 490407, upload-time = "2026-06-28T19:55:42.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/52/b8c79d12276d93e90e707e939b396034c04980caf1235312ef790f8e11fc/regex-2026.6.28-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:f6710f512c57b84f127a23d0f59560a03b64136eff419ae1be5ab557577fe5e3", size = 291988, upload-time = "2026-06-28T19:55:44.549Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d2/6a911f18279daa8d7bb8b20d771ddb6ef31fabd35f5921f9d3ba21640e80/regex-2026.6.28-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c0013958f427bd82509a186b9ff206d66cb8d60a81fc797a4c717afd18c5b0ba", size = 289704, upload-time = "2026-06-28T19:55:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/22/ad1955c47c669291a05804d53d7071cc0732dfdf166857be38003cedc2d1/regex-2026.6.28-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94f06cdcd6421f8e194ad312ea608020381250df9b8a57661c1b57e9e5273878", size = 797017, upload-time = "2026-06-28T19:55:48.166Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/67/a83159ff8703ab4d0c2cf99e76ebf289b7b4a501623241d09f88f3614f80/regex-2026.6.28-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ec9689392f7494ff4e3f8e7e8522f9158f11023f337eaaf04a64542fc45bbf26", size = 866112, upload-time = "2026-06-28T19:55:51.047Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/09/7bff2d6dbbd77421b3274aa51db1c887381cbc5b6eda93598c3e882ea345/regex-2026.6.28-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:aa084684e6d2078bf6139e374d1fc2af5ddc1ac7122759a2db716d68169f6fd0", size = 911554, upload-time = "2026-06-28T19:55:53.707Z" },
+    { url = "https://files.pythonhosted.org/packages/29/44/ae59c3826e7ba492e56795cdf74ea2a7b5b7c5ea116afb79ee4956a5dff1/regex-2026.6.28-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:40455e6840dc4e96a6fe50f4cedc957de2752c954d91e789812be55d49be199a", size = 800665, upload-time = "2026-06-28T19:55:55.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/19/6fd033d2ab00f35d445aaeaf3307c1e721424dcbfd48f6f65c857cb939cf/regex-2026.6.28-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:530b5c223b9ca5dd8370ac502e080aee0e4ded32be987c6564b425fb5523d581", size = 777243, upload-time = "2026-06-28T19:55:57.909Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/9d/99730f26df4938049ab1e652ca75e967b4c6739444e18d9707bfdb8af20c/regex-2026.6.28-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e0ed273ecd1a89be84466c1749bfe58609cc2a32b5d5e05006c4625ba96411b", size = 785784, upload-time = "2026-06-28T19:56:00.072Z" },
+    { url = "https://files.pythonhosted.org/packages/48/49/105cd57162f5fc5c04cc917a1388a060cf8427e5c14353cd9044660fbf4d/regex-2026.6.28-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:0ab0d5344311fc8e8667078942056c3b9c9b4a4b1cc99f2eb8a5af54554f4acc", size = 860914, upload-time = "2026-06-28T19:56:02.017Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/a5/788245a95b69018f58bff2f4fd27d007cacaea088cdb390979743f1b2571/regex-2026.6.28-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:eacb79625323d9f7e7925366b917f492b8356fad58f5dc4fa12ff8c21d8f4ca9", size = 765915, upload-time = "2026-06-28T19:56:05.021Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/01/292065a39a004b05e67a337b18213670a7cb919d6856ac2d7df7f1a10dbb/regex-2026.6.28-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:20f4d87702702aa1d572721e146f301660c50eef6fd6cb596e48a22b0ace17db", size = 851404, upload-time = "2026-06-28T19:56:07.251Z" },
+    { url = "https://files.pythonhosted.org/packages/98/9e/a93d865db0e13483ae1a01d81e2ce16d4a7fe2f9b9fe4aac4cc08590b136/regex-2026.6.28-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1e693940a3b9e6d6e4dc2a54ecaa74b74934f77af1ef95f518a74261ef7cc1bc", size = 789373, upload-time = "2026-06-28T19:56:09.894Z" },
+    { url = "https://files.pythonhosted.org/packages/82/0c/38b1685ad4017d78efbc8fa7dbbf96d8113b53750c8aa2d3609defd46605/regex-2026.6.28-cp314-cp314-win32.whl", hash = "sha256:234a51e20ebc18ab83b2c0600cf28f2e884560a0e00f743878f0b7d8e7c4cf03", size = 272496, upload-time = "2026-06-28T19:56:11.83Z" },
+    { url = "https://files.pythonhosted.org/packages/55/50/e19f261ff9ba9b50722a529e09b1743ecf65eb348be99d0fd2cd7fcede1c/regex-2026.6.28-cp314-cp314-win_amd64.whl", hash = "sha256:7b15c437bc4604f03ceb3f8d37eae2f8930e320e1bc556b259848c639d9eec1a", size = 280754, upload-time = "2026-06-28T19:56:13.758Z" },
+    { url = "https://files.pythonhosted.org/packages/36/b8/c9e68f3a9e33be73f20990b2c065b144ff2d0aa242608a950d8c4f3b56e8/regex-2026.6.28-cp314-cp314-win_arm64.whl", hash = "sha256:c6e6f790d01380a74ad564f216c533b86504afb61bf66f2b2e11e7f1a3e287a7", size = 280979, upload-time = "2026-06-28T19:56:15.928Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e6/21c425a37880c650d007c4171c6a80325446d830d85f5fbf335e7205b1e7/regex-2026.6.28-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3527a72adcbe9e3600f1553b497d397c1a371d227580d41d96c3c5964109b65c", size = 494282, upload-time = "2026-06-28T19:56:18.049Z" },
+    { url = "https://files.pythonhosted.org/packages/07/50/6647a7ccf5ffff995ba955a0b7d766440f4e58ce1666549c8ee998f2b972/regex-2026.6.28-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:a644f6408692812f5ead82519eed680e08d5d546fddbd9f7d9514e3c73899aa5", size = 293977, upload-time = "2026-06-28T19:56:20.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/dc/a3e141a4eaf125e50f63105570c01fa477c06ac5259dcfa95e9b90760e84/regex-2026.6.28-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:8e2fae6bb883648346f84db270dc9aafc29d8e895f62b88a75ccc83b09519820", size = 292432, upload-time = "2026-06-28T19:56:22.345Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ee/2ac1a6b9f167f8ff69f5a789938cc103b60cff41b24a6990daced8b88e34/regex-2026.6.28-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:debe623e09cee97ef9404575e936c610aac9bb08358c5099aaef14644a6871f2", size = 811877, upload-time = "2026-06-28T19:56:25.056Z" },
+    { url = "https://files.pythonhosted.org/packages/df/7b/9a5505ee92180bcae300b1018b9ff3d3c19962436e66f2505f255e9fde35/regex-2026.6.28-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:cc579c91fb4605773483a8d940b136bcc5b854fff44fa14a1572a038f46563f1", size = 871212, upload-time = "2026-06-28T19:56:27.352Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4d/d61a702a9f9d1bd29b22cbef1aed6d477baa961232a7eb4d91b7775b0b3e/regex-2026.6.28-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e7c42be203d84ecf7d487ff23f8a61ef0eb0534fa0fc317a2fce8c065d20618f", size = 917507, upload-time = "2026-06-28T19:56:29.762Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/60/1308066f5966b65fbb6905b99ba37e9f1cd753dd0ac08485f8257334ee92/regex-2026.6.28-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e8184b4e2fdaf9cdfe77e38f15a4d9dc149168c9c29eb0ea17c5481d3bb80546", size = 816389, upload-time = "2026-06-28T19:56:32.043Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/5c/57ce2cb8d714ee0b7f11c7ee4cfe2af66df2b90f147feadcb538609a3a02/regex-2026.6.28-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:697f103104f5872d64078d8eeac59979960be8ee76115a2d3f31096312e2a400", size = 785890, upload-time = "2026-06-28T19:56:34.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/fd/1d5350d3a8a327bff0fccacb911732baf7b5b6f5529c0e3fa602a23e7dad/regex-2026.6.28-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:714d2b1aa29beef0ddfcdc72ad0771c05326551a8bb0680b0ddf74bfaad87387", size = 801451, upload-time = "2026-06-28T19:56:36.749Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/79/3c9e4f8a0306e030ad5a43bbbc01625fb28d58a813bc52d42fd1cc63fb2e/regex-2026.6.28-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0f09f62e450cc2f113018cc8412aeea3a120a04e1ca7e801a0d441583f9a3b06", size = 866504, upload-time = "2026-06-28T19:56:38.994Z" },
+    { url = "https://files.pythonhosted.org/packages/65/12/f747de475b54f4709efb24dd0fbc8467c64cec91f5db0d047b079646ee78/regex-2026.6.28-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:731ea12d5aeb2577eaef2393d6428b995f76eb35f68a89e03e15a97719d1de19", size = 773047, upload-time = "2026-06-28T19:56:41.061Z" },
+    { url = "https://files.pythonhosted.org/packages/58/3c/f02f860e0500c1b2d61a79dec7e214b37fb9656281dcddc92397edf96678/regex-2026.6.28-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:51e952c8783eabd4706d0f63922f219bcfc1bef9b8cb35941c0d1a0396578858", size = 856665, upload-time = "2026-06-28T19:56:43.466Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/6c/28b3fa222513484be9dee26b7222bda109056c43ea28aa2314262ca48816/regex-2026.6.28-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:43248fe4c0ab8fbb223588a0795b11268940072c97bba30ea8f9b49d8cdfde34", size = 803573, upload-time = "2026-06-28T19:56:45.791Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/f0/8f86cf1a1fd85c5ab0c503c9fe4607ad4ad48978b2d8b435d94465e134c7/regex-2026.6.28-cp314-cp314t-win32.whl", hash = "sha256:fc1eddc25ad23c0f1344ab280d961ac595ead48292d7c779497975942373f493", size = 274515, upload-time = "2026-06-28T19:56:47.948Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/de/f8613c03b36786ddef2c930d28f9bcae861fcd541cc9203a870956cf1e83/regex-2026.6.28-cp314-cp314t-win_amd64.whl", hash = "sha256:ede8d8e53b6dde0a50f7eca902f0af76d87ab02a55aba7542da68ae3e5dfe83d", size = 283650, upload-time = "2026-06-28T19:56:50.614Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/f3/f5ec86839bbabe33b6dee649b62ff9a445d43de6b0ad780cf6b83c56f61e/regex-2026.6.28-cp314-cp314t-win_arm64.whl", hash = "sha256:4da6f6a72f8700b97a1a765e837fb7d5750bfd9f13acea7bae498f573e3a70a8", size = 283338, upload-time = "2026-06-28T19:56:52.879Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3665,6 +3971,32 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
+]
+
+[[package]]
+name = "responses"
+version = "0.26.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/1a/4af3e6d659394b809838490b144e4ab8d7ed3b9fecc7ca78f5d2f79b1a3d/responses-0.26.2.tar.gz", hash = "sha256:9c9259b46a8349197edebf43cfa68a87e1a2802ef503ff8b2fecbabc0b45afd8", size = 84030, upload-time = "2026-07-03T16:44:50.325Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/28/693e1d9ebf72baa062ded80d837a035b86ce75eda5a269379e9e2b1008a8/responses-0.26.2-py3-none-any.whl", hash = "sha256:6fdfeabd58e5ec473b98dfe02e6d46d3173bd8dd573eff2ccccf1a05a5135364", size = 35609, upload-time = "2026-07-03T16:44:49.1Z" },
+]
+
+[[package]]
+name = "rfc3339-validator"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
 ]
 
 [[package]]
@@ -3769,6 +4101,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/10/9b/5f14927848d2fd4aa891fd88d883788c5a7baba561c7874732364045708c/ruff-0.15.20-py3-none-win32.whl", hash = "sha256:ed65ef510e43a137207e0f01cfcf998aeddb1aeeda5c9d35023e910284d7cf21", size = 10857322, upload-time = "2026-06-25T17:20:28.612Z" },
     { url = "https://files.pythonhosted.org/packages/fa/f0/fe47c501f9dea92a26d788ff98bb5d92ed4cb4c88792c5c88af6b697dc8e/ruff-0.15.20-py3-none-win_amd64.whl", hash = "sha256:a525c81c70fb0380344dd1d8745d8cc1c890b7fc94a58d5a07bd8eb9557b8415", size = 11993274, upload-time = "2026-06-25T17:20:31.871Z" },
     { url = "https://files.pythonhosted.org/packages/d7/2b/9555445e1201d92b3195f45cdb153a0b68f24e0a4273f6e3d5ab46e212bb/ruff-0.15.20-py3-none-win_arm64.whl", hash = "sha256:2f5b2a6d614e8700388806a14996c40fab2c47b819ef57d790a34878858ed9ca", size = 11343498, upload-time = "2026-06-25T17:20:35.03Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f6/94/dcdaeb1713cab9c84def276cfac7388b17c7d9855bbcfe88d77e4dbafd44/s3transfer-0.19.0.tar.gz", hash = "sha256:ce436931687addc4c1712d52d40b32f53e88315723f107ffa20ba82b05a0f685", size = 165171, upload-time = "2026-06-16T19:44:51.599Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/46/5f/4c174edad94f82de888ac00a5ddd8d07b35609b6c94f0bdf4d74af57703e/s3transfer-0.19.0-py3-none-any.whl", hash = "sha256:777cc2415536f1debadb5c2ef7779275d0fc0fe0e042411cdd6caebeb2685262", size = 90101, upload-time = "2026-06-16T19:44:50.439Z" },
 ]
 
 [[package]]
@@ -3986,6 +4330,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/89/b4a0bcfdf4f71a3dea31379f095929613d7e4528a0996bca6aa964cd0dca/structlog-26.1.0.tar.gz", hash = "sha256:f63a716cbd1b1291cf7661de7794b455acfa4c43c5bcf1630e6ad5ddc1adb3b7", size = 1459881, upload-time = "2026-06-06T07:33:39.348Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/18/489c97b834dfff9cf2fc2507cede4bcd4b11e67f84bc462acd1992496f86/structlog-26.1.0-py3-none-any.whl", hash = "sha256:e081a26d6c373e6d201eca24eede26d8ffab07f88f477822e679183428d3d91e", size = 73764, upload-time = "2026-06-06T07:33:38.046Z" },
+]
+
+[[package]]
+name = "sympy"
+version = "1.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mpmath" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
 ]
 
 [[package]]
@@ -4498,6 +4854,15 @@ requires-dist = [
     { name = "patito" },
     { name = "polars", specifier = ">=1.0.0" },
     { name = "xgboost", specifier = ">=2.1.0" },
+]
+
+[[package]]
+name = "xmltodict"
+version = "1.0.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/70/80f3b7c10d2630aa66414bf23d210386700aa390547278c789afa994fd7e/xmltodict-1.0.4.tar.gz", hash = "sha256:6d94c9f834dd9e44514162799d344d815a3a4faec913717a9ecbfa5be1bb8e61", size = 26124, upload-time = "2026-02-22T02:21:22.074Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/34/98a2f52245f4d47be93b580dae5f9861ef58977d73a79eb47c58f1ad1f3a/xmltodict-1.0.4-py3-none-any.whl", hash = "sha256:a4a00d300b0e1c59fc2bfccb53d7b2e88c32f200df138a0dd2229f842497026a", size = 13580, upload-time = "2026-02-22T02:21:21.039Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Second half of **Deployment workstream 1 — S3-capable data paths** ([roadmap](https://openclimatefix.github.io/nged-substation-forecast/roadmap/live-service/#deployment-workstream-1-s3-capable-data-paths-the-biggest-unknown-start-first)). PR #278 landed the configurable `data_path` / `local_artifacts_path` roots (#50); this makes the eight managed data tables actually read and write over `s3://` so the forecast can run as an ephemeral Fargate task. Closes #121.

## Design
Models and MLflow never touch S3 — only the data tables do — so the change is confined to the IO layer:

- **`Settings`** gains optional `data_store_endpoint_url / _access_key_id / _secret_access_key / _region` fields (all default `""`) and a `storage_options` property. Empty on AWS (delta-rs' object_store auto-discovers the Fargate task's IAM-role credentials); populated from those settings only for a dev/MinIO/S3-compatible endpoint. The `aws_*` keys are the shared object_store aliases understood by delta-rs, polars cloud IO **and** obstore, so one dict feeds every IO site.
- **`contracts._uri`** gains `ensure_local_parent` (mkdir only when local; no-op on a remote URI, which has no directories), `delta_table_exists` (`DeltaTable.is_deltatable`) and `object_exists` (obstore `head`, for the remote parquet files).
- **`storage_options` is threaded** through `delta_store.write_nwp` / `write_power_forecasts`, `Nwp.scan_delta`, and every asset-level `scan_delta` / `read_delta` / `read_parquet` / `write_parquet` / `write_delta` / `DeltaTable(...)` in `assets`, `cv_assets`, `production_assets`, `plot_jobs`, `dashboard` and `nged_data.storage`. The mkdir/exists write-guards become `ensure_local_parent` / `delta_table_exists` / `object_exists`, deleting the three `# FIXME: won't work on S3` comments. Model cache, production-model dir and plots stay on local `Path` by design (XGBoost `save_model`, `shutil`, Altair are local-only).

**Stays 100% local by construction:** both roots still default under `PROJECT_ROOT/data`, `storage_options` is empty with no dev creds, and `ensure_local_parent` runs the existing local mkdir when the URI is local.

## Tests
- **New `tests/test_s3_data_paths.py`** (`integration` marker, `importorskip("moto")` — no Docker, no boto3): an in-process moto S3 server, driven entirely through a `Settings` pointed at an `s3://` `data_path`. Proves Delta + parquet round-trip over `s3://` through the production helpers **and that partition pruning survives on S3** (the `.explain()` assertion the single-fold-in-RAM memory design depends on).
- New `packages/contracts/tests/test_uri.py` and `storage_options` unit tests in `test_settings.py`; `test_storage.py` adapted to the new URI-`str` API.

Empirically verified against moto before writing the test: plain `storage_options` (endpoint + creds + `aws_allow_http`) round-trips Delta and prunes partitions — no conditional-put/unsafe-rename flags needed (deltalake 1.6 uses native S3 conditional-put).

### Known moto limitation (documented in the test)
The `deltalake.DeltaTable` *class* client (`is_deltatable`, `DeltaTable(...).partitions()`) hangs against moto's dev server at the connection level — even on an existing table — while the functional `write_deltalake` + polars + obstore paths work fine. It's the standard API that works on real S3/MinIO, so the moto test exercises the polars/obstore paths only rather than shipping a 3-minute stall.

## Verification
`ruff check` · `ruff format` · `ty check` (0 diagnostics) · **229 passed** (218 prior + 11 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)