### PR TITLE
Dashboard: toggle between local and S3 data sources without restarting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,8 @@ __marimo__/
 # Environment variables & secrets
 .env
 .env.backup
+# Dashboard S3-mode overrides (issue #297); the committed .env.s3.example documents the keys.
+packages/dashboard/.env.s3
 
 #######################
 # Data storage

--- a/packages/dashboard/.env.s3.example
+++ b/packages/dashboard/.env.s3.example
@@ -1,0 +1,20 @@
+# S3-mode overrides for the dashboard's "Data source" toggle (issue #297).
+#
+# Copy this file to `.env.s3` (git-ignored) and fill in the real values. When the
+# dashboard's "Data source" toggle is set to "s3", these values are layered on top of the
+# root `.env`, pointing the dashboard's data tables at the real S3 buckets without
+# restarting marimo. The root `.env` is untouched and still means "local pipeline" for the
+# rest of the app.
+#
+# Only the data-table roots and object-store credentials are overridden here; the local
+# artifact paths (model cache, production model) stay laptop-local in both modes.
+
+DATA_PATH_INTERNAL=s3://your-internal-bucket/data
+DATA_PATH_DELIVERY=s3://your-delivery-bucket/data
+
+# Object-store credentials for the data tables. Leave DATA_STORE_ENDPOINT_URL blank for real
+# AWS S3 (only set it for a MinIO/S3-compatible dev endpoint).
+DATA_STORE_ENDPOINT_URL=
+DATA_STORE_ACCESS_KEY_ID=your-access-key-id
+DATA_STORE_SECRET_ACCESS_KEY=your-secret-access-key
+DATA_STORE_REGION=eu-west-1

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -1,3 +1,24 @@
 # Dashboard
 
 Marimo web app for visualising power forecasts, telemetry, and evaluation metrics.
+
+## Switching between local and S3 data sources
+
+The dashboard has a **Data source** toggle (`local` / `s3`) that switches which data tables it
+reads without restarting marimo, so you can compare a fully local pipeline against production
+data in one session.
+
+- **local** reads only the root `.env` — the same local-pipeline config the rest of the app uses.
+- **s3** layers a git-ignored `packages/dashboard/.env.s3` on top of the root `.env`, overriding
+  the data-path roots (`DATA_PATH_INTERNAL`, `DATA_PATH_DELIVERY`) and the `DATA_STORE_*`
+  credentials to point at the real S3 buckets.
+
+To enable S3 mode, copy the committed example and fill in the real values:
+
+```bash
+cp packages/dashboard/.env.s3.example packages/dashboard/.env.s3
+```
+
+Only the data tables follow the toggle. Local artifact paths (model cache, production model) are
+never overridden by `.env.s3`, so they stay laptop-local in both modes. If `.env.s3` is missing,
+the `s3` selection falls back to local paths and the UI flags it.

--- a/packages/dashboard/main.py
+++ b/packages/dashboard/main.py
@@ -6,11 +6,10 @@ __generated_with = "0.23.6"
 app = marimo.App(width="full")
 
 with app.setup:
+    from pathlib import Path
     from typing import cast
 
-    from contracts.settings import Settings
-
-    settings = Settings()
+    from contracts.settings import PROJECT_ROOT, Settings
 
     from datetime import datetime
 
@@ -26,11 +25,64 @@ with app.setup:
     from contracts.typing_utils import typeddict_to_dict
     from plotting.ocf_theme import BLUE
 
-    BASE_DELTA_PATH = settings.power_time_series_data_path
+    ROOT_ENV: Path = PROJECT_ROOT / ".env"
+    """Root .env — the local-pipeline config shared with the rest of the app."""
+    DASHBOARD_S3_ENV: Path = PROJECT_ROOT / "packages" / "dashboard" / ".env.s3"
+    """Git-ignored S3-mode overrides, layered on top of ROOT_ENV when the toggle is 's3'."""
+
+    def _settings_for_source(source: str) -> Settings:
+        """Instantiate Settings for the dashboard's selected data source.
+
+        "local" reads only the root .env (the local pipeline, same as the rest of the app).
+        "s3" layers packages/dashboard/.env.s3 on top of the root .env, overriding the
+        data-path roots and object-store credentials to point at the real S3 buckets, so
+        production data can be viewed without restarting marimo.
+
+        Only the data tables follow the toggle: .env.s3 sets DATA_PATH_INTERNAL,
+        DATA_PATH_DELIVERY and the DATA_STORE_* credentials. It deliberately does not set
+        LOCAL_ARTIFACTS_PATH, so the model cache and production model stay laptop-local in
+        both modes. A missing .env.s3 is silently skipped by pydantic-settings, so "s3"
+        then falls back to the root .env's local paths (the UI flags this).
+        """
+        if source == "s3":
+            # _env_file is a pydantic-settings builtin kwarg not modelled by ty's synthesised
+            # BaseModel __init__; the list layers .env.s3 over the root .env (later file wins).
+            return Settings(_env_file=[ROOT_ENV, DASHBOARD_S3_ENV])  # ty: ignore[unknown-argument]
+        return Settings()
 
 
 @app.cell
 def _():
+    source = mo.ui.radio(
+        options=["local", "s3"],
+        value="local",
+        label="Data source",
+        inline=True,
+    )
+    source
+    return (source,)
+
+
+@app.cell
+def _(source):
+    settings = _settings_for_source(source.value)
+    if source.value == "s3" and not DASHBOARD_S3_ENV.exists():
+        status = mo.callout(
+            mo.md(
+                f"No `{DASHBOARD_S3_ENV.name}` found next to `main.py`. Copy "
+                f"`{DASHBOARD_S3_ENV.name}.example` to `{DASHBOARD_S3_ENV.name}` and fill in "
+                "the S3 buckets and credentials. Falling back to local data."
+            ),
+            kind="warn",
+        )
+    else:
+        status = mo.md(f"Reading **{source.value}** data from `{settings.nged_data_path}`.")
+    status
+    return (settings,)
+
+
+@app.cell
+def _(settings):
     metadata_path = settings.metadata_path
     df = TimeSeriesMetadata.validate(
         pl.read_parquet(metadata_path, storage_options=typeddict_to_dict(settings.storage_options))
@@ -94,9 +146,10 @@ def _(arrow_table):
 
 
 @app.cell
-def _():
+def _(settings):
     delta_df = pl.scan_delta(
-        BASE_DELTA_PATH, storage_options=typeddict_to_dict(settings.storage_options)
+        settings.power_time_series_data_path,
+        storage_options=typeddict_to_dict(settings.storage_options),
     ).filter(
         # Filter to only show recent data. Altair crashes if you try to show too much data.
         pl.col("time") > pl.lit(datetime(2026, 3, 1)).cast(UTC_DATETIME_DTYPE)


### PR DESCRIPTION
Implements #297.

## What

Adds a marimo **Data source** radio (`local` / `s3`) to [`packages/dashboard/main.py`](packages/dashboard/main.py) that reactively re-instantiates `Settings`, so the dashboard can display local pipeline output or the real S3 buckets side by side in one marimo session — no process restart.

- **local** reads only the root `.env` — unchanged meaning: the local pipeline shared with the rest of the app.
- **s3** layers a git-ignored `packages/dashboard/.env.s3` on top of the root `.env` (`Settings(_env_file=[root, dashboard_s3])`, later file wins), overriding `DATA_PATH_INTERNAL`, `DATA_PATH_DELIVERY` and the `DATA_STORE_*` credentials to point at the real S3 buckets.

No new config system — this is the same `Settings` class and pydantic-settings' builtin `_env_file` layering, as the issue design specified.

## Design points honoured

- **Local artifacts stay pinned to local.** `.env.s3` deliberately does not set `LOCAL_ARTIFACTS_PATH`, so `production_model_path` and `model_cache_base_path` remain laptop-local in both modes. Verified empirically: in `s3` mode `nged_data_path`/`power_forecasts_data_path` become `s3://…` while `production_model_path`/`model_cache_base_path` stay local.
- **Missing `.env.s3` is handled gracefully.** pydantic-settings silently skips a non-existent env file, so `s3` then falls back to the root `.env`'s local paths; the UI flags this with a warning callout.

## Also included

- `packages/dashboard/.env.s3.example` (committed) documenting the keys.
- `.gitignore` entry for the real `packages/dashboard/.env.s3`.
- Dashboard README section explaining the toggle.

## Verification

- `ruff check` / `ruff format` / `ty check` / `pymarkdown` all pass (pre-commit hooks green).
- `marimo export script` validates the notebook cell graph (exit 0).
- Confirmed `_env_file` list-layering precedence and missing-file fallback empirically, plus the local-vs-s3 path derivation above.

Closes #297.

🤖 Generated with [Claude Code](https://claude.com/claude-code)