### PR TITLE
Fix S3 test isolation: reset moto state per test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -335,6 +335,17 @@ group past the cap, streaming engine included. Full analysis:
   are unaffected — only row counts and row indices wrap. Both verified empirically.
 - Tables past the cap today: NWP (~5.9B rows). `power_forecasts` will pass it at V2 scale.
 
+### Testing Gotcha: moto's S3 backend is process-global — reset it per test
+
+The in-process `moto` server used for the S3 tests keeps its bucket contents in a **process-global
+backend that outlives the `ThreadedMotoServer` object**, so a module-scoped server does not hand
+each test a clean slate. A test whose write path runs twice against that server — a re-run, or
+state left behind by an earlier test — reads stale data: an appended Delta table returns double the
+rows, and an `object_exists` precondition sees a leftover parquet. Keep the *server* module-scoped
+for speed, but give each test a **function-scoped** fixture that `POST`s to `/moto-api/reset` and
+recreates the bucket before the test body runs, so every test starts pristine and independent of
+execution order. `tests/test_s3_data_paths.py` is the canonical pattern.
+
 ## This is a young project
 
 The project is a new, green-field project. No one else is using this code yet. Which means:

--- a/tests/test_s3_data_paths.py
+++ b/tests/test_s3_data_paths.py
@@ -70,18 +70,35 @@ def _free_port() -> int:
 
 
 @pytest.fixture(scope="module")
-def s3_endpoint() -> Iterator[str]:
-    """Start an in-process moto S3 server and create the test bucket (no boto3, no Docker)."""
+def _moto_server() -> Iterator[str]:
+    """Start one in-process moto S3 server for the module (no boto3, no Docker)."""
     port = _free_port()
     server = ThreadedMotoServer(port=port)
     server.start()
-    endpoint = f"http://127.0.0.1:{port}"
-    # Create the bucket with a bare HTTP PUT — object_store never creates buckets itself.
-    urllib.request.urlopen(urllib.request.Request(f"{endpoint}/{_BUCKET}", method="PUT")).close()
     try:
-        yield endpoint
+        yield f"http://127.0.0.1:{port}"
     finally:
         server.stop()
+
+
+@pytest.fixture
+def s3_endpoint(_moto_server: str) -> str:
+    """Reset moto to a pristine state and (re)create the test bucket for each test.
+
+    moto's S3 backend is process-global and outlives the server object, so it is *not* reset
+    when the module-scoped server is reused across tests. Without a per-test reset, any test
+    whose write path runs a second time — a re-run, or state left by an earlier test — would
+    read leftover objects (a doubled Delta table, a pre-existing metadata parquet) and fail.
+    Resetting before every test makes each test independent of execution order and prior state.
+    """
+    urllib.request.urlopen(
+        urllib.request.Request(f"{_moto_server}/moto-api/reset", method="POST")
+    ).close()
+    # Create the bucket with a bare HTTP PUT — object_store never creates buckets itself.
+    urllib.request.urlopen(
+        urllib.request.Request(f"{_moto_server}/{_BUCKET}", method="PUT")
+    ).close()
+    return _moto_server
 
 
 def _s3_settings(endpoint: str, prefix: str) -> Settings:


### PR DESCRIPTION
## What

The three S3 round-trip tests in `tests/test_s3_data_paths.py` shared a single **module-scoped** moto server and created the bucket once, at server start. moto's S3 backend is **process-global and outlives the server object**, so it is not cleared between tests. Any test whose write path ran a second time against the same server — a re-run, or state left behind — read stale data and failed:

- `test_nwp_round_trip_over_s3` — `write_nwp` **appends**, so a second write made `Nwp.scan_delta` return 12 rows instead of 6 (`assert 12 == 6`).
- `test_metadata_parquet_round_trip_over_s3` — the `assert not object_exists(...)` precondition saw a pre-existing metadata parquet.

## Fix

Split the fixture into a module-scoped server (`_moto_server`) and a function-scoped `s3_endpoint` that `POST`s `/moto-api/reset` and recreates the bucket before every test. Each test now starts from a pristine backend, so the suite is independent of execution order and prior state. **Assertions are unchanged** — only isolation is strengthened.

## Verification

- Full suite: `231 passed`.
- Reproduced the failure mode directly: without a reset, a second `write_nwp` gives `height = 12` and the metadata object pre-exists; with the per-test reset, every run gives `height = 6` and `object_exists = False`.

## Context

Surfaced while investigating two failures reported on the `upgrade-uv-lock` branch. That lock bump (boto3/botocore 1.43.46→47, google-auth 2.55.2→2.56.0) is **not** the cause — the Delta S3 write path goes through delta-rs (Rust `object_store`), not boto3/botocore, and the suite passes 231/231 on both the old and upgraded lock. The failures are this pre-existing test-isolation gap, which is why they belong in their own PR rather than the lock branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)