### PR TITLE
Add manual AWS compute setup + ECR push recipe

### DIFF
--- a/docs/live_service/deployment.md
+++ b/docs/live_service/deployment.md
@@ -1,13 +1,17 @@
 # Deploying a new production image
 
-How to get a promoted champion model into a runnable production image. Design rationale for why
-the container is built this way — bake the model in at build time, no MLflow at runtime — lives
-in [Production Deployment — Design](../architecture/production-deployment.md); this page is the
+How to get a promoted champion model into a runnable production image, and run it on AWS. Design
+rationale for why the container is built this way — bake the model in at build time, no MLflow
+at runtime — lives in
+[Production Deployment — Design](../architecture/production-deployment.md); this page is the
 mechanical recipe.
 
-> **Scope: building and verifying the image.** Pushing the image to a live AWS deployment (ECR,
-> compute) is a separate, not-yet-built step — see the
-> [AWS architecture](../roadmap/live-service.md#aws-architecture) roadmap section for that plan.
+> **Scope: manual, point-and-click AWS compute — not yet the unattended deployment.** Steps 4–8
+> below get a verified image onto ECR and running as a one-off Fargate task, which is enough to
+> confirm the whole path end-to-end. The always-on control-plane box (Dagster daemon, Postgres,
+> `EcsRunLauncher`, the 6-hourly schedule) and infra-as-code are still not built — see
+> [AWS architecture](../roadmap/live-service.md#aws-architecture) for that plan. Everything here
+> is done by hand in the AWS console; no Terraform/CDK yet.
 
 ## Step 1 — Pick and promote a champion model
 
@@ -58,12 +62,97 @@ no `DATA_PATH` was mounted for this isolated test). A full end-to-end run needs 
 `DATA_PATH` (local mount or S3 credentials) supplied via environment variables, per
 [Environment & storage setup](setup.md).
 
-## Step 4 — Push to ECR and deploy (not yet built)
+## Step 4 — Create the ECR repository
 
-Pushing the verified image to ECR and running it as a scheduled Fargate task needs the AWS
-compute infrastructure itself, which doesn't exist yet — see
-[Live service: AWS architecture](../roadmap/live-service.md#aws-architecture) and
-[#286](https://github.com/openclimatefix/nged-substation-forecast/issues/286).
+In the AWS console → **ECR** → **Create repository** (same `eu-west-2` region as the S3 bucket
+in [Environment & storage setup: Step 1](setup.md#step-1-create-the-s3-bucket)):
+
+1. **Visibility** Private.
+2. **Name** `nged-forecast` (matches the local image tag used in [Step 2](#step-2-build-the-image)
+   above — keeps `docker build -t nged-forecast:<tag>` and the ECR URI consistent).
+3. **Scan on push** on — free vulnerability scanning, no reason not to.
+4. Leave tag immutability off; image tags here are already unique per `git rev-parse HEAD`
+   short-SHA, so nothing relies on retagging.
+
+## Step 5 — Push the image to ECR
+
+Authenticate Docker against the new repository, then tag and push the image built in
+[Step 2](#step-2-build-the-image):
+
+```bash
+aws ecr get-login-password --region eu-west-2 \
+  | docker login --username AWS --password-stdin <account-id>.dkr.ecr.eu-west-2.amazonaws.com
+
+docker tag nged-forecast:<run-id-short> \
+  <account-id>.dkr.ecr.eu-west-2.amazonaws.com/nged-forecast:<run-id-short>
+
+docker push <account-id>.dkr.ecr.eu-west-2.amazonaws.com/nged-forecast:<run-id-short>
+```
+
+`<account-id>` is the 12-digit AWS account ID (visible in the console's top-right account menu,
+or `aws sts get-caller-identity --query Account --output text`).
+
+## Step 6 — IAM roles for the task
+
+Fargate tasks need **two** separate roles, not one — they serve different principals:
+
+- **Task execution role** — used by the *ECS agent* itself, before your code ever runs: pulling
+  the image from ECR and shipping container output to CloudWatch Logs. Create a role for the
+  `ecs-tasks.amazonaws.com` service and attach the AWS-managed
+  `AmazonECSTaskExecutionRolePolicy` — it already covers exactly these two things, so no custom
+  policy is needed.
+- **Task role** — used by *your code* once it's running: this is what lets the container read
+  and write the data bucket. Reuse the same S3 policy from
+  [Environment & storage setup: Step 2](setup.md#step-2-grant-access-with-iam), attached to a
+  second role (also trusted by `ecs-tasks.amazonaws.com`). Nothing else is needed — with this
+  role attached, delta-rs' `object_store` auto-discovers temporary credentials at runtime, so
+  `DATA_STORE_*` stays unset (see [setup.md's IAM-role row](setup.md#step-3-point-settings-at-the-bucket)).
+
+No static AWS keys anywhere in either role — this is the same IAM-role auto-discovery setup.md
+already relies on for compute running on AWS.
+
+## Step 7 — Create the ECS cluster and Fargate task definition
+
+1. **ECS** → **Clusters** → **Create cluster** → *Networking only* (Fargate; no EC2 instances to
+   manage) — a bare cluster is just a namespace, so a single `nged-forecast` cluster is enough
+   for now.
+2. **ECS** → **Task definitions** → **Create new task definition** → *Fargate*:
+   - **Task role**: the task role from [Step 6](#step-6-iam-roles-for-the-task).
+   - **Task execution role**: the execution role from [Step 6](#step-6-iam-roles-for-the-task).
+   - **Task size**: 4 vCPU / 16 GB, **ARM64** (`linux/arm64`) — matches the measured inference
+     peak (~9 GB) and the image's own build target (see the Dockerfile's ARM build note); ARM
+     Fargate is also ~20% cheaper than x86 for the same size.
+   - **Container**: image URI `<account-id>.dkr.ecr.eu-west-2.amazonaws.com/nged-forecast:<tag>`
+     from [Step 5](#step-5-push-the-image-to-ecr); log configuration → **awslogs**, a new
+     CloudWatch log group (e.g. `/ecs/nged-forecast`), region `eu-west-2`.
+   - **Environment variables**: at minimum `DATA_PATH=s3://<your-bucket>/data` (see
+     [setup.md's on-AWS settings](setup.md#step-3-point-settings-at-the-bucket)) — leave
+     `DATA_STORE_*` unset, since the task role supplies credentials.
+
+## Step 8 — Verify: run the task manually
+
+There's no schedule yet, so trigger one task directly and confirm the whole path end-to-end —
+this mirrors the "manual `RunTask`" verification the roadmap's
+[AWS architecture](../roadmap/live-service.md#aws-architecture) plan already anticipates as the
+fallback verification path regardless of the eventual always-on architecture:
+
+```bash
+aws ecs run-task \
+  --cluster nged-forecast \
+  --task-definition nged-forecast \
+  --launch-type FARGATE \
+  --network-configuration "awsvpcConfiguration={subnets=[<subnet-id>],securityGroups=[<sg-id>],assignPublicIp=ENABLED}" \
+  --overrides '{"containerOverrides": [{"name": "<container-name>", "command": [
+    "job", "execute", "-m", "nged_substation_forecast.definitions", "-j", "live_forecasts_job",
+    "--tags", "{\"dagster/partition\": \"<key>\"}"
+  ]}]}'
+```
+
+`assignPublicIp=ENABLED` (with a public subnet) is the simplest way to give the task internet
+egress for its ECR pull and S3/CloudWatch calls without a NAT gateway; revisit once the
+always-on control-plane box (and its VPC design) exists. Follow the run in **ECS** → the
+cluster → **Tasks**, then **CloudWatch Logs** for the container's output — confirm it reaches
+`load_forecaster_from_dir` and a new forecast lands under `s3://<your-bucket>/data/power_forecasts/…`.
 
 ## See also
 
@@ -71,4 +160,7 @@ compute infrastructure itself, which doesn't exist yet — see
   built this way.
 - [Running live forecasts end-to-end](dagster-workflow.md) — driving the promoted model day to
   day once it's live, and backfilling missed slots.
-- [Environment & storage setup](setup.md) — where data tables and local artifacts live.
+- [Environment & storage setup](setup.md) — where data tables and local artifacts live, and the
+  S3 bucket + IAM policy Steps 4–8 above build on.
+- [Live service: AWS architecture](../roadmap/live-service.md#aws-architecture) — the always-on
+  control-plane box, scheduling, and infra-as-code, still to come.

--- a/docs/live_service/deployment.md
+++ b/docs/live_service/deployment.md
@@ -96,13 +96,13 @@ or `aws sts get-caller-identity --query Account --output text`).
 
 Fargate tasks need **two** separate roles, not one — they serve different principals:
 
-- **Task execution role** — used by the *ECS agent* itself, before your code ever runs: pulling
-  the image from ECR and shipping container output to CloudWatch Logs. Create a role for the
-  `ecs-tasks.amazonaws.com` service and attach the AWS-managed
-  `AmazonECSTaskExecutionRolePolicy` — it already covers exactly these two things, so no custom
-  policy is needed.
-- **Task role** — used by *your code* once it's running: this is what lets the container read
-  and write the data bucket. Reuse the same S3 policy from
+- **Task execution role**, `nged-forecast-task-execution-role` — used by the *ECS agent* itself,
+  before your code ever runs: pulling the image from ECR and shipping container output to
+  CloudWatch Logs. Create a role for the `ecs-tasks.amazonaws.com` service and attach the
+  AWS-managed `AmazonECSTaskExecutionRolePolicy` — it already covers exactly these two things, so
+  no custom policy is needed.
+- **Task role**, `nged-forecast-task-role` — used by *your code* once it's running: this is what
+  lets the container read and write the data bucket. Reuse the same S3 policy from
   [Environment & storage setup: Step 2](setup.md#step-2-grant-access-with-iam), attached to a
   second role (also trusted by `ecs-tasks.amazonaws.com`). Nothing else is needed — with this
   role attached, delta-rs' `object_store` auto-discovers temporary credentials at runtime, so
@@ -125,7 +125,7 @@ already relies on for compute running on AWS.
    - **Container**: image URI `<account-id>.dkr.ecr.eu-west-2.amazonaws.com/nged-forecast:<tag>`
      from [Step 5](#step-5-push-the-image-to-ecr); log configuration → **awslogs**, a new
      CloudWatch log group (e.g. `/ecs/nged-forecast`), region `eu-west-2`.
-   - **Environment variables**: at minimum `DATA_PATH=s3://<your-bucket>/data` (see
+   - **Environment variables**: at minimum `DATA_PATH=s3://nged-forecast-data/data` (see
      [setup.md's on-AWS settings](setup.md#step-3-point-settings-at-the-bucket)) — leave
      `DATA_STORE_*` unset, since the task role supplies credentials.
 
@@ -138,6 +138,7 @@ fallback verification path regardless of the eventual always-on architecture:
 
 ```bash
 aws ecs run-task \
+  --region eu-west-2 \
   --cluster nged-forecast \
   --task-definition nged-forecast \
   --launch-type FARGATE \
@@ -148,11 +149,16 @@ aws ecs run-task \
   ]}]}'
 ```
 
+> **Region matters here.** Unlike the `docker` commands above (region is baked into the ECR
+> URI), the AWS CLI falls back to your configured default region if `--region` is omitted —
+> check yours with `aws configure get region` and don't assume it's `eu-west-2`.
+
 `assignPublicIp=ENABLED` (with a public subnet) is the simplest way to give the task internet
 egress for its ECR pull and S3/CloudWatch calls without a NAT gateway; revisit once the
 always-on control-plane box (and its VPC design) exists. Follow the run in **ECS** → the
 cluster → **Tasks**, then **CloudWatch Logs** for the container's output — confirm it reaches
-`load_forecaster_from_dir` and a new forecast lands under `s3://<your-bucket>/data/power_forecasts/…`.
+`load_forecaster_from_dir` and a new forecast lands under
+`s3://nged-forecast-data/data/power_forecasts/…`.
 
 ## See also
 

--- a/docs/live_service/setup.md
+++ b/docs/live_service/setup.md
@@ -127,7 +127,7 @@ In the AWS console → **S3** → **Create bucket**:
 
 1. **Region** `eu-west-2` (London) — keep every resource in one region so S3 ↔ compute transfer
    stays free.
-2. **Name** e.g. `nged-flexpectation-data` (bucket names are globally unique; pick your own).
+2. **Name** e.g. `nged-forecast-data` (bucket names are globally unique; pick your own).
 3. Leave **Block all public access** **on**, and default **SSE-S3** encryption on. Nothing here is
    public.
 4. **Versioning** is optional and not required by the app.
@@ -148,8 +148,8 @@ Create an IAM policy scoped to just this bucket:
       "Effect": "Allow",
       "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"],
       "Resource": [
-        "arn:aws:s3:::nged-flexpectation-data",
-        "arn:aws:s3:::nged-flexpectation-data/*"
+        "arn:aws:s3:::nged-forecast-data",
+        "arn:aws:s3:::nged-forecast-data/*"
       ]
     }
   ]
@@ -172,14 +172,14 @@ local disk. What else you set depends on Step 2:
 **On AWS compute (IAM role)** — credentials and region are auto-discovered, so just:
 
 ```dotenv
-DATA_PATH=s3://nged-flexpectation-data/data
+DATA_PATH=s3://nged-forecast-data/data
 ```
 
 **From your laptop (IAM user access key)** — supply the key and region, but **not** an endpoint URL
 (that is only for non-AWS/MinIO endpoints, and it would wrongly allow plain HTTP):
 
 ```dotenv
-DATA_PATH=s3://nged-flexpectation-data/data
+DATA_PATH=s3://nged-forecast-data/data
 DATA_STORE_ACCESS_KEY_ID=<access key id>
 DATA_STORE_SECRET_ACCESS_KEY=<secret access key>
 DATA_STORE_REGION=eu-west-2
@@ -191,7 +191,7 @@ Polars, and obstore all understand, so this one dict feeds every read and write.
 ### Step 4 — Verify
 
 With the above in place, materialise any data-writing asset (e.g. `power_time_series_and_metadata`)
-from the Dagster UI, then confirm the objects appear under `s3://nged-flexpectation-data/data/…` in
+from the Dagster UI, then confirm the objects appear under `s3://nged-forecast-data/data/…` in
 the S3 console. Because `LOCAL_ARTIFACTS_PATH` stayed local, a subsequent `promoted_model`
 materialisation still writes the model to `<repo>/data/production_model/` on disk — the two roots
 behaving independently is exactly what you want to see.

--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -144,9 +144,9 @@ filesystem). Two requirements also firmed up that Level 1 does not serve:
 2. **An always-on dev dashboard** (a simple Marimo web app showing the latest forecasts) —
    so *something* must be always-on regardless.
 
-**Current decision status: leaning Option B (small EC2 control-plane box + `EcsRunLauncher`),
-final call pending.** The five options researched are recorded below so the decision has a
-durable record. The implementation workstreams are identical under every option except the
+**Decision: Option B (small EC2 control-plane box + `EcsRunLauncher`), decided 2026-07-11.** The
+five options researched are recorded below so the decision has a durable record. The
+implementation workstreams are identical under every option except the
 infrastructure one.
 
 ### Cost summary
@@ -435,7 +435,7 @@ A Dagster sensor that fires on each `power_time_series_and_metadata` materialisa
 Sensor preferred over a schedule so it fires on the actual data update.
 
 Note this sensor needs a running Dagster daemon — [Option B](#option-b-recommended-small-ec2-control-plane-box-ecsrunlauncher-2535month)
-(the direction we're leaning) provides one. If the deployment instead ships Option A (nothing
+(the decided direction) provides one. If the deployment instead ships Option A (nothing
 always-on), skip the sensor and run the monitoring step as the final op of the one-shot
 production job (the production-job workstream below already reserves that slot).
 
@@ -505,19 +505,31 @@ partition keys come from Dagster natively, and missed slots are backfilled from 
 
 ### Deployment workstream 3 — AWS infrastructure
 
+> **Status: partially done.** The pieces common to every architecture option — ECR, IAM task
+> roles, and a Fargate task definition, all set up by hand in the AWS console, plus a manual
+> `RunTask` to verify the whole path end-to-end — are ✅ implemented; see
+> [Deploying a new production image](https://openclimatefix.github.io/nged-substation-forecast/live_service/deployment/#step-4-create-the-ecr-repository)
+> (steps 4–8). The Option B–specific pieces below (the always-on EC2 box, `EcsRunLauncher`,
+> scheduling) and infra-as-code are still 🚧, tracked as follow-up work.
+
 Common to all options:
 
-- **ECR** repository; image pushed by the CI/container build (tag = model run-id + git SHA).
-- **S3**: one data bucket mirroring the local `data/` layout (`nwp_data/`,
-  `power_forecasts/`, …). NGED-delivery bucket/prefix is a later step (v0.1 is "forecast
-  running", not "delivery contract live").
-- **IAM task role**: S3 read/write on the data bucket, ECR pull, CloudWatch Logs — no static
-  AWS keys anywhere.
-- **Fargate task definitions**: start 4 vCPU / 16 GB ARM for live runs (measured inference
-  peak ~9 GB); a bigger (e.g. 8 vCPU / 32 GB) definition for backtests. Right-size after a
-  week of CloudWatch metrics.
-- **Alerting**: EventBridge rule on task stopped with non-zero exit → SNS → email.
-- Codify as infra-as-code once there's enough to justify it — per the
+- ✅ **ECR** repository; image pushed by hand for now (tag = model run-id + git SHA) — a CI
+  container build is a later, infra-as-code-era step.
+- ✅ **S3**: one data bucket mirroring the local `data/` layout (`nwp_data/`,
+  `power_forecasts/`, …) — see [Environment & storage setup](https://openclimatefix.github.io/nged-substation-forecast/live_service/setup/#running-on-aws-manual-point-and-click).
+  NGED-delivery bucket/prefix is a later step (v0.1 is "forecast running", not "delivery
+  contract live").
+- ✅ **IAM roles**: turned out to be **two** roles, not one — a task *execution* role
+  (`AmazonECSTaskExecutionRolePolicy`: ECR pull + CloudWatch Logs) and a task role (the S3
+  read/write policy from `setup.md`) — see
+  [Deploying a new production image: Step 6](https://openclimatefix.github.io/nged-substation-forecast/live_service/deployment/#step-6-iam-roles-for-the-task)
+  for why they're split. No static AWS keys anywhere.
+- ✅ **Fargate task definition**: 4 vCPU / 16 GB ARM for live runs (measured inference peak
+  ~9 GB). 🚧 A bigger (e.g. 8 vCPU / 32 GB) definition for backtests is not yet built.
+  Right-size the live definition after a week of CloudWatch metrics.
+- 🚧 **Alerting**: EventBridge rule on task stopped with non-zero exit → SNS → email.
+- 🚧 Codify as infra-as-code once there's enough to justify it — per the
   [Access phasing sequencing note](#access-phasing), that point is Stage 2, not Stage 1.
   **Open question, not yet decided:** this section originally specified a small Terraform
   module (one file), but a later conversation argued for **AWS CDK (Python)** instead —
@@ -525,8 +537,9 @@ Common to all options:
   benefit from HCL, and CDK lets the infra be written in Python rather than learning a new
   language for it. Terraform vs CDK is Jack's call to make when Stage 2 work starts; this page
   does not pick one.
-- Document the few one-time manual steps (SNS subscription confirm, Tailscale join) in a runbook
-  page (`docs/live_service/deployment.md`, extending the promotion runbook above).
+- 🚧 Document the few one-time manual steps still to come (SNS subscription confirm, Tailscale
+  join) in the same runbook page (`docs/live_service/deployment.md`) once Option B's control-
+  plane box is built.
 
 Option B adds (instead of option A's hourly EventBridge Scheduler → `RunTask` cron):
 
@@ -554,6 +567,7 @@ order issues were opened.
 | [#50 Define all paths in Settings](https://github.com/openclimatefix/nged-substation-forecast/issues/50) | S3-capable data paths — done |
 | [#222 Build the production Docker image](https://github.com/openclimatefix/nged-substation-forecast/issues/222) | [Production model artifacts](#production-model-artifacts) — done ([promotion runbook](https://openclimatefix.github.io/nged-substation-forecast/live_service/deployment/)) |
 | [#206 Deploy to AWS!](https://github.com/openclimatefix/nged-substation-forecast/issues/206) | This page (the options above supersede its cost analysis; the issue links back here) |
+| [#286 Create docs for setting up compute infra on AWS](https://github.com/openclimatefix/nged-substation-forecast/issues/286) | [Deployment workstream 3](#deployment-workstream-3-aws-infrastructure) — the option-agnostic pieces (ECR, IAM roles, Fargate task definition) done; Option B's control-plane box still 🚧 |
 | [#197 Make fold-run param logging re-run-safe](https://github.com/openclimatefix/nged-substation-forecast/issues/197) | Bug fix folded into the v0.1 epic (MLflow param immutability on re-runs) |
 | [#63 Send telemetry to OCF's Sentry.io](https://github.com/openclimatefix/nged-substation-forecast/issues/63) | Observability — CloudWatch + SNS first; Sentry as the follow-up |
 | [#246 Scale `power_fcst` to [−1, +1] using the static P99 effective capacity](https://github.com/openclimatefix/nged-substation-forecast/issues/246) | Not yet detailed on this page — decided 2026-07-03 (see the issue for the full worklist); slot in before the version bump below |


### PR DESCRIPTION
## Summary

Closes #286.

Fills the gap `docs/live_service/deployment.md`'s old Step 4 left open ("push to ECR and point the ECS task definition at the new tag... not yet built"): a step-by-step, console-driven recipe for:

- Creating the ECR repository and pushing the built image (Steps 4–5).
- The two IAM roles Fargate actually needs — task **execution** role (ECR pull + CloudWatch Logs, via the AWS-managed `AmazonECSTaskExecutionRolePolicy`) vs. task role (S3 access, reusing the policy already documented in `setup.md`). These are separate principals despite the roadmap's earlier single "IAM task role" bullet — clarified in the roadmap update below too (Step 6).
- Creating the ECS cluster and a Fargate task definition sized per the roadmap's cost analysis (4 vCPU / 16 GB ARM) (Step 7).
- Verifying end-to-end with a manual `aws ecs run-task`, confirming a forecast lands in S3 (Step 8).

**Scope**: deliberately limited to the pieces common to every AWS architecture option researched in the roadmap (ECR, IAM, task definition). The Option B–specific control plane (EC2 box, `EcsRunLauncher`, Postgres, Marimo, scheduling) is separate, larger follow-up work, not part of this issue.

**Roadmap updates** (`docs/roadmap/live-service.md`):
- Option B is now **decided** (per discussion), not "leaning, final call pending."
- "Deployment workstream 3" bullets annotated per-item (✅/🚧) with what's shipped vs. still open, since the workstream ships in pieces rather than atomically — added a status banner pointing at the new runbook.
- Added #286 to the "Related GitHub issues" table.

**Caveat**: no live AWS run has been executed against this guide — I don't have AWS credentials in this environment (session expired, confirmed with `aws sts get-caller-identity`). Per the earlier discussion, this is the agreed "best-effort" draft; Jack will step through it against the real account and report back anything that needs correcting.

## Test plan

- [x] `uv run pymarkdown scan -r docs README.md CLAUDE.md metadata/README.md packages/*/README.md` — clean (one pre-existing, unrelated warning)
- [x] `uv run mkdocs build --strict` — builds clean
- [x] Verified every anchor referenced in this PR (`step-4-create-the-ecr-repository`, `step-6-iam-roles-for-the-task`, `running-on-aws-manual-point-and-click`, etc.) against the actual rendered HTML `id` attributes, not just guessed slugs
- [ ] Jack: walk through Steps 4–8 against the real AWS account and flag anything that needs a tweak

🤖 Generated with [Claude Code](https://claude.com/claude-code)