### PR TITLE
Fix off-by-one in ptype null-threshold validation

### DIFF
--- a/packages/contracts/src/contracts/weather_schemas.py
+++ b/packages/contracts/src/contracts/weather_schemas.py
@@ -200,9 +200,9 @@ class Nwp(pt.Model):
     categorical_precipitation_type_surface: int | None = pt.Field(
         dtype=pl.UInt8,
         description=(
-            "This field is always NaN for init_times on and before 2024-11-13. Derived from"
-            " ECMWF's `ptype` field, which was added to ECMWF's Open Data dataset when IFS Cycle"
-            " 49r1 was released in Nov 2024. See https://codes.ecmwf.int/grib/param-db/260015"
+            "This field is always NaN for init_times on and before 2024-11-12, and populated from"
+            " the 2024-11-13 00Z run onwards (confirmed by direct inspection of the source data)."
+            " Derived from ECMWF's `ptype` field. See https://codes.ecmwf.int/grib/param-db/260015"
             " 0=No precipitation; 1=Rain; 2=Thunderstorm; 3=Freezing rain; 4=Mixed/ice;"
             " 5=Snow; 6=Wet snow; 7=Mixture of rain and snow; 8=Ice pellets; 9=Graupel;"
             " 10=Hail; 11=Drizzle; 12=Freezing drizzle; 13=Hail (less than 5 mm);"
@@ -289,11 +289,13 @@ class Nwp(pt.Model):
         cls, dataframe: pt.DataFrame[Self]
     ) -> None:
         """Check that `categorical_precipitation_type_surface` is all-null when
-        init_time <= 2024-11-13, and is never null afterwards.
+        init_time <= 2024-11-12, and is never null afterwards.
 
-        ECMWF only introduced `ptype` into their public data on 2024-11-14.
+        Confirmed by direct inspection of the source data: the 2024-11-13 00Z run is the first
+        run with `ptype` populated (0% null across all lead times), while 2024-11-12 and earlier
+        are 100% null.
         """
-        threshold_date = datetime(2024, 11, 13, tzinfo=timezone.utc)
+        threshold_date = datetime(2024, 11, 12, tzinfo=timezone.utc)
 
         # Partition the dataframe based on the threshold date
         partition_col = "is_before_or_on_threshold"
@@ -310,13 +312,13 @@ class Nwp(pt.Model):
         if not before_or_on["categorical_precipitation_type_surface"].is_null().all():
             raise ValueError(
                 "categorical_precipitation_type_surface must be all null for "
-                "init_time <= 2024-11-13"
+                "init_time <= 2024-11-12"
             )
 
         # Check after threshold
         if after["categorical_precipitation_type_surface"].is_null().any():
             raise ValueError(
-                "categorical_precipitation_type_surface must not be null for init_time > 2024-11-13"
+                "categorical_precipitation_type_surface must not be null for init_time > 2024-11-12"
             )
 
     @classmethod

--- a/packages/contracts/tests/test_weather_schemas_validation.py
+++ b/packages/contracts/tests/test_weather_schemas_validation.py
@@ -7,17 +7,17 @@ from contracts.weather_schemas import Nwp
 
 
 def test_categorical_precipitation_type_surface_validation():
-    # Test case 1: Valid data (all null before 2024-11-13, not null after)
+    # Test case 1: Valid data (all null before 2024-11-12, not null after)
     df_valid = pl.DataFrame(
         {
             "nwp_model_id": ["ECMWF_ENS_0_25_degree", "ECMWF_ENS_0_25_degree"],
             "init_time": [
+                datetime(2024, 11, 12, tzinfo=timezone.utc),
                 datetime(2024, 11, 13, tzinfo=timezone.utc),
-                datetime(2024, 11, 14, tzinfo=timezone.utc),
             ],
             "valid_time": [
-                datetime(2024, 11, 13, 0, tzinfo=timezone.utc),
-                datetime(2024, 11, 14, 1, tzinfo=timezone.utc),
+                datetime(2024, 11, 12, 0, tzinfo=timezone.utc),
+                datetime(2024, 11, 13, 1, tzinfo=timezone.utc),
             ],
             "ensemble_member": [1, 1],
             "h3_index": [1, 1],
@@ -40,16 +40,16 @@ def test_categorical_precipitation_type_surface_validation():
     # This should pass
     Nwp.validate(pt.DataFrame(df_valid).set_model(Nwp).cast())
 
-    # Test case 2: Invalid data (not null before 2024-11-13)
+    # Test case 2: Invalid data (not null before 2024-11-12)
     df_invalid_before = df_valid.with_columns(
         pl.Series("categorical_precipitation_type_surface", [1, 1])
     )
-    with pytest.raises(ValueError, match="must be all null for init_time <= 2024-11-13"):
+    with pytest.raises(ValueError, match="must be all null for init_time <= 2024-11-12"):
         Nwp.validate(pt.DataFrame(df_invalid_before).set_model(Nwp).cast())
 
-    # Test case 3: Invalid data (null after 2024-11-13)
+    # Test case 3: Invalid data (null after 2024-11-12)
     df_invalid_after = df_valid.with_columns(
         pl.Series("categorical_precipitation_type_surface", [None, None])
     )
-    with pytest.raises(ValueError, match="must not be null for init_time > 2024-11-13"):
+    with pytest.raises(ValueError, match="must not be null for init_time > 2024-11-12"):
         Nwp.validate(pt.DataFrame(df_invalid_after).set_model(Nwp).cast())


### PR DESCRIPTION
## Summary
- `Nwp._check_variables_that_were_introduced_after_start_of_dataset` hardcoded `2024-11-13` as the last all-null date for `categorical_precipitation_type_surface` (ptype), based on a comment claiming ECMWF's `ptype` field was introduced on `2024-11-14`.
- Direct inspection of the source data (fetching the raw `2024-11-13` 00Z run from Dynamical's Icechunk store, and checking already-materialized data on either side of it) shows the real cutover is one day earlier: `2024-11-12` and earlier are 100% null, and `2024-11-13` itself is already 0% null (fully populated).
- This was blocking the `ecmwf_ens` Dagster asset's `2024-11-13` partition from ever materializing — every retry hit the same validation error since it's a deterministic code bug, not transient upstream data.

## Investigation context
This was one of 11 failed `ecmwf_ens` partitions investigated. The other 10 are a separate, upstream issue (spurious per-pixel NaNs from Dynamical.org), reported as [dynamical-org/reformatters#722](https://github.com/dynamical-org/reformatters/issues/722) and out of scope here.

## Test plan
- [x] `uv run pytest packages/contracts/tests/test_weather_schemas_validation.py -v` — updated test passes with corrected boundary
- [x] `uv run pytest packages/contracts` — full package suite passes (45 passed)
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [x] `uv run ty check` — clean
- [x] Re-materialized the `ecmwf_ens` `2024-11-13` partition on this branch — now succeeds (7,243,785 rows written; `categorical_precipitation_type_surface` fully populated, 0 nulls, as expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)