### PR TITLE
Document Polars 32-bit IdxSize row-count wraparound (closes #293)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,6 +310,23 @@ def apply(self, scan: pt.LazyFrame[MySchema]) -> pt.LazyFrame[MySchema]:
     return pt.LazyFrame.from_existing(lf).set_model(MySchema)  # zero-copy re-wrap
 ```
 
+### Polars Gotcha: row counts silently wrap past 2³² rows (32-bit `IdxSize`)
+
+Default Polars builds use a 32-bit row index (`IdxSize`), capping any single materialised frame,
+row count, or row index at 2³² (~4.29 billion) rows. Past the cap there is **no error** — counts
+wrap modulo 2³²: `pl.len()` over the 5.9-billion-row NWP dev table returns 1,652,180,189
+(= 5,947,147,485 mod 2³²), and `group_by(...).agg(pl.len())` wraps identically for any single
+group past the cap, streaming engine included. Full analysis:
+[Architecture Overview → The other hard ceiling](https://openclimatefix.github.io/nged-substation-forecast/architecture/overview/#the-other-hard-ceiling-polars-32-bit-row-index).
+
+- **Never row-count a table that can exceed 2³² rows with Polars.** Use the Delta log instead —
+  `DeltaTable(path).count()`, or sum `num_records` over `get_add_actions(flatten=True)` — both
+  metadata-only and exact.
+- Filtered/partition-pruned queries whose *result* stays under 2³² rows are correct even when the
+  underlying scan is bigger, and value aggregations (`sum`, `min`/`max`, quantiles) over >2³² rows
+  are unaffected — only row counts and row indices wrap. Both verified empirically.
+- Tables past the cap today: NWP (~5.9B rows). `power_forecasts` will pass it at V2 scale.
+
 ## This is a young project
 
 The project is a new, green-field project. No one else is using this code yet. Which means:

--- a/docs/architecture/forecast-delivery.md
+++ b/docs/architecture/forecast-delivery.md
@@ -318,6 +318,15 @@ the bucket and query it like a database. The same mechanism powers our own pipel
 [lazy evaluation strategy](overview.md#lazy-evaluation-strategy) that keeps our training memory
 bounded is exactly what keeps NGED's reads cheap.
 
+One caveat for anyone querying the *whole* table with Polars: default Polars builds cap any
+single row count or materialised frame at 2³² (~4.29 billion) rows, and a count past the cap
+**silently wraps** rather than erroring — so once a table passes that size (our internal NWP
+table already has, and `power_forecasts` will at V2 scale), whole-table row counts must come from
+the Delta transaction log (`DeltaTable(path).count()`), not `pl.len()` over an unfiltered scan.
+Filtered queries whose results stay under the cap — i.e. every read pattern described above —
+are unaffected. Details in
+[Architecture Overview → The other hard ceiling](overview.md#the-other-hard-ceiling-polars-32-bit-row-index).
+
 ## An established industry pattern
 
 We're also in good company. "Analytical data as cloud-optimised files on object storage,

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -71,6 +71,47 @@ What actually prunes the NWP scan — verified with `LazyFrame.explain()`:
 
 Prediction is bounded by chunking on **`init_time`** (`_PREDICT_INIT_CHUNK`, 14 days), *not* by cell. `init_time` is both the partition key and the axis that fans the output out across runs, so a chunk's forecast frame stays small while each partition is read exactly once and all series/cells/members are processed together (a per-*cell* loop instead OOMs on the busiest cell — 10 series × 51 members × the 10-month window ≈ 116M rows ≈ 25 GB). Measured end-to-end on the `mid_2025_to_mid_2026` fold: training peaks ~5 GB and the full 51-member validation prediction (~321M forecast rows) peaks ~9 GB — both well under a 24 GB laptop.
 
+### The other hard ceiling: Polars' 32-bit row index
+
+RAM is not the only bound a Polars query must respect. Default Polars builds use a 32-bit row
+index (`IdxSize`), so any single materialised frame, row count, or row index is capped at
+**2³² ≈ 4.29 billion rows** — and crossing the cap raises **no error**. Row counts wrap modulo
+2³²: `pl.scan_delta` over the ~5.9-billion-row NWP dev table reports
+1,652,180,189 rows via `.select(pl.len())` (= 5,947,147,485 mod 2³², exactly), and
+`group_by(...).agg(pl.len())` wraps identically for any single group past the cap, streaming
+engine included. This was investigated and empirically pinned down in
+[issue #293](https://github.com/openclimatefix/nged-substation-forecast/issues/293): the
+wraparound reproduces on plain Parquet scans (it is not a Delta Lake bug), and the
+`polars-u64-idx` build (64-bit index, lags mainline releases) returns correct counts on the same
+queries.
+
+What is and isn't affected — each verified empirically on 5-billion-row scans:
+
+| Operation on a >2³²-row scan | Outcome |
+|---|---|
+| `pl.len()` / `group_by(...).agg(pl.len())` where a count exceeds 2³² | **Silently wraps mod 2³²** |
+| Materialising a single frame of ≥2³² rows | Unsupported (in practice RAM is exhausted first, which at least fails loudly) |
+| Filtered / partition-pruned query whose *result* is < 2³² rows | Correct |
+| Value aggregations (`sum`, `min`/`max`, quantiles) over > 2³² rows | Correct — values aren't indices |
+
+The rules that follow:
+
+* **Never row-count a table that can exceed 2³² rows with Polars.** Whole-table counts and
+  data-completeness checks must come from the Delta transaction log — `DeltaTable(path).count()`,
+  or summing `num_records` over `get_add_actions(flatten=True)` — which is metadata-only, exact,
+  and reads no data files.
+* The [lazy evaluation strategy](#lazy-evaluation-strategy) above already keeps every production
+  collect far below the cap (input pruning + `init_time` chunking), so pipeline reads are
+  unaffected. The cap is a second, independent reason that rule exists: an unbounded collect of a
+  V2-scale table wouldn't just OOM, its row accounting would be wrong.
+* Tables past the cap today: **NWP** (~5.9B rows). **`power_forecasts`** will pass it at V2 scale
+  (~1 trillion rows — see [forecast delivery](forecast-delivery.md#how-big-is-flexpectations-power-forecast-data)).
+  The one code path that must be re-chunked before then is the `metrics` asset, which currently
+  collects a whole `(experiment_name, fold_id)` group of `power_forecasts` at once and discovers
+  groups via a full-table `unique()` — fine at V1 (≤ ~414M rows/fold), but a V2 fold is tens of
+  billions of rows, so scoring will need to chunk within a fold (e.g. by `valid_time` window or
+  `time_series_id` batch) for RAM reasons anyway; the index cap makes it correctness-critical too.
+
 ## The Universal Model Interface
 
 All forecasting models subclass `BaseForecaster` (defined in `ml_core`), which provides a common `train` / `predict` / `save` / `load` interface. The model wrapper encapsulates the model weights and all translation logic, keeping Dagster assets completely agnostic to the underlying implementation. Each subclass of `BaseForecaster` is responsible for defining:

--- a/docs/background/requirements.md
+++ b/docs/background/requirements.md
@@ -11,7 +11,7 @@
 * Probabilistic, half-hourly, 14-day horizon forecasts updated every 6 hours. Within that
   horizon, users mostly act on forecasts roughly **1 to 10 days ahead**, so skill in that band
   matters most.
-    * For the day-ahead forecast: NGED want to look at the forecast at 11am to see the forecast from midnight to 
+    * For the day-ahead forecast: NGED want to look at the forecast at 11am to see the forecast from midnight to
     23:59 on the next day.
 * Cover substations (primary, BSP, GSP), metered generators (solar PV, wind, BESS, etc.), and customer meters.
 * Automatically detect and compensate for **switching events** — where power is diverted from one substation to another due to maintenance, changing the local demand signature.

--- a/docs/ml_experimentation/dagster-workflow.md
+++ b/docs/ml_experimentation/dagster-workflow.md
@@ -201,7 +201,11 @@ in the run config dialog before launching.
    so the predicates push straight into the Delta scan: naming an experiment/fold prunes to just
    that partition rather than reading the whole (unbounded) table.
 2. Discovers the matching `(experiment_name, fold_id)` groups, then loads and scores **one group at
-   a time** — peak memory is a single fold, not the entire matched population. For each group:
+   a time** — peak memory is a single fold, not the entire matched population. (A whole fold is
+   the *coarsest* chunk Polars can safely materialise: fine at V1 scale, but a V2-scale fold will
+   need sub-fold chunking — see
+   [The other hard ceiling: Polars' 32-bit row index](../architecture/overview.md#the-other-hard-ceiling-polars-32-bit-row-index).)
+   For each group:
    a. Calls `compute_metrics()` — joins observed power, averages ensemble members, computes
       MAE / NMAE / RMSE / MBE per `(time_series_id, fold_id, power_fcst_model_name)`.
    b. Enriches rows with scope (`evaluation_scope`), window bounds (`window_start`, `window_end`,


### PR DESCRIPTION
Closes #293.

## What this is

#293's `pl.scan_delta` "undercount" on the NWP table is a **silent 32-bit wraparound in Polars'
default build, not data loss**: 1,652,180,189 = 5,947,147,485 mod 2³², exactly. Full evidence
(exact reproduction, a Delta-free plain-Parquet repro, and verification that the `polars-u64-idx`
build returns the correct count on the same table) is in
[the root-cause comment on #293](https://github.com/openclimatefix/nged-substation-forecast/issues/293#issuecomment-4959652987).

The decision is to **stay on the default 32-bit `IdxSize` build** and document the limitation
thoroughly instead. This PR is that documentation.

## Is staying on 32-bit safe?

Yes, today — verified by a sweep of every read of the NWP / `power_forecasts` /
`power_time_series` tables in production and library code: every `.collect()` is bounded far
below 2³² rows per frame (partition pruning, `init_time` chunking, per-slot live reads), no
production code row-counts an unbounded scan of a >2³²-row table, and no
`with_row_index`-style completeness check exists against these tables.

Additional empirical findings folded into the docs (each tested on 5-billion-row scans):

- `group_by(...).agg(pl.len())` wraps the same way when a single group exceeds 2³² — streaming
  engine included.
- Filtered/pruned queries whose *result* stays under 2³² rows are exactly correct even when the
  underlying scan is bigger.
- Value aggregations (`sum`, `min`/`max`, quantiles) over >2³² rows are exactly correct — only
  row counts and row indices wrap.

The one forward-looking hazard is the **`metrics` asset at V2 scale**: it collects a whole
`(experiment_name, fold_id)` group of `power_forecasts` at once (fine at V1's ≤ ~414M rows/fold;
a V2 fold is tens of billions of rows) and discovers groups via a full-table `unique()`. It needs
sub-fold chunking before V2 for RAM reasons anyway; the index cap makes that correctness-critical
too. This is now called out in the docs at the metrics step and in the architecture overview.

## Changes

- **`docs/architecture/overview.md`** — new section *"The other hard ceiling: Polars' 32-bit row
  index"* under the Lazy Evaluation Strategy: the wraparound mechanics, an affected/unaffected
  table, the rules (Delta-log metadata for whole-table counts), and the V2 metrics-path flag.
- **`docs/architecture/forecast-delivery.md`** — short caveat in *"Lazy reads"*: whole-table row
  counts on >2³²-row tables must come from the Delta log, not `pl.len()`; the read patterns the
  page recommends are unaffected.
- **`docs/ml_experimentation/dagster-workflow.md`** — note at the `metrics` step that a whole
  fold is the coarsest safely-materialisable chunk, with a link to the overview section.
- **`CLAUDE.md`** — new Polars gotcha section so code assistants don't row-count big tables with
  Polars.
- **`docs/background/requirements.md`** — drive-by fix of a pre-existing trailing space that
  failed `pymarkdown` repo-wide.

Related GitHub housekeeping already done alongside this PR: #293's body updated with the
confirmed root cause (red-herring candidate causes removed), and the #294 ↔ #293 dependency link
removed (#294's partition-path encoding is exonerated; it stands alone as an ergonomics
improvement).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
