### PR TITLE
Extract GitHub GraphQL cheatsheet from CLAUDE.md into a project skill

### DIFF
--- a/.claude/skills/github-graphql/SKILL.md
+++ b/.claude/skills/github-graphql/SKILL.md
@@ -1,0 +1,115 @@
+---
+name: github-graphql
+description: >-
+  Concrete gh api graphql invocations for the GitHub operations this repo's issue/PR workflow
+  needs but plain gh issue/pr commands can't do: attaching a sub-issue to its parent epic,
+  reordering sub-issues within a parent, setting an issue's org-level Type, and setting a GitHub
+  Projects (v2) field (Status/Project/Area) on an item. Use this skill whenever you're about to
+  run one of those four operations for openclimatefix/nged-substation-forecast — e.g. when
+  CLAUDE.md's "Creating GitHub issues" section says to attach/position a sub-issue, set Type, or
+  set project fields, or whenever you'd otherwise reach for `gh api graphql` and aren't sure of
+  the mutation name, its input fields, or how to obtain the node IDs it needs.
+---
+
+# GitHub GraphQL cheatsheet
+
+Every mutation below operates on GraphQL **node IDs**, not the issue/PR numbers or URLs `gh`
+normally works with. Get a node ID with:
+
+```bash
+gh issue view <number> --json id --jq .id   # works for PRs too via `gh pr view`
+```
+
+All commands below assume the repo `openclimatefix/nged-substation-forecast`; swap the owner/name
+if pointed at a different repo. Each mutation's input fields were confirmed against GitHub's live
+schema via `gh api graphql` introspection (`{ __type(name: "<MutationName>Input") { inputFields {
+name } } }`) — re-check with the same technique if a call below ever starts failing, since GitHub
+occasionally adds/renames fields.
+
+## Attach a sub-issue to its parent
+
+`addSubIssue` — `issueId` is the **parent's** node ID, `subIssueId` is the **child's**:
+
+```bash
+gh api graphql -f query='
+  mutation($issueId: ID!, $subIssueId: ID!) {
+    addSubIssue(input: {issueId: $issueId, subIssueId: $subIssueId}) {
+      subIssue { number }
+    }
+  }' -f issueId="<parent node id>" -f subIssueId="<child node id>"
+```
+
+Do this *before* trying to reorder the sub-issue — `reprioritizeSubIssue` below assumes the
+attachment already exists.
+
+## Reorder a sub-issue within its parent's list
+
+`reprioritizeSubIssue`. `afterId`/`beforeId` take a **sibling sub-issue's** node ID (not the
+parent's) and are mutually exclusive — pass whichever one expresses where the issue should land:
+
+```bash
+gh api graphql -f query='
+  mutation($issueId: ID!, $subIssueId: ID!, $afterId: ID) {
+    reprioritizeSubIssue(input: {issueId: $issueId, subIssueId: $subIssueId, afterId: $afterId}) {
+      issue { number }
+    }
+  }' -f issueId="<parent node id>" -f subIssueId="<child node id>" -f afterId="<sibling node id>"
+```
+
+## Set an issue's Type
+
+`updateIssueIssueType`. Issue-type IDs are stable per-org, so look them up once and reuse:
+
+```bash
+gh api graphql -f query='
+  { repository(owner: "openclimatefix", name: "nged-substation-forecast") {
+      issueTypes(first: 10) { nodes { id name } }
+  } }'
+```
+
+then:
+
+```bash
+gh api graphql -f query='
+  mutation($issueId: ID!, $issueTypeId: ID!) {
+    updateIssueIssueType(input: {issueId: $issueId, issueTypeId: $issueTypeId}) {
+      issue { number }
+    }
+  }' -f issueId="<issue node id>" -f issueTypeId="<issue type node id>"
+```
+
+## Set a GitHub Projects (v2) field
+
+Prefer `gh project item-edit` over raw GraphQL — it wraps `updateProjectV2ItemFieldValue` for you
+and only drop to the raw mutation if it doesn't cover the field type you need (e.g. iteration
+fields it can't set). Gather the IDs it needs:
+
+```bash
+gh project view 33 --owner openclimatefix --format json --jq .id          # project node ID
+gh project field-list 33 --owner openclimatefix --format json             # field + option IDs
+gh project item-add 33 --owner openclimatefix --url <issue-url> \
+  --format json --jq .id                                                  # item node ID
+```
+
+Then, for a single-select field (Status, Project, Area are all single-select in this repo's
+board):
+
+```bash
+gh project item-edit --id <item node id> --project-id <project node id> \
+  --field-id <field node id> --single-select-option-id <option id>
+```
+
+If raw GraphQL is genuinely needed, the mutation is:
+
+```bash
+gh api graphql -f query='
+  mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+    updateProjectV2ItemFieldValue(input: {
+      projectId: $projectId, itemId: $itemId, fieldId: $fieldId,
+      value: {singleSelectOptionId: $optionId}
+    }) {
+      projectV2Item { id }
+    }
+  }' -f projectId="<project node id>" -f itemId="<item node id>" \
+     -f fieldId="<field node id>" -f optionId="<option id>"
+```

--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,9 @@ test.parquet
 example_data/
 packages/dynamical_data/example_data
 site/
+
+#######################
+# Claude Code
+
+# Personal permission allowlist — local to this machine, not project config.
+.claude/settings.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,65 +98,9 @@ JackKelly` right after creating the PR.
 `main`, so use a merge commit (`gh pr merge --merge`) or rebase (`gh pr merge --rebase`), not
 `gh pr merge --squash`.
 
-**GitHub GraphQL cheatsheet** — concrete `gh api graphql` calls for the mutations referenced
-above. All of them need **node IDs**, not issue/PR numbers or URLs — get one with `gh issue view
-<number> --json id --jq .id` (works for PRs too via `gh pr view`).
-
-- **Attach a sub-issue to its parent** — `addSubIssue` (not referenced above, but needed before
-  `reprioritizeSubIssue` can reorder it):
-
-  ```bash
-  gh api graphql -f query='
-    mutation($issueId: ID!, $subIssueId: ID!) {
-      addSubIssue(input: {issueId: $issueId, subIssueId: $subIssueId}) {
-        subIssue { number }
-      }
-    }' -f issueId="<parent node id>" -f subIssueId="<child node id>"
-  ```
-
-- **Reorder a sub-issue** in its parent's list — `reprioritizeSubIssue`. `afterId`/`beforeId`
-  take a *sibling sub-issue's* node ID (not the parent's), and are mutually exclusive:
-
-  ```bash
-  gh api graphql -f query='
-    mutation($issueId: ID!, $subIssueId: ID!, $afterId: ID) {
-      reprioritizeSubIssue(input: {issueId: $issueId, subIssueId: $subIssueId, afterId: $afterId}) {
-        issue { number }
-      }
-    }' -f issueId="<parent node id>" -f subIssueId="<child node id>" -f afterId="<sibling node id>"
-  ```
-
-- **Set an issue's Type** — `updateIssueIssueType`. Look up the type IDs once per repo (they're
-  stable, so worth keeping handy):
-
-  ```bash
-  gh api graphql -f query='
-    { repository(owner: "openclimatefix", name: "nged-substation-forecast") {
-        issueTypes(first: 10) { nodes { id name } }
-    } }'
-  ```
-
-  then:
-
-  ```bash
-  gh api graphql -f query='
-    mutation($issueId: ID!, $issueTypeId: ID!) {
-      updateIssueIssueType(input: {issueId: $issueId, issueTypeId: $issueTypeId}) {
-        issue { number }
-      }
-    }' -f issueId="<issue node id>" -f issueTypeId="<issue type node id>"
-  ```
-
-- **Set a project field** — prefer `gh project item-edit` (it wraps `updateProjectV2ItemFieldValue`
-  for you; drop to raw GraphQL only if it doesn't cover the field type you need). Get the
-  project's node ID with `gh project view 33 --owner openclimatefix --format json --jq .id`, the
-  field/option IDs with `gh project field-list 33 --owner openclimatefix --format json`, and the
-  item's ID from `gh project item-add`'s own JSON output (`--format json --jq .id`):
-
-  ```bash
-  gh project item-edit --id <item node id> --project-id <project node id> \
-    --field-id <field node id> --single-select-option-id <option id>
-  ```
+**GitHub GraphQL calls** (attaching/reordering sub-issues, setting an issue's Type, setting a
+project field) — see the `github-graphql` skill (`.claude/skills/github-graphql/`) for exact
+`gh api graphql` invocations and how to obtain the node IDs they need.
 
 **Ship-time triage** — when a PR lands a roadmap item, that PR (or an immediate follow-up)
 must also:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,3 +132,7 @@ plugins.md024.siblings_only = true
 # sub-list as nested when it's indented a full 4 spaces; 2-space indent (this rule's default)
 # silently renders as a flat, unnested list instead. Match the renderer, not the default.
 plugins.md007.indent = 4
+# Front matter: Claude Code skills (.claude/skills/*/SKILL.md) require a YAML frontmatter block.
+# Without this, pymarkdown misreads the frontmatter as document content (e.g. "---" as a setext
+# heading underline), producing spurious heading-style/blank-line errors.
+extensions.front-matter.enabled = true


### PR DESCRIPTION
## Summary

- Moves the "GitHub GraphQL cheatsheet" content added in #299's follow-up commit out of
  `CLAUDE.md` and into a new project skill, `.claude/skills/github-graphql/SKILL.md`. That
  content (exact `gh api graphql` invocations for `addSubIssue`, `reprioritizeSubIssue`,
  `updateIssueIssueType`, and the project-field update) is pure reference syntax only needed at
  the moment of running one of those calls, so it doesn't need to be primed into every session's
  context the way `CLAUDE.md` is — a skill loads on demand instead. `CLAUDE.md` now just points
  at the skill. Every mutation's input fields were (re-)verified against GitHub's live schema via
  `gh api graphql` introspection before being written down.
- Enables pymarkdown's `front-matter` extension in `pyproject.toml`. `SKILL.md` files require a
  YAML frontmatter block, which the linter was otherwise misreading as document content (`---` as
  a setext heading underline), producing spurious `MD003`/`MD022`/`MD023`/`MD026`/`MD041` errors.
- Adds `.claude/settings.local.json` to `.gitignore`. It turned out to be untracked, personal
  machine-local permission-allowlist state (mirrors `.env` — never meant to be committed), noticed
  while staging the new skill file.

Kept in `CLAUDE.md` (considered and deliberately not extracted): the ship-time triage checklist
and the Polars/Patito "gotcha" call-outs. Both fail silently if forgotten (doc/issue rot; subtly
wrong dtype/pushdown/row-count behaviour that looks correct at a glance), so they need to stay
always-primed rather than behind a trigger-based skill lookup.

## Test plan

- [x] `uv run pymarkdown scan .claude/skills/github-graphql/SKILL.md` — clean (after enabling the
      `front-matter` extension)
- [x] `uv run pymarkdown scan -r docs README.md CLAUDE.md metadata/README.md packages/*/README.md`
      — clean
- [x] Every read-only ID-lookup command in the skill (`gh issue view --json id`, the
      `issueTypes` query, `gh project view`/`field-list`) run live against this repo and returns
      real node IDs
- [x] `git check-ignore -v .claude/settings.local.json` confirms it's now excluded
- [x] Pre-commit hooks (ruff, ty, pymarkdown) pass on the commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)