### PR TITLE
Split production-deployment docs into architecture (why) vs live_service (how)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ never to a `github.com/.../blob/main/docs/...` path.
 
 ## How planning works
 
-Full description and a "which place do I use?" table: `docs/roadmap/index.md`. In brief:
+Full description and a "which place do I use?" table: `docs/documentation-guide.md`. In brief:
 
 - **GitHub** (issues + the OCF Project board) is the *complete, ordered* task list — task-level
   priority lives only there. When current priorities matter, query it with `gh` (epics map 1:1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,9 +35,11 @@ hook.
 
 `docs/` contains a lot of useful information beyond API reference: forward-looking plans and
 their ordering (`docs/roadmap/`), durable explainers of solution methods (`docs/techniques/`),
-background/requirements context (`docs/background/`), and architecture notes
-(`docs/architecture/`). When planning new features, check `docs/` for relevant prior discussion
-before proposing an approach.
+background/requirements context (`docs/background/`), design rationale for what's already built
+(`docs/architecture/`), and step-by-step operational how-to for what's already built
+(`docs/ml_experimentation/`, `docs/live_service/` — design and how-to are deliberately separate
+pages, cross-linked via "See also"). When planning new features, check `docs/` for relevant prior
+discussion before proposing an approach.
 
 The docs are published at <https://openclimatefix.github.io/nged-substation-forecast>. When
 linking to a docs page from anywhere outside `docs/` itself (GitHub issues, PR bodies, code
@@ -163,7 +165,7 @@ Each `BaseForecaster` also carries a `feature_engineer: ClassVar[FeatureEngineer
 - **Comments must reflect current state only** — never reference previous iterations of the
   code or deleted files.
 - **Code links only to durable docs** — `docs/background/`, `docs/techniques/`,
-  `docs/architecture/`, `docs/ml_experimentation/`. Never link from code *or* docs to `plans/`
+  `docs/architecture/`, `docs/ml_experimentation/`, `docs/live_service/`. Never link from code *or* docs to `plans/`
   files, and never from code to `docs/roadmap/` pages or to any
   "Implementation details (deleted when this ships)" section — all of those are deleted when
   the work lands, so the reference rots. (Docs-to-docs links into `docs/roadmap/` are fine;

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@
 
 # Production image for the live-forecast service. Bakes the champion model into the image at
 # build time and loads it via a plain save/load — no MLflow, run ID, or cache lookup at
-# runtime. See docs/architecture/production-deployment.md for the promotion runbook and
-# docs/roadmap/live-service.md#production-model-artifacts for why this design was chosen.
+# runtime. See docs/live_service/deployment.md for the promotion runbook and
+# docs/architecture/production-deployment.md for why this design was chosen.
 #
 # Build (arm64 — ARM Fargate is ~20% cheaper and the candidate control-plane boxes are
 # Graviton; add --platform linux/arm64 if building on an x86 host):

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -1,76 +1,52 @@
-# Production Deployment — the Container Build
+# Production Deployment — Design
 
-How the champion model gets from an MLflow leaderboard to a running production container.
-Design rationale lives in
-[Live service → Production model artifacts](../roadmap/live-service.md#production-model-artifacts):
-**bake the champion model into the image at build time**, loaded via a plain `save`/`load` — no
-MLflow, run ID, or cache lookup at runtime. Promotion is therefore rebuild + redeploy, which is
-auditable via image tags and keeps MLflow completely out of the production runtime.
+How the champion model gets from an MLflow leaderboard into a running production container, and
+why. For the step-by-step recipe — promote a model, build the image, verify it, push it — see
+[Deploying a new production image](../live_service/deployment.md).
 
-This page assumes you've already read
-[Running live forecasts end-to-end](../live_service/dagster-workflow.md), which covers
-promoting a model and running `live_forecasts` **locally**. This page covers the one extra step
-needed to run the same thing as an unattended container: getting the promoted model *into* an
-image.
+## Baking the model into the image at build time
 
-## The promotion runbook
+Production forecasts run as ephemeral Fargate tasks under every AWS architecture option being
+considered (see [Live service: AWS architecture](../roadmap/live-service.md#aws-architecture)).
+An ephemeral container has no persistent disk and, under some architecture options, no reachable
+tracking server — so production inference needs some way to get a model without depending on
+either.
 
-1. **Pick the champion fold run ID** from the MLflow leaderboard — see
-   [Running live forecasts end-to-end → Step 1](../live_service/dagster-workflow.md#step-1-pick-a-champion-model).
+**Decision: bake the champion model into the image at build time, loaded via a plain
+`save`/`load` — no MLflow, run ID, or cache involved at runtime.** The model directory is
+produced once, out of band (a researcher picks the champion fold from the MLflow leaderboard and
+downloads its artifacts to local disk), then `COPY`'d into the image at build time. Promotion
+becomes rebuild + redeploy, which is auditable (image tags) and keeps MLflow completely out of
+the production runtime under every architecture option.
 
-2. **Materialise `promoted_model`** to populate `data/production_model/` on disk. This is the
-   same asset the local workflow uses — no separate script — either from the Dagster UI
-   ("Materialize" with `PromotedModelConfig.mlflow_run_id` filled in), or headlessly:
+**Rejected alternative:** MLflow artifact root on S3 fetched at container startup — more runtime
+moving parts, needs tracking-store access from prod, and slower cold starts.
 
-   ```bash
-   uv run dagster asset materialize -m nged_substation_forecast.definitions --select promoted_model \
-     --config-json '{"ops": {"promoted_model": {"config": {"mlflow_run_id": "<run-id>"}}}}'
-   ```
+This is deliberately simpler than reusing `BaseForecaster.load_from_mlflow`'s cache (the
+mechanism the CV pipeline already uses — see
+[ML orchestration: model artifacts](ml-orchestration.md#model-artifacts-mlflow-artifact-store-immutable-local-cache)):
+v0.1 has no MLflow dependency to cache against in the first place.
 
-3. **Build the image.** The build never contacts MLflow — it only `COPY`s the directory step 2
-   just populated, so it stays hermetic:
+**Future work:** once production wants to pick up a new champion without a rebuild + redeploy
+(e.g. after the [XGBoost quick wins](../roadmap/xgboost-improvements.md) start landing
+regularly), switch to fetching the champion model from MLflow dynamically — at that point
+`load_from_mlflow`'s local-disk cache becomes the production-resilience mechanism again (serving
+from disk on a cache hit so the live service survives an MLflow outage), exactly as it does for
+CV today.
 
-   ```bash
-   docker build \
-     --build-arg MODEL_RUN_ID=<run-id> \
-     --build-arg GIT_SHA=$(git rev-parse HEAD) \
-     -t nged-forecast:<run-id-short> .
-   ```
+## Why promotion is a Dagster asset, not a script
 
-   `MODEL_RUN_ID` and `GIT_SHA` are stamped as OCI labels (and `GIT_SHA` also as a runtime env
-   var) purely for traceability — confirm with `docker inspect nged-forecast:<tag>`.
+The "researcher downloads artifacts" step above is a manually-triggered Dagster asset,
+`promoted_model` (config `mlflow_run_id`), rather than a bare script — promotion becomes a
+materialisation, giving an audit trail and lineage for free. The download logic itself
+(`ml_core._production_helpers.fetch_model_artifacts`) is a pure, asset-independent helper, so
+nothing about this decision couples it to Dagster.
 
-4. **Push to ECR and point the ECS task definition at the new tag.** (ECR repository and ECS
-   task definitions are provisioned by the AWS infrastructure work,
-   [#206](https://github.com/openclimatefix/nged-substation-forecast/issues/206) — not yet
-   built at the time this page was written.)
-
-## Verifying a build locally
-
-Before trusting a new image, confirm it actually runs with **zero network access** — this is
-the test that matters, since the entire point of baking the model in is that production
-inference has no MLflow dependency at runtime:
-
-```bash
-docker run --network=none nged-forecast:<tag> \
-  job execute -m nged_substation_forecast.definitions -j live_forecasts_job \
-  --tags '{"dagster/partition": "<key>"}'
-```
-
-Partition selection uses `--tags`, not `--select`/`--partition`: `dagster job execute` has no
-`--partition` flag at all, and `dagster asset materialize --select <asset>` (which does) hits a
-pre-existing, unrelated `antlr4-python3-runtime`/Python 3.14 incompatibility in Dagster's own
-asset-selection-string parser — reproduces identically outside Docker, on a plain `dg dev`
-checkout, so it's an upstream/environment issue, not something introduced by this image.
-Selecting by job name (`-j`) skips that parser entirely.
-
-**Verified 2026-07-10** against a real promoted model: the run reaches
-`load_forecaster_from_dir` and loads the model successfully (confirmed via the step ordering in
-`production_assets.py` — model load happens before the NWP-availability lookup) with zero
-`mlflow` mentions anywhere in the log, then fails only on missing NWP data access (expected —
-no `DATA_PATH` was mounted for this isolated test). A full end-to-end run needs a real
-`DATA_PATH` (local mount or S3 credentials) supplied via environment variables, per
-[Environment & storage setup](../live_service/setup.md).
+**The Docker build reuses this same asset** (headlessly, via `dagster asset materialize`) — no
+separate fetch script was built, since a bare script would have duplicated the asset's audit
+trail for no benefit. The `docker build` step itself stays outside Dagster: it only ever runs on
+a laptop today, and image build/push becomes a CI-shaped concern once an MLflow tracking server
+and AWS infra exist — not something worth orchestrating through Dagster in the meantime.
 
 ## Two subtleties for the AWS deployment (not yet built)
 
@@ -90,8 +66,10 @@ Recorded here so they aren't lost when the Fargate work
 
 ## See also
 
-- [Live service roadmap](../roadmap/live-service.md) — the full v0.1 design, including AWS
-  architecture options still being decided.
+- [Live service roadmap](../roadmap/live-service.md) — the full v0.1 design, including the
+  AWS architecture options still being decided.
+- [Deploying a new production image](../live_service/deployment.md) — the step-by-step
+  promotion/build/push runbook.
 - [Environment & storage setup](../live_service/setup.md) — where data tables and local
   artifacts live, and how to point `Settings` at S3.
 - [ML Orchestration Design](ml-orchestration.md) — why production inference doesn't reuse the

--- a/docs/documentation-guide.md
+++ b/docs/documentation-guide.md
@@ -1,0 +1,62 @@
+# Documentation Guide
+
+How this repository's documentation and planning content is organized — where to look for
+something, and where to put something new.
+
+> **Status legend** (used throughout the design docs below):
+> ✅ **Implemented** — exists in code today ·
+> 🚧 **Planned** — designed, not yet built ·
+> 🔬 **Research** — exploratory / v2.
+
+## How planning works
+
+Planning content lives in four places with deliberately non-overlapping jobs:
+
+| Place | Job |
+|---|---|
+| **GitHub** ([issues](https://github.com/openclimatefix/nged-substation-forecast/issues) + the OCF Project board) | The **complete, ordered task list** — including quick tweaks and non-code tasks — plus all discussion. **Fine-grained prioritisation lives only in GitHub.** Epics map 1:1 to the [roadmap milestones](roadmap/index.md#milestones); dependencies are recorded as `blocked by` issue relationships. |
+| **[`docs/roadmap/`](roadmap/index.md)** | Design depth: What we plan to build and *why*. The milestone arc and inter-plan dependencies are recorded here; fine-grained task-level ordering is not. |
+| **`docs/`[techniques](techniques/index.md), [background](background/network.md), [architecture](architecture/overview.md), [ml_experimentation](ml_experimentation/index.md), [live_service](live_service/index.md)** | What is already built — design (`architecture/`) and operational how-to (`ml_experimentation/`, `live_service/`) alike. This is where content moves to from `docs/roadmap/` after implementation. |
+| **`plans/`** (repo root, not published) | At most **one** file: the mechanical checklist for the PR currently in flight, deleted when it merges. Usually empty. |
+
+**Relationship between `docs/roadmap/` and GitHub**: Every substantial 🚧 plan in the
+`docs/roadmap/` folder has a GitHub issue, and every dependency stated in `docs/roadmap/` exists as
+a `blocked by` link on GitHub — but GitHub freely contains small issues with no counterpart here in
+the docs. (🔬 research ideas are exempt from GitHub until they are promoted to a milestone.) The
+litmus test for needing a design doc in `docs/roadmap/`: *does it take more than a few sentences to explain?*
+
+When a piece of work ships, its design content **moves out** of `roadmap/` to its permanent home
+— and the roadmap page shrinks; when a page's last 🚧 item ships, the page is deleted. That
+permanent home splits along a **why vs. how** line: `architecture/` holds system design — the
+decisions and rationale, written once and rarely re-read step-by-step — while
+[`ml_experimentation/`](ml_experimentation/index.md) and
+[`live_service/`](live_service/index.md) hold operational how-to — step-by-step recipes for
+running what's already built, one per area (ML backtesting vs. the live production service).
+Each `architecture/` design page names its how-to counterpart (and vice versa) in a "See also"
+section — e.g. [ML Orchestration Design](architecture/ml-orchestration.md) ↔
+[ML Experimentation](ml_experimentation/index.md), and
+[Production Deployment — Design](architecture/production-deployment.md) ↔
+[Deploying a new production image](live_service/deployment.md). A page mixing the two — design
+rationale followed by a runbook with literal commands — is a sign it should split along this line.
+The `docs/roadmap/` folder therefore contains **only design for work that is not yet implemented**,
+and is never a mirror of the code. Because roadmap pages are deletable, **code must never link into
+`roadmap/`** — instead, code docstrings link to the durable sections (`techniques/`,
+`architecture/`, `background/`, `ml_experimentation/`, `live_service/`) instead. The *methods*
+behind these plans — differentiable physics, learned encoders, the disaggregation-evaluation
+protocol — live in [Techniques](techniques/index.md) for exactly this reason: they survive the
+roadmap items that apply them.
+
+### Which place do I use?
+
+| I want to… | Go to |
+|---|---|
+| Decide what to work on this morning | The GitHub Project board (complete, ordered) |
+| Discuss / challenge a plan | GitHub issue comments (fold conclusions back into the roadmap page) |
+| Think through a substantial design | A `docs/roadmap/` page, reviewed via PR |
+| Communicate direction to NGED / leadership | The [milestones](roadmap/index.md#milestones) (published site) |
+| Give an AI coding tool context on the broader plan | `docs/roadmap/` (plus `gh` for live task priorities) |
+| Understand a method (DP, encoders, …) | [`docs/techniques/`](techniques/index.md) |
+| Understand *why* something already built works the way it does | [`docs/architecture/`](architecture/overview.md) |
+| Learn *how* to run/operate something already built, step by step | [`docs/ml_experimentation/`](ml_experimentation/index.md), [`docs/live_service/`](live_service/index.md) |
+| File a quick tweak or a non-code task | A GitHub issue only — no markdown needed |
+| Write the mechanical checklist for the PR in flight | `plans/` (single file, deleted on merge) |

--- a/docs/index.md
+++ b/docs/index.md
@@ -45,4 +45,7 @@ operational systems, rather than us silently working around the gap.
 - [Live Service](live_service/index.md) — operating the live, 6-hourly production service: promoting a champion model and backfilling missed runs
 - [Roadmap](roadmap/index.md) — planned future work, plus detailed design docs for the delivery tables, forecast building blocks, metrics & leaderboard, data sources, differentiable physics, switching events, disaggregation evaluation, and encoders
 
-> Documentation convention: `roadmap/` holds **only not-yet-implemented** design. Once a feature ships, its docs move out to a permanent home (e.g. `architecture/` or `ml_experimentation/`), leaving a one-line pointer behind.
+> New to this repo? See the [Documentation Guide](documentation-guide.md) for how these sections
+> relate to each other and to GitHub issues — including the rule that `roadmap/` holds **only
+> not-yet-implemented** design, moving out to a permanent home (`architecture/` for design
+> rationale, `ml_experimentation/`/`live_service/` for step-by-step how-to) once a feature ships.

--- a/docs/live_service/deployment.md
+++ b/docs/live_service/deployment.md
@@ -1,0 +1,74 @@
+# Deploying a new production image
+
+How to get a promoted champion model into a runnable production image. Design rationale for why
+the container is built this way — bake the model in at build time, no MLflow at runtime — lives
+in [Production Deployment — Design](../architecture/production-deployment.md); this page is the
+mechanical recipe.
+
+> **Scope: building and verifying the image.** Pushing the image to a live AWS deployment (ECR,
+> compute) is a separate, not-yet-built step — see the
+> [AWS architecture](../roadmap/live-service.md#aws-architecture) roadmap section for that plan.
+
+## Step 1 — Pick and promote a champion model
+
+Follow [Running live forecasts end-to-end: Step 1](dagster-workflow.md#step-1-pick-a-champion-model)
+and [Step 2](dagster-workflow.md#step-2-materialise-promoted_model) to materialise
+`promoted_model`. This populates `data/production_model/` on disk — the same directory the
+image build below `COPY`s from.
+
+## Step 2 — Build the image
+
+The build never contacts MLflow — it only `COPY`s the directory Step 1 just populated, so it
+stays hermetic:
+
+```bash
+docker build \
+  --build-arg MODEL_RUN_ID=<run-id> \
+  --build-arg GIT_SHA=$(git rev-parse HEAD) \
+  -t nged-forecast:<run-id-short> .
+```
+
+`MODEL_RUN_ID` and `GIT_SHA` are stamped as OCI labels (and `GIT_SHA` also as a runtime env
+var) purely for traceability — confirm with `docker inspect nged-forecast:<tag>`.
+
+## Step 3 — Verify the build locally
+
+Before trusting a new image, confirm it actually runs with **zero network access** — this is
+the test that matters, since the entire point of baking the model in is that production
+inference has no MLflow dependency at runtime:
+
+```bash
+docker run --network=none nged-forecast:<tag> \
+  job execute -m nged_substation_forecast.definitions -j live_forecasts_job \
+  --tags '{"dagster/partition": "<key>"}'
+```
+
+Partition selection uses `--tags`, not `--select`/`--partition`: `dagster job execute` has no
+`--partition` flag at all, and `dagster asset materialize --select <asset>` (which does) hits a
+pre-existing, unrelated `antlr4-python3-runtime`/Python 3.14 incompatibility in Dagster's own
+asset-selection-string parser — reproduces identically outside Docker, on a plain `dg dev`
+checkout, so it's an upstream/environment issue, not something introduced by this image.
+Selecting by job name (`-j`) skips that parser entirely.
+
+**Verified 2026-07-10** against a real promoted model: the run reaches
+`load_forecaster_from_dir` and loads the model successfully (confirmed via the step ordering in
+`production_assets.py` — model load happens before the NWP-availability lookup) with zero
+`mlflow` mentions anywhere in the log, then fails only on missing NWP data access (expected —
+no `DATA_PATH` was mounted for this isolated test). A full end-to-end run needs a real
+`DATA_PATH` (local mount or S3 credentials) supplied via environment variables, per
+[Environment & storage setup](setup.md).
+
+## Step 4 — Push to ECR and deploy (not yet built)
+
+Pushing the verified image to ECR and running it as a scheduled Fargate task needs the AWS
+compute infrastructure itself, which doesn't exist yet — see
+[Live service: AWS architecture](../roadmap/live-service.md#aws-architecture) and
+[#286](https://github.com/openclimatefix/nged-substation-forecast/issues/286).
+
+## See also
+
+- [Production Deployment — Design](../architecture/production-deployment.md) — why the image is
+  built this way.
+- [Running live forecasts end-to-end](dagster-workflow.md) — driving the promoted model day to
+  day once it's live, and backfilling missed slots.
+- [Environment & storage setup](setup.md) — where data tables and local artifacts live.

--- a/docs/live_service/index.md
+++ b/docs/live_service/index.md
@@ -2,12 +2,16 @@
 
 How to operate the production forecasting service day to day. Unlike
 [the roadmap](../roadmap/index.md) (forward-looking design for work not yet built), this is the
-durable home for live-service operational docs once each piece ships — where
-[the roadmap's Live Service page](../roadmap/live-service.md) sends readers as its sections land
-(so far: the `live_forecasts` and `promoted_model` assets and local 6-hourly automation; still
-to come: production monitoring, the container build, AWS deployment). Once the whole v0.1 epic
-ships, the roadmap page is deleted and this section is the sole home for how the live service
-works.
+durable home for live-service **operational** docs — step-by-step recipes for running what's
+already built — once each piece ships. Design rationale (the *why*) lives in
+[`docs/architecture/`](../architecture/overview.md) instead; see that folder's
+[Production Deployment — Design](../architecture/production-deployment.md) page for this area's
+counterpart.
+[The roadmap's Live Service page](../roadmap/live-service.md) sends readers here as its sections
+land (so far: the `live_forecasts` and `promoted_model` assets, local 6-hourly automation, and
+the container build/verify runbook; still to come: production monitoring, AWS compute). Once the
+whole v0.1 epic ships, the roadmap page is deleted and this section is the sole home for how the
+live service works.
 
 This is distinct from [ML Experimentation](../ml_experimentation/index.md): that area covers
 training and backtesting candidate models against historical data; this area covers picking one
@@ -18,6 +22,8 @@ of those candidates as the running production model and keeping live forecasts f
 - [Environment & storage setup](setup.md) — where the data tables and local artifacts live, and
   how to configure credentials for running locally, against a local MinIO, or with the data tables
   on AWS S3.
+- [Deploying a new production image](deployment.md) — step-by-step recipe: promote a champion
+  model, build the image, verify it runs with zero MLflow dependency.
 - [Running live forecasts end-to-end](dagster-workflow.md) — step-by-step recipe: promote a
   champion model to `promoted_model`, let the 6-hourly `live_forecasts` schedule run (or
   materialise a slot by hand), inspect a forecast, and backfill a missed slot in replay mode.

--- a/docs/live_service/setup.md
+++ b/docs/live_service/setup.md
@@ -115,7 +115,7 @@ against an in-process `moto` server.)
 > **data tables** at S3 — which is all the ephemeral-compute deployment needs from the storage layer,
 > and is enough to run the stack from your laptop against an S3 `DATA_PATH` today. Building the
 > production container itself is covered by
-> [Production Deployment](https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/);
+> [Deploying a new production image](deployment.md);
 > running it as an unattended, scheduled **Fargate task** (ECR, EventBridge scheduling) is a
 > separate, not-yet-built roadmap item — see the
 > [AWS architecture](https://openclimatefix.github.io/nged-substation-forecast/roadmap/live-service/#aws-architecture)

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -19,7 +19,7 @@ Planning content lives in four places with deliberately non-overlapping jobs:
 |---|---|
 | **GitHub** ([issues](https://github.com/openclimatefix/nged-substation-forecast/issues) + the OCF Project board) | The **complete, ordered task list** — including quick tweaks and non-code tasks — plus all discussion. **Fine-grained prioritisation lives only in GitHub.** Epics map 1:1 to the milestones below; dependencies are recorded as `blocked by` issue relationships. |
 | **`docs/roadmap/` (this folder)** | Design depth: What we plan to build and *why*. The milestone arc and inter-plan dependencies are recorded here; fine-grained task-level ordering is not. |
-| **`docs/`[techniques](../techniques/index.md), [background](../background/network.md), [architecture](../architecture/overview.md)** | What is already built. This is where content moves to from `docs/roadmap/` after implementation. |
+| **`docs/`[techniques](../techniques/index.md), [background](../background/network.md), [architecture](../architecture/overview.md), [ml_experimentation](../ml_experimentation/index.md), [live_service](../live_service/index.md)** | What is already built — design (`architecture/`) and operational how-to (`ml_experimentation/`, `live_service/`) alike. This is where content moves to from `docs/roadmap/` after implementation. |
 | **`plans/`** (repo root, not published) | At most **one** file: the mechanical checklist for the PR currently in flight, deleted when it merges. Usually empty. |
 
 **Relationship between `docs/roadmap/` and GitHub**: Every substantial 🚧 plan in the
@@ -28,16 +28,26 @@ a `blocked by` link on GitHub — but GitHub freely contains small issues with n
 the docs. (🔬 research ideas are exempt from GitHub until they are promoted to a milestone.) The
 litmus test for needing a design doc in `docs/roadmap/`: *does it take more than a few sentences to explain?*
 
-When a piece of work ships, its design content **moves out** of `roadmap/` to its permanent home —
-`architecture/` for system design, [`ml_experimentation/`](../ml_experimentation/index.md) for ML
-methodology — and the roadmap page shrinks; when a page's last 🚧 item ships, the page is deleted.
+When a piece of work ships, its design content **moves out** of `roadmap/` to its permanent home
+— and the roadmap page shrinks; when a page's last 🚧 item ships, the page is deleted. That
+permanent home splits along a **why vs. how** line: `architecture/` holds system design — the
+decisions and rationale, written once and rarely re-read step-by-step — while
+[`ml_experimentation/`](../ml_experimentation/index.md) and
+[`live_service/`](../live_service/index.md) hold operational how-to — step-by-step recipes for
+running what's already built, one per area (ML backtesting vs. the live production service).
+Each `architecture/` design page names its how-to counterpart (and vice versa) in a "See also"
+section — e.g. [ML Orchestration Design](../architecture/ml-orchestration.md) ↔
+[ML Experimentation](../ml_experimentation/index.md), and
+[Production Deployment — Design](../architecture/production-deployment.md) ↔
+[Deploying a new production image](../live_service/deployment.md). A page mixing the two — design
+rationale followed by a runbook with literal commands — is a sign it should split along this line.
 The `docs/roadmap/` folder therefore contains **only design for work that is not yet implemented**,
 and is never a mirror of the code. Because roadmap pages are deletable, **code must never link into
 `roadmap/`** — instead, code docstrings link to the durable sections (`techniques/`,
-`architecture/`, `background/`, `ml_experimentation/`) instead. The *methods* behind these plans —
-differentiable physics, learned encoders, the disaggregation-evaluation protocol — live in
-[Techniques](../techniques/index.md) for exactly this reason: they survive the roadmap items that
-apply them.
+`architecture/`, `background/`, `ml_experimentation/`, `live_service/`) instead. The *methods*
+behind these plans — differentiable physics, learned encoders, the disaggregation-evaluation
+protocol — live in [Techniques](../techniques/index.md) for exactly this reason: they survive the
+roadmap items that apply them.
 
 ### Which place do I use?
 
@@ -49,7 +59,8 @@ apply them.
 | Communicate direction to NGED / leadership | The [milestones](#milestones) below (published site) |
 | Give an AI coding tool context on the broader plan | `docs/roadmap/` (plus `gh` for live task priorities) |
 | Understand a method (DP, encoders, …) | [`docs/techniques/`](../techniques/index.md) |
-| Understand what's already built | [`docs/architecture/`](../architecture/overview.md), [`docs/ml_experimentation/`](../ml_experimentation/index.md) |
+| Understand *why* something already built works the way it does | [`docs/architecture/`](../architecture/overview.md) |
+| Learn *how* to run/operate something already built, step by step | [`docs/ml_experimentation/`](../ml_experimentation/index.md), [`docs/live_service/`](../live_service/index.md) |
 | File a quick tweak or a non-code task | A GitHub issue only — no markdown needed |
 | Write the mechanical checklist for the PR in flight | `plans/` (single file, deleted on merge) |
 

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -6,63 +6,14 @@ review and a reprioritisation (decided 2026-07-01): **the top priority is gettin
 forecast running on AWS** — scientific-improvement work waits until the live service is running.
 Technical plans change as we learn more — treat this as a best-estimate, not a guarantee.
 
+> For how this page relates to GitHub issues, `docs/architecture/`, and the rest of the docs —
+> and which place to put new planning content — see the
+> [Documentation Guide](../documentation-guide.md).
+>
 > **Status legend** (used throughout these design docs):
 > ✅ **Implemented** — exists in code today ·
 > 🚧 **Planned** — designed, not yet built ·
 > 🔬 **Research** — exploratory / v2.
-
-## How planning works
-
-Planning content lives in four places with deliberately non-overlapping jobs:
-
-| Place | Job |
-|---|---|
-| **GitHub** ([issues](https://github.com/openclimatefix/nged-substation-forecast/issues) + the OCF Project board) | The **complete, ordered task list** — including quick tweaks and non-code tasks — plus all discussion. **Fine-grained prioritisation lives only in GitHub.** Epics map 1:1 to the milestones below; dependencies are recorded as `blocked by` issue relationships. |
-| **`docs/roadmap/` (this folder)** | Design depth: What we plan to build and *why*. The milestone arc and inter-plan dependencies are recorded here; fine-grained task-level ordering is not. |
-| **`docs/`[techniques](../techniques/index.md), [background](../background/network.md), [architecture](../architecture/overview.md), [ml_experimentation](../ml_experimentation/index.md), [live_service](../live_service/index.md)** | What is already built — design (`architecture/`) and operational how-to (`ml_experimentation/`, `live_service/`) alike. This is where content moves to from `docs/roadmap/` after implementation. |
-| **`plans/`** (repo root, not published) | At most **one** file: the mechanical checklist for the PR currently in flight, deleted when it merges. Usually empty. |
-
-**Relationship between `docs/roadmap/` and GitHub**: Every substantial 🚧 plan in the
-`docs/roadmap/` folder has a GitHub issue, and every dependency stated in `docs/roadmap/` exists as
-a `blocked by` link on GitHub — but GitHub freely contains small issues with no counterpart here in
-the docs. (🔬 research ideas are exempt from GitHub until they are promoted to a milestone.) The
-litmus test for needing a design doc in `docs/roadmap/`: *does it take more than a few sentences to explain?*
-
-When a piece of work ships, its design content **moves out** of `roadmap/` to its permanent home
-— and the roadmap page shrinks; when a page's last 🚧 item ships, the page is deleted. That
-permanent home splits along a **why vs. how** line: `architecture/` holds system design — the
-decisions and rationale, written once and rarely re-read step-by-step — while
-[`ml_experimentation/`](../ml_experimentation/index.md) and
-[`live_service/`](../live_service/index.md) hold operational how-to — step-by-step recipes for
-running what's already built, one per area (ML backtesting vs. the live production service).
-Each `architecture/` design page names its how-to counterpart (and vice versa) in a "See also"
-section — e.g. [ML Orchestration Design](../architecture/ml-orchestration.md) ↔
-[ML Experimentation](../ml_experimentation/index.md), and
-[Production Deployment — Design](../architecture/production-deployment.md) ↔
-[Deploying a new production image](../live_service/deployment.md). A page mixing the two — design
-rationale followed by a runbook with literal commands — is a sign it should split along this line.
-The `docs/roadmap/` folder therefore contains **only design for work that is not yet implemented**,
-and is never a mirror of the code. Because roadmap pages are deletable, **code must never link into
-`roadmap/`** — instead, code docstrings link to the durable sections (`techniques/`,
-`architecture/`, `background/`, `ml_experimentation/`, `live_service/`) instead. The *methods*
-behind these plans — differentiable physics, learned encoders, the disaggregation-evaluation
-protocol — live in [Techniques](../techniques/index.md) for exactly this reason: they survive the
-roadmap items that apply them.
-
-### Which place do I use?
-
-| I want to… | Go to |
-|---|---|
-| Decide what to work on this morning | The GitHub Project board (complete, ordered) |
-| Discuss / challenge a plan | GitHub issue comments (fold conclusions back into the roadmap page) |
-| Think through a substantial design | A `docs/roadmap/` page, reviewed via PR |
-| Communicate direction to NGED / leadership | The [milestones](#milestones) below (published site) |
-| Give an AI coding tool context on the broader plan | `docs/roadmap/` (plus `gh` for live task priorities) |
-| Understand a method (DP, encoders, …) | [`docs/techniques/`](../techniques/index.md) |
-| Understand *why* something already built works the way it does | [`docs/architecture/`](../architecture/overview.md) |
-| Learn *how* to run/operate something already built, step by step | [`docs/ml_experimentation/`](../ml_experimentation/index.md), [`docs/live_service/`](../live_service/index.md) |
-| File a quick tweak or a non-code task | A GitHub issue only — no markdown needed |
-| Write the mechanical checklist for the PR in flight | `plans/` (single file, deleted on merge) |
 
 ## Design documents
 

--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -119,46 +119,13 @@ deps: [ecmwf_ens, power_time_series_and_metadata]
 
 Issue: [#222](https://github.com/openclimatefix/nged-substation-forecast/issues/222)
 
-> **Status: ✅ Implemented.** The `Dockerfile` (repo root) and the promotion runbook now live at
-> [Production Deployment](https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/),
-> the permanent home this section's shipped material moves to. Remaining work on this page —
-> the [AWS infrastructure](#aws-architecture) itself — is unaffected.
-
-The deployment below runs forecasts as ephemeral Fargate tasks under every architecture
-option. An ephemeral container has no persistent disk and, under some architecture options, no
-reachable tracking server — so without a decision here, production inference has no way to get
-a model. This must be decided before writing the Dockerfile.
-
-**Decision: bake the champion model into the image at build time, loaded via a plain
-`save`/`load` — no MLflow, run ID, or cache involved at runtime.** The model directory is
-produced once, out of band (a researcher picks the champion fold from the MLflow leaderboard
-and downloads its artifacts to local disk), then `COPY`'d into the image at build time.
-Promotion becomes rebuild + redeploy, which is auditable (image tags) and keeps MLflow
-completely out of the production runtime under every architecture option. Rejected
-alternative: MLflow artifact root on S3 fetched at container startup — more runtime moving
-parts, needs tracking-store access from prod, and slower cold starts.
-
-This is deliberately simpler than reusing `BaseForecaster.load_from_mlflow`'s cache (the
-mechanism the CV pipeline already uses — see
-[ML orchestration](../architecture/ml-orchestration.md#model-artifacts-mlflow-artifact-store-immutable-local-cache)):
-v0.1 has no MLflow dependency to cache against in the first place. **Future work:** once
-production wants to pick up a new champion without a rebuild + redeploy (e.g. after the
-[XGBoost quick wins](xgboost-improvements.md) start landing regularly), switch to fetching the
-champion model from MLflow dynamically — at that point `load_from_mlflow`'s local-disk cache
-becomes the production-resilience mechanism again (serving from disk on a cache hit so the live
-service survives an MLflow outage), exactly as it does for CV today.
-
-**Local operation (implemented):** for running on Jack's laptop, the "researcher downloads
-artifacts" step above is a manually-triggered Dagster asset, `promoted_model` (config
-`mlflow_run_id`), rather than a bare script — promotion becomes a materialisation, giving an
-audit trail and lineage for free. The download logic itself
-(`ml_core._production_helpers.fetch_model_artifacts`) is a pure, asset-independent helper.
-**The Docker build reuses this same asset** (headlessly, via `dagster asset materialize`) —
-no separate fetch script was built; see
-[Production Deployment](https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/)
-for why a bare script would have been redundant, and why the `docker build` step itself stays
-outside Dagster (it would only ever run on a laptop, and image build/push is a CI-shaped
-concern once an MLflow tracking server and AWS infra exist).
+> **Status: ✅ Done.** The design decision (bake the champion model into the image at build
+> time; no MLflow at runtime) and its rationale now live at
+> [Production Deployment — Design](https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/);
+> the promotion/build/verify runbook lives at
+> [Deploying a new production image](https://openclimatefix.github.io/nged-substation-forecast/live_service/deployment/).
+> Remaining work on this page — the [AWS infrastructure](#aws-architecture) itself — is
+> unaffected.
 
 ## AWS architecture
 
@@ -559,7 +526,7 @@ Common to all options:
   language for it. Terraform vs CDK is Jack's call to make when Stage 2 work starts; this page
   does not pick one.
 - Document the few one-time manual steps (SNS subscription confirm, Tailscale join) in a runbook
-  page (`docs/architecture/production-deployment.md`, extending the promotion runbook above).
+  page (`docs/live_service/deployment.md`, extending the promotion runbook above).
 
 Option B adds (instead of option A's hourly EventBridge Scheduler → `RunTask` cron):
 
@@ -585,7 +552,7 @@ order issues were opened.
 | [#208 Run every 6 hours locally and backfill missing runs (as a test)](https://github.com/openclimatefix/nged-substation-forecast/issues/208) | [Deployment workstream 1](#deployment-workstream-1-the-production-job-local-dress-rehearsal) — done, via native per-asset schedules |
 | [#121 Use obstore instead of pathlib](https://github.com/openclimatefix/nged-substation-forecast/issues/121) | S3-capable data paths — done ([setup guide](https://openclimatefix.github.io/nged-substation-forecast/live_service/setup/)) |
 | [#50 Define all paths in Settings](https://github.com/openclimatefix/nged-substation-forecast/issues/50) | S3-capable data paths — done |
-| [#222 Build the production Docker image](https://github.com/openclimatefix/nged-substation-forecast/issues/222) | [Production model artifacts](#production-model-artifacts) — done ([promotion runbook](https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/)) |
+| [#222 Build the production Docker image](https://github.com/openclimatefix/nged-substation-forecast/issues/222) | [Production model artifacts](#production-model-artifacts) — done ([promotion runbook](https://openclimatefix.github.io/nged-substation-forecast/live_service/deployment/)) |
 | [#206 Deploy to AWS!](https://github.com/openclimatefix/nged-substation-forecast/issues/206) | This page (the options above supersede its cost analysis; the issue links back here) |
 | [#197 Make fold-run param logging re-run-safe](https://github.com/openclimatefix/nged-substation-forecast/issues/197) | Bug fix folded into the v0.1 epic (MLflow param immutability on re-runs) |
 | [#63 Send telemetry to OCF's Sentry.io](https://github.com/openclimatefix/nged-substation-forecast/issues/63) | Observability — CloudWatch + SNS first; Sentry as the follow-up |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,7 @@ plugins:
 
 nav:
   - Home: index.md
+  - Documentation Guide: documentation-guide.md
   - Background & Challenges:
       - NGED Network: background/network.md
       - Requirements: background/requirements.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,7 +50,7 @@ nav:
       - Overview: architecture/overview.md
       - Forecast Delivery: architecture/forecast-delivery.md
       - ML Orchestration Design: architecture/ml-orchestration.md
-      - Production Deployment: architecture/production-deployment.md
+      - Production Deployment Design: architecture/production-deployment.md
       - Code Style: architecture/code-style.md
   - ML Experimentation:
       - Overview: ml_experimentation/index.md
@@ -61,6 +61,7 @@ nav:
   - Live Service:
       - Overview: live_service/index.md
       - Environment & storage setup: live_service/setup.md
+      - Deploying a new production image: live_service/deployment.md
       - Running live forecasts end-to-end: live_service/dagster-workflow.md
   - Roadmap:
       - Overview: roadmap/index.md


### PR DESCRIPTION
## Summary

While scoping [#286](https://github.com/openclimatefix/nged-substation-forecast/issues/286) (AWS compute setup docs), noticed `architecture/production-deployment.md` mixed design rationale with a literal step-by-step runbook — inconsistent with the why-vs-how split already used elsewhere (`architecture/ml-orchestration.md` vs `ml_experimentation/`). Fixed before building on top of it, then found the same "two jobs on one page" shape in `roadmap/index.md` itself and fixed that too.

**Design vs. how-to split** (`production-deployment.md`):
- Moved the step-by-step promotion runbook (build image, verify locally) to a new `docs/live_service/deployment.md`, matching the "how" role the rest of `live_service/` plays.
- Trimmed `docs/architecture/production-deployment.md` to design rationale only, and actually moved the substance that `roadmap/live-service.md`'s "Production model artifacts" section claimed (but never completed) moving out of the roadmap.
- Fixed the `Dockerfile` header comment, which linked into `docs/roadmap/` — a violation of CLAUDE.md's own "code must never link into `roadmap/`" rule (roadmap pages get deleted once shipped).

**Docs-organization guide extracted from `roadmap/index.md`**:
- `roadmap/index.md`'s "How planning works" + "Which place do I use?" content was meta/process guidance about the whole docs site (GitHub, `plans/`, `architecture/`, `ml_experimentation/`, `live_service/`, `roadmap/` itself) — not roadmap content, and buried under a nav section a reader not doing planning work would reasonably skip.
- Extracted it into a new top-level `docs/documentation-guide.md`, nav-listed near Home. `roadmap/index.md` keeps only its actual content (status legend, design docs, milestone arc) plus a one-line pointer. `docs/index.md` and `CLAUDE.md`'s pointers retarget to the new page.
- Wrote the architecture-vs-how-to (why vs. how) rule down explicitly in the new guide, so future docs don't re-mix the two.
- Added `docs/live_service/` to CLAUDE.md's list of durable docs code may link to (it was omitted alongside `ml_experimentation/`, which plays the same role).

No behavioural/code changes — docs only.

## Test plan

- [x] `uv run pymarkdown scan -r docs README.md CLAUDE.md metadata/README.md packages/*/README.md` — clean (one pre-existing, unrelated warning in `background/requirements.md`)
- [x] `uv run mkdocs build --strict` — builds clean
- [x] Scripted check that every internal markdown link/anchor touched in this PR resolves to an existing file/heading
- [x] Confirmed no existing anchors pointed into the headings extracted to `documentation-guide.md`, so the move has no dangling inbound links
- [x] Pre-commit hooks passed on both commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)