### PR TITLE
Promote live_forecasts design rationale out of the roadmap

### DIFF
--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -34,6 +34,40 @@ regularly), switch to fetching the champion model from MLflow dynamically — at
 from disk on a cache hit so the live service survives an MLflow outage), exactly as it does for
 CV today.
 
+## Live inference is single-run, not bulk
+
+The `live_forecasts` asset engineers features in **single-run mode** — an explicit
+`power_fcst_init_time` supplied by the partition, joined across all 51 NWP ensemble members —
+never bulk mode's one-`power_fcst_init_time`-per-NWP-run derivation (see
+[ML orchestration: forecast cadence under-sampling](ml-orchestration.md#known-limitation-forecast-cadence-under-sampling-in-cv)
+for where bulk mode's per-NWP-run derivation matters instead: CV/backtesting, not live inference).
+A production run issues one forecast for one explicit init time every 6 hours; bulk mode's
+derivation has no meaning for a single live materialisation.
+
+## NWP availability: `live` vs `replay` is asymmetric by design
+
+`live_forecasts`' `availability_mode` config resolves which NWP run to join against, and the two
+modes are deliberately asymmetric:
+
+- **`"live"`** joins the freshest NWP run actually present in Delta, with **no modelled
+  publication delay** — reality already constrains the table to genuinely published runs, so a
+  faster provider is used automatically without a config change.
+- **`"replay"`** joins the freshest run at least `nwp_publication_delay_hours` old, reconstructing
+  what was genuinely available at that historical init time. Without the delay, a replay would
+  leak NWP runs that only landed after the fact — a lookahead-bias bug, not just an inaccuracy.
+
+The scheduled path always uses `"live"`; backfills of missed or historical partitions use
+`"replay"`. The mode is an explicit, manually-set flag rather than an automatic
+live-iff-recent rule — the ambiguity of "recent" isn't worth resolving for a backfill path that's
+already manually triggered.
+
+## Serving only the trained population
+
+`live_forecasts` forecasts exactly the production model's `trained_time_series_ids` (recorded in
+`meta.json`), never the current day's eligibility set. This is the train==predict population
+invariant: a time series the model never saw during training must never receive a live forecast,
+even if it would otherwise qualify today.
+
 ## Why promotion is a Dagster asset, not a script
 
 The "researcher downloads artifacts" step above is a manually-triggered Dagster asset,

--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -64,56 +64,18 @@ plan (phases 0–6.7 complete, PRs #182–#214); its final cleanup phase lives i
 
 Issue: [#221](https://github.com/openclimatefix/nged-substation-forecast/issues/221)
 
-> **Status: ✅ Implemented**, alongside the `promoted_model` promotion asset (below) and local
-> 6-hourly automation (`dg dev` + persistent `DAGSTER_HOME`, part of
-> [#208](https://github.com/openclimatefix/nged-substation-forecast/issues/208)). For the
-> operational runbook — promoting a model, running the schedule, backfilling a missed slot — see
-> [Live Service](../live_service/index.md), the permanent home this page's shipped material moves
-> to (and, eventually, this whole page, once every section below has landed). Remaining work on
-> this page — the [container build](#production-model-artifacts) and
-> [AWS infrastructure](#aws-architecture) — is unaffected.
-
-Everything up to the CV leaderboard loop is built; the production inference path is not. This
-asset is what the deployed container runs every 6 hours: load the production model, forecast
-the latest NWP, write to `power_forecasts` with `fold_id="live"`.
-
-```text
-partitions_def: TimeWindowPartitionsDefinition(cron="0 0,6,12,18 * * *", ...)
-deps: [ecmwf_ens, power_time_series_and_metadata]
-```
-
-- **Model loading:** `ForecasterClass.load(path)` — a plain disk load of the model directory
-  baked into the container image at build time (see
-  [Production model artifacts](#production-model-artifacts)); no MLflow client, run ID, or
-  cache lookup involved. The concrete class is reconstructed from the `model_class` field in
-  the saved model's `meta.json`.
-- **Population:** forecast **only** the `trained_time_series_ids` recorded in the production
-  model's `meta.json` — never a series the model has not seen (the train==predict invariant).
-- **Inference mode:** **single-run** feature engineering (`engineer_features(power_fcst_init_time=…)`)
-  across **all 51 NWP ensemble members**, where `power_fcst_init_time` is the partition's
-  scheduled time. Deliberately *not* bulk mode: production forecasts one explicit
-  `power_fcst_init_time`, not one-per-NWP-run.
-- **NWP availability semantics** via a `RunConfig` field
-  `availability_mode: Literal["live", "replay"]` (default `"live"`):
-    - `"live"` — the scheduled path. `power_fcst_init_time = now`; join the **freshest NWP run
-      actually present** in Delta with `nwp_init_time <= power_fcst_init_time`. **No** modelled
-      publication delay: reality already constrains the table to genuinely published runs, so if
-      the provider speeds up we automatically use fresher data.
-    - `"replay"` — re-running a *past* slot (e.g. yesterday's failed run, today).
-      `power_fcst_init_time = the historical partition time`; join the freshest run with
-      `nwp_init_time <= power_fcst_init_time − nwp_publication_delay_hours`. The delay
-      reconstructs what was actually *available* at the historical `power_fcst_init_time` —
-      without it we would leak NWP runs that only landed afterwards.
-    - The scheduled sensor/schedule always uses `"live"` for the current partition; manual
-      backfills of past partitions use `"replay"`. The explicit flag is the source of truth (an
-      automatic live-iff-recent rule is a possible later convenience).
-- Load the needed NWP via `TimeWindowPartitionMapping` against the daily-partitioned
-  `ecmwf_ens`.
-- **Write:** `forecaster.predict(..., fold_id="live")`, then an **idempotent overwrite** of
-  this run's `power_fcst_init_time` rows in `power_forecasts` (`replaceWhere`), so re-running a
-  6-hourly partition (or a replay) never duplicates rows.
-- **Logs nothing to MLflow.** A 6-hourly forecast run is not an experiment; live performance
-  is tracked by [production monitoring](#production-monitoring), never by this asset.
+> **Status: ✅ Implemented**, alongside the `promoted_model` promotion asset and local 6-hourly
+> automation (`dg dev` + persistent `DAGSTER_HOME`, part of
+> [#208](https://github.com/openclimatefix/nged-substation-forecast/issues/208)). The design
+> rationale (single-run vs. bulk mode, the `live`/`replay` asymmetry, the trained-population
+> invariant) now lives at
+> [Production Deployment — Design: Live inference](https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/#live-inference-is-single-run-not-bulk);
+> the operational runbook — promoting a model, running the schedule, backfilling a missed slot —
+> is [Running live forecasts end-to-end](../live_service/dagster-workflow.md), the permanent home
+> this page's shipped material moves to (and, eventually, this whole page, once every section
+> below has landed). Remaining work on this page — the
+> [container build](#production-model-artifacts) and [AWS infrastructure](#aws-architecture) — is
+> unaffected.
 
 ## Production model artifacts
 


### PR DESCRIPTION
## Summary

Closes #300 — reviewed `docs/roadmap/live-service.md` for implemented ideas that hadn't yet
been moved to their permanent resting place.

Found one gap: the **`live_forecasts` asset** section had never been trimmed after shipping,
unlike its **Production model artifacts** sibling section right below it (which was already
reduced to a status banner pointing at `docs/architecture/production-deployment.md` and
`docs/live_service/`). The `live_forecasts` section still carried the full design rationale
(single-run vs. bulk mode, the `live`/`replay` NWP-availability asymmetry, the
trained-population invariant) even though:

- The reasoning belongs in `docs/architecture/` per this repo's docs split (design vs.
  operational how-to).
- The operational detail is already documented at
  [Running live forecasts end-to-end](docs/live_service/dagster-workflow.md).

## Changes

- Added a **"Live inference"** section to
  [Production Deployment — Design](docs/architecture/production-deployment.md) capturing the
  design rationale that was living only in the roadmap.
- Trimmed the roadmap's `live_forecasts` asset section to a status banner linking to both the
  new design section and the existing operational runbook — matching the pattern already used
  for `Production model artifacts`.

I checked the other roadmap pages (`delivery-tables.md`, `metrics-and-leaderboard.md`) and the
rest of `live-service.md` (AWS architecture, production monitoring, the "Implementation
details" workstreams) — those already correctly reflect what's shipped vs. still open
(confirmed against issues #206, #224, #246, all still open), so no further changes were needed
there.

## Test plan

- [x] `uv run pymarkdown scan -r docs README.md CLAUDE.md metadata/README.md packages/*/README.md` passes
- [x] `uv run mkdocs build --strict` builds clean, no broken internal links/anchors
- [x] Manually verified the new anchor (`#live-inference-is-single-run-not-bulk`) resolves and
      cross-links in both directions

🤖 Generated with [Claude Code](https://claude.com/claude-code)