### PR TITLE
docs: record NGED's post-NIA operating model and the handover plan

### DIFF
--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -22,6 +22,13 @@ the production runtime under every architecture option.
 **Rejected alternative:** MLflow artifact root on S3 fetched at container startup — more runtime
 moving parts, needs tracking-store access from prod, and slower cold starts.
 
+This decision also serves the post-NIA operating model, in which a non-expert at NGED operates
+the service day to day (see
+[Requirements → Operating model & handover](../background/requirements.md#operating-model-handover)):
+there is no tracking server on the hot path to break, and the model simply freezes between
+OCF's scheduled expert interventions — under a vendor-develops / operator-runs split, that is a
+feature, not a limitation.
+
 This is deliberately simpler than reusing `BaseForecaster.load_from_mlflow`'s cache (the
 mechanism the CV pipeline already uses — see
 [ML orchestration: model artifacts](ml-orchestration.md#model-artifacts-mlflow-artifact-store-immutable-local-cache)):

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -22,8 +22,8 @@ the production runtime under every architecture option.
 **Rejected alternative:** MLflow artifact root on S3 fetched at container startup — more runtime
 moving parts, needs tracking-store access from prod, and slower cold starts.
 
-This decision also serves the post-NIA operating model, in which a non-expert at NGED operates
-the service day to day (see
+This decision also serves the preferred post-NIA operating model, in which a non-expert at
+NGED operates the service day to day (see
 [Requirements → Operating model & handover](../background/requirements.md#operating-model-handover)):
 there is no tracking server on the hot path to break, and the model simply freezes between
 OCF's scheduled expert interventions — under a vendor-develops / operator-runs split, that is a

--- a/docs/background/requirements.md
+++ b/docs/background/requirements.md
@@ -23,6 +23,38 @@
 * Model and forecast *unmetered* solar PV and wind power on each primary substation by disaggregating net power flow.
 * Disaggregate and forecast other distributed energy resources (DERs): EV chargers, heat pumps, price-sensitive batteries.
 
+## Operating model & handover
+
+NGED confirmed (2026-07-14) that their preference for running Flexpectation business-as-usual
+*after* the NIA project is for **NGED to run our code themselves, on NGED's own AWS
+infrastructure**. This sets a standing design requirement for everything we build:
+
+* **The service must be operable day to day by a non-expert at NGED** — every routine action
+  reduced to a dashboard check, a button in the Dagster UI, or a runbook. See
+  [Handover to NGED](../roadmap/handover.md) for the engineering consequences and the handover
+  workstreams.
+* **Uptime requirements are deliberately lenient.** Nothing very bad happens if the service
+  misses a day: NGED can always read the previous forecasts from S3, and each forecast extends
+  14 days ahead. We still aim for a highly robust service, but recovery is "next business day,
+  via runbook", never a 2am page.
+
+The phasing:
+
+1. For the duration of the NIA project, OCF develops **and runs** Flexpectation on OCF's own
+   AWS account (unchanged from the existing plan).
+2. We will not know whether the service is truly hand-over-able until OCF has run the full v2
+   service (~2,500 time series) for a few months. NGED has accepted this.
+3. In the last few months of the NIA project, NGED progressively takes control of the service,
+   with OCF support. NGED then decides whether to run it themselves.
+4. Post-NIA, OCF is no longer on call; NGED handles day-to-day issues. OCF may continue
+   developing the software and models, possibly under a retainer — details TBD.
+
+A **hybrid model** may prove beneficial: NGED runs the production service while OCF continues
+to develop the code and ML models, and perhaps runs a second service instance of its own (e.g.
+adapted for other DNOs, or feeding OCF's substation forecasts into a commercial demand-forecast
+product). This makes account-portable infrastructure doubly valuable — see
+[Handover to NGED](../roadmap/handover.md#4-infrastructure-as-code-portable-to-ngeds-account).
+
 ## Forecast Delivery
 
 OCF delivers forecasts as **Delta Lake tables on AWS S3**, updated every 6 hours. Delta Lake provides ACID transactions, meaning NGED never reads an incomplete forecast. (Why Delta Lake rather than a REST API? See [Forecast Delivery](../architecture/forecast-delivery.md).) The tables are designed as "building blocks" that NGED can combine to construct:

--- a/docs/background/requirements.md
+++ b/docs/background/requirements.md
@@ -27,7 +27,9 @@
 
 NGED confirmed (2026-07-14) that their preference for running Flexpectation business-as-usual
 *after* the NIA project is for **NGED to run our code themselves, on NGED's own AWS
-infrastructure**. This sets a standing design requirement for everything we build:
+infrastructure**. This is a statement of preference, not yet a commitment: NGED still need to
+check with their DSO, Cyber, and IT&D teams before giving a concrete answer. Even so, it sets
+a standing design requirement for everything we build:
 
 * **The service must be operable day to day by a non-expert at NGED** — every routine action
   reduced to a dashboard check, a button in the Dagster UI, or a runbook. See

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,6 +22,11 @@ Each forecast is:
 
 **Version 2** (future): Scale to approximately 2,500 time series covering all of NGED's primary substations and most customer meters.
 
+**After the NIA project**: NGED intends to run the service themselves, on NGED's own AWS
+infrastructure — so the service is being built to be operable day to day by a non-expert. See
+[Requirements → Operating model & handover](background/requirements.md#operating-model-handover)
+and the [Handover to NGED](roadmap/handover.md) design page.
+
 ## More than a forecast
 
 A large part of this project is building a production forecasting system and researching novel

--- a/docs/index.md
+++ b/docs/index.md
@@ -22,8 +22,9 @@ Each forecast is:
 
 **Version 2** (future): Scale to approximately 2,500 time series covering all of NGED's primary substations and most customer meters.
 
-**After the NIA project**: NGED intends to run the service themselves, on NGED's own AWS
-infrastructure — so the service is being built to be operable day to day by a non-expert. See
+**After the NIA project**: NGED's stated preference (pending sign-off from their internal
+teams) is to run the service themselves, on NGED's own AWS infrastructure — so the service is
+being built to be operable day to day by a non-expert. See
 [Requirements → Operating model & handover](background/requirements.md#operating-model-handover)
 and the [Handover to NGED](roadmap/handover.md) design page.
 

--- a/docs/live_service/index.md
+++ b/docs/live_service/index.md
@@ -18,8 +18,9 @@ training and backtesting candidate models against historical data; this area cov
 of those candidates as the running production model and keeping live forecasts flowing from it.
 
 **Audience note:** today these runbooks are written for OCF (Python-literate researchers), but
-after the NIA project the day-to-day operator will be a non-expert at NGED — NGED confirmed
-(2026-07-14) they intend to run the service themselves, on their own AWS account. Every routine
+after the NIA project the day-to-day operator is expected to be a non-expert at NGED — NGED's
+stated preference (2026-07-14, pending their internal sign-off) is to run the service
+themselves, on their own AWS account. Every routine
 operator action must therefore eventually reduce to a dashboard check, a button in the Dagster
 UI, or a runbook a non-Python-expert can follow; before handover, these pages get an editing
 pass with that operator as the audience, plus a top-level "operator contract" page indexing

--- a/docs/live_service/index.md
+++ b/docs/live_service/index.md
@@ -17,6 +17,14 @@ This is distinct from [ML Experimentation](../ml_experimentation/index.md): that
 training and backtesting candidate models against historical data; this area covers picking one
 of those candidates as the running production model and keeping live forecasts flowing from it.
 
+**Audience note:** today these runbooks are written for OCF (Python-literate researchers), but
+after the NIA project the day-to-day operator will be a non-expert at NGED — NGED confirmed
+(2026-07-14) they intend to run the service themselves, on their own AWS account. Every routine
+operator action must therefore eventually reduce to a dashboard check, a button in the Dagster
+UI, or a runbook a non-Python-expert can follow; before handover, these pages get an editing
+pass with that operator as the audience, plus a top-level "operator contract" page indexing
+them. See [Handover to NGED](../roadmap/handover.md).
+
 ## Documents
 
 - [Environment & storage setup](setup.md) — where the data tables and local artifacts live, and

--- a/docs/roadmap/handover.md
+++ b/docs/roadmap/handover.md
@@ -1,0 +1,172 @@
+# Handover to NGED
+
+> **Status: 🚧 Planned.** This page is the design record for the post-NIA operating model NGED
+> confirmed on **2026-07-14**: NGED will run Flexpectation themselves, on NGED's own AWS
+> account, after the NIA project ends. The requirement itself is recorded in
+> [Requirements → Operating model & handover](../background/requirements.md#operating-model-handover);
+> this page holds the engineering consequences and the handover workstreams. A GitHub epic for
+> this milestone is still to be created — until it exists, this page is the plan of record.
+
+## What this changes (and what it doesn't)
+
+For the remainder of the NIA project, nothing about the milestone arc changes: OCF develops and
+runs Flexpectation on OCF's AWS account, exactly as [the roadmap](index.md#milestones) already
+plans. What changes is a **standing design constraint** on everything we build from now on:
+
+**The service must be operable day to day by a non-expert at NGED.** The operator's scarce
+skill is ops, not Python — if the service is designed well, the day-to-day maintainer should
+never touch Python at all. Every routine action must reduce to "look at a dashboard, click a
+button in the Dagster UI, or follow a runbook". Anything that can't be reduced to that is, by
+definition, OCF's job, done on a scheduled cadence (e.g. quarterly maintenance windows) rather
+than reactively.
+
+Several decisions already made serve this constraint well, and this page makes that connection
+explicit so we don't accidentally undo them:
+
+- **The champion model is baked into the container image** with no MLflow (or any tracking
+  server) on the production hot path — see
+  [Production Deployment — Design](../architecture/production-deployment.md). Under the
+  handover model this is a feature twice over: there are fewer runtime moving parts to break,
+  and the model simply *freezes* between OCF's scheduled interventions.
+- **Replay mode** means a missed slot is recovered by a one-click UI backfill, not by an
+  engineer reconstructing state — see
+  [Running live forecasts end-to-end](../live_service/dagster-workflow.md).
+- **Promotion is rebuild + redeploy**, auditable via image tags — no live mutable model
+  registry for an operator to mis-drive.
+- **No static AWS keys** (IAM roles throughout) removes a whole class of credential-expiry
+  incidents, and matches the constraints corporate AWS environments typically impose anyway.
+- **Lenient uptime requirements**: nothing very bad happens if the service misses a day,
+  because NGED can always read the previous forecasts from S3 (forecasts extend 14 days
+  ahead). Recovery can therefore always be "next business day, via runbook", never "2am page".
+
+The honest caveat: the failures a non-expert can't handle mostly live at the *boundaries*, not
+in our code — an NWP provider changing formats, NGED SCADA feed schema drift, credential and
+certificate expiry, and AWS account plumbing. The workstreams below are aimed squarely at
+those boundaries.
+
+## Workstreams
+
+### 1. The operator contract
+
+Write an explicit, short **operator contract**: an enumeration of every action the NGED
+operator is ever expected to take — acknowledge an alert, backfill a missed slot via replay
+mode, restart the daemon, rebuild the control-plane box, escalate to OCF. Keep it to roughly
+**ten items or fewer**, each one a documented button-press or a single command with a runbook
+page in [`docs/live_service/`](../live_service/index.md).
+
+Everything *not* on that list — model promotion, dependency upgrades, schema changes,
+infrastructure changes — is OCF's job by definition, handled on a scheduled maintenance
+cadence (and, post-NIA, under whatever support arrangement is agreed).
+
+The existing `docs/live_service/` runbooks are the natural home for this material, but they
+are currently written for *us* (Python-literate researchers). Before handover they need an
+editing pass with the NGED operator as the audience, plus a top-level "operator contract" page
+that indexes them.
+
+### 2. Alert on absence, not just failure
+
+Per-task failure alerts (the planned EventBridge → SNS rule on non-zero task exit) miss whole
+classes of silent failure: a hung daemon, a full disk, an expired credential, a schedule that
+simply stopped firing. The fix is a **dead-man's switch**: an alarm that fires when *no
+successful forecast has landed in N hours* (e.g. 8 hours, i.e. one missed 6-hourly slot plus
+margin), regardless of why.
+
+The [production monitoring plan](live-service.md#production-monitoring) already sketches a
+"no fresh forecast" staleness alarm; this workstream promotes it from a nice-to-have to the
+**primary** alert, because it is the one alert whose false-negative rate a non-expert operator
+cannot compensate for.
+
+Every alert — dead-man's switch and per-task alike — must link directly to a runbook that ends
+in either a specific operator action or "escalate to OCF". An alert without a runbook is a bug
+in the operator contract.
+
+### 3. De-pet the control-plane box
+
+The always-on EC2 control-plane box ([Option B](live-service.md#aws-architecture)) is the
+riskiest element under a non-expert operating model: an unattended pet VM accumulates entropy —
+disks fill, instances get retirement notices, OS patches drift. Mitigations, roughly in build
+order:
+
+- EC2 auto-recovery alarm and instance status-check alarm (some of this is already sketched in
+  the Option B plan).
+- Log rotation and scheduled disk-cleanup jobs on the box.
+- Most importantly: a **tested, unattended rebuild-from-scratch script**, so the runbook
+  answer to "the box is sick" is *destroy and recreate*, never *diagnose*. This is the point
+  at which infrastructure-as-code stops being premature complexity and becomes the thing that
+  lets a non-expert redeploy safely.
+
+### 4. Infrastructure-as-code, portable to NGED's account
+
+The live-service plan already defers infra-as-code to
+[Access-phasing Stage 2](live-service.md#access-phasing) — that sequencing stands. What the
+handover requirement adds:
+
+- **By handover time, IaC is mandatory, not optional.** The rebuild-from-scratch runbook
+  (workstream 3) and the deployment into NGED's account (workstream 5) both depend on it.
+- **The IaC must be account-portable**: no OCF-specific resource names, account IDs, or
+  network assumptions baked in. Deploying into a second AWS account should be "set variables,
+  apply".
+- The open [Terraform-vs-CDK question](live-service.md#deployment-workstream-3-aws-infrastructure)
+  gains a new input: what NGED's infrastructure teams already know and are allowed to run
+  matters as much as what suits OCF. Ask them before deciding.
+
+The possible **hybrid model** (see
+[Requirements](../background/requirements.md#operating-model-handover)) — NGED running the
+production instance while OCF runs a second instance for development, other DNOs, or
+commercial products — makes account-portability doubly valuable: the second deployment of the
+same IaC is OCF's own.
+
+### 5. Probe NGED's AWS landing zone early
+
+NGED's corporate AWS environment is the biggest unknown, and the one item on this page that
+should start **well before** the final months of the project. Corporate DNO cloud environments
+commonly impose service control policies, mandatory patching/security agents, restricted
+egress, and bans on long-lived credentials — and **Tailscale specifically may not survive
+NGED's security review**. That matters because in the current design
+[the network layer *is* the auth layer](live-service.md#access-phasing): none of the web UIs
+(Dagster, MLflow, Marimo) has built-in authentication, so if Tailscale is prohibited, the
+access design needs an NGED-compatible replacement (e.g. their VPN + private subnets, or an
+SSO-fronted proxy), not just a substitution.
+
+Concrete steps:
+
+- Raise landing-zone constraints with NGED early: what can and can't run in their account,
+  what network ingress/egress is permitted, how their teams authenticate to internal web UIs.
+- Clarify **who the operator actually is**. NGED has IT/infrastructure teams; the realistic
+  split may be a domain person doing the Dagster-level operating while their infrastructure
+  team owns OS- and AWS-level issues. That split changes what the runbooks need to cover (and
+  who game-day training targets).
+- Stand up a **staging copy in NGED's account well before handover** — discovering in the
+  final months that our networking approach is prohibited would be painful.
+
+### 6. Game days
+
+Before handover, run deliberate failure exercises with the actual NGED operator, using only
+the runbooks: break the NWP feed, fill the disk, kill the daemon, expire a credential, let a
+forecast slot get missed. The operator recovers each one unaided (or the runbook gets fixed).
+Game days find documentation gaps faster than any amount of review, and they double as
+operator training.
+
+### 7. Organisational prerequisites (recorded so they're not forgotten)
+
+These are not engineering workstreams, but NIA projects most often fail at the transition to
+business-as-usual for exactly these reasons, so they are recorded here alongside the technical
+work:
+
+- A **named owner at NGED** with allocated time to operate the service.
+- A **budget line** at NGED for the AWS spend and for any OCF support retainer.
+- A written support agreement defining what OCF does post-NIA (scheduled maintenance,
+  emergency fixes, model updates) — the details are TBD, but "in writing" is the requirement.
+
+## Timing and decision gates
+
+- **Now → late NIA project**: OCF develops and runs the service on OCF's AWS account. The
+  operator-contract constraint applies to new design work from today; workstream 5
+  (landing-zone probing) starts early; the rest of the workstreams land alongside the v1/v2
+  milestones they depend on.
+- **Scale gate**: we will not know whether the service is truly hand-over-able until OCF has
+  run the full v2 service (~2,500 time series) for a few months. NGED has accepted this.
+- **Last few months of the NIA project**: progressively hand control to NGED, support them as
+  they get up to speed, run the game days. NGED then decides whether to run it themselves.
+- **Post-NIA**: OCF is no longer on call; NGED handles day-to-day operations. OCF may continue
+  developing the software and models (the hybrid model), possibly under a retainer — all TBD.

--- a/docs/roadmap/handover.md
+++ b/docs/roadmap/handover.md
@@ -76,10 +76,14 @@ Per-task failure alerts miss whole
 classes of silent failure: a hung daemon, a full disk, an expired credential, a schedule that
 simply stopped firing. The fix is a **dead-man's switch**: an alarm that fires when *no
 successful forecast has landed in N hours* (e.g. 8 hours, i.e. one missed 6-hourly slot plus
-margin), regardless of why. Per the portability preference (below), the freshness check is
-plain code runnable on a laptop; only its trigger and delivery must sit outside the service
-being watched — a dead daemon cannot report itself. Details:
-[the dead-man's switch](live-service.md#alert-on-absence-the-dead-mans-switch).
+margin), regardless of why. The planned mechanism is **Sentry cron monitoring**
+([#63](https://github.com/openclimatefix/nged-substation-forecast/issues/63)): each successful
+run checks in with Sentry, and Sentry alerts on a missed check-in — Sentry sits outside the
+service being watched (a dead daemon simply stops checking in), and check-in pings are plain
+portable code. Details:
+[the dead-man's switch](live-service.md#alert-on-absence-the-dead-mans-switch). The handover
+consideration: the Sentry account is OCF's today, so at handover the alert routing (and
+possibly the account itself) moves to NGED.
 
 The [production monitoring plan](live-service.md#production-monitoring) already sketches a
 "no fresh forecast" staleness alarm; this workstream promotes it from a nice-to-have to the

--- a/docs/roadmap/handover.md
+++ b/docs/roadmap/handover.md
@@ -4,8 +4,8 @@
 > confirmed on **2026-07-14**: NGED will run Flexpectation themselves, on NGED's own AWS
 > account, after the NIA project ends. The requirement itself is recorded in
 > [Requirements → Operating model & handover](../background/requirements.md#operating-model-handover);
-> this page holds the engineering consequences and the handover workstreams. A GitHub epic for
-> this milestone is still to be created — until it exists, this page is the plan of record.
+> this page holds the engineering consequences and the handover workstreams. Epic:
+> [#309](https://github.com/openclimatefix/nged-substation-forecast/issues/309).
 
 ## What this changes (and what it doesn't)
 
@@ -35,6 +35,11 @@ explicit so we don't accidentally undo them:
   registry for an operator to mis-drive.
 - **No static AWS keys** (IAM roles throughout) removes a whole class of credential-expiry
   incidents, and matches the constraints corporate AWS environments typically impose anyway.
+- **The pipeline runs end-to-end on a laptop** — the live schedules were dress-rehearsed
+  locally under `dg dev` before any AWS compute existed, and the standing preference is
+  portable application logic over cloud-native glue (e.g. no EventBridge rules) wherever a
+  portable option exists. Portability is what makes the service cheap to move into NGED's
+  account — or anyone else's.
 - **Lenient uptime requirements**: nothing very bad happens if the service misses a day,
   because NGED can always read the previous forecasts from S3 (forecasts extend 14 days
   ahead). Recovery can therefore always be "next business day, via runbook", never "2am page".
@@ -65,11 +70,14 @@ that indexes them.
 
 ### 2. Alert on absence, not just failure
 
-Per-task failure alerts (the planned EventBridge → SNS rule on non-zero task exit) miss whole
+Per-task failure alerts miss whole
 classes of silent failure: a hung daemon, a full disk, an expired credential, a schedule that
 simply stopped firing. The fix is a **dead-man's switch**: an alarm that fires when *no
 successful forecast has landed in N hours* (e.g. 8 hours, i.e. one missed 6-hourly slot plus
-margin), regardless of why.
+margin), regardless of why. Per the portability preference (below), the freshness check is
+plain code runnable on a laptop; only its trigger and delivery must sit outside the service
+being watched — a dead daemon cannot report itself. Details:
+[the dead-man's switch](live-service.md#alert-on-absence-the-dead-mans-switch).
 
 The [production monitoring plan](live-service.md#production-monitoring) already sketches a
 "no fresh forecast" staleness alarm; this workstream promotes it from a nice-to-have to the
@@ -153,10 +161,16 @@ These are not engineering workstreams, but NIA projects most often fail at the t
 business-as-usual for exactly these reasons, so they are recorded here alongside the technical
 work:
 
-- A **named owner at NGED** with allocated time to operate the service.
+- A **named owner at NGED** with allocated time to operate the service. Our current NGED
+  contacts are very engaged, and if they stay the owner question answers itself — the real
+  risk is staff turnover. The mitigation is to institutionalise rather than rely on
+  individuals: everything needed to operate lives in the written runbooks (no tribal
+  knowledge), and the game days train more than one person.
 - A **budget line** at NGED for the AWS spend and for any OCF support retainer.
 - A written support agreement defining what OCF does post-NIA (scheduled maintenance,
   emergency fixes, model updates) — the details are TBD, but "in writing" is the requirement.
+  This also hedges the staff-turnover risk above: an agreement survives the departure of the
+  individuals who championed it.
 
 ## Timing and decision gates
 

--- a/docs/roadmap/handover.md
+++ b/docs/roadmap/handover.md
@@ -55,44 +55,41 @@ those boundaries.
 
 ### 1. The operator contract
 
-Write an explicit, short **operator contract**: an enumeration of every action the NGED
-operator is ever expected to take — acknowledge an alert, backfill a missed slot via replay
-mode, restart the daemon, rebuild the control-plane box, escalate to OCF. Keep it to roughly
-**ten items or fewer**, each one a documented button-press or a single command with a runbook
-page in [`docs/live_service/`](../live_service/index.md).
+Write an explicit, short **operator contract**: an enumeration of every action the NGED operator is
+ever expected to take — acknowledge an alert, backfill a missed slot via replay mode, restart the
+daemon, rebuild the control-plane box, escalate to OCF. Keep it to roughly **ten items or fewer**,
+each one a documented button-press or a single command with a runbook page in
+[`docs/live_service/`](../live_service/index.md).
 
-Everything *not* on that list — model promotion, dependency upgrades, schema changes,
-infrastructure changes — is OCF's job by definition, handled on a scheduled maintenance
-cadence (and, post-NIA, under whatever support arrangement is agreed).
+Everything *not* on that list — model promotion, dependency upgrades, schema changes, infrastructure
+changes — is OCF's job by definition, handled on a scheduled maintenance cadence (and, post-NIA,
+under whatever support arrangement is agreed).
 
-The existing `docs/live_service/` runbooks are the natural home for this material, but they
-are currently written for *us* (Python-literate researchers). Before handover they need an
-editing pass with the NGED operator as the audience, plus a top-level "operator contract" page
-that indexes them.
+The existing [`docs/live_service/`](../live_service/index.md) runbooks are the natural home for this
+material, but the docs are currently written for *OCF* (Python-literate researchers). Before
+handover they need an editing pass with the NGED operator as the audience, plus a top-level
+"operator contract" page that indexes them.
 
 ### 2. Alert on absence, not just failure
 
-Per-task failure alerts miss whole
-classes of silent failure: a hung daemon, a full disk, an expired credential, a schedule that
-simply stopped firing. The fix is a **dead-man's switch**: an alarm that fires when *no
-successful forecast has landed in N hours* (e.g. 8 hours, i.e. one missed 6-hourly slot plus
-margin), regardless of why. The planned mechanism is **Sentry cron monitoring**
-([#63](https://github.com/openclimatefix/nged-substation-forecast/issues/63)): each successful
-run checks in with Sentry, and Sentry alerts on a missed check-in — Sentry sits outside the
-service being watched (a dead daemon simply stops checking in), and check-in pings are plain
-portable code. Details:
-[the dead-man's switch](live-service.md#alert-on-absence-the-dead-mans-switch). The handover
-consideration: the Sentry account is OCF's today, so at handover the alert routing (and
+Per-task failure alerts miss whole classes of silent failure: a hung daemon, a full disk, an expired
+credential, a schedule that simply stopped firing. The fix is a **dead-man's switch**: an alarm that
+fires when *no successful forecast has landed in N hours* (e.g. 8 hours, i.e. one missed 6-hourly
+slot plus margin), regardless of why. The planned mechanism is **Sentry cron monitoring**
+([#63](https://github.com/openclimatefix/nged-substation-forecast/issues/63)): each successful run
+checks in with Sentry, and Sentry alerts on a missed check-in — Sentry sits outside the service
+being watched (a dead daemon simply stops checking in), and check-in pings are plain portable code.
+Details: [the dead-man's switch](live-service.md#alert-on-absence-the-dead-mans-switch). The
+handover consideration: the Sentry account is OCF's today, so at handover the alert routing (and
 possibly the account itself) moves to NGED.
 
-The [production monitoring plan](live-service.md#production-monitoring) already sketches a
-"no fresh forecast" staleness alarm; this workstream promotes it from a nice-to-have to the
-**primary** alert, because it is the one alert whose false-negative rate a non-expert operator
-cannot compensate for.
+The [production monitoring plan](live-service.md#production-monitoring) already sketches a "no fresh
+forecast" staleness alarm; this workstream promotes it from a nice-to-have to the **primary** alert,
+because it is the one alert whose false-negative rate a non-expert operator cannot compensate for.
 
-Every alert — dead-man's switch and per-task alike — must link directly to a runbook that ends
-in either a specific operator action or "escalate to OCF". An alert without a runbook is a bug
-in the operator contract.
+Every alert — dead-man's switch and per-task alike — must link directly to a runbook that ends in
+either a specific operator action or "escalate to OCF". An alert without a runbook is a bug in the
+operator contract.
 
 ### 3. De-pet the control-plane box
 

--- a/docs/roadmap/handover.md
+++ b/docs/roadmap/handover.md
@@ -73,13 +73,15 @@ handover they need an editing pass with the NGED operator as the audience, plus 
 ### 2. Alert on absence, not just failure
 
 Per-task failure alerts miss whole classes of silent failure: a hung daemon, a full disk, an expired
-credential, a schedule that simply stopped firing. The fix is a **dead-man's switch**: an alarm that
-fires when *no successful forecast has landed in N hours* (e.g. 8 hours, i.e. one missed 6-hourly
-slot plus margin), regardless of why. The planned mechanism is **Sentry cron monitoring**
+credential, a schedule that simply stopped firing. The fix is a **missed-check-in alarm** (Sentry's
+cron-monitoring terminology): an alarm that fires when *no successful forecast has landed in N
+hours* (e.g. 8 hours, i.e. one missed 6-hourly slot plus margin), regardless of why. The planned
+mechanism is **Sentry cron monitoring**
 ([#63](https://github.com/openclimatefix/nged-substation-forecast/issues/63)): each successful run
 checks in with Sentry, and Sentry alerts on a missed check-in — Sentry sits outside the service
 being watched (a dead daemon simply stops checking in), and check-in pings are plain portable code.
-Details: [the dead-man's switch](live-service.md#alert-on-absence-the-dead-mans-switch). The
+Details:
+[the missed-check-in alarm](live-service.md#alert-on-absence-the-missed-check-in-alarm). The
 handover consideration: the Sentry account is OCF's today, so at handover the alert routing (and
 possibly the account itself) moves to NGED.
 
@@ -87,7 +89,7 @@ The [production monitoring plan](live-service.md#production-monitoring) already 
 forecast" staleness alarm; this workstream promotes it from a nice-to-have to the **primary** alert,
 because it is the one alert whose false-negative rate a non-expert operator cannot compensate for.
 
-Every alert — dead-man's switch and per-task alike — must link directly to a runbook that ends in
+Every alert — missed-check-in and per-task alike — must link directly to a runbook that ends in
 either a specific operator action or "escalate to OCF". An alert without a runbook is a bug in the
 operator contract.
 

--- a/docs/roadmap/handover.md
+++ b/docs/roadmap/handover.md
@@ -1,8 +1,10 @@
 # Handover to NGED
 
 > **Status: 🚧 Planned.** This page is the design record for the post-NIA operating model NGED
-> confirmed on **2026-07-14**: NGED will run Flexpectation themselves, on NGED's own AWS
-> account, after the NIA project ends. The requirement itself is recorded in
+> stated as their preference on **2026-07-14**: NGED running Flexpectation themselves, on
+> NGED's own AWS account, after the NIA project ends. This is a preference, not yet a
+> commitment — NGED's DSO, Cyber, and IT&D teams still need to sign off — but we design for it
+> from now on. The requirement itself is recorded in
 > [Requirements → Operating model & handover](../background/requirements.md#operating-model-handover);
 > this page holds the engineering consequences and the handover workstreams. Epic:
 > [#309](https://github.com/openclimatefix/nged-substation-forecast/issues/309).
@@ -140,6 +142,9 @@ Concrete steps:
 
 - Raise landing-zone constraints with NGED early: what can and can't run in their account,
   what network ingress/egress is permitted, how their teams authenticate to internal web UIs.
+  These conversations overlap with the internal sign-off NGED needs anyway — their DSO,
+  Cyber, and IT&D teams must approve the operating model before NGED can commit to it — so
+  they double as progress on turning the stated preference into a concrete answer.
 - Clarify **who the operator actually is**. NGED has IT/infrastructure teams; the realistic
   split may be a domain person doing the Dagster-level operating while their infrastructure
   team owns OS- and AWS-level issues. That split changes what the runbooks need to cover (and

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -29,10 +29,10 @@ Technical plans change as we learn more — treat this as a best-estimate, not a
 - [Live service](live-service.md) — the v0.1 deployment: the `live_forecasts` inference
   asset, the champion-model container, the costed AWS architecture options, and production
   monitoring.
-- [Handover to NGED](handover.md) — the post-NIA operating model (NGED runs the service
-  themselves, on NGED's AWS; confirmed 2026-07-14): the operator-contract design constraint,
-  and the handover workstreams (runbooks, alert-on-absence, infra-as-code, NGED landing-zone
-  probing, game days).
+- [Handover to NGED](handover.md) — the preferred post-NIA operating model (NGED runs the
+  service themselves, on NGED's AWS — their stated preference as of 2026-07-14, pending NGED
+  internal sign-off): the operator-contract design constraint, and the handover workstreams
+  (runbooks, alert-on-absence, infra-as-code, NGED landing-zone probing, game days).
 - [XGBoost improvements](xgboost-improvements.md) — the v0.5 experiment backlog: four effort
   tiers, ordered best bang-for-the-buck within each tier, targeting the 3–10 day user band.
 - [Engineering health](engineering-health.md) — CI, reproducibility stamping, NWP
@@ -230,8 +230,9 @@ delivery of the v2 live service)*
 *Epic: [#309](https://github.com/openclimatefix/nged-substation-forecast/issues/309) — see
 [Handover to NGED](handover.md) for the design.*
 
-NGED confirmed (2026-07-14) that after the NIA project they intend to **run Flexpectation
-themselves, on NGED's own AWS infrastructure** (see
+NGED confirmed (2026-07-14) that their *preference* is to **run Flexpectation themselves, on
+NGED's own AWS infrastructure** after the NIA project — not yet a commitment; NGED's DSO,
+Cyber, and IT&D teams still need to sign off (see
 [Requirements → Operating model & handover](../background/requirements.md#operating-model-handover)).
 This is not a single late milestone: it sets a standing design constraint from today (the
 service must be operable day to day by a non-expert — the

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -227,7 +227,8 @@ delivery of the v2 live service)*
 
 ## Handover to NGED (post-NIA operating model)
 
-*Epic: to be created — see [Handover to NGED](handover.md), currently the plan of record.*
+*Epic: [#309](https://github.com/openclimatefix/nged-substation-forecast/issues/309) — see
+[Handover to NGED](handover.md) for the design.*
 
 NGED confirmed (2026-07-14) that after the NIA project they intend to **run Flexpectation
 themselves, on NGED's own AWS infrastructure** (see

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -29,6 +29,10 @@ Technical plans change as we learn more — treat this as a best-estimate, not a
 - [Live service](live-service.md) — the v0.1 deployment: the `live_forecasts` inference
   asset, the champion-model container, the costed AWS architecture options, and production
   monitoring.
+- [Handover to NGED](handover.md) — the post-NIA operating model (NGED runs the service
+  themselves, on NGED's AWS; confirmed 2026-07-14): the operator-contract design constraint,
+  and the handover workstreams (runbooks, alert-on-absence, infra-as-code, NGED landing-zone
+  probing, game days).
 - [XGBoost improvements](xgboost-improvements.md) — the v0.5 experiment backlog: four effort
   tiers, ordered best bang-for-the-buck within each tier, targeting the 3–10 day user band.
 - [Engineering health](engineering-health.md) — CI, reproducibility stamping, NWP
@@ -218,3 +222,20 @@ delivery of the v2 live service)*
 - Disaggregate additional DERs (price-sensitive assets like batteries) from substation power flow
 - Estimate cost savings (£) attributable to each forecasting approach in the leaderboard
 - Build a REST API on top of the Delta Lake delivery mechanism (purely additive — see [when a REST API would earn its keep](../architecture/forecast-delivery.md#when-would-a-rest-api-earn-its-keep))
+
+---
+
+## Handover to NGED (post-NIA operating model)
+
+*Epic: to be created — see [Handover to NGED](handover.md), currently the plan of record.*
+
+NGED confirmed (2026-07-14) that after the NIA project they intend to **run Flexpectation
+themselves, on NGED's own AWS infrastructure** (see
+[Requirements → Operating model & handover](../background/requirements.md#operating-model-handover)).
+This is not a single late milestone: it sets a standing design constraint from today (the
+service must be operable day to day by a non-expert — the
+[operator contract](handover.md#1-the-operator-contract)), one workstream that must start early
+([probing NGED's AWS landing zone](handover.md#5-probe-ngeds-aws-landing-zone-early), since it
+could invalidate the Tailscale-based access design), and a cluster of late-project work
+(runbook hardening, game days, progressive transfer of control). The gate: OCF runs the full
+v2 service for a few months before NGED decides.

--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -217,7 +217,10 @@ subcommands and work with the image's existing `ENTRYPOINT ["dagster"]` unchange
   roles (no static keys); the textbook Dagster-OSS-on-AWS deployment.
 - **Cons:** one pet server (patching, disk, daemon liveness — mitigate with systemd restart
   policies + the monitoring plan's "no fresh forecast" alarm); dagster.yaml/run-launcher
-  config work; 4 GB is comfortable but not roomy (watch Marimo's Delta scans).
+  config work; 4 GB is comfortable but not roomy (watch Marimo's Delta scans). The pet-server
+  risk grows once a non-expert operates the service — the full mitigation list (auto-recovery
+  alarms, disk hygiene, a tested rebuild-from-scratch script) is
+  [Handover workstream 3](handover.md#3-de-pet-the-control-plane-box).
 - Cost trims: t4g.small (2 GB) is **free-trial (750 hrs/month) until 31 Dec 2026** and
   £10.30/£6.50 after, if everything squeezes into 2 GB — likely too tight with Marimo.
 
@@ -373,6 +376,15 @@ IAM roles, security groups, and multiple processes start accumulating enough to 
 codifying and reproducing — see the open Terraform-vs-CDK question in
 [Deployment workstream 3](#deployment-workstream-3-aws-infrastructure).
 
+**Handover caveat (added 2026-07-14):** all three stages are designed for the phase in which
+*OCF* runs the service on OCF's AWS account. Once the service moves to NGED's own AWS account
+(the confirmed post-NIA operating model — see [Handover to NGED](handover.md)), Tailscale
+specifically may not survive NGED's security review, and because the network layer is the auth
+layer here, that would require an NGED-compatible replacement for the whole access design, not
+just a component swap. This is a reason to
+[probe NGED's landing-zone constraints early](handover.md#5-probe-ngeds-aws-landing-zone-early)
+— not a reason to change Stages 1–3, which remain correct for the OCF-run phase.
+
 ## Production monitoring
 
 Issue: [#224](https://github.com/openclimatefix/nged-substation-forecast/issues/224)
@@ -421,6 +433,22 @@ Note this sensor needs a running Dagster daemon — [Option B](#option-b-recomme
 (the decided direction) provides one. If the deployment instead ships Option A (nothing
 always-on), skip the sensor and run the monitoring step as the final op of the one-shot
 production job (the production-job workstream below already reserves that slot).
+
+### Alert on absence: the dead-man's switch
+
+Per-task failure alerts (the EventBridge → SNS rule in
+[Deployment workstream 3](#deployment-workstream-3-aws-infrastructure)) only fire when
+something runs and fails. Whole classes of failure are silent: a hung daemon, a full disk, an
+expired credential, a schedule that stopped firing. The **primary** production alert is
+therefore a dead-man's switch: an alarm that fires when **no successful forecast has landed in
+N hours** (e.g. 8 hours — one missed 6-hourly slot plus margin), regardless of cause. Option B's
+"daemon silently dead" staleness alarm (mentioned under
+[the architecture options](#option-b-recommended-small-ec2-control-plane-box-ecsrunlauncher-2535month))
+is this alarm; recording it here makes it a first-class monitoring deliverable rather than a
+side note. Every alert must link to a runbook that ends in either a specific operator action or
+"escalate" — a requirement that matters doubly under the post-NIA operating model, where the
+day-to-day operator is a non-expert at NGED (see
+[Handover to NGED](handover.md#2-alert-on-absence-not-just-failure)).
 
 ### The `retire_experiment_job`
 
@@ -511,7 +539,10 @@ Common to all options:
 - ✅ **Fargate task definition**: 4 vCPU / 16 GB ARM for live runs (measured inference peak
   ~9 GB). 🚧 A bigger (e.g. 8 vCPU / 32 GB) definition for backtests is not yet built.
   Right-size the live definition after a week of CloudWatch metrics.
-- 🚧 **Alerting**: EventBridge rule on task stopped with non-zero exit → SNS → email.
+- 🚧 **Alerting**: EventBridge rule on task stopped with non-zero exit → SNS → email. Per-task
+  failure alerts are necessary but not sufficient — the
+  [dead-man's switch](#alert-on-absence-the-dead-mans-switch) below catches the silent-failure
+  classes they miss.
 - 🚧 Codify as infra-as-code once there's enough to justify it — per the
   [Access phasing sequencing note](#access-phasing), that point is Stage 2, not Stage 1.
   **Open question, not yet decided:** this section originally specified a small Terraform
@@ -519,7 +550,12 @@ Common to all options:
   specifically for this project, since it's single-cloud (AWS-only), so there's no cross-cloud
   benefit from HCL, and CDK lets the infra be written in Python rather than learning a new
   language for it. Terraform vs CDK is Jack's call to make when Stage 2 work starts; this page
-  does not pick one.
+  does not pick one. The post-NIA operating model (NGED runs the service on NGED's AWS — see
+  [Handover to NGED](handover.md#4-infrastructure-as-code-portable-to-ngeds-account)) adds two
+  inputs to that call: the infra-as-code must be **account-portable** (no OCF-specific names or
+  network assumptions baked in), and what NGED's infrastructure teams already know and are
+  allowed to run matters as much as what suits OCF — worth asking them before deciding. By
+  handover time, infra-as-code is mandatory, not optional.
 - 🚧 Document the few one-time manual steps still to come (SNS subscription confirm, Tailscale
   join) in the same runbook page (`docs/live_service/deployment.md`) once Option B's control-
   plane box is built.

--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -54,7 +54,7 @@ plan (phases 0–6.7 complete, PRs #182–#214); its final cleanup phase lives i
 - Telemetry to Sentry.io
   ([#63](https://github.com/openclimatefix/nged-substation-forecast/issues/63)) — including
   Sentry cron monitoring as the
-  [dead-man's switch](#alert-on-absence-the-dead-mans-switch); basic per-task failure
+  [missed-check-in alarm](#alert-on-absence-the-missed-check-in-alarm); basic per-task failure
   alerting covers v0.1 first.
 - An **MLflow tracking server** (issue [#235](https://github.com/openclimatefix/nged-substation-forecast/issues/235)) and a separate **development dashboard** ([#236](https://github.com/openclimatefix/nged-substation-forecast/issues/236)), both hosted on the
   always-on control-plane box once it exists — see the [note below](#aws-architecture).
@@ -436,21 +436,22 @@ Note this sensor needs a running Dagster daemon — [Option B](#option-b-recomme
 always-on), skip the sensor and run the monitoring step as the final op of the one-shot
 production job (the production-job workstream below already reserves that slot).
 
-### Alert on absence: the dead-man's switch
+### Alert on absence: the missed-check-in alarm
 
 Per-task failure alerts ([Deployment workstream 3](#deployment-workstream-3-aws-infrastructure))
 only fire when something runs and fails. Whole classes of failure are silent: a hung daemon, a
 full disk, an expired credential, a schedule that stopped firing. The **primary** production
-alert is therefore a dead-man's switch: an alarm that fires when **no successful forecast has
-landed in N hours** (e.g. 8 hours — one missed 6-hourly slot plus margin), regardless of cause.
+alert is therefore a **missed-check-in alarm** (Sentry's cron-monitoring terminology): it fires
+when **no successful forecast has landed in N hours** (e.g. 8 hours — one missed 6-hourly slot
+plus margin), regardless of cause.
 Option B's "daemon silently dead" staleness alarm (mentioned under
 [the architecture options](#option-b-recommended-small-ec2-control-plane-box-ecsrunlauncher-2535month))
 is this alarm; recording it here makes it a first-class monitoring deliverable rather than a
 side note.
 
 The alarm's *evaluation and delivery* must sit **outside** the service being watched, because
-a dead daemon cannot report itself — a Dagster sensor alone can never be the dead-man's
-switch. The planned mechanism is **Sentry cron monitoring**
+a dead daemon cannot report itself — a Dagster sensor alone can never provide this alarm.
+The planned mechanism is **Sentry cron monitoring**
 ([#63](https://github.com/openclimatefix/nged-substation-forecast/issues/63)): each successful
 forecast run checks in with Sentry, and Sentry alerts when an expected check-in fails to
 arrive. This satisfies both the outside-the-service requirement and the portability preference
@@ -560,8 +561,8 @@ Common to all options:
   notification edge (SNS, SMTP, …) being platform-specific. Under Option B, Dagster's own
   run-failure sensors are the natural portable mechanism (the daemon evaluates them). Per-task
   failure alerts are necessary but not sufficient — the
-  [dead-man's switch](#alert-on-absence-the-dead-mans-switch) catches the silent-failure
-  classes they miss.
+  [missed-check-in alarm](#alert-on-absence-the-missed-check-in-alarm) catches the
+  silent-failure classes they miss.
 - 🚧 Codify as infra-as-code once there's enough to justify it — per the
   [Access phasing sequencing note](#access-phasing), that point is Stage 2, not Stage 1.
   **Open question, not yet decided:** this section originally specified a small Terraform
@@ -607,7 +608,7 @@ order issues were opened.
 | [#206 Deploy to AWS!](https://github.com/openclimatefix/nged-substation-forecast/issues/206) | This page (the options above supersede its cost analysis; the issue links back here) |
 | [#286 Create docs for setting up compute infra on AWS](https://github.com/openclimatefix/nged-substation-forecast/issues/286) | [Deployment workstream 3](#deployment-workstream-3-aws-infrastructure) — the option-agnostic pieces (ECR, IAM roles, Fargate task definition) done; Option B's control-plane box still 🚧 |
 | [#197 Make fold-run param logging re-run-safe](https://github.com/openclimatefix/nged-substation-forecast/issues/197) | Bug fix folded into the v0.1 epic (MLflow param immutability on re-runs) |
-| [#63 Send telemetry to OCF's Sentry.io](https://github.com/openclimatefix/nged-substation-forecast/issues/63) | Observability — Sentry cron monitoring is the planned [dead-man's switch](#alert-on-absence-the-dead-mans-switch), plus error telemetry |
+| [#63 Send telemetry to OCF's Sentry.io](https://github.com/openclimatefix/nged-substation-forecast/issues/63) | Observability — Sentry cron monitoring provides the planned [missed-check-in alarm](#alert-on-absence-the-missed-check-in-alarm), plus error telemetry |
 | [#246 Scale `power_fcst` to [−1, +1] using the static P99 effective capacity](https://github.com/openclimatefix/nged-substation-forecast/issues/246) | Not yet detailed on this page — decided 2026-07-03 (see the issue for the full worklist); slot in before the version bump below |
 | [#96 Write power forecasts in schema agreed with NGED](https://github.com/openclimatefix/nged-substation-forecast/issues/96) | Deferred to the v1.0 epic ([#133](https://github.com/openclimatefix/nged-substation-forecast/issues/133)) — v0.1 is "forecast running", not "delivery contract live" |
 | [#161 More Dagster-UI metrics + validation for NWP ingestion](https://github.com/openclimatefix/nged-substation-forecast/issues/161) | Deferred to the v0.2 epic ([#138](https://github.com/openclimatefix/nged-substation-forecast/issues/138)) — mostly [NWP ingestion completeness checks](engineering-health.md#nwp-ingestion-completeness-checks-and-dagster-metrics) |

--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -52,8 +52,10 @@ plan (phases 0–6.7 complete, PRs #182–#214); its final cleanup phase lives i
   ([#96](https://github.com/openclimatefix/nged-substation-forecast/issues/96)) — v0.1 is
   "forecast running", not "delivery contract live".
 - Telemetry to Sentry.io
-  ([#63](https://github.com/openclimatefix/nged-substation-forecast/issues/63)) — CloudWatch +
-  SNS cover alerting first.
+  ([#63](https://github.com/openclimatefix/nged-substation-forecast/issues/63)) — including
+  Sentry cron monitoring as the
+  [dead-man's switch](#alert-on-absence-the-dead-mans-switch); basic per-task failure
+  alerting covers v0.1 first.
 - An **MLflow tracking server** (issue [#235](https://github.com/openclimatefix/nged-substation-forecast/issues/235)) and a separate **development dashboard** ([#236](https://github.com/openclimatefix/nged-substation-forecast/issues/236)), both hosted on the
   always-on control-plane box once it exists — see the [note below](#aws-architecture).
 - [Production monitoring](#production-monitoring): score live forecasts over trailing 24h/7d
@@ -446,13 +448,17 @@ Option B's "daemon silently dead" staleness alarm (mentioned under
 is this alarm; recording it here makes it a first-class monitoring deliverable rather than a
 side note.
 
-The freshness check itself is plain portable code — compare the newest forecast in
-`power_forecasts` against the clock — in line with the portability preference in
-[Deployment workstream 3](#deployment-workstream-3-aws-infrastructure). But the check's
-*trigger and delivery* are the one deliberate exception to "no platform glue": they must sit
-**outside** the service being watched, because a dead daemon cannot report itself. Cron on a
-laptop, a scheduled alarm on AWS, or an external dead-man's receiver (a healthchecks-style
-service the pipeline pings on success) all satisfy this; a Dagster sensor alone does not.
+The alarm's *evaluation and delivery* must sit **outside** the service being watched, because
+a dead daemon cannot report itself — a Dagster sensor alone can never be the dead-man's
+switch. The planned mechanism is **Sentry cron monitoring**
+([#63](https://github.com/openclimatefix/nged-substation-forecast/issues/63)): each successful
+forecast run checks in with Sentry, and Sentry alerts when an expected check-in fails to
+arrive. This satisfies both the outside-the-service requirement and the portability preference
+in [Deployment workstream 3](#deployment-workstream-3-aws-infrastructure) — Sentry is external
+to the whole deployment, and a check-in ping is plain code that works identically from a
+laptop, AWS, or any other cloud. One handover consideration: the Sentry account is OCF's
+today, so at handover the alert routing (and possibly the account itself) moves to NGED — see
+[Handover to NGED](handover.md#2-alert-on-absence-not-just-failure).
 
 Every alert must link to a runbook that ends in either a specific operator action or
 "escalate" — a requirement that matters doubly under the post-NIA operating model, where the
@@ -601,7 +607,7 @@ order issues were opened.
 | [#206 Deploy to AWS!](https://github.com/openclimatefix/nged-substation-forecast/issues/206) | This page (the options above supersede its cost analysis; the issue links back here) |
 | [#286 Create docs for setting up compute infra on AWS](https://github.com/openclimatefix/nged-substation-forecast/issues/286) | [Deployment workstream 3](#deployment-workstream-3-aws-infrastructure) — the option-agnostic pieces (ECR, IAM roles, Fargate task definition) done; Option B's control-plane box still 🚧 |
 | [#197 Make fold-run param logging re-run-safe](https://github.com/openclimatefix/nged-substation-forecast/issues/197) | Bug fix folded into the v0.1 epic (MLflow param immutability on re-runs) |
-| [#63 Send telemetry to OCF's Sentry.io](https://github.com/openclimatefix/nged-substation-forecast/issues/63) | Observability — CloudWatch + SNS first; Sentry as the follow-up |
+| [#63 Send telemetry to OCF's Sentry.io](https://github.com/openclimatefix/nged-substation-forecast/issues/63) | Observability — Sentry cron monitoring is the planned [dead-man's switch](#alert-on-absence-the-dead-mans-switch), plus error telemetry |
 | [#246 Scale `power_fcst` to [−1, +1] using the static P99 effective capacity](https://github.com/openclimatefix/nged-substation-forecast/issues/246) | Not yet detailed on this page — decided 2026-07-03 (see the issue for the full worklist); slot in before the version bump below |
 | [#96 Write power forecasts in schema agreed with NGED](https://github.com/openclimatefix/nged-substation-forecast/issues/96) | Deferred to the v1.0 epic ([#133](https://github.com/openclimatefix/nged-substation-forecast/issues/133)) — v0.1 is "forecast running", not "delivery contract live" |
 | [#161 More Dagster-UI metrics + validation for NWP ingestion](https://github.com/openclimatefix/nged-substation-forecast/issues/161) | Deferred to the v0.2 epic ([#138](https://github.com/openclimatefix/nged-substation-forecast/issues/138)) — mostly [NWP ingestion completeness checks](engineering-health.md#nwp-ingestion-completeness-checks-and-dagster-metrics) |

--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -436,16 +436,25 @@ production job (the production-job workstream below already reserves that slot).
 
 ### Alert on absence: the dead-man's switch
 
-Per-task failure alerts (the EventBridge → SNS rule in
-[Deployment workstream 3](#deployment-workstream-3-aws-infrastructure)) only fire when
-something runs and fails. Whole classes of failure are silent: a hung daemon, a full disk, an
-expired credential, a schedule that stopped firing. The **primary** production alert is
-therefore a dead-man's switch: an alarm that fires when **no successful forecast has landed in
-N hours** (e.g. 8 hours — one missed 6-hourly slot plus margin), regardless of cause. Option B's
-"daemon silently dead" staleness alarm (mentioned under
+Per-task failure alerts ([Deployment workstream 3](#deployment-workstream-3-aws-infrastructure))
+only fire when something runs and fails. Whole classes of failure are silent: a hung daemon, a
+full disk, an expired credential, a schedule that stopped firing. The **primary** production
+alert is therefore a dead-man's switch: an alarm that fires when **no successful forecast has
+landed in N hours** (e.g. 8 hours — one missed 6-hourly slot plus margin), regardless of cause.
+Option B's "daemon silently dead" staleness alarm (mentioned under
 [the architecture options](#option-b-recommended-small-ec2-control-plane-box-ecsrunlauncher-2535month))
 is this alarm; recording it here makes it a first-class monitoring deliverable rather than a
-side note. Every alert must link to a runbook that ends in either a specific operator action or
+side note.
+
+The freshness check itself is plain portable code — compare the newest forecast in
+`power_forecasts` against the clock — in line with the portability preference in
+[Deployment workstream 3](#deployment-workstream-3-aws-infrastructure). But the check's
+*trigger and delivery* are the one deliberate exception to "no platform glue": they must sit
+**outside** the service being watched, because a dead daemon cannot report itself. Cron on a
+laptop, a scheduled alarm on AWS, or an external dead-man's receiver (a healthchecks-style
+service the pipeline pings on success) all satisfy this; a Dagster sensor alone does not.
+
+Every alert must link to a runbook that ends in either a specific operator action or
 "escalate" — a requirement that matters doubly under the post-NIA operating model, where the
 day-to-day operator is a non-expert at NGED (see
 [Handover to NGED](handover.md#2-alert-on-absence-not-just-failure)).
@@ -539,9 +548,13 @@ Common to all options:
 - ✅ **Fargate task definition**: 4 vCPU / 16 GB ARM for live runs (measured inference peak
   ~9 GB). 🚧 A bigger (e.g. 8 vCPU / 32 GB) definition for backtests is not yet built.
   Right-size the live definition after a week of CloudWatch metrics.
-- 🚧 **Alerting**: EventBridge rule on task stopped with non-zero exit → SNS → email. Per-task
+- 🚧 **Alerting**: basic per-task failure alerting (a failed run → email). Decided 2026-07-14:
+  prefer **portable alerting logic over AWS-native glue** (no EventBridge rules) — the checks
+  should be plain code that runs end-to-end on a laptop or any cloud, with only the thin
+  notification edge (SNS, SMTP, …) being platform-specific. Under Option B, Dagster's own
+  run-failure sensors are the natural portable mechanism (the daemon evaluates them). Per-task
   failure alerts are necessary but not sufficient — the
-  [dead-man's switch](#alert-on-absence-the-dead-mans-switch) below catches the silent-failure
+  [dead-man's switch](#alert-on-absence-the-dead-mans-switch) catches the silent-failure
   classes they miss.
 - 🚧 Codify as infra-as-code once there's enough to justify it — per the
   [Access phasing sequencing note](#access-phasing), that point is Stage 2, not Stage 1.

--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -378,7 +378,7 @@ codifying and reproducing — see the open Terraform-vs-CDK question in
 
 **Handover caveat (added 2026-07-14):** all three stages are designed for the phase in which
 *OCF* runs the service on OCF's AWS account. Once the service moves to NGED's own AWS account
-(the confirmed post-NIA operating model — see [Handover to NGED](handover.md)), Tailscale
+(the preferred post-NIA operating model — see [Handover to NGED](handover.md)), Tailscale
 specifically may not survive NGED's security review, and because the network layer is the auth
 layer here, that would require an NGED-compatible replacement for the whole access design, not
 just a component swap. This is a reason to

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
   - Roadmap:
       - Overview: roadmap/index.md
       - Live Service: roadmap/live-service.md
+      - Handover to NGED: roadmap/handover.md
       - Delivery Tables: roadmap/delivery-tables.md
       - Forecast Building Blocks: roadmap/forecast-building-blocks.md
       - Metrics & Leaderboard: roadmap/metrics-and-leaderboard.md


### PR DESCRIPTION
## Context

NGED confirmed (2026-07-14) that their preference for running Flexpectation business-as-usual *after* the NIA project is for **NGED to run our code themselves, on NGED's own AWS infrastructure** — possibly under a "hybrid model" in which OCF continues developing the code and ML models (and perhaps runs a second service instance, e.g. adapted for other DNOs or feeding a commercial demand-forecast product). This doesn't change the milestone arc for the remainder of the NIA project, but it does set a standing design constraint (day-to-day operation by a non-expert) and add a handover workstream.

## What this PR does

- **New design page: [Handover to NGED](https://openclimatefix.github.io/nged-substation-forecast/roadmap/handover/)** — the operator-contract design constraint ("the operator's scarce skill is ops, not Python"; every routine action reduces to a dashboard, a Dagster button, or a runbook) and seven workstreams:
    1. The operator contract (≤ ~10 enumerated operator actions, each runbook-backed)
    2. Alert on absence, not just failure (a missed-check-in alarm as the *primary* alert)
    3. De-pet the control-plane box (auto-recovery, disk hygiene, tested rebuild-from-scratch)
    4. Account-portable infrastructure-as-code, mandatory by handover
    5. Probe NGED's AWS landing zone early (Tailscale may not survive their security review — and in the current design the network layer *is* the auth layer)
    6. Game days with the actual NGED operator before handover
    7. Organisational prerequisites (named NGED owner, budget line, written support agreement)

- **[Requirements → Operating model & handover](https://openclimatefix.github.io/nged-substation-forecast/background/requirements/#operating-model-handover)** — the durable record of the requirement itself: the confirmed operating model, the deliberately lenient uptime requirements (previous forecasts stay readable on S3; recovery is "next business day, via runbook", never a 2am page), the four-step phasing, and the hybrid model.

- **Threaded through existing pages**: the Tailscale handover caveat at the end of [Access phasing](https://openclimatefix.github.io/nged-substation-forecast/roadmap/live-service/#access-phasing); a new [missed-check-in-alarm section](https://openclimatefix.github.io/nged-substation-forecast/roadmap/live-service/#alert-on-absence-the-missed-check-in-alarm) under Production monitoring; two new inputs to the open Terraform-vs-CDK question (account-portability; ask NGED's infra teams what they run); an audience note on the [Live Service runbooks](https://openclimatefix.github.io/nged-substation-forecast/live_service/); a note in [Production Deployment — Design](https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/) that the baked-in-model decision serves the vendor-develops/operator-runs split; a "Handover to NGED" milestone section on the [roadmap](https://openclimatefix.github.io/nged-substation-forecast/roadmap/#handover-to-nged-post-nia-operating-model); and the mkdocs nav entry.

## Follow-ups (not in this PR)

- ~~Create the GitHub epic for the handover milestone~~ — done: #309 (Type=Epic, on the OCF board, Status=Todo/Project=NGED/Area=ML); the docs now link to it.
- Raise landing-zone constraints with NGED (workstream 5) — a conversation, not a code change, but the one item that should start well before the final months.

## Verification

- `uv run pymarkdown scan` clean; `uv run mkdocs build --strict` exits 0.
- All new cross-page anchors checked against the rendered HTML (each `id=` present), and the rendered pages spot-checked for the Python-Markdown list-interruption gotcha — no literal list markers leaked into prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

