### PR TITLE
docs(deployment): one lean build+verify step backed by a script

### DIFF
--- a/docs/live_service/deployment.md
+++ b/docs/live_service/deployment.md
@@ -6,7 +6,7 @@ at runtime — lives in
 [Production Deployment — Design](../architecture/production-deployment.md); this page is the
 mechanical recipe.
 
-> **Scope: manual, point-and-click AWS compute — not yet the unattended deployment.** Steps 4–9
+> **Scope: manual, point-and-click AWS compute — not yet the unattended deployment.** Steps 3–8
 > below get a verified image onto ECR and running as a one-off Fargate task, which is enough to
 > confirm the whole path end-to-end. The always-on control-plane box (Dagster daemon, Postgres,
 > `EcsRunLauncher`, the 6-hourly schedule) and infra-as-code are still not built — see
@@ -20,102 +20,43 @@ and [Step 2](dagster-workflow.md#step-2-materialise-promoted_model) to materiali
 `promoted_model`. This populates `data/production_model/` on disk — the same directory the
 image build below `COPY`s from.
 
-## Step 2 — Build the image
+## Step 2 — Build and verify the image
 
-This step and [Step 3](#step-3-verify-the-build-locally) are wrapped in one script — with a
-champion model on disk (Step 1), it builds the image and smoke-tests it in a single command:
+With a champion model on disk (Step 1), one script builds the image and smoke-tests it with
+**zero network access** — the test that matters, since the entire point of baking the model in is
+that production inference has no MLflow dependency at runtime:
 
 ```bash
 scripts/build_and_verify_image.sh <partition-key>   # e.g. 2026-07-04-00:00
 ```
 
-The `<partition-key>` is only used by the Step 3 smoke test; any recent 6-hourly key works (see
-[the partition-semantics note](dagster-workflow.md#step-3-let-the-schedule-run-or-materialise-live_forecasts-by-hand)).
-The script hard-fails only if the runtime touches MLflow — the one hermeticity guarantee worth
-automating — and prints the container log for you to confirm the rest by eye (see Step 3). The
-remainder of this step and Step 3 explain what it does and why, and give the raw commands if you
-would rather run them by hand.
+The `<partition-key>` is any recent 6-hourly key (see
+[the partition-semantics note](dagster-workflow.md#step-3-let-the-schedule-run-or-materialise-live_forecasts-by-hand));
+it only drives the smoke test's one-shot run. The script builds the image tagged with the
+promoted model's run id, runs it offline, and prints the container log with a pass/fail summary.
+It hard-fails only if the runtime touches MLflow — the hermeticity guarantee worth automating —
+and otherwise asks you to confirm by eye that the run loaded the model and failed *only* on
+missing NWP data (expected: no data tables are mounted for this isolated test). The script header
+documents every choice it makes and is the source of truth for the mechanics; a full end-to-end
+run instead needs real data-table roots per [Environment & storage setup](setup.md).
 
-The build never contacts MLflow — it only `COPY`s the directory Step 1 just populated, so it
-stays hermetic:
-
-```bash
-RUN_ID=$(jq -r .mlflow_run_id data/production_model/promotion.json)
-docker build \
-  --build-arg MODEL_RUN_ID="$RUN_ID" \
-  --build-arg GIT_SHA=$(git rev-parse HEAD) \
-  -t nged-forecast:"${RUN_ID:0:12}" .
-```
-
-The run id comes from the directory the build `COPY`s from: Step 1 recorded it in
-`data/production_model/promotion.json` as `mlflow_run_id` (the same value you entered as
-`PromotedModelConfig.mlflow_run_id` when materialising `promoted_model`). Reading it back from
-that file — rather than pasting it — guarantees the label matches the model actually baked in.
-The image tag is just its first 12 hex characters, enough to be unique and human-readable.
-
-`MODEL_RUN_ID` and `GIT_SHA` are stamped as OCI labels (and `GIT_SHA` also as a runtime env
-var) purely for traceability — confirm with `docker inspect nged-forecast:<tag>`.
-
-## Step 3 — Verify the build locally
-
-The [Step 2](#step-2-build-the-image) script already runs this verification; do it by hand only
-when running the raw commands. Before trusting a new image, confirm it actually runs with **zero
-network access** — this is the test that matters, since the entire point of baking the model in
-is that production inference has no MLflow dependency at runtime:
-
-```bash
-docker run --network=none \
-  -e NGED_S3_BUCKET_URL=https://example.com/outbound/ \
-  -e NGED_S3_BUCKET_ACCESS_KEY=dummy \
-  -e NGED_S3_BUCKET_SECRET=dummy \
-  nged-forecast:<tag> \
-  job execute -m nged_substation_forecast.definitions -j live_forecasts_job \
-  --tags '{"dagster/partition": "<key>"}'
-```
-
-The three `NGED_S3_BUCKET_*` values must be **present but don't need to be real**. `Settings`
-declares them as required fields, and several modules instantiate `Settings()` at import time
-(`contracts/weather_schemas.py`, `nged_substation_forecast/definitions.py`, …), so importing
-the code location fails with a pydantic `ValidationError` before Dagster even starts if they
-are missing. Passing dummies keeps the test honest: it proves the image needs only the
-*presence* of these settings at import — never valid credentials, and never the network. The
-deployed task gets the real values as secrets instead (see
-[Step 7](#step-7-store-the-nged-source-credentials-in-parameter-store)).
-
-Partition selection uses `--tags`, not `--select`/`--partition`: `dagster job execute` has no
-`--partition` flag at all, and `dagster asset materialize --select <asset>` (which does) hits a
-pre-existing, unrelated `antlr4-python3-runtime`/Python 3.14 incompatibility in Dagster's own
-asset-selection-string parser — reproduces identically outside Docker, on a plain `dg dev`
-checkout, so it's an upstream/environment issue, not something introduced by this image.
-Selecting by job name (`-j`) skips that parser entirely.
-
-**Verified 2026-07-14** against a real promoted model, with exactly the dummy-credential
-command above: the run reaches `load_forecaster_from_dir` and loads the model successfully
-(confirmed via the step ordering in `production_assets.py` — model load happens before the
-NWP-availability lookup) with zero `mlflow` mentions anywhere in the log, then fails only on
-missing NWP data access (expected — no `DATA_PATH_INTERNAL` was mounted for this isolated
-test). Omitting the dummy `NGED_S3_BUCKET_*` values instead fails at import with the pydantic
-`ValidationError` described above — also verified, so if you see that error, it's the env
-vars, not the image. A full end-to-end run needs real
-data-table roots (local mount or S3 credentials) supplied via environment variables, per
-[Environment & storage setup](setup.md).
-
-## Step 4 — Create the ECR repository
+## Step 3 — Create the ECR repository
 
 In the AWS console → **ECR** → **Create repository** (same `eu-west-2` region as the S3 bucket
 in [Environment & storage setup: Step 1](setup.md#step-1-create-the-s3-buckets)):
 
 1. **Visibility** Private.
-2. **Name** `nged-forecast` (matches the local image tag used in [Step 2](#step-2-build-the-image)
-   above — keeps `docker build -t nged-forecast:<tag>` and the ECR URI consistent).
+2. **Name** `nged-forecast` (matches the local image tag `nged-forecast:<tag>` from
+   [Step 2](#step-2-build-and-verify-the-image), keeping it and the ECR URI consistent).
 3. **Scan on push** on — free vulnerability scanning, no reason not to.
 4. Leave tag immutability off; image tags here are already unique per promoted model (the
-   run id's short prefix from [Step 2](#step-2-build-the-image)), so nothing relies on retagging.
+   run id's short prefix from [Step 2](#step-2-build-and-verify-the-image)), so nothing relies
+   on retagging.
 
-## Step 5 — Push the image to ECR
+## Step 4 — Push the image to ECR
 
 Authenticate Docker against the new repository, then tag and push the image built in
-[Step 2](#step-2-build-the-image):
+[Step 2](#step-2-build-and-verify-the-image):
 
 ```bash
 aws ecr get-login-password --region eu-west-2 \
@@ -130,14 +71,14 @@ docker push <account-id>.dkr.ecr.eu-west-2.amazonaws.com/nged-forecast:<run-id-s
 `<account-id>` is the 12-digit AWS account ID (visible in the console's top-right account menu,
 or `aws sts get-caller-identity --query Account --output text`).
 
-## Step 6 — IAM roles for the task
+## Step 5 — IAM roles for the task
 
 Fargate tasks need **two** separate roles, not one — they serve different principals:
 
 - **Task execution role**, `nged-forecast-task-execution-role` — used by the *ECS agent* itself,
   before your code ever runs: pulling the image from ECR, shipping container output to
   CloudWatch Logs, and injecting the NGED credential secrets from
-  [Step 7](#step-7-store-the-nged-source-credentials-in-parameter-store). Create a role for the
+  [Step 6](#step-6-store-the-nged-source-credentials-in-parameter-store). Create a role for the
   `ecs-tasks.amazonaws.com` service and attach the AWS-managed
   `AmazonECSTaskExecutionRolePolicy` (covers ECR + CloudWatch), plus one small inline policy for
   the secrets — it's the *execution* role that reads them, not the task role, because the ECS
@@ -169,11 +110,11 @@ Fargate tasks need **two** separate roles, not one — they serve different prin
 No static AWS keys anywhere in either role — this is the same IAM-role auto-discovery setup.md
 already relies on for compute running on AWS.
 
-## Step 7 — Store the NGED source credentials in Parameter Store
+## Step 6 — Store the NGED source credentials in Parameter Store
 
 The container can't start without `NGED_S3_BUCKET_URL`, `NGED_S3_BUCKET_ACCESS_KEY`, and
 `NGED_S3_BUCKET_SECRET` (`Settings` requires them at import — see the smoke test in
-[Step 3](#step-3-verify-the-build-locally)), and the deployed service genuinely uses them: the
+[Step 2](#step-2-build-and-verify-the-image)), and the deployed service genuinely uses them: the
 hourly `power_time_series_and_metadata` schedule pulls fresh telemetry from NGED's bucket.
 
 They are also the one credential in this deployment that can't come from an IAM role: NGED's
@@ -187,15 +128,15 @@ times, in `eu-west-2` (same region as everything else):
 
 - **Name**: `/nged-forecast/nged-s3-bucket-url`, `/nged-forecast/nged-s3-bucket-access-key`,
   and `/nged-forecast/nged-s3-bucket-secret` respectively. The shared `/nged-forecast/` prefix
-  is exactly what [Step 6](#step-6-iam-roles-for-the-task)'s execution-role policy grants
+  is exactly what [Step 5](#step-5-iam-roles-for-the-task)'s execution-role policy grants
   access to, so a new secret added under the same prefix later needs no IAM change.
 - **Tier**: Standard (free; these values are tiny, nowhere near the 4 KB limit).
 - **Type**: **SecureString**, with the default `aws/ssm` KMS key — using the default key is
-  what lets Step 6's inline policy skip a `kms:Decrypt` statement.
+  what lets Step 5's inline policy skip a `kms:Decrypt` statement.
 - **Value**: copied from the matching line of your local `.env`.
 
 There is no wiring to do in this step — that happens in the task definition
-([Step 8](#step-8-create-the-ecs-cluster-and-fargate-task-definition)), where each parameter is
+([Step 7](#step-7-create-the-ecs-cluster-and-fargate-task-definition)), where each parameter is
 referenced as a **ValueFrom** environment variable. The ECS agent, authenticated as the
 *execution* role, fetches and decrypts the values just before the container starts; they never
 appear in the task definition, the ECS console, or CloudWatch.
@@ -206,19 +147,19 @@ flagship feature, automatic rotation — NGED's keys rotate on NGED's schedule, 
 NGED does rotate them, just update the parameter values (and your local `.env`); running tasks
 keep the old values until they next start, since injection happens once per container launch.
 
-## Step 8 — Create the ECS cluster and Fargate task definition
+## Step 7 — Create the ECS cluster and Fargate task definition
 
 1. **ECS** → **Clusters** → **Create cluster** → *Networking only* (Fargate; no EC2 instances to
    manage) — a bare cluster is just a namespace, so a single `nged-forecast` cluster is enough
    for now.
 2. **ECS** → **Task definitions** → **Create new task definition** → *Fargate*:
-    - **Task role**: the task role from [Step 6](#step-6-iam-roles-for-the-task).
-    - **Task execution role**: the execution role from [Step 6](#step-6-iam-roles-for-the-task).
+    - **Task role**: the task role from [Step 5](#step-5-iam-roles-for-the-task).
+    - **Task execution role**: the execution role from [Step 5](#step-5-iam-roles-for-the-task).
     - **Task size**: 4 vCPU / 16 GB, **ARM64** (`linux/arm64`) — matches the measured inference
       peak (~9 GB) and the image's own build target (see the Dockerfile's ARM build note); ARM
       Fargate is also ~20% cheaper than x86 for the same size.
     - **Container**: image URI `<account-id>.dkr.ecr.eu-west-2.amazonaws.com/nged-forecast:<tag>`
-      from [Step 5](#step-5-push-the-image-to-ecr); log configuration → **awslogs**, a new
+      from [Step 4](#step-4-push-the-image-to-ecr); log configuration → **awslogs**, a new
       CloudWatch log group (e.g. `/ecs/nged-forecast`), region `eu-west-2`.
     - **Environment variables**: `DATA_PATH_INTERNAL=s3://nged-forecast-internal/data` and
       `DATA_PATH_DELIVERY=s3://nged-forecast-delivery/data` — both are needed, since the delivery
@@ -226,13 +167,13 @@ keep the old values until they next start, since injection happens once per cont
       [setup.md's on-AWS settings](setup.md#step-3-point-settings-at-the-buckets)). Leave
       `DATA_STORE_*` unset, since the task role supplies credentials.
     - **Secrets — the three NGED source-bucket credentials.** Add each Parameter Store entry
-      from [Step 7](#step-7-store-the-nged-source-credentials-in-parameter-store) as an
+      from [Step 6](#step-6-store-the-nged-source-credentials-in-parameter-store) as an
       environment variable of type **ValueFrom** (the console's "Secrets" mechanism): the
       env-var name exactly as `Settings` expects (`NGED_S3_BUCKET_URL`,
       `NGED_S3_BUCKET_ACCESS_KEY`, `NGED_S3_BUCKET_SECRET`), the value the matching parameter
       name (e.g. `/nged-forecast/nged-s3-bucket-url`).
 
-## Step 9 — Verify: run the task manually
+## Step 8 — Verify: run the task manually
 
 There's no schedule yet, so trigger one task directly and confirm the whole path end-to-end —
 this mirrors the "manual `RunTask`" verification the roadmap's
@@ -273,6 +214,6 @@ since `power_forecasts` is one of the five NGED-facing tables (see
 - [Running live forecasts end-to-end](dagster-workflow.md) — driving the promoted model day to
   day once it's live, and backfilling missed slots.
 - [Environment & storage setup](setup.md) — where data tables and local artifacts live, and the
-  S3 bucket + IAM policy Steps 4–9 above build on.
+  S3 bucket + IAM policy Steps 3–8 above build on.
 - [Live service: AWS architecture](../roadmap/live-service.md#aws-architecture) — the always-on
   control-plane box, scheduling, and infra-as-code, still to come.

--- a/docs/live_service/deployment.md
+++ b/docs/live_service/deployment.md
@@ -22,24 +22,46 @@ image build below `COPY`s from.
 
 ## Step 2 — Build the image
 
+This step and [Step 3](#step-3-verify-the-build-locally) are wrapped in one script — with a
+champion model on disk (Step 1), it builds the image and smoke-tests it in a single command:
+
+```bash
+scripts/build_and_verify_image.sh <partition-key>   # e.g. 2026-07-04-00:00
+```
+
+The `<partition-key>` is only used by the Step 3 smoke test; any recent 6-hourly key works (see
+[the partition-semantics note](dagster-workflow.md#step-3-let-the-schedule-run-or-materialise-live_forecasts-by-hand)).
+The script hard-fails only if the runtime touches MLflow — the one hermeticity guarantee worth
+automating — and prints the container log for you to confirm the rest by eye (see Step 3). The
+remainder of this step and Step 3 explain what it does and why, and give the raw commands if you
+would rather run them by hand.
+
 The build never contacts MLflow — it only `COPY`s the directory Step 1 just populated, so it
 stays hermetic:
 
 ```bash
+RUN_ID=$(jq -r .mlflow_run_id data/production_model/promotion.json)
 docker build \
-  --build-arg MODEL_RUN_ID=<run-id> \
+  --build-arg MODEL_RUN_ID="$RUN_ID" \
   --build-arg GIT_SHA=$(git rev-parse HEAD) \
-  -t nged-forecast:<run-id-short> .
+  -t nged-forecast:"${RUN_ID:0:12}" .
 ```
+
+The run id comes from the directory the build `COPY`s from: Step 1 recorded it in
+`data/production_model/promotion.json` as `mlflow_run_id` (the same value you entered as
+`PromotedModelConfig.mlflow_run_id` when materialising `promoted_model`). Reading it back from
+that file — rather than pasting it — guarantees the label matches the model actually baked in.
+The image tag is just its first 12 hex characters, enough to be unique and human-readable.
 
 `MODEL_RUN_ID` and `GIT_SHA` are stamped as OCI labels (and `GIT_SHA` also as a runtime env
 var) purely for traceability — confirm with `docker inspect nged-forecast:<tag>`.
 
 ## Step 3 — Verify the build locally
 
-Before trusting a new image, confirm it actually runs with **zero network access** — this is
-the test that matters, since the entire point of baking the model in is that production
-inference has no MLflow dependency at runtime:
+The [Step 2](#step-2-build-the-image) script already runs this verification; do it by hand only
+when running the raw commands. Before trusting a new image, confirm it actually runs with **zero
+network access** — this is the test that matters, since the entire point of baking the model in
+is that production inference has no MLflow dependency at runtime:
 
 ```bash
 docker run --network=none \
@@ -87,8 +109,8 @@ in [Environment & storage setup: Step 1](setup.md#step-1-create-the-s3-buckets))
 2. **Name** `nged-forecast` (matches the local image tag used in [Step 2](#step-2-build-the-image)
    above — keeps `docker build -t nged-forecast:<tag>` and the ECR URI consistent).
 3. **Scan on push** on — free vulnerability scanning, no reason not to.
-4. Leave tag immutability off; image tags here are already unique per `git rev-parse HEAD`
-   short-SHA, so nothing relies on retagging.
+4. Leave tag immutability off; image tags here are already unique per promoted model (the
+   run id's short prefix from [Step 2](#step-2-build-the-image)), so nothing relies on retagging.
 
 ## Step 5 — Push the image to ECR
 

--- a/docs/live_service/deployment.md
+++ b/docs/live_service/deployment.md
@@ -30,10 +30,16 @@ that production inference has no MLflow dependency at runtime:
 scripts/build_and_verify_image.sh <partition-key>   # e.g. 2026-07-04-00:00
 ```
 
-The `<partition-key>` is any recent 6-hourly key (see
-[the partition-semantics note](dagster-workflow.md#step-3-let-the-schedule-run-or-materialise-live_forecasts-by-hand));
-it only drives the smoke test's one-shot run. The script builds the image tagged with the
-promoted model's run id, runs it offline, and prints the container log with a pass/fail summary.
+The `<partition-key>` only has to be **well-formed** (`YYYY-MM-DD-HH:MM`, e.g. `2026-07-04-00:00`);
+it need not name a partition that already exists. The smoke test fails at the NWP lookup long
+before the slot's validity could matter, so any correctly-formatted key works — off-cadence or
+out-of-range is fine, and only a malformed key fails (fast, with a clear `time data … does not
+match format` error). If you would rather pass a genuine slot: real slots are the 6-hourly
+boundaries at 00:00/06:00/12:00/18:00 UTC from the partition's start date onward; browse the exact
+list under the `live_forecasts` asset in the Dagster UI (see also
+[the partition-semantics note](dagster-workflow.md#step-3-let-the-schedule-run-or-materialise-live_forecasts-by-hand)).
+The script builds the image tagged with the promoted model's run id, runs it offline, and prints
+the container log with a pass/fail summary.
 It hard-fails only if the runtime touches MLflow — the hermeticity guarantee worth automating —
 and otherwise asks you to confirm by eye that the run loaded the model and failed *only* on
 missing NWP data (expected: no data tables are mounted for this isolated test). The script header

--- a/docs/live_service/setup.md
+++ b/docs/live_service/setup.md
@@ -205,7 +205,7 @@ Then attach it to **whichever identity runs the code**:
 - **Compute running on AWS** (an EC2 box or Fargate task) → attach the policy to that resource's
   **IAM role**. Nothing else is needed: `object_store` (used by `delta-rs`) auto-discovers the role's temporary
   credentials and region at runtime, so you leave all four `DATA_STORE_*` settings **empty**. See
-  [Deploying a new production image: Step 6](deployment.md#step-6-iam-roles-for-the-task) for the
+  [Deploying a new production image: Step 5](deployment.md#step-5-iam-roles-for-the-task) for the
   concrete console steps for that role.
 - **Your laptop, running the pipeline** — **not set up yet, deliberately**: for now, only AWS
   compute gets write access, so there's exactly one writer touching the buckets at a time. Running
@@ -285,7 +285,7 @@ DATA_PATH_DELIVERY=s3://nged-forecast-delivery/data
 file, so they are set as plain **environment variables on the container in the ECS task
 definition** — not secrets, since bucket URIs are safe to store in clear text (unlike the NGED
 source credentials, which are injected from Parameter Store). [Deploying a new production image:
-Step 8](deployment.md#step-8-create-the-ecs-cluster-and-fargate-task-definition) shows exactly where
+Step 7](deployment.md#step-7-create-the-ecs-cluster-and-fargate-task-definition) shows exactly where
 in the console. On an EC2 box running the code directly, use the same repo-root `.env` file as the
 laptop case below instead. Either way [`Settings`](#the-configuration-model) reads them identically
 — an environment variable and a `.env` line are interchangeable, and an environment variable wins if

--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -558,8 +558,8 @@ dress rehearsal above.
 > **Status: partially done.** The pieces common to every architecture option — ECR, IAM task
 > roles, and a Fargate task definition, all set up by hand in the AWS console, plus a manual
 > `RunTask` to verify the whole path end-to-end — are ✅ implemented; see
-> [Deploying a new production image](https://openclimatefix.github.io/nged-substation-forecast/live_service/deployment/#step-4-create-the-ecr-repository)
-> (steps 4–8). The accepted option's specific pieces below (the always-on EC2 box,
+> [Deploying a new production image](https://openclimatefix.github.io/nged-substation-forecast/live_service/deployment/#step-3-create-the-ecr-repository)
+> (steps 3–8). The accepted option's specific pieces below (the always-on EC2 box,
 > `EcsRunLauncher`, scheduling) and infra-as-code are still 🚧, tracked as follow-up work.
 
 Common to all options:
@@ -573,7 +573,7 @@ Common to all options:
 - ✅ **IAM roles**: turned out to be **two** roles, not one — a task *execution* role
   (`AmazonECSTaskExecutionRolePolicy`: ECR pull + CloudWatch Logs) and a task role (the S3
   read/write policy from `setup.md`) — see
-  [Deploying a new production image: Step 6](https://openclimatefix.github.io/nged-substation-forecast/live_service/deployment/#step-6-iam-roles-for-the-task)
+  [Deploying a new production image: Step 5](https://openclimatefix.github.io/nged-substation-forecast/live_service/deployment/#step-5-iam-roles-for-the-task)
   for why they're split. No static AWS keys anywhere.
 - ✅ **Fargate task definition**: 4 vCPU / 16 GB ARM for live runs (measured inference peak
   ~9 GB). 🚧 A bigger (e.g. 8 vCPU / 32 GB) definition for backtests is not yet built.

--- a/scripts/build_and_verify_image.sh
+++ b/scripts/build_and_verify_image.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+#
+# Build the production image and smoke-test it with zero network access.
+#
+# This is Steps 2-3 of the deployment runbook rolled into one command. The runbook explains the
+# *why* behind every choice made here — dummy-but-present NGED creds, --network=none, selecting
+# the job with -j rather than a --partition flag — and is the source of truth:
+#   docs/live_service/deployment.md
+#
+# Usage:
+#   scripts/build_and_verify_image.sh <partition-key>
+#   e.g. scripts/build_and_verify_image.sh 2026-07-04-00:00
+#
+# What it gates on, and what it does not:
+#   - HARD FAIL (exit 1) if the runtime touches MLflow. Baking the model in exists precisely so
+#     production inference has no MLflow dependency at runtime; a single "mlflow" mention in the
+#     log means that guarantee has regressed. This is the one check worth automating, because a
+#     reintroduced runtime MLflow call is easy to miss by eye.
+#   - NOT gated: "the model loaded" and "the only failure was missing NWP data". The container is
+#     EXPECTED to exit non-zero here — no NWP table is mounted for this isolated test, so it fails
+#     at the NWP-availability lookup, which runs *after* the model has already loaded. That
+#     ordering is the proof the model loaded; there is no reliable log string to grep for it. Read
+#     the printed log and confirm by eye, per deployment.md Step 3.
+
+set -euo pipefail
+
+PARTITION_KEY="${1:-}"
+if [[ -z "$PARTITION_KEY" ]]; then
+  echo "usage: $0 <partition-key>   e.g. $0 2026-07-04-00:00" >&2
+  exit 2
+fi
+
+PROMOTION_JSON="data/production_model/promotion.json"
+if [[ ! -f "$PROMOTION_JSON" ]]; then
+  echo "error: $PROMOTION_JSON not found — materialise the promoted_model asset first" >&2
+  echo "       (deployment.md Step 1), so the model this build bakes in exists on disk." >&2
+  exit 2
+fi
+
+# The run id is read from the directory the build COPYs from, so the OCI label can never drift
+# from the model actually baked in. The image tag is its first 12 hex chars — unique per promoted
+# model and human-readable.
+RUN_ID="$(jq -r .mlflow_run_id "$PROMOTION_JSON")"
+IMAGE="nged-forecast:${RUN_ID:0:12}"
+
+echo "==> Building ${IMAGE}  (MODEL_RUN_ID=${RUN_ID})"
+docker build \
+  --build-arg MODEL_RUN_ID="$RUN_ID" \
+  --build-arg GIT_SHA="$(git rev-parse HEAD)" \
+  -t "$IMAGE" .
+
+echo
+echo "==> Smoke-testing ${IMAGE} with zero network access (partition ${PARTITION_KEY})"
+# Dummy NGED creds: Settings requires them at import, but they need only be PRESENT — never real,
+# never reachable. --network=none proves runtime inference needs no network at all.
+LOG_FILE="$(mktemp)"
+trap 'rm -f "$LOG_FILE"' EXIT
+set +e
+docker run --network=none \
+  -e NGED_S3_BUCKET_URL=https://example.com/outbound/ \
+  -e NGED_S3_BUCKET_ACCESS_KEY=dummy \
+  -e NGED_S3_BUCKET_SECRET=dummy \
+  "$IMAGE" \
+  job execute -m nged_substation_forecast.definitions -j live_forecasts_job \
+  --tags "{\"dagster/partition\": \"${PARTITION_KEY}\"}" \
+  >"$LOG_FILE" 2>&1
+RUN_EXIT=$?
+set -e
+
+echo "----- container log (exit ${RUN_EXIT}) ----------------------------------------------"
+cat "$LOG_FILE"
+echo "-------------------------------------------------------------------------------------"
+echo
+
+# The one automated gate: hermeticity. Any real runtime MLflow use imports the `mlflow` package,
+# so a broken build surfaces the literal string somewhere in the log (import error, log line, or
+# traceback). A case-insensitive match is therefore a sound, low-rot signal.
+if grep -qi "mlflow" "$LOG_FILE"; then
+  echo "  [FAIL] MLflow appears in the runtime log — the image is NOT hermetic." >&2
+  echo "         Runtime inference must not depend on MLflow. Grep the log above for 'mlflow'." >&2
+  exit 1
+fi
+echo "  [PASS] zero MLflow mentions — runtime is hermetic."
+echo
+echo "  Confirm by eye (deployment.md Step 3) that the log above shows:"
+echo "    - the model loading, then failing ONLY at the NWP-availability lookup, and"
+echo "    - missing NWP data (no DATA_PATH_INTERNAL mounted) as the sole cause — nothing else."
+echo "  A non-zero container exit (${RUN_EXIT}) is EXPECTED here; a zero exit would be suspicious."
+echo
+echo "==> ${IMAGE} passed the automated hermeticity check. Push it with deployment.md Step 5."

--- a/scripts/build_and_verify_image.sh
+++ b/scripts/build_and_verify_image.sh
@@ -2,14 +2,30 @@
 #
 # Build the production image and smoke-test it with zero network access.
 #
-# This is Steps 2-3 of the deployment runbook rolled into one command. The runbook explains the
-# *why* behind every choice made here — dummy-but-present NGED creds, --network=none, selecting
-# the job with -j rather than a --partition flag — and is the source of truth:
-#   docs/live_service/deployment.md
+# This is Step 2 of the deployment runbook (docs/live_service/deployment.md) as one command:
+# build the image with the champion model baked in, then prove it runs hermetically. This header
+# is the source of truth for *why* each choice below is made.
 #
 # Usage:
 #   scripts/build_and_verify_image.sh <partition-key>
 #   e.g. scripts/build_and_verify_image.sh 2026-07-04-00:00
+#
+# The build never contacts MLflow — it only COPYs data/production_model/ (populated by Step 1's
+# `promoted_model` asset) into the image, so it stays hermetic. The MODEL_RUN_ID and GIT_SHA
+# build args become OCI labels purely for traceability (inspect with `docker inspect`).
+#
+# The smoke test choices:
+#   - Dummy NGED creds: `Settings` requires NGED_S3_BUCKET_* at import (several modules
+#     instantiate Settings() at import time), so the code location fails to import without them.
+#     They must be PRESENT but need not be real or reachable — passing dummies proves the image
+#     needs only their *presence* at import, never valid credentials and never the network. The
+#     deployed task gets the real values as secrets (runbook Step 6).
+#   - --network=none: proves runtime inference needs no network at all — the whole point of
+#     baking the model in.
+#   - Job selected with `-j live_forecasts_job`, not `--partition`: `dagster job execute` has no
+#     --partition flag, and `dagster asset materialize --select` hits an unrelated antlr4 / Python
+#     3.14 incompatibility in Dagster's own asset-selection parser. Selecting by job name and
+#     passing the partition via --tags skips that parser entirely.
 #
 # What it gates on, and what it does not:
 #   - HARD FAIL (exit 1) if the runtime touches MLflow. Baking the model in exists precisely so
@@ -20,7 +36,7 @@
 #     EXPECTED to exit non-zero here — no NWP table is mounted for this isolated test, so it fails
 #     at the NWP-availability lookup, which runs *after* the model has already loaded. That
 #     ordering is the proof the model loaded; there is no reliable log string to grep for it. Read
-#     the printed log and confirm by eye, per deployment.md Step 3.
+#     the printed log and confirm by eye.
 
 set -euo pipefail
 
@@ -82,9 +98,9 @@ if grep -qi "mlflow" "$LOG_FILE"; then
 fi
 echo "  [PASS] zero MLflow mentions — runtime is hermetic."
 echo
-echo "  Confirm by eye (deployment.md Step 3) that the log above shows:"
+echo "  Confirm by eye that the log above shows:"
 echo "    - the model loading, then failing ONLY at the NWP-availability lookup, and"
 echo "    - missing NWP data (no DATA_PATH_INTERNAL mounted) as the sole cause — nothing else."
 echo "  A non-zero container exit (${RUN_EXIT}) is EXPECTED here; a zero exit would be suspicious."
 echo
-echo "==> ${IMAGE} passed the automated hermeticity check. Push it with deployment.md Step 5."
+echo "==> ${IMAGE} passed the automated hermeticity check. Push it with the runbook's next step."

--- a/scripts/build_and_verify_image.sh
+++ b/scripts/build_and_verify_image.sh
@@ -10,6 +10,12 @@
 #   scripts/build_and_verify_image.sh <partition-key>
 #   e.g. scripts/build_and_verify_image.sh 2026-07-04-00:00
 #
+# <partition-key> only has to PARSE as YYYY-MM-DD-HH:MM; it need not name a partition that exists.
+# The smoke test dies at the NWP lookup long before the slot matters, so off-cadence / out-of-range
+# keys work fine and only a malformed key fails (fast, with a clear "time data ... does not match
+# format" error). Real slots — for a genuine run — are the 6-hourly UTC boundaries from the
+# `live_forecasts` partition start onward, browsable in the Dagster UI.
+#
 # The build never contacts MLflow — it only COPYs data/production_model/ (populated by Step 1's
 # `promoted_model` asset) into the image, so it stays hermetic. The MODEL_RUN_ID and GIT_SHA
 # build args become OCI labels purely for traceability (inspect with `docker inspect`).


### PR DESCRIPTION
## What

The production-image runbook's build + local-verify path is now a single command backed by [`scripts/build_and_verify_image.sh`](https://github.com/openclimatefix/nged-substation-forecast/blob/docs/deployment-build-verify-script/scripts/build_and_verify_image.sh):

```bash
scripts/build_and_verify_image.sh <partition-key>
```

The former Steps 2 (build) and 3 (verify) in `docs/live_service/deployment.md` collapse into one lean **Step 2 — Build and verify the image**. The raw `docker build` / `docker run` snippets are gone from the page — the script is the source of truth for the exact commands, and the rationale that justified them (dummy-but-present NGED creds, `--network=none`, `-j` not `--partition`, run-id provenance) lives in the script's header comment so nothing is lost.

## Design notes

- **Run id read from `promotion.json`, not pasted.** The script reads `mlflow_run_id` from `data/production_model/promotion.json` — the directory the build `COPY`s from — so the `MODEL_RUN_ID` OCI label can never drift from the model actually baked in. The image tag is that id's first 12 hex chars.
- **Gates on exactly one thing: hermeticity.** Hard-fails (exit 1) only if `mlflow` appears anywhere in the runtime log — the guarantee baking the model in exists to protect, and the regression easiest to miss by eye.
- **Everything else stays a human read.** The container is *expected* to exit non-zero here: with no NWP table mounted it fails at the NWP-availability lookup, which runs *after* the model loads. That ordering is the proof the model loaded — there's no reliable log string to grep for it — so the script prints the full log and a checklist rather than faking a PASS.

## Also

- Fixes a stale justification in the ECR step: image tags are unique per promoted model (the run id's short prefix), not per `git rev-parse HEAD` short-SHA.
- Renumbers the AWS steps that followed (old 4–9 → 3–8) and retargets every cross-reference, including inbound links from `setup.md` and `roadmap/live-service.md`.

## Verification

Ran `scripts/build_and_verify_image.sh 2026-07-13-00:00` end-to-end: build succeeds, the `--network=none` smoke test fails only at `_available_nwp_init_times` with `TableNotFoundError` for the NWP path, zero `mlflow` mentions, script exits 0. `mkdocs build --strict` exits 0; `pymarkdown` clean; script syntax ok.

🤖 Generated with [Claude Code](https://claude.com/claude-code)