### PR TITLE
Declare contracts dependency in nged_data and dashboard

### DIFF
--- a/packages/dashboard/pyproject.toml
+++ b/packages/dashboard/pyproject.toml
@@ -6,6 +6,7 @@ readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
     "altair>=6.0.0",
+    "contracts",
     "lonboard>=0.13.0",
     "marimo>=0.19.7",
     "plotting",

--- a/packages/nged_data/pyproject.toml
+++ b/packages/nged_data/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 description = "Package for handling NGED JSON data"
 requires-python = ">=3.14"
 dependencies = [
+    "contracts",
     "obstore",
     "patito",
     "polars>=1.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -917,6 +917,7 @@ version = "0.1.0"
 source = { virtual = "packages/dashboard" }
 dependencies = [
     { name = "altair" },
+    { name = "contracts" },
     { name = "geoarrow-pyarrow" },
     { name = "lonboard" },
     { name = "marimo" },
@@ -936,6 +937,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "altair", specifier = ">=6.0.0" },
+    { name = "contracts", editable = "packages/contracts" },
     { name = "geoarrow-pyarrow", specifier = ">=0.2.0" },
     { name = "lonboard", specifier = ">=0.13.0" },
     { name = "marimo", specifier = ">=0.19.7" },
@@ -2502,6 +2504,7 @@ name = "nged-data"
 version = "0.0.1"
 source = { editable = "packages/nged_data" }
 dependencies = [
+    { name = "contracts" },
     { name = "obstore" },
     { name = "patito" },
     { name = "polars" },
@@ -2510,6 +2513,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "contracts", editable = "packages/contracts" },
     { name = "obstore" },
     { name = "patito" },
     { name = "polars", specifier = ">=1.0.0" },


### PR DESCRIPTION
## Summary
- `nged_data` and `dashboard` both import `contracts` (Patito schemas) directly but didn't declare it in their `pyproject.toml` — it only worked because other workspace members happened to pull it in transitively.
- Added `contracts` to `dependencies` in both `packages/nged_data/pyproject.toml` and `packages/dashboard/pyproject.toml`, matching the pattern used by `geo`, `dynamical_data`, `ml_core`, `delta_store`, and `xgboost_forecaster`. Re-ran `uv sync` to update `uv.lock`.

## Test plan
- [x] `uv run ruff check packages/nged_data packages/dashboard` — passes
- [x] `uv run ty check` — same 15 pre-existing diagnostics as before the change (all in `packages/notebooks`, unrelated)
- [x] `uv run pytest packages/nged_data` — 11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)