### PR TITLE
Split data into two S3 buckets: NGED delivery contract vs OCF internal

### DIFF
--- a/docs/architecture/forecast-delivery.md
+++ b/docs/architecture/forecast-delivery.md
@@ -264,11 +264,28 @@ to spend on the forecasts themselves instead.
 
 ## Securing it
 
-The bucket holds data about NGED's customers, so it is not public: it is protected with
+Both buckets hold data about NGED's customers, so neither is public: both are protected with
 standard S3/IAM authentication. With a single consumer this is straightforward — one
 authenticated principal, no entitlement matrix — and it mirrors exactly how NGED protect their
 own time-series JSON bucket, which we read the same way. Every tool named above supports
-authenticated S3 access natively.
+authenticated S3 access natively. That "single authenticated principal" is a dedicated IAM
+**user**, not a cross-account role: Excel and Power BI, both named above as expected clients,
+have no support for AWS role-assumption — they need a plain access key and secret, which only an
+IAM user (not a role) provides.
+
+**Two buckets, not one.** OCF shares more than the five delivery tables with NGED — there's no
+reason to withhold the NWP and raw-telemetry tables OCF's own pipeline works with day to day, and
+NGED are already finding uses for data beyond the minimal contract (see
+[Evolving requirements](#evolving-requirements) above). But those internal tables are not a
+contract: their schemas may change shape at any time, with no deprecation cycle, exactly because
+nothing external is supposed to depend on them staying stable. Splitting them into a second,
+separately-named S3 bucket makes that distinction impossible to miss — a bucket name in a URI
+survives being pasted into a script or a Slack message even out of context, where a path prefix
+within one bucket is easier to skim past. The same single IAM user reads both buckets; the
+split is a naming/documentation signal, not an access-control boundary. See [Environment &
+storage setup](https://openclimatefix.github.io/nged-substation-forecast/live_service/setup/#running-on-aws-manual-point-and-click)
+for the concrete bucket/IAM setup and [Delivery tables](../roadmap/delivery-tables.md) for
+exactly which five tables are the stable contract.
 
 ## Strict data contracts (machine-verifiable)
 

--- a/docs/live_service/deployment.md
+++ b/docs/live_service/deployment.md
@@ -65,7 +65,7 @@ no `DATA_PATH` was mounted for this isolated test). A full end-to-end run needs 
 ## Step 4 — Create the ECR repository
 
 In the AWS console → **ECR** → **Create repository** (same `eu-west-2` region as the S3 bucket
-in [Environment & storage setup: Step 1](setup.md#step-1-create-the-s3-bucket)):
+in [Environment & storage setup: Step 1](setup.md#step-1-create-the-s3-buckets)):
 
 1. **Visibility** Private.
 2. **Name** `nged-forecast` (matches the local image tag used in [Step 2](#step-2-build-the-image)
@@ -102,11 +102,12 @@ Fargate tasks need **two** separate roles, not one — they serve different prin
   AWS-managed `AmazonECSTaskExecutionRolePolicy` — it already covers exactly these two things, so
   no custom policy is needed.
 - **Task role**, `nged-forecast-task-role` — used by *your code* once it's running: this is what
-  lets the container read and write the data bucket. Reuse the same S3 policy from
+  lets the container read and write **both** data buckets (delivery and internal). Reuse the same
+  S3 policy from
   [Environment & storage setup: Step 2](setup.md#step-2-grant-access-with-iam), attached to a
   second role (also trusted by `ecs-tasks.amazonaws.com`). Nothing else is needed — with this
   role attached, delta-rs' `object_store` auto-discovers temporary credentials at runtime, so
-  `DATA_STORE_*` stays unset (see [setup.md's IAM-role row](setup.md#step-3-point-settings-at-the-bucket)).
+  `DATA_STORE_*` stays unset (see [setup.md's IAM-role row](setup.md#step-3-point-settings-at-the-buckets)).
 
 No static AWS keys anywhere in either role — this is the same IAM-role auto-discovery setup.md
 already relies on for compute running on AWS.
@@ -125,8 +126,12 @@ already relies on for compute running on AWS.
    - **Container**: image URI `<account-id>.dkr.ecr.eu-west-2.amazonaws.com/nged-forecast:<tag>`
      from [Step 5](#step-5-push-the-image-to-ecr); log configuration → **awslogs**, a new
      CloudWatch log group (e.g. `/ecs/nged-forecast`), region `eu-west-2`.
-   - **Environment variables**: at minimum `DATA_PATH=s3://nged-forecast-data/data` (see
-     [setup.md's on-AWS settings](setup.md#step-3-point-settings-at-the-bucket)) — leave
+   - **Environment variables**: `DATA_PATH=s3://nged-forecast-internal/data`,
+     `POWER_FORECASTS_DATA_PATH=s3://nged-forecast-delivery/data/power_forecasts`, and
+     `EFFECTIVE_CAPACITY_DATA_PATH=s3://nged-forecast-delivery/data/effective_capacity` — all
+     three are needed, since the delivery tables live in a separate bucket from everything
+     `DATA_PATH` derives by default (see
+     [setup.md's on-AWS settings](setup.md#step-3-point-settings-at-the-buckets)). Leave
      `DATA_STORE_*` unset, since the task role supplies credentials.
 
 ## Step 8 — Verify: run the task manually
@@ -158,7 +163,9 @@ egress for its ECR pull and S3/CloudWatch calls without a NAT gateway; revisit o
 always-on control-plane box (and its VPC design) exists. Follow the run in **ECS** → the
 cluster → **Tasks**, then **CloudWatch Logs** for the container's output — confirm it reaches
 `load_forecaster_from_dir` and a new forecast lands under
-`s3://nged-forecast-data/data/power_forecasts/…`.
+`s3://nged-forecast-delivery/data/power_forecasts/…` — the delivery bucket, not the internal one,
+since `power_forecasts` is one of the five NGED-facing tables (see
+[setup.md: Step 3](setup.md#step-3-point-settings-at-the-buckets)).
 
 ## See also
 

--- a/docs/live_service/setup.md
+++ b/docs/live_service/setup.md
@@ -30,6 +30,12 @@ The single most important idea is that there are **two** roots, not one:
 | Data tables | `DATA_PATH` | **Yes** | NWP, power observations, forecasts, metrics, metadata, H3 weights |
 | Local artifacts | `LOCAL_ARTIFACTS_PATH` | No — always local | Trained-model cache, the promoted production model, plot HTML |
 
+> **On AWS, "data tables" itself splits across two buckets** — the five NGED-facing delivery
+> tables live separately from everything else, via the per-table path overrides described in the
+> "derive from root" convention just below. See [Running on AWS: Step
+> 3](#step-3-point-settings-at-the-buckets) for the concrete setup, and [Forecast Delivery:
+> Securing it](../architecture/forecast-delivery.md#securing-it) for why.
+
 They are split for an **architectural** reason, not merely because XGBoost and Altair happen to
 write to local files (a library that can't write to S3 can always be bridged — write to a tempdir,
 upload — as MLflow does internally). The real reason is that **nothing under `LOCAL_ARTIFACTS_PATH`
@@ -66,7 +72,10 @@ root*: after validation, `NWP_DATA_PATH` becomes `<DATA_PATH>/NWP`, `METADATA_PA
 
 Set `DATA_PATH` alone and all nine data tables move together. Setting an individual table (e.g.
 `NWP_DATA_PATH=s3://other-bucket/NWP`) overrides just that one — useful for keeping one big table on
-a separate bucket, and nothing else needs to change.
+a separate bucket, and nothing else needs to change. [Running on AWS: Step
+3](#step-3-point-settings-at-the-buckets) is exactly this pattern applied on purpose: `DATA_PATH`
+defaults to OCF's internal bucket, and the delivery tables are individually overridden to a
+second, NGED-facing bucket.
 
 ### The `.env` file and NGED source credentials
 
@@ -121,24 +130,34 @@ against an in-process `moto` server.)
 > [AWS architecture](https://openclimatefix.github.io/nged-substation-forecast/roadmap/live-service/#aws-architecture)
 > section for that plan.
 
-### Step 1 — Create the S3 bucket
+### Step 1 — Create the S3 buckets
 
-In the AWS console → **S3** → **Create bucket**:
+**Two** buckets, not one — split so the five tables that form NGED's stable delivery contract are
+physically separate from OCF's own working data, which may change shape at any time with no
+notice. See [Forecast Delivery: Securing it](../architecture/forecast-delivery.md#securing-it)
+for why this split exists, and [Delivery tables](https://openclimatefix.github.io/nged-substation-forecast/roadmap/delivery-tables/)
+for exactly which five tables count as "delivery."
 
-1. **Region** `eu-west-2` (London) — keep every resource in one region so S3 ↔ compute transfer
-   stays free.
-2. **Name** e.g. `nged-forecast-data` (bucket names are globally unique; pick your own).
-3. Leave **Block all public access** **on**, and default **SSE-S3** encryption on. Nothing here is
-   public.
-4. **Versioning** is optional and not required by the app.
+In the AWS console → **S3** → **Create bucket**, twice:
 
-No DynamoDB lock table is needed. The `deltalake` version we use commits via S3's native
-conditional-put, so concurrent-safe Delta writes work on plain S3 with no lock table and no
-`AWS_S3_ALLOW_UNSAFE_RENAME` flag.
+1. **Region** `eu-west-2` (London) for both — keep every resource in one region so S3 ↔ compute
+   transfer stays free.
+2. **Names**: `nged-forecast-delivery` (the 5 NGED-facing tables) and `nged-forecast-internal`
+   (NWP, raw power telemetry, forecast metrics, and everything else OCF's pipeline needs but
+   hasn't promised to keep stable). Bucket names are globally unique; pick your own if these are
+   taken.
+3. Leave **Block all public access** **on**, and default **SSE-S3** encryption on, for both.
+   Nothing here is public.
+4. **Versioning** is optional and not required by the app, for either bucket.
+
+No DynamoDB lock table is needed for either bucket. The `deltalake` version we use commits via
+S3's native conditional-put, so concurrent-safe Delta writes work on plain S3 with no lock table
+and no `AWS_S3_ALLOW_UNSAFE_RENAME` flag.
 
 ### Step 2 — Grant access with IAM
 
-Create an IAM policy scoped to just this bucket:
+OCF's own pipeline needs to read and write **both** buckets (internal tables during ingestion and
+training; delivery tables at forecast time), so one IAM policy covers both:
 
 ```json
 {
@@ -148,8 +167,10 @@ Create an IAM policy scoped to just this bucket:
       "Effect": "Allow",
       "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"],
       "Resource": [
-        "arn:aws:s3:::nged-forecast-data",
-        "arn:aws:s3:::nged-forecast-data/*"
+        "arn:aws:s3:::nged-forecast-delivery",
+        "arn:aws:s3:::nged-forecast-delivery/*",
+        "arn:aws:s3:::nged-forecast-internal",
+        "arn:aws:s3:::nged-forecast-internal/*"
       ]
     }
   ]
@@ -161,40 +182,85 @@ Attach it to **whichever identity runs the code**:
 - **Compute running on AWS** (an EC2 box or Fargate task) → attach the policy to that resource's
   **IAM role**. Nothing else is needed: delta-rs' object_store auto-discovers the role's temporary
   credentials and region at runtime, so you leave all four `DATA_STORE_*` settings **empty**.
-- **Your laptop, against the real bucket** → attach the policy to an **IAM user**, create an access
-  key for it, and set the credentials via `DATA_STORE_*` (Step 3).
+- **Your laptop, against the real buckets** → attach the policy to an **IAM user**, create an
+  access key for it, and set the credentials via `DATA_STORE_*` (Step 3).
 
-### Step 3 — Point `Settings` at the bucket
+### Step 3 — Point `Settings` at the buckets
 
-Set `DATA_PATH` to the bucket URI, and leave `LOCAL_ARTIFACTS_PATH` unset so models and plots stay on
-local disk. What else you set depends on Step 2:
+Unlike a single-bucket setup, this now needs `DATA_PATH` **plus** an explicit override per
+delivery table, rather than one setting:
+
+| Setting | Bucket | Why |
+|---|---|---|
+| `DATA_PATH` (root) | `nged-forecast-internal` | Every table derives from this unless overridden below — deliberately **fails closed**: forgetting to override a new delivery table just leaves it in the internal bucket (invisible to NGED, a functional bug to catch in testing), rather than a forgotten override on a new internal table accidentally exposing it in the delivery bucket. |
+| `POWER_FORECASTS_DATA_PATH` | `nged-forecast-delivery` | Table 1, `power_forecast` — see the caveat below. |
+| `EFFECTIVE_CAPACITY_DATA_PATH` | `nged-forecast-delivery` | Table 4, `effective_capacity`. |
+
+The other three delivery tables (`power_forecast_warnings`, `asset_health_history`,
+`substation_switching`) don't have `Settings` fields yet — none are implemented in code. When
+they land, their paths need the same explicit override to `nged-forecast-delivery`.
+
+> **Caveat: `power_forecasts` isn't purely delivery data.** The table holds every CV/backtest
+> experiment alongside live production forecasts, distinguished only by `fold_id` (`"live"` for
+> production — see [Running live forecasts end-to-end](dagster-workflow.md)). Pointing the whole
+> table at the delivery bucket means OCF's own experiment churn is physically stored there too —
+> not a new problem this split introduces (it's one table today regardless of bucket), and NGED
+> already needs to filter on `fold_id="live"`. Splitting the table itself by `fold_id` across
+> buckets would need an actual code change to the write path, not just a `Settings` override, so
+> it's out of scope here.
 
 **On AWS compute (IAM role)** — credentials and region are auto-discovered, so just:
 
 ```dotenv
-DATA_PATH=s3://nged-forecast-data/data
+DATA_PATH=s3://nged-forecast-internal/data
+POWER_FORECASTS_DATA_PATH=s3://nged-forecast-delivery/data/power_forecasts
+EFFECTIVE_CAPACITY_DATA_PATH=s3://nged-forecast-delivery/data/effective_capacity
 ```
 
-**From your laptop (IAM user access key)** — supply the key and region, but **not** an endpoint URL
-(that is only for non-AWS/MinIO endpoints, and it would wrongly allow plain HTTP):
+**From your laptop (IAM user access key)** — same three paths, plus the key, secret, and region,
+but **not** an endpoint URL (that is only for non-AWS/MinIO endpoints, and it would wrongly allow
+plain HTTP):
 
 ```dotenv
-DATA_PATH=s3://nged-forecast-data/data
+DATA_PATH=s3://nged-forecast-internal/data
+POWER_FORECASTS_DATA_PATH=s3://nged-forecast-delivery/data/power_forecasts
+EFFECTIVE_CAPACITY_DATA_PATH=s3://nged-forecast-delivery/data/effective_capacity
 DATA_STORE_ACCESS_KEY_ID=<access key id>
 DATA_STORE_SECRET_ACCESS_KEY=<secret access key>
 DATA_STORE_REGION=eu-west-2
 ```
 
 The four `DATA_STORE_*` fields map onto the shared `aws_*` object_store option keys that delta-rs,
-Polars, and obstore all understand, so this one dict feeds every read and write.
+Polars, and obstore all understand, so this one dict feeds every read and write — to both buckets
+alike, since bucket choice is entirely a matter of which URI each path setting resolves to.
 
 ### Step 4 — Verify
 
-With the above in place, materialise any data-writing asset (e.g. `power_time_series_and_metadata`)
-from the Dagster UI, then confirm the objects appear under `s3://nged-forecast-data/data/…` in
-the S3 console. Because `LOCAL_ARTIFACTS_PATH` stayed local, a subsequent `promoted_model`
-materialisation still writes the model to `<repo>/data/production_model/` on disk — the two roots
-behaving independently is exactly what you want to see.
+With the above in place, materialise a delivery-table asset (e.g. `live_forecasts`, which writes
+`power_forecasts`) from the Dagster UI, then confirm the objects appear under
+`s3://nged-forecast-delivery/data/power_forecasts/…` in the S3 console. Then materialise an
+internal-table asset (e.g. `power_time_series_and_metadata`) and confirm it lands under
+`s3://nged-forecast-internal/data/NGED/…` instead — two different buckets is exactly what you
+want to see. Because `LOCAL_ARTIFACTS_PATH` stayed local, a subsequent `promoted_model`
+materialisation still writes the model to `<repo>/data/production_model/` on disk.
+
+### Step 5 — Grant NGED read access (recommended; confirm before doing this)
+
+> This step hasn't been agreed as final yet — recorded here as the current recommendation so it
+> isn't lost, but check before actually creating anything.
+
+[Forecast Delivery: Securing it](../architecture/forecast-delivery.md#securing-it) already
+assumes **a single authenticated AWS user** for NGED, with no per-user entitlement matrix needed
+— NGED is the only consumer. That points at a dedicated **IAM user** (not a cross-account role):
+Excel and Power BI are named as expected client tools in that same page, and neither supports
+AWS role-assumption — they need a plain access key and secret, the same shape of credential an
+IAM user provides.
+
+Recommended shape: **one** IAM user (not one per bucket — the stability signal comes from the
+bucket split itself, not from access segmentation), with a read-only policy across both bucket
+ARNs (`s3:GetObject`, `s3:ListBucket` — no `PutObject`/`DeleteObject`), and an access key handed
+to NGED the same way Step 2's laptop credentials are configured. Rotate the key periodically once
+this is live.
 
 ### Viewing forecasts on AWS
 
@@ -204,15 +270,16 @@ exits — the file would never be seen. `plot_power_forecast` is a **local-devel
 materialise it on your laptop, open the HTML in a browser.
 
 The durable, S3-native way to look at forecasts is the **dashboard**
-(`packages/dashboard/main.py`), which reads the `power_forecasts` and metadata tables directly from
-`DATA_PATH` (with the same `storage_options`) and renders on demand — no plot files to persist.
-Point it at the same `Settings` and it works identically whether `DATA_PATH` is local or `s3://`.
+(`packages/dashboard/main.py`), which reads whichever tables it needs directly via their
+`Settings` paths (with the same `storage_options`) and renders on demand — no plot files to
+persist, and no need to know or care which bucket a given table resolves to. Point it at the same
+`Settings` and it works identically whether each path is local or `s3://`.
 
 ### At-a-glance: which settings for which environment
 
-| Environment | `DATA_PATH` | `DATA_STORE_*` |
-|---|---|---|
-| Local (default) | unset → `<repo>/data` | none |
-| Local MinIO rehearsal | `s3://…` | all four, incl. `ENDPOINT_URL` |
-| Laptop → real S3 | `s3://…` | key + secret + region (no endpoint) |
-| Compute on AWS (IAM role) | `s3://…` | none (auto-discovered) |
+| Environment | `DATA_PATH` | Delivery-table overrides | `DATA_STORE_*` |
+|---|---|---|---|
+| Local (default) | unset → `<repo>/data` | unset | none |
+| Local MinIO rehearsal | `s3://…` | unset (single bucket) | all four, incl. `ENDPOINT_URL` |
+| Laptop → real S3 | `s3://nged-forecast-internal/…` | `s3://nged-forecast-delivery/…` | key + secret + region (no endpoint) |
+| Compute on AWS (IAM role) | `s3://nged-forecast-internal/…` | `s3://nged-forecast-delivery/…` | none (auto-discovered) |

--- a/docs/roadmap/delivery-tables.md
+++ b/docs/roadmap/delivery-tables.md
@@ -19,8 +19,17 @@ additional benefit.
   readable from Excel, Polars, pandas, DuckDB, Power BI, etc. The full rationale (including the
   comparison with a custom REST API) is on the durable
   [Forecast Delivery](../architecture/forecast-delivery.md) architecture page.
-- **Access**: the bucket holds forecasts about NGED's customers, so it is protected with S3
-  authentication (mirroring how NGED protects their own time-series JSON bucket).
+- **Which bucket**: these five tables live in a dedicated `nged-forecast-delivery` S3 bucket,
+  physically separate from OCF's own working tables (NWP, raw power telemetry, forecast metrics,
+  …) in a second `nged-forecast-internal` bucket. NGED gets read access to both — there's no
+  reason to withhold the internal tables — but only the five below are a **stable contract**: the
+  internal bucket's tables may change shape at any time with no notice. See
+  [Forecast Delivery: Securing it](../architecture/forecast-delivery.md#securing-it) for why, and
+  [Environment & storage setup](https://openclimatefix.github.io/nged-substation-forecast/live_service/setup/#running-on-aws-manual-point-and-click)
+  for the concrete bucket/IAM setup.
+- **Access**: both buckets hold data about NGED's customers, so neither is public — both are
+  protected with S3 authentication (mirroring how NGED protects their own time-series JSON
+  bucket).
 - **Update cadence**: every 6 hours, when a new forecast run is generated.
 - **Reading it** is a one-liner — `scan_delta` is lazy and only fetches the partitions a query
   touches, so a single forecast comes back in a fraction of a second even though the full dataset is


### PR DESCRIPTION
## Summary

Follow-up to the discussion on #289's PR: rather than sharing just the five [delivery tables](https://openclimatefix.github.io/nged-substation-forecast/roadmap/delivery-tables/) with NGED, we're sharing OCF's internal working tables too (NWP, raw power telemetry, forecast metrics) — but making the stability difference impossible to miss by splitting them into a **second S3 bucket**, rather than just a path prefix within one bucket.

- `nged-forecast-delivery` — the 5 tables in `delivery-tables.md`, the stable NGED contract.
- `nged-forecast-internal` — NWP, `power_time_series`, metadata, forecast metrics, and anything else OCF's own pipeline needs, explicitly may-change-anytime.

**Why a bucket, not a prefix**: a bucket name in a URI survives being pasted into a script or a Slack message even out of context; a path prefix (`.../internal/...`) is easier to skim past. Same single IAM user/principal reads both buckets — the split is a naming/documentation signal, not an access-control boundary. `docs/architecture/forecast-delivery.md` already assumed "a single authenticated AWS user" for NGED before this PR, so this isn't a new access pattern, just applying it across two bucket ARNs instead of one.

**`Settings` mapping** (`setup.md` Step 3): `DATA_PATH` defaults to the *internal* bucket; the two currently-implemented delivery tables (`power_forecasts`, `effective_capacity`) get explicit per-table overrides to the delivery bucket. Chosen deliberately to **fail closed**: forgetting to override a new delivery table just leaves it invisible to NGED (a bug caught in testing), rather than a forgotten override on a new internal table silently exposing it.

**Caveat flagged rather than silently decided**: `power_forecasts` already mixes live rows with every CV/backtest experiment, distinguished only by `fold_id`. The whole table moves to the delivery bucket as one unit (NGED already filters `fold_id="live"`) — splitting the table itself by `fold_id` across buckets would need an actual code change to the write path, which is out of scope here.

**NGED authentication (recommended, not yet confirmed)**: added a Step 5 to `setup.md`, explicitly marked as "recorded here as the current recommendation... check before actually creating anything" — a single IAM **user** (not a cross-account role), since Excel and Power BI (both named as expected clients in `forecast-delivery.md`) need a plain access key, not role-assumption.

No AWS resources were created for this — still docs-only, and the account remains a clean slate (checked).

## Test plan

- [x] `uv run pymarkdown scan -r docs README.md CLAUDE.md metadata/README.md packages/*/README.md` — clean (one pre-existing, unrelated warning)
- [x] `uv run mkdocs build --strict` — builds clean
- [x] Verified every anchor touched in this PR (`step-1-create-the-s3-buckets`, `step-3-point-settings-at-the-buckets`, `securing-it`, etc.) against the actual rendered HTML `id` attributes
- [x] Scripted check that every internal markdown link resolves to an existing file
- [ ] Jack: confirm the Step 5 NGED-access recommendation before anything is actually created

🤖 Generated with [Claude Code](https://claude.com/claude-code)