### PR TITLE
docs: remove confusing previous-design references from the setup runbook

### DIFF
--- a/docs/architecture/ml-orchestration.md
+++ b/docs/architecture/ml-orchestration.md
@@ -80,6 +80,50 @@ mean-across-folds leaderboard number. Mid-window performance on an incomplete wi
 obtained through the `metrics` asset's `ad_hoc` evaluation scope, which never feeds the
 leaderboard.
 
+## Fold-design alternatives considered
+
+We considered three other ways to slice the limited honest data and chose the
+[single fold](../ml_experimentation/cross-validation-folds.md#current-state-a-single-fold). These
+are recorded so the decision is auditable and so we can revisit them as more data lands.
+
+### Monthly expanding CV — rejected (redundant folds)
+
+Slide a 12-month validation window forward by one month per fold, expanding training by one month
+each time (fold 1 validates 2025-04→2026-03, fold 2 validates 2025-05→2026-04, …). This "buys"
+several folds from today's data, but consecutive folds share **11/12 of the validation window** and
+>90% of the training data, so their metrics are correlated ~0.9+. The effective number of
+independent folds is barely more than one; the small spread across them **understates** true
+sampling variance (false confidence in stability), at N× the compute for almost-duplicate
+information. One month is too small a change to make the folds meaningfully different.
+
+### Quarterly non-overlapping walk-forward — deferred (the sound multi-fold option)
+
+Expanding training, but validate on the **next 3 months, non-overlapping**:
+
+| Fold | Train | Validate (3 mo, non-overlapping) |
+|---|---|---|
+| 2025-Q2 | 2024-04-01 → 2025-03-31 | 2025-04 → 2025-06 |
+| 2025-Q3 | 2024-04-01 → 2025-06-30 | 2025-07 → 2025-09 |
+| 2025-Q4 | 2024-04-01 → 2025-09-30 | 2025-10 → 2025-12 |
+| 2026-Q1 | 2024-04-01 → 2025-12-31 | 2026-01 → 2026-03 |
+
+Because the validation windows do not overlap, the folds are **genuinely independent**
+measurements, and the set covers all four seasons (so you see seasonal skill variation, then report
+per-season and the mean). This is the statistically sound version of what monthly CV reaches for.
+We deferred it to keep the initial CV setup minimal; it is the recommended next step if we want
+multiple folds
+*before* the ECMWF back-fill enables the full yearly protocol.
+
+### Yearly folds backed by CERRA — rejected for validation
+
+Keep the yearly 2022–2025 folds now by training on **CERRA reanalysis** for the pre-2024-04-01
+years. Rejected: CERRA is *reanalysis* (it ingests future observations), so validating on it
+measures the model's response to near-perfect weather, not **forecast** skill — systematically
+misleading — and a leaderboard mixing CERRA folds and ECMWF folds is apples-to-oranges. It would
+also pull a large CERRA-ingestion effort forward. CERRA is valuable, but for **pre-training** (see
+[Cross-validation folds: Target](../ml_experimentation/cross-validation-folds.md#target-multiple-yearly-folds)),
+not for validation.
+
 ## Two metric stores, one division of labour
 
 Metrics live in **both** MLflow and the `forecast_metrics` Delta table, deliberately, because

--- a/docs/live_service/setup.md
+++ b/docs/live_service/setup.md
@@ -138,9 +138,9 @@ against an in-process `moto` server.)
 
 ### Step 1 — Create the S3 buckets
 
-**Two** buckets, not one — split so the five tables that form NGED's stable delivery contract are
-physically separate from OCF's own working data, which may change shape at any time with no
-notice. See [Forecast Delivery: Securing it](../architecture/forecast-delivery.md#securing-it)
+We split storage across **two** buckets so the five tables that form NGED's stable delivery
+contract are physically separate from OCF's own working data, which may change shape at any time
+with no notice. See [Forecast Delivery: Securing it](../architecture/forecast-delivery.md#securing-it)
 for why this split exists, and [Delivery tables](https://openclimatefix.github.io/nged-substation-forecast/roadmap/delivery-tables/)
 for exactly which five tables count as "delivery."
 
@@ -251,7 +251,7 @@ Then attach it to **whichever identity runs the code**:
 
 ### Step 3 — Point `Settings` at the buckets
 
-Unlike a single-bucket setup, this now needs **both** data-table roots set, one per bucket:
+This needs **both** data-table roots set, one per bucket:
 
 | Setting | Bucket | Why |
 |---|---|---|
@@ -262,8 +262,8 @@ The other three delivery tables (`power_forecast_warnings`, `asset_health_histor
 `substation_switching`) don't have `Settings` fields yet — none are implemented in code. When
 they land, they need to be wired into `Settings._derive_unset_paths` to derive from
 `DATA_PATH_DELIVERY` alongside the two above (the per-field env var override — e.g.
-`POWER_FORECASTS_DATA_PATH`, still works as an escape valve for a one-off case, but is no longer
-the primary mechanism for the delivery/internal split).
+`POWER_FORECASTS_DATA_PATH` — still works as an escape valve for a one-off case, but the
+delivery/internal split is driven by root derivation, not per-table overrides).
 
 > **Design choice: NGED sees every CV/backtest fold, not just live production forecasts.** The
 > `power_forecasts` table holds every CV/backtest experiment alongside live production forecasts,

--- a/docs/ml_experimentation/cross-validation-folds.md
+++ b/docs/ml_experimentation/cross-validation-folds.md
@@ -75,42 +75,7 @@ is a training-time technique, distinct from the validation folds described here.
 
 ## Alternatives considered
 
-We considered three other ways to slice the limited honest data and chose the single fold above.
-These are recorded so the decision is auditable and so we can revisit them as more data lands.
-
-### Monthly expanding CV — rejected (redundant folds)
-
-Slide a 12-month validation window forward by one month per fold, expanding training by one month
-each time (fold 1 validates 2025-04→2026-03, fold 2 validates 2025-05→2026-04, …). This "buys"
-several folds from today's data, but consecutive folds share **11/12 of the validation window** and
->90% of the training data, so their metrics are correlated ~0.9+. The effective number of
-independent folds is barely more than one; the small spread across them **understates** true
-sampling variance (false confidence in stability), at N× the compute for almost-duplicate
-information. One month is too small a change to make the folds meaningfully different.
-
-### Quarterly non-overlapping walk-forward — deferred (the sound multi-fold option)
-
-Expanding training, but validate on the **next 3 months, non-overlapping**:
-
-| Fold | Train | Validate (3 mo, non-overlapping) |
-|---|---|---|
-| 2025-Q2 | 2024-04-01 → 2025-03-31 | 2025-04 → 2025-06 |
-| 2025-Q3 | 2024-04-01 → 2025-06-30 | 2025-07 → 2025-09 |
-| 2025-Q4 | 2024-04-01 → 2025-09-30 | 2025-10 → 2025-12 |
-| 2026-Q1 | 2024-04-01 → 2025-12-31 | 2026-01 → 2026-03 |
-
-Because the validation windows do not overlap, the folds are **genuinely independent**
-measurements, and the set covers all four seasons (so you see seasonal skill variation, then report
-per-season and the mean). This is the statistically sound version of what monthly CV reaches for.
-We deferred it to keep the initial CV setup minimal; it is the recommended next step if we want
-multiple folds
-*before* the ECMWF back-fill enables the full yearly protocol.
-
-### Yearly folds backed by CERRA — rejected for validation
-
-Keep the yearly 2022–2025 folds now by training on **CERRA reanalysis** for the pre-2024-04-01
-years. Rejected: CERRA is *reanalysis* (it ingests future observations), so validating on it
-measures the model's response to near-perfect weather, not **forecast** skill — systematically
-misleading — and a leaderboard mixing CERRA folds and ECMWF folds is apples-to-oranges. It would
-also pull a large CERRA-ingestion effort forward. CERRA is valuable, but for **pre-training**
-(above), not for validation.
+We weighed three other ways to slice the limited honest data — monthly expanding CV, quarterly
+non-overlapping walk-forward, and yearly folds backed by CERRA reanalysis — before settling on the
+single fold above. The reasoning for rejecting or deferring each is recorded in
+[ML Experiment Orchestration — Design Decisions](../architecture/ml-orchestration.md#fold-design-alternatives-considered).

--- a/docs/ml_experimentation/index.md
+++ b/docs/ml_experimentation/index.md
@@ -13,5 +13,5 @@ roadmap.
 - [Model configuration](model-configuration.md) — how to set hyperparameters and choose
   features; the full feature vocabulary and the lookahead-bias guardrails.
 - [Cross-validation folds](cross-validation-folds.md) — the expanding-window CV protocol, the
-  current single fold and why the data constrains us to it, the target multiple-yearly-fold
-  protocol, and the fold-design alternatives we considered.
+  current single fold and why the data constrains us to it, and the target multiple-yearly-fold
+  protocol.


### PR DESCRIPTION
The run-book docs in `docs/live_service/` and `docs/ml_experimentation/` should describe only the **current** design — a first-time reader has no knowledge of the project's design history, so framing something as a departure from an earlier design (or parking rejected designs inside the runbook) is confusing. Rejected/considered designs belong in the design-rationale docs (`docs/architecture/`) instead.

## 1. Removed previous-design references from `setup.md`

A sweep of both run-book directories found three phrasings, all in `docs/live_service/setup.md`, all residue of the earlier single-bucket → two-bucket change:

- **Step 3** — "Unlike a single-bucket setup, this **now** needs both data-table roots set" → states the current requirement directly ("This needs both data-table roots set, one per bucket").
- **Step 3** — "the per-field env var override ... is **no longer** the primary mechanism for the delivery/internal split" → describes how the split is driven today ("the delivery/internal split is driven by root derivation, not per-table overrides").
- **Step 1** — "**Two** buckets, not one — split so that ..." → rewritten to the preferred prose form from CLAUDE.md's style guide ("We split storage across two buckets so ..."), which also drops the implicit contrast with a one-bucket design.

Other `not one`/`unlike` matches in the sweep were left alone: they're teaching emphasis or contrasts with the roadmap/other commands in the same page, not references to a superseded project design.

## 2. Moved the CV "Alternatives considered" section into architecture

`docs/ml_experimentation/cross-validation-folds.md` carried an "Alternatives considered" section documenting rejected/deferred fold-slicing designs (monthly expanding CV, quarterly non-overlapping walk-forward, yearly CERRA folds). That is design rationale, not runbook content, so it moved verbatim into **[ML Experiment Orchestration — Design Decisions](https://openclimatefix.github.io/nged-substation-forecast/architecture/ml-orchestration/#fold-design-alternatives-considered)**, alongside the other rejected experiment-layer designs.

- Retargeted the two intra-doc references in the moved text ("chose the single fold above", "pre-training (above)") to links back into the CV page.
- The CV page keeps a one-line pointer to the rationale; its `index.md` entry no longer claims to hold the alternatives.

Verified with `uv run mkdocs build --strict` (passes) and confirmed the new `#fold-design-alternatives-considered` anchor and both back-link targets exist in the generated HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)