### PR TITLE
Split data_path into data_path_delivery / data_path_internal in Settings

### DIFF
--- a/docs/live_service/deployment.md
+++ b/docs/live_service/deployment.md
@@ -58,8 +58,8 @@ Selecting by job name (`-j`) skips that parser entirely.
 `load_forecaster_from_dir` and loads the model successfully (confirmed via the step ordering in
 `production_assets.py` — model load happens before the NWP-availability lookup) with zero
 `mlflow` mentions anywhere in the log, then fails only on missing NWP data access (expected —
-no `DATA_PATH` was mounted for this isolated test). A full end-to-end run needs a real
-`DATA_PATH` (local mount or S3 credentials) supplied via environment variables, per
+no `DATA_PATH_INTERNAL` was mounted for this isolated test). A full end-to-end run needs real
+data-table roots (local mount or S3 credentials) supplied via environment variables, per
 [Environment & storage setup](setup.md).
 
 ## Step 4 — Create the ECR repository
@@ -126,11 +126,9 @@ already relies on for compute running on AWS.
    - **Container**: image URI `<account-id>.dkr.ecr.eu-west-2.amazonaws.com/nged-forecast:<tag>`
      from [Step 5](#step-5-push-the-image-to-ecr); log configuration → **awslogs**, a new
      CloudWatch log group (e.g. `/ecs/nged-forecast`), region `eu-west-2`.
-   - **Environment variables**: `DATA_PATH=s3://nged-forecast-internal/data`,
-     `POWER_FORECASTS_DATA_PATH=s3://nged-forecast-delivery/data/power_forecasts`, and
-     `EFFECTIVE_CAPACITY_DATA_PATH=s3://nged-forecast-delivery/data/effective_capacity` — all
-     three are needed, since the delivery tables live in a separate bucket from everything
-     `DATA_PATH` derives by default (see
+   - **Environment variables**: `DATA_PATH_INTERNAL=s3://nged-forecast-internal/data` and
+     `DATA_PATH_DELIVERY=s3://nged-forecast-delivery/data` — both are needed, since the delivery
+     tables live in a separate bucket from everything else (see
      [setup.md's on-AWS settings](setup.md#step-3-point-settings-at-the-buckets)). Leave
      `DATA_STORE_*` unset, since the task role supplies credentials.
 

--- a/docs/live_service/setup.md
+++ b/docs/live_service/setup.md
@@ -19,22 +19,23 @@ credentials reach them**.
 Everything here is driven by [`Settings`](../api/contracts/index.md) (in
 `packages/contracts/src/contracts/settings.py`), populated from a `.env` file in the repo root and
 from environment variables. Environment variables win over `.env`, which wins over the defaults;
-every field name maps to an upper-case env var (`data_path` → `DATA_PATH`).
+every field name maps to an upper-case env var (`data_path_internal` → `DATA_PATH_INTERNAL`).
 
-### Two storage roots
+### Three storage roots
 
-The single most important idea is that there are **two** roots, not one:
+The single most important idea is that there are **three** roots, not one:
 
 | Root | Env var | May be `s3://`? | Holds |
 |---|---|---|---|
-| Data tables | `DATA_PATH` | **Yes** | NWP, power observations, forecasts, metrics, metadata, H3 weights |
+| Internal data tables | `DATA_PATH_INTERNAL` | **Yes** | NWP, power observations, forecast metrics — everything not on the NGED-facing delivery list |
+| Delivery data tables | `DATA_PATH_DELIVERY` | **Yes** | The NGED-facing delivery tables (`power_forecast`, `effective_capacity`, …) |
 | Local artifacts | `LOCAL_ARTIFACTS_PATH` | No — always local | Trained-model cache, the promoted production model, plot HTML |
 
-> **On AWS, "data tables" itself splits across two buckets** — the five NGED-facing delivery
-> tables live separately from everything else, via the per-table path overrides described in the
-> "derive from root" convention just below. See [Running on AWS: Step
-> 3](#step-3-point-settings-at-the-buckets) for the concrete setup, and [Forecast Delivery:
-> Securing it](../architecture/forecast-delivery.md#securing-it) for why.
+> **On AWS, the two data-table roots point at two separate buckets** — `DATA_PATH_DELIVERY`
+> hard-codes the five NGED-facing delivery tables (see the "derive from root" convention just
+> below), so shipping a new delivery table can't silently leave it in the internal bucket. See
+> [Running on AWS: Step 3](#step-3-point-settings-at-the-buckets) for the concrete setup, and
+> [Forecast Delivery: Securing it](../architecture/forecast-delivery.md#securing-it) for why.
 
 They are split for an **architectural** reason, not merely because XGBoost and Altair happen to
 write to local files (a library that can't write to S3 can always be bridged — write to a tempdir,
@@ -58,24 +59,27 @@ container image, not to shared storage:
   deployed service.
 
 So the deployed AWS runtime reads its model from the image, reads data from S3, and writes forecasts
-to S3 — it never uses `LOCAL_ARTIFACTS_PATH` as shared storage at all. Both roots default to
+to S3 — it never uses `LOCAL_ARTIFACTS_PATH` as shared storage at all. All three roots default to
 `<repo>/data`, so out of the box everything lives under one local directory and the distinction is
-invisible; it only matters once `DATA_PATH` becomes an `s3://` URI.
+invisible; it only matters once `DATA_PATH_INTERNAL` and `DATA_PATH_DELIVERY` become `s3://` URIs.
 
 ### The "derive from root" convention
 
 Each individual table has its own setting (`NWP_DATA_PATH`, `POWER_FORECASTS_DATA_PATH`, …), but you
 almost never set them. Each defaults to an empty string, a sentinel meaning *derive me from my
-root*: after validation, `NWP_DATA_PATH` becomes `<DATA_PATH>/NWP`, `METADATA_PATH` becomes
-`<DATA_PATH>/NGED/metadata.parquet`, and so on. The full default layout lives in
-`Settings._derive_unset_paths` and nowhere else.
+root*: after validation, `NWP_DATA_PATH` becomes `<DATA_PATH_INTERNAL>/NWP`, `METADATA_PATH` becomes
+`<DATA_PATH_INTERNAL>/NGED/metadata.parquet`, and so on. The NGED-facing delivery tables are the
+exception: `POWER_FORECASTS_DATA_PATH` and `EFFECTIVE_CAPACITY_DATA_PATH` derive from
+`DATA_PATH_DELIVERY` instead — hard-coded in `Settings._derive_unset_paths`, which is the full
+default layout and the only place it lives.
 
-Set `DATA_PATH` alone and all nine data tables move together. Setting an individual table (e.g.
+Set `DATA_PATH_INTERNAL` alone and every non-delivery table moves together; set `DATA_PATH_DELIVERY`
+alone and both delivery tables move together. Setting an individual table (e.g.
 `NWP_DATA_PATH=s3://other-bucket/NWP`) overrides just that one — useful for keeping one big table on
 a separate bucket, and nothing else needs to change. [Running on AWS: Step
-3](#step-3-point-settings-at-the-buckets) is exactly this pattern applied on purpose: `DATA_PATH`
-defaults to OCF's internal bucket, and the delivery tables are individually overridden to a
-second, NGED-facing bucket.
+3](#step-3-point-settings-at-the-buckets) is exactly this pattern applied on purpose: on AWS,
+`DATA_PATH_INTERNAL` points at OCF's internal bucket and `DATA_PATH_DELIVERY` points at the
+NGED-facing bucket — no per-table override needed for either of today's two delivery tables.
 
 ### The `.env` file and NGED source credentials
 
@@ -101,12 +105,13 @@ then [run the workflow](dagster-workflow.md). Nothing in this section is needed 
 
 ### Optional: rehearse S3 locally with MinIO
 
-To exercise the exact S3 read/write code paths without touching AWS, point `DATA_PATH` at a local
-[MinIO](https://min.io/) (or any S3-compatible) endpoint and supply all four `DATA_STORE_*`
-settings:
+To exercise the exact S3 read/write code paths without touching AWS, point both `DATA_PATH_INTERNAL`
+and `DATA_PATH_DELIVERY` at the same local [MinIO](https://min.io/) (or any S3-compatible) endpoint
+and supply all four `DATA_STORE_*` settings:
 
 ```dotenv
-DATA_PATH=s3://my-bucket/data
+DATA_PATH_INTERNAL=s3://my-bucket/data
+DATA_PATH_DELIVERY=s3://my-bucket/data
 DATA_STORE_ENDPOINT_URL=http://localhost:9000
 DATA_STORE_ACCESS_KEY_ID=minioadmin
 DATA_STORE_SECRET_ACCESS_KEY=minioadmin
@@ -122,7 +127,7 @@ against an in-process `moto` server.)
 
 > **Scope: data tables on S3, not the full unattended deployment.** This section covers pointing the
 > **data tables** at S3 — which is all the ephemeral-compute deployment needs from the storage layer,
-> and is enough to run the stack from your laptop against an S3 `DATA_PATH` today. Building the
+> and is enough to run the stack from your laptop against S3 data-table roots today. Building the
 > production container itself is covered by
 > [Deploying a new production image](deployment.md);
 > running it as an unattended, scheduled **Fargate task** (ECR, EventBridge scheduling) is a
@@ -216,18 +221,19 @@ Attach it to **whichever identity runs the code**:
 
 ### Step 3 — Point `Settings` at the buckets
 
-Unlike a single-bucket setup, this now needs `DATA_PATH` **plus** an explicit override per
-delivery table, rather than one setting:
+Unlike a single-bucket setup, this now needs **both** data-table roots set, one per bucket:
 
 | Setting | Bucket | Why |
 |---|---|---|
-| `DATA_PATH` (root) | `nged-forecast-internal` | Every table derives from this unless overridden below — deliberately **fails closed**: forgetting to override a new delivery table just leaves it in the internal bucket (invisible to NGED, a functional bug to catch in testing), rather than a forgotten override on a new internal table accidentally exposing it in the delivery bucket. |
-| `POWER_FORECASTS_DATA_PATH` | `nged-forecast-delivery` | Table 1, `power_forecast` — see the caveat below. |
-| `EFFECTIVE_CAPACITY_DATA_PATH` | `nged-forecast-delivery` | Table 4, `effective_capacity`. |
+| `DATA_PATH_INTERNAL` (root) | `nged-forecast-internal` | Every non-delivery table derives from this. |
+| `DATA_PATH_DELIVERY` (root) | `nged-forecast-delivery` | `power_forecasts_data_path` and `effective_capacity_data_path` derive from this, hard-coded in `Settings._derive_unset_paths` — deliberately **fails closed**: a new delivery table added to the schema but not wired into that derivation stays on `DATA_PATH_INTERNAL` (invisible to NGED, a functional bug caught by `test_settings.py`'s guard test), rather than a forgotten override on a new internal table accidentally exposing it in the delivery bucket. |
 
 The other three delivery tables (`power_forecast_warnings`, `asset_health_history`,
 `substation_switching`) don't have `Settings` fields yet — none are implemented in code. When
-they land, their paths need the same explicit override to `nged-forecast-delivery`.
+they land, they need to be wired into `Settings._derive_unset_paths` to derive from
+`DATA_PATH_DELIVERY` alongside the two above (the per-field env var override — e.g.
+`POWER_FORECASTS_DATA_PATH`, still works as an escape valve for a one-off case, but is no longer
+the primary mechanism for the delivery/internal split).
 
 > **Design choice: NGED sees every CV/backtest fold, not just live production forecasts.** The
 > `power_forecasts` table holds every CV/backtest experiment alongside live production forecasts,
@@ -240,19 +246,17 @@ they land, their paths need the same explicit override to `nged-forecast-deliver
 **On AWS compute (IAM role)** — credentials and region are auto-discovered, so just:
 
 ```dotenv
-DATA_PATH=s3://nged-forecast-internal/data
-POWER_FORECASTS_DATA_PATH=s3://nged-forecast-delivery/data/power_forecasts
-EFFECTIVE_CAPACITY_DATA_PATH=s3://nged-forecast-delivery/data/effective_capacity
+DATA_PATH_INTERNAL=s3://nged-forecast-internal/data
+DATA_PATH_DELIVERY=s3://nged-forecast-delivery/data
 ```
 
-**From your laptop (IAM user access key)** — same three paths, plus the key, secret, and region,
+**From your laptop (IAM user access key)** — same two roots, plus the key, secret, and region,
 but **not** an endpoint URL (that is only for non-AWS/MinIO endpoints, and it would wrongly allow
 plain HTTP):
 
 ```dotenv
-DATA_PATH=s3://nged-forecast-internal/data
-POWER_FORECASTS_DATA_PATH=s3://nged-forecast-delivery/data/power_forecasts
-EFFECTIVE_CAPACITY_DATA_PATH=s3://nged-forecast-delivery/data/effective_capacity
+DATA_PATH_INTERNAL=s3://nged-forecast-internal/data
+DATA_PATH_DELIVERY=s3://nged-forecast-delivery/data
 DATA_STORE_ACCESS_KEY_ID=<access key id>
 DATA_STORE_SECRET_ACCESS_KEY=<secret access key>
 DATA_STORE_REGION=eu-west-2
@@ -305,10 +309,10 @@ persist, and no need to know or care which bucket a given table resolves to. Poi
 
 ### At-a-glance: which settings for which environment
 
-| Environment | `DATA_PATH` | Delivery-table overrides | `DATA_STORE_*` |
+| Environment | `DATA_PATH_INTERNAL` | `DATA_PATH_DELIVERY` | `DATA_STORE_*` |
 |---|---|---|---|
-| Local (default) | unset → `<repo>/data` | unset | none |
-| Local MinIO rehearsal | `s3://…` | unset (single bucket) | all four, incl. `ENDPOINT_URL` |
+| Local (default) | unset → `<repo>/data` | unset → `<repo>/data` | none |
+| Local MinIO rehearsal | `s3://…` | same `s3://…` (single bucket) | all four, incl. `ENDPOINT_URL` |
 | Laptop → real S3 (pipeline) | `s3://nged-forecast-internal/…` | `s3://nged-forecast-delivery/…` | key + secret + region, read/write IAM user (no endpoint) |
 | Laptop → real S3 (dashboard only) | `s3://nged-forecast-internal/…` | `s3://nged-forecast-delivery/…` | key + secret + region, read-only IAM user (no endpoint) |
 | Compute on AWS (IAM role) | `s3://nged-forecast-internal/…` | `s3://nged-forecast-delivery/…` | none (auto-discovered) |

--- a/packages/contracts/src/contracts/_uri.py
+++ b/packages/contracts/src/contracts/_uri.py
@@ -8,7 +8,7 @@ The existence/parent helpers below give the asset IO layer a single local-or-rem
 call for the two things it does around every Delta/parquet write: make sure the parent
 directory exists (a no-op on object stores, which have no directories) and check whether a
 table/object is already there. Remote calls go through delta-rs / obstore with the caller's
-``storage_options`` so the same code path serves both a local ``data_path`` and an ``s3://`` one.
+``storage_options`` so the same code path serves both a local data-path root and an ``s3://`` one.
 """
 
 import posixpath
@@ -31,7 +31,7 @@ class ObjectStoreOptions(TypedDict, total=False):
     Authored as a ``TypedDict`` (rather than a bare ``dict[str, str]``) so ``ty`` checks every key
     where it is written — see ``Settings.storage_options``. Widen it to the plain ``dict`` the IO
     libraries expect with ``typeddict_to_dict`` at each call boundary. Empty on AWS (object_store
-    auto-discovers the IAM-role credentials and region) and for a local ``data_path``.
+    auto-discovers the IAM-role credentials and region) and for a local data-path root.
     """
 
     aws_endpoint_url: str

--- a/packages/contracts/src/contracts/settings.py
+++ b/packages/contracts/src/contracts/settings.py
@@ -96,34 +96,47 @@ class Settings(BaseSettings):
         description=(
             "Static CSV of per-NWP-model metadata (H3 resolution, provider, ensemble flag),"
             " checked into the repo and read by NwpMetaData.load. A code-relative resource"
-            " (like cv_config_path), so it stays a local Path even when data_path is a remote URI."
+            " (like cv_config_path), so it stays a local Path even when the data tables are a"
+            " remote URI."
         ),
     )
 
     # --- Storage roots -------------------------------------------------------------------
     #
-    # data_path holds the (S3-capable) data tables; local_artifacts_path holds the always-local
-    # model cache, production model, and plots. Why they are split, and what belongs in each:
+    # data_path_internal and data_path_delivery hold the (S3-capable) data tables; local_
+    # artifacts_path holds the always-local model cache, production model, and plots. Why they
+    # are split, and what belongs in each:
     # https://openclimatefix.github.io/nged-substation-forecast/live_service/setup/
 
-    data_path: str = Field(
+    data_path_internal: str = Field(
         default=str(PROJECT_ROOT / "data"),
         description=(
-            "Root of the managed data tables (NWP, power, forecasts, metrics, …). A local path"
-            " by default; may be a remote URI (e.g. 's3://bucket/data') so the data tables live"
-            " on S3. Every *_data_path below that is left unset derives from this root."
+            "Root of OCF's own working data tables (NWP, power, forecast_metrics, …). A local"
+            " path by default; may be a remote URI (e.g. 's3://bucket/data') so the data tables"
+            " live on S3. Every *_data_path below that is left unset derives from this root,"
+            " except the NGED-facing delivery tables, which derive from data_path_delivery"
+            " instead."
+        ),
+    )
+    data_path_delivery: str = Field(
+        default=str(PROJECT_ROOT / "data"),
+        description=(
+            "Root of the NGED-facing delivery tables (power_forecasts, effective_capacity, …)."
+            " Defaults to the same local path as data_path_internal, so local dev sees one"
+            " directory and the split is invisible; on AWS this points at the separate,"
+            " NGED-facing bucket."
         ),
     )
     local_artifacts_path: str = Field(
         default=str(PROJECT_ROOT / "data"),
         description=(
             "Root of the always-local artifacts (model cache, production model, plots). Kept"
-            " separate from data_path because these back local-filesystem-only libraries and"
-            " must stay local even when data_path is a remote URI."
+            " separate from the data-table roots because these back local-filesystem-only"
+            " libraries and must stay local even when the data tables live on S3."
         ),
     )
 
-    # --- Object-store credentials for the data tables (used only when data_path is remote) --
+    # --- Object-store credentials for the data tables (used only when a data-path root is remote)
     #
     # All empty by default; unset on AWS (object_store auto-discovers the IAM-role credentials),
     # set only for a dev/MinIO endpoint. The AWS/dev split, and how these differ from the
@@ -153,7 +166,7 @@ class Settings(BaseSettings):
         """delta-rs / polars / obstore ``storage_options`` for the managed data tables.
 
         Empty on AWS — object_store auto-discovers the Fargate task's IAM-role credentials and
-        region — and empty for a local ``data_path`` (delta-rs ignores it there). Populated from
+        region — and empty for a local data-path root (delta-rs ignores it there). Populated from
         the ``data_store_*`` settings only for a dev/MinIO/S3-compatible endpoint. The ``aws_*``
         keys are the shared object_store aliases understood by delta-rs, polars cloud IO, and
         obstore alike, so one value feeds every IO site. Returned as an ``ObjectStoreOptions``
@@ -172,18 +185,21 @@ class Settings(BaseSettings):
             options["aws_region"] = self.data_store_region
         return options
 
-    # --- Managed data tables (derive from data_path unless explicitly set) ----------------
+    # --- Managed data tables (derive from a root unless explicitly set) --------------------
     #
-    # Each defaults to "" — a sentinel meaning "derive from data_path in _derive_unset_paths".
-    # The derive-from-root convention and per-table overrides:
-    # https://openclimatefix.github.io/nged-substation-forecast/live_service/setup/
+    # Each defaults to "" — a sentinel meaning "derive from data_path_internal or
+    # data_path_delivery in _derive_unset_paths". The derive-from-root convention and per-table
+    # overrides: https://openclimatefix.github.io/nged-substation-forecast/live_service/setup/
 
     nged_data_path: str = ""
     """Directory holding the NGED power_time_series Delta table and metadata parquet."""
     nwp_data_path: str = ""
     """Delta table of NWP weather data."""
     power_forecasts_data_path: str = ""
-    """Delta table of power forecasts (partitioned by experiment_name, fold_id)."""
+    """Delta table of power forecasts (partitioned by experiment_name, fold_id).
+
+    An NGED-facing delivery table — derives from data_path_delivery, not data_path_internal.
+    """
     forecast_metrics_data_path: str = ""
     """Delta table of forecast evaluation metrics."""
     power_time_series_data_path: str = ""
@@ -204,7 +220,8 @@ class Settings(BaseSettings):
         description=(
             "Delta table of per-series effective capacity (v0.1: full-history P99 of |power|),"
             " written by the effective_capacity asset and read by the metrics asset as the NMAE"
-            " denominator."
+            " denominator. An NGED-facing delivery table — derives from data_path_delivery, not"
+            " data_path_internal."
         ),
     )
     h3_grid_weights_path: str = ""
@@ -247,22 +264,25 @@ class Settings(BaseSettings):
         The default layout lives here and nowhere else. A field set explicitly (e.g. via its
         env var) keeps its value; only the "" sentinels are derived.
         """
-        self.nged_data_path = self.nged_data_path or uri_join(self.data_path, "NGED")
-        self.nwp_data_path = self.nwp_data_path or uri_join(self.data_path, "NWP")
-        self.power_forecasts_data_path = self.power_forecasts_data_path or uri_join(
-            self.data_path, "power_forecasts"
-        )
+        self.nged_data_path = self.nged_data_path or uri_join(self.data_path_internal, "NGED")
+        self.nwp_data_path = self.nwp_data_path or uri_join(self.data_path_internal, "NWP")
         self.forecast_metrics_data_path = self.forecast_metrics_data_path or uri_join(
-            self.data_path, "forecast_metrics"
+            self.data_path_internal, "forecast_metrics"
         )
         self.eligible_time_series_data_path = self.eligible_time_series_data_path or uri_join(
-            self.data_path, "eligible_time_series"
-        )
-        self.effective_capacity_data_path = self.effective_capacity_data_path or uri_join(
-            self.data_path, "effective_capacity"
+            self.data_path_internal, "eligible_time_series"
         )
         self.h3_grid_weights_path = self.h3_grid_weights_path or uri_join(
-            self.data_path, "h3_grid_weights.parquet"
+            self.data_path_internal, "h3_grid_weights.parquet"
+        )
+        # NGED-facing delivery tables (see docs/roadmap/delivery-tables.md) derive from
+        # data_path_delivery instead, so a new delivery table can't silently land in the
+        # internal bucket by inheriting the default derivation.
+        self.power_forecasts_data_path = self.power_forecasts_data_path or uri_join(
+            self.data_path_delivery, "power_forecasts"
+        )
+        self.effective_capacity_data_path = self.effective_capacity_data_path or uri_join(
+            self.data_path_delivery, "effective_capacity"
         )
         # Derived from nged_data_path (itself derived above).
         self.power_time_series_data_path = self.power_time_series_data_path or uri_join(

--- a/packages/contracts/tests/test_settings.py
+++ b/packages/contracts/tests/test_settings.py
@@ -20,9 +20,9 @@ def test_settings_validation_invalid_url():
 
 
 def test_paths_derive_from_data_root():
-    """Unset data-table paths derive from data_path; nested tables sit under nged_data_path."""
+    """Unset data-table paths derive from data_path_internal; nested tables sit under nged_data_path."""
     settings = Settings(
-        data_path="/srv/data",
+        data_path_internal="/srv/data",
         nged_s3_bucket_url="https://example.com",
         nged_s3_bucket_access_key="key",
         nged_s3_bucket_secret="secret",
@@ -34,10 +34,58 @@ def test_paths_derive_from_data_root():
     assert settings.h3_grid_weights_path == "/srv/data/h3_grid_weights.parquet"
 
 
-def test_remote_data_path_keeps_artifacts_local():
-    """A remote data_path yields s3:// data tables while artifacts stay under local_artifacts_path."""
+def test_delivery_paths_derive_from_delivery_root():
+    """Delivery-table paths derive from data_path_delivery, independently of data_path_internal."""
     settings = Settings(
-        data_path="s3://bucket/data",
+        data_path_internal="s3://internal-bucket/data",
+        data_path_delivery="s3://delivery-bucket/data",
+        nged_s3_bucket_url="https://example.com",
+        nged_s3_bucket_access_key="key",
+        nged_s3_bucket_secret="secret",
+    )
+    assert settings.power_forecasts_data_path == "s3://delivery-bucket/data/power_forecasts"
+    assert settings.effective_capacity_data_path == "s3://delivery-bucket/data/effective_capacity"
+    assert settings.nwp_data_path == "s3://internal-bucket/data/NWP"
+
+
+def test_delivery_fields_are_exactly_the_known_delivery_tables():
+    """Guards against a new delivery table being added but never wired into _derive_unset_paths.
+
+    If this test fails after adding a new *_data_path field, decide whether it belongs in the
+    NGED-facing delivery bucket (see docs/roadmap/delivery-tables.md) and update either this set
+    or Settings._derive_unset_paths accordingly.
+    """
+    known_delivery_fields = {"power_forecasts_data_path", "effective_capacity_data_path"}
+    # Always-local artifacts derive from local_artifacts_path, not either data-table root, so
+    # they're excluded from this internal-vs-delivery check even though their names also end in
+    # "_data_path".
+    local_artifact_fields = {"plots_data_path", "model_cache_base_path", "production_model_path"}
+    settings = Settings(
+        data_path_internal="/internal",
+        data_path_delivery="/delivery",
+        nged_s3_bucket_url="https://example.com",
+        nged_s3_bucket_access_key="key",
+        nged_s3_bucket_secret="secret",
+    )
+    managed_data_table_fields = {
+        name
+        for name in Settings.model_fields
+        if (name.endswith("_data_path") or name in {"metadata_path", "h3_grid_weights_path"})
+        and name not in local_artifact_fields
+    }
+    for field_name in managed_data_table_fields:
+        value = getattr(settings, field_name)
+        if field_name in known_delivery_fields:
+            assert value.startswith("/delivery"), f"{field_name} should derive from /delivery"
+        else:
+            assert value.startswith("/internal"), f"{field_name} should derive from /internal"
+
+
+def test_remote_data_path_keeps_artifacts_local():
+    """A remote data_path_internal yields s3:// data tables while artifacts stay under local_artifacts_path."""
+    settings = Settings(
+        data_path_internal="s3://bucket/data",
+        data_path_delivery="s3://bucket/data",
         local_artifacts_path="/local/artifacts",
         nged_s3_bucket_url="https://example.com",
         nged_s3_bucket_access_key="key",
@@ -53,7 +101,8 @@ def test_remote_data_path_keeps_artifacts_local():
 def test_explicit_path_overrides_derivation():
     """An explicitly set path wins over derivation from its root."""
     settings = Settings(
-        data_path="s3://bucket/data",
+        data_path_internal="s3://bucket/data",
+        data_path_delivery="s3://bucket/data",
         plots_data_path="s3://other-bucket/plots",
         nwp_data_path="/mnt/fast/NWP",
         nged_s3_bucket_url="https://example.com",
@@ -69,7 +118,7 @@ def test_explicit_path_overrides_derivation():
 def test_storage_options_empty_without_dev_credentials():
     """With no ``data_store_*`` credentials set, ``storage_options`` is empty (the AWS default)."""
     settings = Settings(
-        data_path="s3://bucket/data",
+        data_path_internal="s3://bucket/data",
         nged_s3_bucket_url="https://example.com",
         nged_s3_bucket_access_key="key",
         nged_s3_bucket_secret="secret",
@@ -80,7 +129,7 @@ def test_storage_options_empty_without_dev_credentials():
 def test_storage_options_populated_from_dev_credentials():
     """The ``data_store_*`` settings map onto the shared ``aws_*`` object_store option keys."""
     settings = Settings(
-        data_path="s3://bucket/data",
+        data_path_internal="s3://bucket/data",
         data_store_endpoint_url="http://localhost:9000",
         data_store_access_key_id="minio",
         data_store_secret_access_key="minio123",

--- a/tests/test_s3_data_paths.py
+++ b/tests/test_s3_data_paths.py
@@ -1,7 +1,7 @@
 """S3 integration tests for the managed data tables (issue #121).
 
 Exercises the data-table IO layer against a real S3 endpoint — an in-process ``moto`` server, so
-no Docker or network — driven entirely through ``Settings`` pointed at an ``s3://`` ``data_path``.
+no Docker or network — driven entirely through ``Settings`` pointed at an ``s3://`` data-path root.
 Proves the two things the S3 migration must guarantee and that the local test suite cannot:
 
 1. Delta and parquet tables round-trip over ``s3://`` through the production write/read helpers
@@ -87,12 +87,14 @@ def s3_endpoint() -> Iterator[str]:
 def _s3_settings(endpoint: str, prefix: str) -> Settings:
     """A ``Settings`` whose data tables live under ``s3://{_BUCKET}/{prefix}`` on the moto server.
 
-    Only ``data_path`` and the ``data_store_*`` credentials are set; every ``*_data_path`` derives
-    from ``data_path`` through the normal validator, so the test drives the real derivation +
+    Only ``data_path_internal``/``data_path_delivery`` and the ``data_store_*`` credentials are
+    set (both roots point at the same prefix, as in local dev); every ``*_data_path`` derives from
+    one of the two roots through the normal validator, so the test drives the real derivation +
     ``storage_options`` chain rather than hand-built URIs.
     """
     return Settings(
-        data_path=f"s3://{_BUCKET}/{prefix}",
+        data_path_internal=f"s3://{_BUCKET}/{prefix}",
+        data_path_delivery=f"s3://{_BUCKET}/{prefix}",
         data_store_endpoint_url=endpoint,
         data_store_access_key_id="test",
         data_store_secret_access_key="test",


### PR DESCRIPTION
## Summary

Closes #296.

- Renames `Settings.data_path` → `data_path_internal` (env var `DATA_PATH` → `DATA_PATH_INTERNAL`). Safe now — no live environment sets `DATA_PATH=s3://…` yet.
- Adds `data_path_delivery` (env var `DATA_PATH_DELIVERY`), defaulting to the same local path as `data_path_internal` so local dev is unchanged.
- `Settings._derive_unset_paths` now hard-codes `power_forecasts_data_path` and `effective_capacity_data_path` (today's two implemented NGED-facing delivery tables) to derive from `data_path_delivery`, instead of relying on a per-environment env var override that lives outside version control. Everything else continues deriving from `data_path_internal`. The per-field override remains available as an escape valve for one-off cases.
- Credentials stay unsplit (`DATA_STORE_*`/`storage_options` cover both roots), matching the IAM setup that already grants one identity access to both bucket ARNs.
- Adds a guard test in `test_settings.py` asserting exactly the known delivery fields derive from `data_path_delivery` and every other managed-data-table field derives from `data_path_internal` — so a future delivery table added to the schema but not wired into `_derive_unset_paths` fails a test instead of silently landing in the wrong bucket.
- Updates `docs/live_service/setup.md` (three-root model, "derive from root" section, Step 3, at-a-glance table) and `docs/live_service/deployment.md` (Step 7's env vars, now 2 lines instead of 3).
- Sweeps remaining generic `data_path`/`DATA_PATH` prose references in `_uri.py` and docs now that no field is literally named `data_path`.

## Test plan

- [x] `uv run pytest packages/contracts/tests/test_settings.py -q` — 9 passed
- [x] `uv run pytest -q` (full suite, excluding S3 integration) — 228 passed
- [x] `uv run pytest tests/test_s3_data_paths.py -q -m integration` — 3 passed (moto-backed S3 round-trip, both roots)
- [x] `uv run ruff check .` — clean
- [x] `uv run ty check` — clean (pre-existing unrelated notebook import errors only)
- [x] `uv run pymarkdown scan -r docs README.md CLAUDE.md metadata/README.md packages/*/README.md` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)