### PR TITLE
Deliberate CV/backtest sharing, dashboard IAM user, region rationale

### DIFF
--- a/docs/architecture/forecast-delivery.md
+++ b/docs/architecture/forecast-delivery.md
@@ -306,11 +306,29 @@ reach on the order of a **trillion rows** (~100 billion rows/year/model × sever
 several models) — at that volume, a per-GB storage premium compounds into real money rather
 than staying a rounding error.
 
-`eu-west-2` is picked **now**, mainly because NGED's own S3 bucket is already in `eu-west-2` —
-keeping OCF and NGED in the same region avoids cross-region transfer cost/latency if NGED ever
-reads directly from our buckets. This is provisional: NGED haven't yet confirmed whether a
-GB-resident region is a hard requirement for this data, and we're waiting on their reply before
-treating the region choice as final.
+`eu-west-2` is picked **now**, mainly because NGED's own S3 bucket is already in `eu-west-2`.
+The benefit that matters here is **data transfer**, not the compute/storage premium above — and
+it depends on *how* NGED reads, which the AWS Price List API pins down precisely:
+
+| Read path | Rate |
+|---|---|
+| S3 → another AWS service, **same region** (even a different account) | **$0** |
+| S3 → another AWS service, **`eu-west-1` ↔ `eu-west-2`** (cross-region) | $0.02/GB |
+| S3 → public internet ("data transfer out"), **either region** | $0.09/GB (first 10 TB/month) — identical in both regions |
+
+Same-region AWS-to-AWS transfer is free even across accounts, but internet-egress pricing
+doesn't vary by region at all — so matching regions only pays off if NGED reads via **their own
+AWS-hosted compute** (e.g. Athena, Glue, an EC2/Lambda job) in `eu-west-2`, not if they read via
+a desktop client like Excel or Power BI over the public internet, where the region choice makes
+no difference to the bill. That AWS-native path is the one v2 scale points towards anyway:
+Excel caps out at ~1,048,576 rows, so once `power_forecasts` reaches the trillion-row range,
+NGED pulling "a sizeable chunk" of it stops being something a spreadsheet can do at all — they
+would need their own query engine against our bucket, and running that in `eu-west-2` is what
+turns those reads free instead of $0.02–0.09/GB.
+
+This is still provisional: NGED haven't yet confirmed whether a GB-resident region is a hard
+requirement for this data, and we're waiting on their reply before treating the region choice as
+final.
 
 ## Strict data contracts (machine-verifiable)
 

--- a/docs/architecture/forecast-delivery.md
+++ b/docs/architecture/forecast-delivery.md
@@ -287,6 +287,31 @@ storage setup](https://openclimatefix.github.io/nged-substation-forecast/live_se
 for the concrete bucket/IAM setup and [Delivery tables](../roadmap/delivery-tables.md) for
 exactly which five tables are the stable contract.
 
+**Why `eu-west-2`, not the cheaper `eu-west-1`?** AWS Price List API data (2026-07-03) shows
+Ireland (`eu-west-1`) consistently cheaper than London (`eu-west-2`) — not hugely for the
+always-on control-plane box, but noticeably for the Fargate compute that actually runs
+inference:
+
+| SKU | `eu-west-1` (Ireland) | `eu-west-2` (London) | London premium |
+|---|---|---|---|
+| EC2 `t4g.medium` on-demand | $0.0368/hr | $0.0376/hr | +2.2% |
+| Fargate ARM vCPU-hour | $0.03238/hr | $0.03725/hr | +15.0% |
+| Fargate ARM GB-hour | $0.00356/hr | $0.00409/hr | +14.9% |
+| S3 Standard storage (first 50 TB) | $0.023/GB-mo | $0.024/GB-mo | +4.3% |
+
+At v1 scale this premium is a rounding error — maybe £1–3/month on a ~£25–35/month bill (see
+[AWS architecture: Cost summary](../roadmap/live-service.md#cost-summary)). It matters more at
+v2 scale: NGED's population grows from 32 to ~2,500 time series, and `power_forecasts` could
+reach on the order of a **trillion rows** (~100 billion rows/year/model × several years ×
+several models) — at that volume, a per-GB storage premium compounds into real money rather
+than staying a rounding error.
+
+`eu-west-2` is picked **now**, mainly because NGED's own S3 bucket is already in `eu-west-2` —
+keeping OCF and NGED in the same region avoids cross-region transfer cost/latency if NGED ever
+reads directly from our buckets. This is provisional: NGED haven't yet confirmed whether a
+GB-resident region is a hard requirement for this data, and we're waiting on their reply before
+treating the region choice as final.
+
 ## Strict data contracts (machine-verifiable)
 
 The project makes strict use of Patito data contracts (defined in the

--- a/docs/live_service/setup.md
+++ b/docs/live_service/setup.md
@@ -182,8 +182,34 @@ Attach it to **whichever identity runs the code**:
 - **Compute running on AWS** (an EC2 box or Fargate task) → attach the policy to that resource's
   **IAM role**. Nothing else is needed: delta-rs' object_store auto-discovers the role's temporary
   credentials and region at runtime, so you leave all four `DATA_STORE_*` settings **empty**.
-- **Your laptop, against the real buckets** → attach the policy to an **IAM user**, create an
-  access key for it, and set the credentials via `DATA_STORE_*` (Step 3).
+- **Your laptop, running the pipeline** (ingestion, training, backfilling) → attach the read/write
+  policy above to an **IAM user**, create an access key for it, and set the credentials via
+  `DATA_STORE_*` (Step 3).
+- **Your laptop, running only the dashboard** (`packages/dashboard/main.py` — see
+  [#283](https://github.com/openclimatefix/nged-substation-forecast/issues/283)) → it only ever
+  reads, so give it a separate, read-only **IAM user** instead of reusing the pipeline's read/write
+  credential:
+
+  ```json
+  {
+    "Version": "2012-10-17",
+    "Statement": [
+      {
+        "Effect": "Allow",
+        "Action": ["s3:GetObject", "s3:ListBucket"],
+        "Resource": [
+          "arn:aws:s3:::nged-forecast-delivery",
+          "arn:aws:s3:::nged-forecast-delivery/*",
+          "arn:aws:s3:::nged-forecast-internal",
+          "arn:aws:s3:::nged-forecast-internal/*"
+        ]
+      }
+    ]
+  }
+  ```
+
+  Same `DATA_STORE_*` shape as the pipeline laptop (Step 3), just backed by a narrower key —
+  losing this key can't corrupt any table, only leak read access to it.
 
 ### Step 3 — Point `Settings` at the buckets
 
@@ -200,14 +226,13 @@ The other three delivery tables (`power_forecast_warnings`, `asset_health_histor
 `substation_switching`) don't have `Settings` fields yet — none are implemented in code. When
 they land, their paths need the same explicit override to `nged-forecast-delivery`.
 
-> **Caveat: `power_forecasts` isn't purely delivery data.** The table holds every CV/backtest
-> experiment alongside live production forecasts, distinguished only by `fold_id` (`"live"` for
-> production — see [Running live forecasts end-to-end](dagster-workflow.md)). Pointing the whole
-> table at the delivery bucket means OCF's own experiment churn is physically stored there too —
-> not a new problem this split introduces (it's one table today regardless of bucket), and NGED
-> already needs to filter on `fold_id="live"`. Splitting the table itself by `fold_id` across
-> buckets would need an actual code change to the write path, not just a `Settings` override, so
-> it's out of scope here.
+> **Design choice: NGED sees every CV/backtest fold, not just live production forecasts.** The
+> `power_forecasts` table holds every CV/backtest experiment alongside live production forecasts,
+> distinguished by `fold_id` (`"live"` for production — see
+> [Running live forecasts end-to-end](dagster-workflow.md)). Pointing the whole table at the
+> delivery bucket is deliberate, not an accidental side effect of the bucket split: it lets NGED
+> see how each of OCF's model versions actually behaves, not just whichever one is currently
+> promoted. NGED filters on `fold_id="live"` when it only wants the current production forecast.
 
 **On AWS compute (IAM role)** — credentials and region are auto-discovered, so just:
 
@@ -281,5 +306,6 @@ persist, and no need to know or care which bucket a given table resolves to. Poi
 |---|---|---|---|
 | Local (default) | unset → `<repo>/data` | unset | none |
 | Local MinIO rehearsal | `s3://…` | unset (single bucket) | all four, incl. `ENDPOINT_URL` |
-| Laptop → real S3 | `s3://nged-forecast-internal/…` | `s3://nged-forecast-delivery/…` | key + secret + region (no endpoint) |
+| Laptop → real S3 (pipeline) | `s3://nged-forecast-internal/…` | `s3://nged-forecast-delivery/…` | key + secret + region, read/write IAM user (no endpoint) |
+| Laptop → real S3 (dashboard only) | `s3://nged-forecast-internal/…` | `s3://nged-forecast-delivery/…` | key + secret + region, read-only IAM user (no endpoint) |
 | Compute on AWS (IAM role) | `s3://nged-forecast-internal/…` | `s3://nged-forecast-delivery/…` | none (auto-discovered) |

--- a/docs/live_service/setup.md
+++ b/docs/live_service/setup.md
@@ -141,7 +141,10 @@ for exactly which five tables count as "delivery."
 In the AWS console → **S3** → **Create bucket**, twice:
 
 1. **Region** `eu-west-2` (London) for both — keep every resource in one region so S3 ↔ compute
-   transfer stays free.
+   transfer stays free. It isn't the cheapest region available (`eu-west-1` runs meaningfully
+   cheaper for Fargate); see [Forecast Delivery: Securing it](../architecture/forecast-delivery.md#securing-it)
+   for the price comparison and why `eu-west-2` is picked anyway, provisionally, pending NGED
+   confirmation.
 2. **Names**: `nged-forecast-delivery` (the 5 NGED-facing tables) and `nged-forecast-internal`
    (NWP, raw power telemetry, forecast metrics, and everything else OCF's pipeline needs but
    hasn't promised to keep stable). Bucket names are globally unique; pick your own if these are


### PR DESCRIPTION
## Summary

- Reworded the `power_forecasts` caveat in [setup.md](https://github.com/openclimatefix/nged-substation-forecast/blob/main/docs/live_service/setup.md#step-3-point-settings-at-the-buckets): sharing every CV/backtest fold with NGED (not just live production forecasts) is a **deliberate design choice**, not an accidental side effect of the two-bucket split — it lets NGED see how each of OCF's model versions actually behaves, not just the currently-promoted one.
- Added a **read-only IAM user** variant to Step 2, for laptop-only [dashboard](https://github.com/openclimatefix/nged-substation-forecast/blob/main/packages/dashboard/main.py) use ([#283](https://github.com/openclimatefix/nged-substation-forecast/issues/283)), distinct from the existing read/write IAM user used by the pipeline laptop workflow (ingestion/training/backfilling). The dashboard never writes, so it gets a narrower-blast-radius credential instead of reusing the pipeline's.
- Updated the "At-a-glance" table to distinguish the two laptop rows (pipeline vs. dashboard-only).
- Added a `eu-west-1` vs `eu-west-2` compute/storage price comparison to [Forecast Delivery: Securing it](https://github.com/openclimatefix/nged-substation-forecast/blob/main/docs/architecture/forecast-delivery.md#securing-it) (AWS Price List API, 2026-07-03), plus a precise data-transfer-pricing breakdown: same-region S3-to-AWS-service transfer is free (even cross-account), but internet-egress pricing is identical regardless of region. So matching NGED's `eu-west-2` only pays off in data-transfer terms if NGED reads via their own AWS-hosted compute there, rather than via desktop Excel/Power BI over the internet — and v2's trillion-row scale makes that AWS-native path the likely one, since Excel can't hold that many rows anyway. Still marked provisional pending NGED's own confirmation on region.

## Test plan

- [x] `uv run pymarkdown scan docs/live_service/setup.md docs/architecture/forecast-delivery.md` — clean
- [x] `uv run mkdocs build --strict` — clean, no warnings/errors
- [x] Verified the `#securing-it` anchor resolves in the built HTML
- [x] Data-transfer pricing figures (same-region free / cross-region $0.02/GB / internet egress $0.09/GB, identical both regions) verified against the AWS Price List API (`AWSDataTransfer` service code)