### PR TITLE
docs(nav): collapse nav sections by default on desktop

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "mkdocs",
+      "runtimeExecutable": "uv",
+      "runtimeArgs": ["run", "mkdocs", "serve", "-a", "127.0.0.1:8765"],
+      "port": 8765
+    }
+  ]
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,8 +2,6 @@ site_name: NGED Substation Forecast
 theme:
   name: material
   features:
-    - navigation.sections
-    - navigation.expand
     - content.code.copy
 
 markdown_extensions:


### PR DESCRIPTION
## Problem

On desktop, the docs sidebar rendered every section fully expanded as one long flat list, making top-level section headings hard to distinguish from page links (they differed only by grey colour and font weight).

## Root cause

The `navigation.sections` Material theme feature converts each top-level nav group into a *static section* on viewports ≥ 1220px: a grey, non-interactive heading whose children are always rendered visible, regardless of toggle state. (`navigation.expand` was a red herring — it only affects collapsible items, of which a two-level nav has none while `navigation.sections` is active.)

## Fix

Remove both `navigation.sections` and `navigation.expand`, restoring Material's default sidebar: only the top-level entries are shown, each collapsed by default and expandable with a click — matching how the mobile drawer already behaved.

Verified against a live `mkdocs serve`: the served HTML contains no `md-nav__item--section` items, and the rendered sidebar shows the nine top-level entries collapsed, expanding correctly on click. `mkdocs build --strict` passes.

Also adds `.claude/launch.json` so Claude Code sessions can launch the mkdocs preview server with one call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)