### PR TITLE
docs(live-service): update ECR Step 5 to match current AWS console

### DIFF
--- a/docs/live_service/aws.md
+++ b/docs/live_service/aws.md
@@ -176,16 +176,31 @@ documents every choice it makes and is the source of truth for the mechanics.
 ECR (Elastic Container Registry) is AWS's private Docker-image store — where the image just built
 gets pushed so AWS compute can pull it. In the [AWS
 console](https://eu-west-2.console.aws.amazon.com) →
-**[ECR](https://eu-west-2.console.aws.amazon.com/ecr)** → **Create repository** (same `eu-west-2`
-region as the S3 buckets in [Step 1](#step-1-create-the-s3-buckets)):
+**[ECR](https://eu-west-2.console.aws.amazon.com/ecr)** → **Create repository** → private (same
+`eu-west-2` region as the S3 buckets in [Step 1](#step-1-create-the-s3-buckets)):
 
-1. **Visibility** Private.
-2. **Name** `nged-forecast` (matches the local image tag `nged-forecast:<tag>` from
-   [Step 4](#step-4-build-and-verify-the-image), keeping it and the ECR URI consistent).
-3. **Scan on push** on — free vulnerability scanning, no reason not to.
-4. Leave tag immutability off; image tags here are already unique per promoted model (the
-   run id's short prefix from [Step 4](#step-4-build-and-verify-the-image)), so nothing relies
-   on retagging.
+1. **Repository name**: `nged-forecast`, with **no namespace prefix**. The scripts hard-code this
+   exact flat name — `scripts/push_and_deploy_image.sh` derives the remote URI as
+   `<account-id>.dkr.ecr.eu-west-2.amazonaws.com/nged-forecast:<tag>` — and it matches the local
+   image tag `nged-forecast:<tag>` from [Step 4](#step-4-build-and-verify-the-image). A namespace
+   is only an optional `prefix/` for grouping many repositories; adding one would break that
+   derived URI.
+2. **Image tag mutability**: leave at **Mutable** (the default), and leave **Mutable tag
+   exclusions** empty. Image tags here are already unique per promoted model (the run id's short
+   prefix from [Step 4](#step-4-build-and-verify-the-image)), so nothing relies on retagging —
+   but nothing needs immutability enforced, either.
+3. **Encryption settings**: leave at **AES-256** (the default). The console warns this can't be
+   changed after creation, which is fine — the app has no KMS requirement, for the same reason
+   the S3 buckets in [Step 1](#step-1-create-the-s3-buckets) stay on SSE-S3.
+4. **Image scanning settings**: leave the **Scan on push** toggle **off**. The console marks this
+   per-repository setting deprecated — scanning is now configured once at the *registry* level,
+   which is done right after creating the repository (next step below).
+5. Click **Create**, then turn on registry-level scanning so every push still gets free
+   vulnerability scanning: **ECR** → **Private registry** → **Settings** → **Scanning
+   configuration** → keep the scan type at **Basic** (free; **Enhanced** hands scanning to Amazon
+   Inspector, which costs money) → add a **scan on push** filter of `*` (or `nged-forecast`).
+   This is a one-time registry setting, so it also covers any repository created later under a
+   matching filter.
 
 ## Step 6 — Push the image to ECR
 

--- a/docs/live_service/aws.md
+++ b/docs/live_service/aws.md
@@ -179,28 +179,29 @@ console](https://eu-west-2.console.aws.amazon.com) →
 **[ECR](https://eu-west-2.console.aws.amazon.com/ecr)** → **Create repository** → private (same
 `eu-west-2` region as the S3 buckets in [Step 1](#step-1-create-the-s3-buckets)):
 
-1. **Repository name**: `nged-forecast`, with **no namespace prefix**. The scripts hard-code this
-   exact flat name — `scripts/push_and_deploy_image.sh` derives the remote URI as
-   `<account-id>.dkr.ecr.eu-west-2.amazonaws.com/nged-forecast:<tag>` — and it matches the local
-   image tag `nged-forecast:<tag>` from [Step 4](#step-4-build-and-verify-the-image). A namespace
-   is only an optional `prefix/` for grouping many repositories; adding one would break that
-   derived URI.
-2. **Image tag mutability**: leave at **Mutable** (the default), and leave **Mutable tag
-   exclusions** empty. Image tags here are already unique per promoted model (the run id's short
-   prefix from [Step 4](#step-4-build-and-verify-the-image)), so nothing relies on retagging —
-   but nothing needs immutability enforced, either.
-3. **Encryption settings**: leave at **AES-256** (the default). The console warns this can't be
-   changed after creation, which is fine — the app has no KMS requirement, for the same reason
-   the S3 buckets in [Step 1](#step-1-create-the-s3-buckets) stay on SSE-S3.
-4. **Image scanning settings**: leave the **Scan on push** toggle **off**. The console marks this
-   per-repository setting deprecated — scanning is now configured once at the *registry* level,
-   which is done right after creating the repository (next step below).
-5. Click **Create**, then turn on registry-level scanning so every push still gets free
-   vulnerability scanning: **ECR** → **Private registry** → **Settings** → **Scanning
-   configuration** → keep the scan type at **Basic** (free; **Enhanced** hands scanning to Amazon
-   Inspector, which costs money) → add a **scan on push** filter of `*` (or `nged-forecast`).
-   This is a one-time registry setting, so it also covers any repository created later under a
-   matching filter.
+- **Repository name**: `nged-forecast`, with **no namespace prefix**. The scripts hard-code this
+  exact flat name — `scripts/push_and_deploy_image.sh` derives the remote URI as
+  `<account-id>.dkr.ecr.eu-west-2.amazonaws.com/nged-forecast:<tag>` — and it matches the local
+  image tag `nged-forecast:<tag>` from [Step 4](#step-4-build-and-verify-the-image). A namespace
+  is only an optional `prefix/` for grouping many repositories; adding one would break that
+  derived URI.
+- **Every other setting on the create-repository form can stay at its console default:**
+    - **Image tag mutability** (Mutable) and **Mutable tag exclusions** (empty) — image tags here
+      are already unique per promoted model (the run id's short prefix from
+      [Step 4](#step-4-build-and-verify-the-image)), so nothing relies on retagging — but nothing
+      needs immutability enforced, either.
+    - **Encryption settings** (AES-256) — the console warns this can't be changed after creation,
+      which is fine: the app has no KMS requirement, for the same reason the S3 buckets in
+      [Step 1](#step-1-create-the-s3-buckets) stay on SSE-S3.
+    - **Scan on push** (off) — the console marks this per-repository setting deprecated; scanning
+      is now configured once at the *registry* level, which is done right after creating the
+      repository (next bullet).
+- Click **Create**, then turn on registry-level scanning so every push still gets free
+  vulnerability scanning: **ECR** → **Private registry** → **Settings** → **Scanning
+  configuration** → keep the scan type at **Basic** (free; **Enhanced** hands scanning to Amazon
+  Inspector, which costs money) → add a **scan on push** filter of `*` (or `nged-forecast`).
+  This is a one-time registry setting, so it also covers any repository created later under a
+  matching filter.
 
 ## Step 6 — Push the image to ECR
 

--- a/docs/live_service/aws.md
+++ b/docs/live_service/aws.md
@@ -196,12 +196,13 @@ console](https://eu-west-2.console.aws.amazon.com) →
     - **Scan on push** (off) — the console marks this per-repository setting deprecated; scanning
       is now configured once at the *registry* level, which is done right after creating the
       repository (next bullet).
-- Click **Create**, then turn on registry-level scanning so every push still gets free
-  vulnerability scanning: **ECR** → **Private registry** → **Settings** → **Scanning
-  configuration** → keep the scan type at **Basic** (free; **Enhanced** hands scanning to Amazon
-  Inspector, which costs money) → add a **scan on push** filter of `*` (or `nged-forecast`).
-  This is a one-time registry setting, so it also covers any repository created later under a
-  matching filter.
+- Click **Create**, then turn on registry-level scanning so every push still gets free vulnerability
+  scanning: **ECR** → **Private registry** → **Features & Settings** → [**Scanning** →
+  **configure**](https://eu-west-2.console.aws.amazon.com/ecr/private-registry/edit-scanning) → keep
+  the scan type at **Basic** ("basic" is free; Enhanced hands scanning to Amazon Inspector, which
+  costs money) → either check the **Scan on push all repositories** check box _or_ add a filter of
+  `nged-forecast`. This is a one-time registry setting, so it also covers any repository created
+  later under a matching filter.
 
 ## Step 6 — Push the image to ECR
 


### PR DESCRIPTION
## What

Updates [Setting up the live service on AWS — Step 5](https://openclimatefix.github.io/nged-substation-forecast/live_service/aws/#step-5-create-the-ecr-repository) to match the current AWS console's create-repository form, which has changed since the step was written.

## Why

Walking through the runbook today, the form no longer matches the doc:

- The per-repository **Scan on push** toggle is now marked **deprecated** in the console — scanning moved to a single registry-level configuration. The doc said to turn the toggle on.
- The form now surfaces settings the doc didn't mention (**Mutable tag exclusions**, **Encryption settings**), and it wasn't explicit that the repository name must be the flat `nged-forecast` with no namespace prefix — `scripts/push_and_deploy_image.sh` hard-codes that exact name when deriving the remote image URI.

## Changes

- Name step now explains the no-namespace requirement and why (the script's derived URI).
- Each remaining form setting gets an explicit instruction: tag mutability **Mutable** (default), exclusions empty, encryption **AES-256** (default, mirroring the SSE-S3 reasoning from Step 1).
- The deprecated per-repo scan toggle is left **off**; a new final point sets up the replacement — registry-level **Basic** scanning with a scan-on-push filter — keeping the original intent (free vulnerability scanning on every push).

🤖 Generated with [Claude Code](https://claude.com/claude-code)