### PR TITLE
Add the production Dockerfile and promotion runbook

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,20 @@
+# Ignore everything, then explicitly un-ignore only what the build needs, so the context stays
+# small (in particular: never the rest of data/ — NWP/power/forecasts tables can be huge — only
+# data/production_model/, the promoted champion model). Docker's ignore-then-allow semantics
+# require every ancestor directory of an allowed path to be un-ignored too, not just the final
+# glob, hence the repeated entries below.
+*
+
+!/pyproject.toml
+!/uv.lock
+!/README.md
+
+!/packages
+!/packages/**
+
+!/src
+!/src/**
+
+!/data
+!/data/production_model
+!/data/production_model/**

--- a/.dockerignore
+++ b/.dockerignore
@@ -18,3 +18,9 @@
 !/data
 !/data/production_model
 !/data/production_model/**
+
+!/conf
+!/conf/**
+
+!/metadata
+!/metadata/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,17 +46,35 @@ LABEL org.opencontainers.image.source="https://github.com/openclimatefix/nged-su
 
 ENV GIT_SHA="${GIT_SHA}" \
     PATH="/app/.venv/bin:${PATH}" \
-    PRODUCTION_MODEL_PATH="/app/data/production_model"
+    PRODUCTION_MODEL_PATH="/app/data/production_model" \
+    CV_CONFIG_PATH="/app/conf/cv/default.yaml" \
+    NWP_METADATA_CSV_PATH="/app/metadata/nwp_metadata.csv"
+# CV_CONFIG_PATH/NWP_METADATA_CSV_PATH override contracts.settings.Settings' PROJECT_ROOT-
+# relative defaults, which resolve to a path *inside* .venv under this --no-editable install
+# (PROJECT_ROOT = Path(__file__).parents[4] assumes an editable-install directory depth) —
+# empirically confirmed necessary: without them, importing nged_substation_forecast.definitions
+# (which eagerly loads the CV config at module scope, in defs/cv_assets.py) fails with
+# FileNotFoundError: /app/.venv/conf/cv/default.yaml. cv_assets.py now reads CV_CONFIG_PATH
+# directly (not via a Settings() instance, to stay credential-free at import time), so this env
+# var is honoured; nwp_metadata_csv_path was already read via an instantiated Settings and so
+# needed no source change.
 
 WORKDIR /app
 
 COPY --from=builder /app/.venv /app/.venv
 COPY data/production_model/ data/production_model/
+COPY conf/ conf/
+COPY metadata/ metadata/
 
 ENTRYPOINT ["dagster"]
 # The default target: live_forecasts_job is the real, already-existing partitioned job
 # (defs/schedules.py). Under Option B, EcsRunLauncher overrides this command per run, and the
 # same image separately serves as the code-location server — this default only matters for
-# `docker run` smoke tests. Requires --partition <key> at run time, e.g.:
-#   docker run --network=none <image> job execute -j live_forecasts_job --partition <key>
+# `docker run` smoke tests. Partition selection is via --tags, not --select/--partition:
+# `dagster job execute` has no --partition flag at all, and `--select <asset>` hits a pre-
+# existing, unrelated antlr4-python3-runtime/Python-3.14 incompatibility in Dagster's own
+# asset-selection-string parser (confirmed reproducing outside Docker too, on plain `dg dev`).
+# Job-name selection (-j) skips that parser entirely, so this is the reliable invocation:
+#   docker run --network=none <image> job execute -j live_forecasts_job \
+#     --tags '{"dagster/partition": "<key>"}'
 CMD ["job", "execute", "-m", "nged_substation_forecast.definitions", "-j", "live_forecasts_job"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,62 @@
+# syntax=docker/dockerfile:1
+
+# Production image for the live-forecast service. Bakes the champion model into the image at
+# build time and loads it via a plain save/load — no MLflow, run ID, or cache lookup at
+# runtime. See docs/architecture/production-deployment.md for the promotion runbook and
+# docs/roadmap/live-service.md#production-model-artifacts for why this design was chosen.
+#
+# Build (arm64 — ARM Fargate is ~20% cheaper and the candidate control-plane boxes are
+# Graviton; add --platform linux/arm64 if building on an x86 host):
+#   docker build --build-arg MODEL_RUN_ID=<id> --build-arg GIT_SHA=$(git rev-parse HEAD) \
+#     -t nged-forecast:<id-short> .
+#
+# The champion model must already be promoted to data/production_model/ (via the
+# `promoted_model` Dagster asset) before running this build — the build itself never talks to
+# MLflow, so it copies that directory from the build context hermetically.
+
+FROM ghcr.io/astral-sh/uv:python3.14-bookworm-slim AS builder
+
+WORKDIR /app
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PROJECT_ENVIRONMENT=/app/.venv
+
+# Full workspace: uv needs every member's pyproject.toml present to resolve uv.lock, even
+# though --no-editable below only ends up installing the root project's actual dependencies.
+COPY pyproject.toml uv.lock README.md ./
+COPY packages/ packages/
+COPY src/ src/
+
+# --no-editable installs every workspace package as a regular wheel into .venv, so .venv is
+# fully self-contained and portable into the runtime stage with no source tree alongside it —
+# verified empirically: the installed nged_substation_forecast package imports fine with the
+# repo checkout absent entirely.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --no-editable
+
+FROM ghcr.io/astral-sh/uv:python3.14-bookworm-slim AS runtime
+
+ARG MODEL_RUN_ID
+ARG GIT_SHA
+
+LABEL org.opencontainers.image.source="https://github.com/openclimatefix/nged-substation-forecast" \
+      org.opencontainers.image.revision="${GIT_SHA}" \
+      org.openclimatefix.model-run-id="${MODEL_RUN_ID}"
+
+ENV GIT_SHA="${GIT_SHA}" \
+    PATH="/app/.venv/bin:${PATH}" \
+    PRODUCTION_MODEL_PATH="/app/data/production_model"
+
+WORKDIR /app
+
+COPY --from=builder /app/.venv /app/.venv
+COPY data/production_model/ data/production_model/
+
+ENTRYPOINT ["dagster"]
+# The default target: live_forecasts_job is the real, already-existing partitioned job
+# (defs/schedules.py). Under Option B, EcsRunLauncher overrides this command per run, and the
+# same image separately serves as the code-location server — this default only matters for
+# `docker run` smoke tests. Requires --partition <key> at run time, e.g.:
+#   docker run --network=none <image> job execute -j live_forecasts_job --partition <key>
+CMD ["job", "execute", "-m", "nged_substation_forecast.definitions", "-j", "live_forecasts_job"]

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -53,13 +53,23 @@ inference has no MLflow dependency at runtime:
 
 ```bash
 docker run --network=none nged-forecast:<tag> \
-  job execute -m nged_substation_forecast.definitions -j live_forecasts_job --partition <key>
+  job execute -m nged_substation_forecast.definitions -j live_forecasts_job \
+  --tags '{"dagster/partition": "<key>"}'
 ```
 
-If this loads the model and only fails later on data access (no `DATA_PATH` reachable inside
-`--network=none`), that's expected — the point is confirming the model load itself needs no
-network call. A full end-to-end run needs a real `DATA_PATH` (local mount or S3 credentials)
-supplied via environment variables, per
+Partition selection uses `--tags`, not `--select`/`--partition`: `dagster job execute` has no
+`--partition` flag at all, and `dagster asset materialize --select <asset>` (which does) hits a
+pre-existing, unrelated `antlr4-python3-runtime`/Python 3.14 incompatibility in Dagster's own
+asset-selection-string parser — reproduces identically outside Docker, on a plain `dg dev`
+checkout, so it's an upstream/environment issue, not something introduced by this image.
+Selecting by job name (`-j`) skips that parser entirely.
+
+**Verified 2026-07-10** against a real promoted model: the run reaches
+`load_forecaster_from_dir` and loads the model successfully (confirmed via the step ordering in
+`production_assets.py` — model load happens before the NWP-availability lookup) with zero
+`mlflow` mentions anywhere in the log, then fails only on missing NWP data access (expected —
+no `DATA_PATH` was mounted for this isolated test). A full end-to-end run needs a real
+`DATA_PATH` (local mount or S3 credentials) supplied via environment variables, per
 [Environment & storage setup](../live_service/setup.md).
 
 ## Two subtleties for the AWS deployment (not yet built)

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -1,0 +1,88 @@
+# Production Deployment — the Container Build
+
+How the champion model gets from an MLflow leaderboard to a running production container.
+Design rationale lives in
+[Live service → Production model artifacts](../roadmap/live-service.md#production-model-artifacts):
+**bake the champion model into the image at build time**, loaded via a plain `save`/`load` — no
+MLflow, run ID, or cache lookup at runtime. Promotion is therefore rebuild + redeploy, which is
+auditable via image tags and keeps MLflow completely out of the production runtime.
+
+This page assumes you've already read
+[Running live forecasts end-to-end](../live_service/dagster-workflow.md), which covers
+promoting a model and running `live_forecasts` **locally**. This page covers the one extra step
+needed to run the same thing as an unattended container: getting the promoted model *into* an
+image.
+
+## The promotion runbook
+
+1. **Pick the champion fold run ID** from the MLflow leaderboard — see
+   [Running live forecasts end-to-end → Step 1](../live_service/dagster-workflow.md#step-1--pick-a-champion-model).
+
+2. **Materialise `promoted_model`** to populate `data/production_model/` on disk. This is the
+   same asset the local workflow uses — no separate script — either from the Dagster UI
+   ("Materialize" with `PromotedModelConfig.mlflow_run_id` filled in), or headlessly:
+
+   ```bash
+   uv run dagster asset materialize -m nged_substation_forecast.definitions --select promoted_model \
+     --config-json '{"ops": {"promoted_model": {"config": {"mlflow_run_id": "<run-id>"}}}}'
+   ```
+
+3. **Build the image.** The build never contacts MLflow — it only `COPY`s the directory step 2
+   just populated, so it stays hermetic:
+
+   ```bash
+   docker build \
+     --build-arg MODEL_RUN_ID=<run-id> \
+     --build-arg GIT_SHA=$(git rev-parse HEAD) \
+     -t nged-forecast:<run-id-short> .
+   ```
+
+   `MODEL_RUN_ID` and `GIT_SHA` are stamped as OCI labels (and `GIT_SHA` also as a runtime env
+   var) purely for traceability — confirm with `docker inspect nged-forecast:<tag>`.
+
+4. **Push to ECR and point the ECS task definition at the new tag.** (ECR repository and ECS
+   task definitions are provisioned by the AWS infrastructure work,
+   [#206](https://github.com/openclimatefix/nged-substation-forecast/issues/206) — not yet
+   built at the time this page was written.)
+
+## Verifying a build locally
+
+Before trusting a new image, confirm it actually runs with **zero network access** — this is
+the test that matters, since the entire point of baking the model in is that production
+inference has no MLflow dependency at runtime:
+
+```bash
+docker run --network=none nged-forecast:<tag> \
+  job execute -m nged_substation_forecast.definitions -j live_forecasts_job --partition <key>
+```
+
+If this loads the model and only fails later on data access (no `DATA_PATH` reachable inside
+`--network=none`), that's expected — the point is confirming the model load itself needs no
+network call. A full end-to-end run needs a real `DATA_PATH` (local mount or S3 credentials)
+supplied via environment variables, per
+[Environment & storage setup](../live_service/setup.md).
+
+## Two subtleties for the AWS deployment (not yet built)
+
+Recorded here so they aren't lost when the Fargate work
+([#206](https://github.com/openclimatefix/nged-substation-forecast/issues/206)) starts:
+
+- **Freshness without persistent Dagster state.** If the eventual AWS deployment runs the
+  container one-shot with no daemon behind it (the "nothing always-on" architecture option),
+  "which `ecmwf_ens` partitions need materialising" must be derived from **Delta table
+  contents vs Dynamical.org availability**, not from Dagster's own materialisation records —
+  those evaporate with a throwaway, non-persistent `DAGSTER_HOME`. This doesn't apply to a
+  daemon-backed deployment (persistent `DAGSTER_HOME`), where Dagster's records are reliable.
+- **Delta commits as the freshness record.** Delta table commits already give an atomic
+  "outputs are the freshness record" property for free — just ensure the forecast Delta write
+  is a run's *final* write, so a run that fails after writing forecasts but before some later
+  step doesn't get treated as stale on the next freshness check.
+
+## See also
+
+- [Live service roadmap](../roadmap/live-service.md) — the full v0.1 design, including AWS
+  architecture options still being decided.
+- [Environment & storage setup](../live_service/setup.md) — where data tables and local
+  artifacts live, and how to point `Settings` at S3.
+- [ML Orchestration Design](ml-orchestration.md) — why production inference doesn't reuse the
+  CV pipeline's MLflow-artifact cache.

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -16,7 +16,7 @@ image.
 ## The promotion runbook
 
 1. **Pick the champion fold run ID** from the MLflow leaderboard — see
-   [Running live forecasts end-to-end → Step 1](../live_service/dagster-workflow.md#step-1--pick-a-champion-model).
+   [Running live forecasts end-to-end → Step 1](../live_service/dagster-workflow.md#step-1-pick-a-champion-model).
 
 2. **Materialise `promoted_model`** to populate `data/production_model/` on disk. This is the
    same asset the local workflow uses — no separate script — either from the Dagster UI

--- a/docs/live_service/setup.md
+++ b/docs/live_service/setup.md
@@ -113,11 +113,11 @@ against an in-process `moto` server.)
 
 > **Scope: data tables on S3, not the full unattended deployment.** This section covers pointing the
 > **data tables** at S3 — which is all the ephemeral-compute deployment needs from the storage layer,
-> and is enough to run the stack from your laptop against an S3 `DATA_PATH` today. Running the
-> forecast itself as an unattended, scheduled **Fargate task** (the container build, ECR, EventBridge
-> scheduling) is a separate, not-yet-built roadmap item — see
-> [Live service roadmap → Production model artifacts](https://openclimatefix.github.io/nged-substation-forecast/roadmap/live-service/#production-model-artifacts)
-> ([#222](https://github.com/openclimatefix/nged-substation-forecast/issues/222)) and the
+> and is enough to run the stack from your laptop against an S3 `DATA_PATH` today. Building the
+> production container itself is covered by
+> [Production Deployment](https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/);
+> running it as an unattended, scheduled **Fargate task** (ECR, EventBridge scheduling) is a
+> separate, not-yet-built roadmap item — see the
 > [AWS architecture](https://openclimatefix.github.io/nged-substation-forecast/roadmap/live-service/#aws-architecture)
 > section for that plan.
 

--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -9,7 +9,7 @@
 > [inference asset](#the-live_forecasts-asset) (#221, done) → the
 > [local dress rehearsal](#deployment-workstream-1-the-production-job-local-dress-rehearsal)
 > (#208, done) → S3-capable data paths (#121, #50, done)
-> → the [champion-model container](#production-model-artifacts) (#222) → the
+> → the [champion-model container](#production-model-artifacts) (#222, done) → the
 > [AWS infrastructure](#aws-architecture) (#206) → smaller cleanup (#197, #63, #246) →
 > [the v0.1 version bump](#related-github-issues) (#209).
 > [Production monitoring](#production-monitoring) (#224) is tracked separately and deferred
@@ -119,6 +119,11 @@ deps: [ecmwf_ens, power_time_series_and_metadata]
 
 Issue: [#222](https://github.com/openclimatefix/nged-substation-forecast/issues/222)
 
+> **Status: ✅ Implemented.** The `Dockerfile` (repo root) and the promotion runbook now live at
+> [Production Deployment](https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/),
+> the permanent home this section's shipped material moves to. Remaining work on this page —
+> the [AWS infrastructure](#aws-architecture) itself — is unaffected.
+
 The deployment below runs forecasts as ephemeral Fargate tasks under every architecture
 option. An ephemeral container has no persistent disk and, under some architecture options, no
 reachable tracking server — so without a decision here, production inference has no way to get
@@ -147,9 +152,13 @@ service survives an MLflow outage), exactly as it does for CV today.
 artifacts" step above is a manually-triggered Dagster asset, `promoted_model` (config
 `mlflow_run_id`), rather than a bare script — promotion becomes a materialisation, giving an
 audit trail and lineage for free. The download logic itself
-(`ml_core._production_helpers.fetch_model_artifacts`) is a pure, asset-independent helper, so
-the eventual `scripts/fetch_model.py` wrapper for the Docker build (below) stays a thin call
-into the same function.
+(`ml_core._production_helpers.fetch_model_artifacts`) is a pure, asset-independent helper.
+**The Docker build reuses this same asset** (headlessly, via `dagster asset materialize`) —
+no separate fetch script was built; see
+[Production Deployment](https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/)
+for why a bare script would have been redundant, and why the `docker build` step itself stays
+outside Dagster (it would only ever run on a laptop, and image build/push is a CI-shaped
+concern once an MLflow tracking server and AWS infra exist).
 
 ## AWS architecture
 
@@ -477,57 +486,6 @@ free. No coupling needed; the ordering is flexible.
 
 ## Implementation details (deleted when this ships)
 
-### Container build
-
-Dockerfile (repo root):
-
-- Multi-stage `uv` build (standard pattern: `ghcr.io/astral-sh/uv` image, `uv sync --frozen
-  --no-dev`, copy `.venv` + source into a slim `python:3.14` runtime stage).
-- Build args: `MODEL_RUN_ID` (the champion fold run ID, stamped only as an OCI label for
-  traceability — the build never contacts MLflow with it), `GIT_SHA` (stamped as an OCI label
-  and env var; complements
-  [reproducibility stamping](engineering-health.md#reproducibility-stamp-git-sha-and-delta-table-versions-on-mlflow-runs)).
-- Model injection: keep the image build hermetic — the build **copies** a plain model
-  directory from the build context (`data/production_model/`, populated beforehand by a small
-  script, e.g. `scripts/fetch_model.py`, that downloads the champion run's artifacts straight
-  from MLflow — a one-off, researcher-run step, not the `load_from_mlflow` cache wrapper).
-  `COPY` it to a fixed in-image path that the entrypoint passes straight to `ForecasterClass.load`.
-  Downloading from inside `docker build` is rejected (needs tracking credentials in the build).
-- Entrypoint: `dagster job execute` one-shot (the exact job comes with the `live_forecasts`
-  asset; until that exists, the entrypoint can materialise the data-ingestion assets so the
-  image is testable now). Under Option B the same image also serves as the code-location
-  server on the control-plane box and as the `EcsRunLauncher` run image — the launcher
-  overrides the command, so the one-shot entrypoint stays the default either way. Build for
-  **arm64** (ARM Fargate is 20% cheaper and the candidate control-plane boxes are Graviton).
-
-Settings: add a simple fixed path (e.g. `Settings.production_model_path`) for where the
-in-image model directory lives — no MLflow-related setting is needed for v0.1.
-
-Promotion runbook — short page `docs/architecture/production-deployment.md` (permanent docs,
-written when this ships):
-
-1. Pick the champion fold run ID from the MLflow leaderboard.
-2. `uv run python scripts/fetch_model.py --run-id <id>` → populates `data/production_model/`.
-3. `docker build --build-arg MODEL_RUN_ID=<id> --build-arg GIT_SHA=$(git rev-parse HEAD)
-   -t nged-forecast:<id-short> .` and push to ECR.
-4. Point the ECS task definition at the new tag.
-
-Also record the two issue-#206 subtleties the review surfaced, so they're not lost when the
-Fargate work starts: (a) whenever the job executes one-shot without persistent Dagster state
-(Option A), "which `ecmwf_ens` partitions need materialising" must be derived from Delta
-contents vs Dynamical availability, not Dagster's materialisation records — the local dress
-rehearsal below sidestepped this by running the daemon with a *persistent* `DAGSTER_HOME`, so
-Dagster's own records were fine to rely on there; (b) Delta commits already give the atomic
-"outputs are the freshness record" property — just ensure the forecast Delta write is the
-run's final write.
-
-Container verification:
-
-1. `docker build` with a smoke-test-fold run ID succeeds.
-2. `docker run` **with no network access to any MLflow store** loads the model straight from
-   disk and executes the entrypoint — this is the critical test.
-3. Image labels show the run ID and git SHA (`docker inspect`).
-
 ### Deployment workstream 1 — the production job (local dress rehearsal)
 
 Issue: [#208](https://github.com/openclimatefix/nged-substation-forecast/issues/208)
@@ -615,7 +573,7 @@ order issues were opened.
 | [#208 Run every 6 hours locally and backfill missing runs (as a test)](https://github.com/openclimatefix/nged-substation-forecast/issues/208) | [Deployment workstream 1](#deployment-workstream-1-the-production-job-local-dress-rehearsal) — done, via native per-asset schedules |
 | [#121 Use obstore instead of pathlib](https://github.com/openclimatefix/nged-substation-forecast/issues/121) | S3-capable data paths — done ([setup guide](https://openclimatefix.github.io/nged-substation-forecast/live_service/setup/)) |
 | [#50 Define all paths in Settings](https://github.com/openclimatefix/nged-substation-forecast/issues/50) | S3-capable data paths — done |
-| [#222 Build the production Docker image](https://github.com/openclimatefix/nged-substation-forecast/issues/222) | [Production model artifacts](#production-model-artifacts) + the container-build notes above |
+| [#222 Build the production Docker image](https://github.com/openclimatefix/nged-substation-forecast/issues/222) | [Production model artifacts](#production-model-artifacts) — done ([promotion runbook](https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/)) |
 | [#206 Deploy to AWS!](https://github.com/openclimatefix/nged-substation-forecast/issues/206) | This page (the options above supersede its cost analysis; the issue links back here) |
 | [#197 Make fold-run param logging re-run-safe](https://github.com/openclimatefix/nged-substation-forecast/issues/197) | Bug fix folded into the v0.1 epic (MLflow param immutability on re-runs) |
 | [#63 Send telemetry to OCF's Sentry.io](https://github.com/openclimatefix/nged-substation-forecast/issues/63) | Observability — CloudWatch + SNS first; Sentry as the follow-up |

--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -270,6 +270,18 @@ reserved**) runs the Dagster daemon + webserver + code-location server + Postgre
 UI-launched backtests — is dispatched by `EcsRunLauncher` to an ephemeral Fargate task sized
 to the job. Add ~£1.80 EBS, £5–7/month live Fargate, ~£0.65/backtest.
 
+**One image, four roles.** The daemon, webserver, and code-location server all run from the
+*same* [production image](../architecture/production-deployment.md) the ephemeral Fargate runs
+use (harmless — the baked-in champion model is dead weight for the first three, only a run's
+actual execution touches it) — a `docker-compose.yml` on the box just launches each as a
+separate service with a different command override. One gotcha worth recording now, before
+that compose file gets written: `dagster-webserver` and `dagster-daemon` are **separate
+console-script binaries**, not subcommands of the `dagster` CLI, so those two services need
+`entrypoint: ["dagster-webserver"]` / `["dagster-daemon"]` overrides, not just a `command:`
+override — unlike `dagster code-server start` (the code-location-server role) and `dagster job
+execute`/`dagster asset materialize` (the ephemeral-run role), which are both ordinary `dagster`
+subcommands and work with the image's existing `ENTRYPOINT ["dagster"]` unchanged.
+
 - **Pros:** Dagster properly (history, UI backfills, sensors, concurrency pools enforced
   centrally); backtests get big ephemeral compute; dashboard rides free; EC2 IAM instance
   roles (no static keys); the textbook Dagster-OSS-on-AWS deployment.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
       - Overview: architecture/overview.md
       - Forecast Delivery: architecture/forecast-delivery.md
       - ML Orchestration Design: architecture/ml-orchestration.md
+      - Production Deployment: architecture/production-deployment.md
       - Code Style: architecture/code-style.md
   - ML Experimentation:
       - Overview: ml_experimentation/index.md

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -5,6 +5,7 @@ thin orchestration shell delegating its logic to the pure helpers in ``ml_core._
 the logic stays fast to unit-test and the assets stay readable.
 """
 
+import os
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Final
@@ -52,10 +53,16 @@ from ml_core._mlflow_runs import (
 
 # The CV folds are the shared leaderboard evaluation protocol, read from conf/cv/default.yaml
 # (never hard-coded) so every experiment and asset agrees on the same folds. Loaded at import so
-# the partition keys are available when Dagster builds the asset graph. PROJECT_ROOT is used here
-# (rather than Settings, which needs the .env secrets) so the partition set can be built without
-# any credentials.
-_cv_config = load_cv_config(Settings.model_fields["cv_config_path"].default)
+# the partition keys are available when Dagster builds the asset graph. The raw CV_CONFIG_PATH
+# env var is read directly here (rather than instantiating Settings, which needs the .env
+# secrets) so the partition set can be built without any credentials — while still respecting
+# the same env var Settings' cv_config_path field would use, unlike reading
+# Settings.model_fields["cv_config_path"].default directly, which silently ignores it (that
+# default is also PROJECT_ROOT-relative, which only resolves correctly for an editable install;
+# a production image built with `uv sync --no-editable` must set CV_CONFIG_PATH explicitly).
+_cv_config = load_cv_config(
+    Path(os.environ.get("CV_CONFIG_PATH", Settings.model_fields["cv_config_path"].default))
+)
 
 cv_fold_partitions = StaticPartitionsDefinition(_cv_config.fold_ids)
 """One partition per canonical CV fold (by fold year, e.g. "2022"). Experiment-independent."""


### PR DESCRIPTION
## Summary

- Adds `Dockerfile` (repo root, multi-stage `uv` build) and `.dockerignore`, implementing the design already recorded in [Live service → Production model artifacts](https://openclimatefix.github.io/nged-substation-forecast/roadmap/live-service/#production-model-artifacts): bake the champion model into the image at build time, load it via a plain `save`/`load`, zero MLflow at runtime.
- Adds the permanent promotion runbook, `docs/architecture/production-deployment.md` (wired into `mkdocs.yml` nav), plus the two AWS-deployment subtleties the roadmap flagged for later (Option A partition derivation; Delta commit ordering).
- Ship-time triage on `docs/roadmap/live-service.md`: deletes the now-shipped "Container build" implementation-details subsection, marks "Production model artifacts" ✅ Implemented, updates the build-order banner and the related-issues table. Also notes a forward-looking gotcha for #206 (Option B): `dagster-webserver`/`dagster-daemon` are separate console-script binaries, not `dagster` subcommands, so their eventual docker-compose services need an `entrypoint` override, not just `command`.
- **Fixes a real bug found by actually running the container** (see "What testing found" below): `src/nged_substation_forecast/defs/cv_assets.py` now reads `CV_CONFIG_PATH` directly instead of a class-level default that silently ignored env var overrides.

## Design deviation from the roadmap's original sketch

The roadmap sketched a `scripts/fetch_model.py` CLI wrapper around `ml_core._production_helpers.fetch_model_artifacts`. That function is already exposed, tested, and lineage-tracked via the existing `promoted_model` Dagster asset — confirmed the Dagster CLI drives it headlessly with no new code:

```bash
uv run dagster asset materialize -m nged_substation_forecast.definitions --select promoted_model \
  --config-json '{"ops": {"promoted_model": {"config": {"mlflow_run_id": "<id>"}}}}'
```

So no fetch script was built — the promotion runbook's step 2 is the command above (or "Materialize" in the Dagster UI). Also considered and rejected: moving `docker build` itself into a Dagster op. It would only ever run on a laptop (Docker-in-Docker is unwanted on the eventual Fargate/EC2 target this image runs on), and image build/push is a CI-shaped concern once an MLflow tracking server (#235) and AWS infra (#206) exist, not a data-pipeline concern. `docker build` stays a plain, CI-portable shell command.

## Dockerfile design notes

- Both stages use `ghcr.io/astral-sh/uv:python3.14-bookworm-slim` (verified this tag exists on ghcr.io before using it).
- `uv sync --frozen --no-dev --no-editable` in the builder stage, so `.venv` is fully self-contained and portable — the runtime stage only needs `COPY --from=builder /app/.venv` + `data/production_model/` + `conf/` + `metadata/` (the last two needed because of the bug below), no source tree.
- Default `CMD` targets the real, already-existing `live_forecasts_job` (`defs/schedules.py`). `EcsRunLauncher` overrides this per run in production; the default only matters for `docker run` smoke tests.

## What testing found (Docker wasn't available when this PR first opened — it is now, and I ran the real build/smoke-test)

Two real, previously-undiscoverable-without-actually-running-it bugs, both fixed in this PR:

1. **`PROJECT_ROOT`-relative Settings defaults break under `--no-editable` installs.** `contracts/settings.py`'s `PROJECT_ROOT = Path(__file__).parents[4]` assumes an editable-install directory depth; under `--no-editable` it resolves to `/app/.venv` instead of `/app`. This breaks `cv_config_path` and `nwp_metadata_csv_path`'s defaults. Worked around at the image level: `COPY conf/` + `metadata/` into the image and set `CV_CONFIG_PATH`/`NWP_METADATA_CSV_PATH` env vars (not a `contracts` source change — `PROJECT_ROOT` itself is unchanged, flagging it here as a latent fragility for awareness).
2. **`cv_assets.py:58` silently ignored the `CV_CONFIG_PATH` env var override**, reading `Settings.model_fields["cv_config_path"].default` (the raw class-level default) instead of resolving through an instance — the only field in the codebase read this way (confirmed via grep). This blocks **every** Dagster CLI invocation against the image, not just CV-related ones, since `cv_assets` is eagerly imported by `definitions.py` and this line runs at module-import time. Fixed to read `os.environ.get("CV_CONFIG_PATH", ...)` directly — preserving the original, deliberate "no `Settings()` instantiation, no credentials needed at import time" property (there's a comment explaining why), while actually respecting the env var.

Also found and worked around (documented, not a bug in our code): `dagster job execute` has no `--partition` flag, and `dagster asset materialize --select <asset>` hits a **pre-existing, unrelated** `antlr4-python3-runtime`/Python-3.14 incompatibility in Dagster's own asset-selection-string parser — confirmed reproducing identically outside Docker, on a plain local `dg dev` checkout. Switched the default `CMD` and the runbook's documented smoke-test command to `job execute -j live_forecasts_job --tags '{"dagster/partition": "<key>"}'`, which selects by job name and skips that parser entirely.

**Verified, for real:**
- `docker build` succeeds; `docker inspect` shows the `MODEL_RUN_ID`/`GIT_SHA` OCI labels correctly.
- `docker run --network=none ... job execute -j live_forecasts_job --tags '{"dagster/partition": "2026-07-04-00:00"}'` reaches `load_forecaster_from_dir` and **loads the promoted model successfully** (confirmed via the step ordering in `production_assets.py` — model load happens before the NWP-availability lookup that ultimately fails), with **zero `mlflow` mentions anywhere in the log** — the core property this whole design exists to guarantee. It then fails only on missing NWP data access, which is expected since no `DATA_PATH` was mounted for this isolated, credential-free test.
- `uv run dagster job execute -m nged_substation_forecast.definitions -j live_forecasts_job --tags ...` also run locally (outside Docker) against real local Delta data — completed with `RUN_SUCCESS`, confirming the `cv_assets.py` fix didn't just avoid an error but that the pipeline genuinely still works end-to-end.

Closes #222.

## Test plan

- [x] `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check` — all clean.
- [x] `uv run pymarkdown scan -r docs README.md CLAUDE.md metadata/README.md packages/*/README.md` — clean (one pre-existing unrelated failure in `docs/background/requirements.md`, confirmed present on `main` too).
- [x] `uv run pytest` — full suite, 229 passed, no regressions from the `cv_assets.py` change.
- [x] `docker build` + `docker inspect` + `docker run --network=none ... job execute -j live_forecasts_job --tags ...` — all run for real, see "What testing found" above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)