### PR TITLE
docs: explain how to set DATA_PATH_* on AWS compute in setup Step 3

### DIFF
--- a/docs/live_service/setup.md
+++ b/docs/live_service/setup.md
@@ -273,12 +273,23 @@ delivery/internal split is driven by root derivation, not per-table overrides).
 > see how each of OCF's model versions actually behaves, not just whichever one is currently
 > promoted. NGED filters on `fold_id="live"` when it only wants the current production forecast.
 
-**On AWS compute (IAM role)** — credentials and region are auto-discovered, so just:
+**On AWS compute (IAM role)** — credentials and region are auto-discovered, so only the two roots
+are needed:
 
 ```dotenv
 DATA_PATH_INTERNAL=s3://nged-forecast-internal/data
 DATA_PATH_DELIVERY=s3://nged-forecast-delivery/data
 ```
+
+*How* you set these two depends on the compute. A Fargate task has no repo checkout and no `.env`
+file, so they are set as plain **environment variables on the container in the ECS task
+definition** — not secrets, since bucket URIs are safe to store in clear text (unlike the NGED
+source credentials, which are injected from Parameter Store). [Deploying a new production image:
+Step 8](deployment.md#step-8-create-the-ecs-cluster-and-fargate-task-definition) shows exactly where
+in the console. On an EC2 box running the code directly, use the same repo-root `.env` file as the
+laptop case below instead. Either way [`Settings`](#the-configuration-model) reads them identically
+— an environment variable and a `.env` line are interchangeable, and an environment variable wins if
+both are set.
 
 **From your laptop (IAM user access key)** — same two roots, plus the key, secret, and region,
 but **not** an endpoint URL (that is only for non-AWS/MinIO endpoints, and it would wrongly allow

--- a/docs/live_service/setup.md
+++ b/docs/live_service/setup.md
@@ -138,9 +138,9 @@ against an in-process `moto` server.)
 
 ### Step 1 — Create the S3 buckets
 
-**Two** buckets, not one — split so the five tables that form NGED's stable delivery contract are
-physically separate from OCF's own working data, which may change shape at any time with no
-notice. See [Forecast Delivery: Securing it](../architecture/forecast-delivery.md#securing-it)
+We split storage across **two** buckets so the five tables that form NGED's stable delivery
+contract are physically separate from OCF's own working data, which may change shape at any time
+with no notice. See [Forecast Delivery: Securing it](../architecture/forecast-delivery.md#securing-it)
 for why this split exists, and [Delivery tables](https://openclimatefix.github.io/nged-substation-forecast/roadmap/delivery-tables/)
 for exactly which five tables count as "delivery."
 
@@ -251,7 +251,7 @@ Then attach it to **whichever identity runs the code**:
 
 ### Step 3 — Point `Settings` at the buckets
 
-Unlike a single-bucket setup, this now needs **both** data-table roots set, one per bucket:
+This needs **both** data-table roots set, one per bucket:
 
 | Setting | Bucket | Why |
 |---|---|---|
@@ -262,8 +262,8 @@ The other three delivery tables (`power_forecast_warnings`, `asset_health_histor
 `substation_switching`) don't have `Settings` fields yet — none are implemented in code. When
 they land, they need to be wired into `Settings._derive_unset_paths` to derive from
 `DATA_PATH_DELIVERY` alongside the two above (the per-field env var override — e.g.
-`POWER_FORECASTS_DATA_PATH`, still works as an escape valve for a one-off case, but is no longer
-the primary mechanism for the delivery/internal split).
+`POWER_FORECASTS_DATA_PATH` — still works as an escape valve for a one-off case, but the
+delivery/internal split is driven by root derivation, not per-table overrides).
 
 > **Design choice: NGED sees every CV/backtest fold, not just live production forecasts.** The
 > `power_forecasts` table holds every CV/backtest experiment alongside live production forecasts,


### PR DESCRIPTION
## What

[Environment & storage setup: Step 3](https://openclimatefix.github.io/nged-substation-forecast/live_service/setup/#step-3-point-settings-at-the-buckets)'s **On AWS compute (IAM role)** block showed the two bucket-root values (`DATA_PATH_INTERNAL`, `DATA_PATH_DELIVERY`) in a `dotenv` fence but never said *how* they actually get set on AWS compute. A Fargate task has no repo checkout and no `.env` file, so a dotenv snippet alone leaves the reader without the mechanism.

## Change

Add a short paragraph to Step 3 explaining:

- On a **Fargate task**, the two roots are set as plain **environment variables on the container in the ECS task definition** — not secrets, since bucket URIs are safe in clear text (contrast the NGED source credentials, which are injected from Parameter Store). Cross-links the concrete console recipe already in [Deploying a new production image: Step 8](https://openclimatefix.github.io/nged-substation-forecast/live_service/deployment/#step-8-create-the-ecs-cluster-and-fargate-task-definition).
- On an **EC2 box** running the code directly, use the same repo-root `.env` file as the laptop case.
- Either way `Settings` reads them identically — env var and `.env` line are interchangeable, env var wins if both set (consistent with the precedence stated at the top of the page).

Docs-only; `pymarkdown` clean.