### PR TITLE
docs: explain ECS/Fargate in AWS Step 9; restructure the production-deployment design doc

### DIFF
--- a/docs/architecture/forecast-delivery.md
+++ b/docs/architecture/forecast-delivery.md
@@ -355,7 +355,12 @@ Choosing Delta Lake over a bespoke REST API removes an entire service from the p
 - no authentication microservice or token lifecycle to manage;
 - no client SDK for NGED to install and for us to maintain;
 - availability is S3's SLA, not something we are on call for: The on-call engineer _only_ has to
-  check the forecast has run at 00, 06, 12, and 18 hours. They aren't _constantly_ on call.
+  check the forecast has run at 00, 06, 12, and 18 hours. They aren't _constantly_ on call;
+- no maintenance windows to negotiate with NGED: because NGED reads forecasts from S3 rather
+  than from any OCF-run service, and new forecasts land only every 6 hours, the gap between one
+  forecast run and the next is a built-in maintenance window — OCF compute can be stopped,
+  patched, or rebuilt between runs without interrupting NGED's reads (see
+  [Requirements → Uptime: lenient by design](../background/requirements.md#uptime-lenient-by-design)).
 
 For a small team whose mission is forecast quality, that's a lot of engineering effort we get
 to spend on the forecasts themselves instead.

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -260,6 +260,16 @@ the model post-NIA and release new container images for NGED to test, but that a
 TBD — and either way it only changes which *image* NGED runs, never whether their production
 runtime needs MLflow.)
 
+Rejecting this design says nothing against MLflow itself — MLflow remains the backbone of ML
+experimentation: training runs log their models, configs, and metrics to it, and the champion
+is *chosen* from an MLflow leaderboard (see
+[ML orchestration: model artifacts](ml-orchestration.md#model-artifacts-mlflow-artifact-store-immutable-local-cache)
+for the design, and [ML experimentation](../ml_experimentation/index.md) for the day-to-day
+workflow). The boundary this rejection draws is between ML R&D and production: research uses
+MLflow constantly, while production's hot path never touches it. MLflow's job ends at the
+moment of promotion, when the chosen champion is copied out of the tracking store and baked
+into the image.
+
 The idea may still return in a stronger form: the **future work** note at the end of
 [Bake the model into the image at build time](#bake-the-model-into-the-image-at-build-time) —
 the section describing the accepted design this one lost to — describes fetching the champion

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -23,7 +23,10 @@ that only a daemon can: schedules, sensors, run monitoring, and declarative auto
 The design accepts two trade-offs:
 
 - **Single point of failure.** The daemon on one VM has no managed scheduler watching it; a
-  quiet box failure could silently miss slots. Mitigation: the
+  quiet box failure could silently miss slots. The blast radius is small, because the project's
+  [uptime requirements are lenient by design](../background/requirements.md#uptime-lenient-by-design):
+  previously published forecasts stay readable from S3 and extend 14 days ahead, so a missed
+  slot degrades forecast freshness rather than cutting NGED off. Mitigation: the
   [missed-check-in alarm](../roadmap/live-service.md#alert-on-absence-the-missed-check-in-alarm)
   — each successful 6-hourly run checks in with an external monitoring service (Sentry cron
   monitoring is the planned mechanism), and an alert fires when an expected check-in fails to

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -36,6 +36,14 @@ The design accepts two trade-offs:
 - **No run-level auto-retry after a hard crash.** Accepted; covered by the existing
   replay/backfill mode for missed slots plus the missed-check-in alarm.
 
+"Always-on" is also less demanding than it sounds, because the box comes with **built-in
+maintenance windows**: forecasts are produced only every 6 hours, and NGED reads published
+forecasts directly from S3 (see [Forecast Delivery](forecast-delivery.md)), so the gap between
+one forecast run and the next is a regular window in which the VM can be stopped, patched, or
+rebuilt without NGED noticing — and even an overrun costs only a single slot, recoverable via
+replay-mode backfill. See
+[Requirements → Uptime: lenient by design](../background/requirements.md#uptime-lenient-by-design).
+
 Several other orchestration shapes were considered and rejected — see
 [Considered but rejected designs](#considered-but-rejected-designs).
 

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -201,7 +201,7 @@ Postgres — as a long-running ECS service on Fargate, instead of on an EC2 VM. 
 real: Fargate has no operating system for us to install or patch (AWS owns and maintains the
 hosts), so the one piece of self-maintained OS in the deployment would disappear.
 
-**Why we rejected it.** Four reasons:
+**Why we rejected it.** Five reasons:
 
 1. **Fargate's premium pays off exactly where this workload can't use it.** Fargate's
    per-second billing wins for compute that runs a few minutes per day — which is why the
@@ -211,13 +211,22 @@ hosts), so the one piece of self-maintained OS in the deployment would disappear
    Fargate and EC2 rates in the
    [region price table](forecast-delivery.md#securing-it)).
 
-2. **Postgres needs a disk that Fargate doesn't have.** A Fargate task has no persistent local
+2. **The box is planned to host more than the control plane.** The same VM is the intended
+   home of the MLflow tracking server and the Marimo dashboard — which is why the
+   [EventBridge rejection](#no-control-plane-eventbridge-scheduler-launching-ecs-tasks) counts
+   the VM as a cost that exists anyway. A VM absorbs each additional long-running service as
+   one more entry in the same `docker-compose.yml`, using headroom already paid for; as Fargate
+   services, each would be its own always-on task paying the premium above over again — and
+   MLflow brings its own persistence needs (its backend store and artifact root), running into
+   the disk problem below a second time.
+
+3. **Postgres needs a disk that Fargate doesn't have.** A Fargate task has no persistent local
    storage, so the Postgres container (run, event, and schedule history) could not come along.
    It would have to move to managed RDS — more cost, and one more AWS-specific service to
    recreate at handover — or onto EFS, a network filesystem that Postgres tolerates poorly. On
    the VM, Postgres's data is simply a Docker volume on the instance's own disk.
 
-3. **It trades a portable artifact for AWS-specific glue.** The control plane's deployment
+4. **It trades a portable artifact for AWS-specific glue.** The control plane's deployment
    description *is* its `docker-compose.yml`: the laptop and the cloud run the same artifact.
    As an ECS service, that description becomes task definitions, service configuration, and
    (per the previous point) RDS — the same AWS coupling that helped reject the
@@ -226,7 +235,7 @@ hosts), so the one piece of self-maintained OS in the deployment would disappear
    version of the same friction: on the VM, joining the tailnet is one `tailscale up`, whereas
    a Fargate service needs a Tailscale sidecar container with its own state management.
 
-4. **The benefit is smaller than it looks.** The OS burden Fargate would remove is one Ubuntu
+5. **The benefit is smaller than it looks.** The OS burden Fargate would remove is one Ubuntu
    box that patches itself (`unattended-upgrades`), can be stopped for maintenance in any of
    the built-in 6-hourly maintenance windows
    ([above](#run-the-dagster-control-plane-continuously-on-one-small-vm)), and is slated for a

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -194,6 +194,46 @@ would fire any 6-hourly ticks missed while it slept.
 the web UI would be unavailable most of the time; and something else would still need to
 reliably wake the daemon — which reintroduces the scheduling problem one level up.
 
+### An always-on Fargate service for the control plane
+
+**The design.** Run the always-on control plane — daemon, webserver, code-location server, and
+Postgres — as a long-running ECS service on Fargate, instead of on an EC2 VM. The appeal is
+real: Fargate has no operating system for us to install or patch (AWS owns and maintains the
+hosts), so the one piece of self-maintained OS in the deployment would disappear.
+
+**Why we rejected it.** Four reasons:
+
+1. **Fargate's premium pays off exactly where this workload can't use it.** Fargate's
+   per-second billing wins for compute that runs a few minutes per day — which is why the
+   forecast worker runs there. For a box that runs 24/7, the same premium just compounds: at
+   `eu-west-2` on-demand rates, an always-on 2 vCPU / 4 GB Fargate service costs roughly
+   **2.4× the `t4g.medium` VM** it would replace (~\$66/month vs ~\$27/month, from the ARM
+   Fargate and EC2 rates in the
+   [region price table](forecast-delivery.md#securing-it)).
+
+2. **Postgres needs a disk that Fargate doesn't have.** A Fargate task has no persistent local
+   storage, so the Postgres container (run, event, and schedule history) could not come along.
+   It would have to move to managed RDS — more cost, and one more AWS-specific service to
+   recreate at handover — or onto EFS, a network filesystem that Postgres tolerates poorly. On
+   the VM, Postgres's data is simply a Docker volume on the instance's own disk.
+
+3. **It trades a portable artifact for AWS-specific glue.** The control plane's deployment
+   description *is* its `docker-compose.yml`: the laptop and the cloud run the same artifact.
+   As an ECS service, that description becomes task definitions, service configuration, and
+   (per the previous point) RDS — the same AWS coupling that helped reject the
+   [EventBridge design](#no-control-plane-eventbridge-scheduler-launching-ecs-tasks), in both
+   its portability and its handover form. The Tailscale-based access design adds a quieter
+   version of the same friction: on the VM, joining the tailnet is one `tailscale up`, whereas
+   a Fargate service needs a Tailscale sidecar container with its own state management.
+
+4. **The benefit is smaller than it looks.** The OS burden Fargate would remove is one Ubuntu
+   box that patches itself (`unattended-upgrades`), can be stopped for maintenance in any of
+   the built-in 6-hourly maintenance windows
+   ([above](#run-the-dagster-control-plane-continuously-on-one-small-vm)), and is slated for a
+   tested rebuild-from-scratch script (see
+   [Handover: de-pet the control-plane box](../roadmap/handover.md#3-de-pet-the-control-plane-box))
+   so that the answer to a sick box is *destroy and recreate*, never *diagnose*.
+
 ### Fetching the champion model from MLflow at container startup
 
 **The design.** Host the MLflow artifact root on S3 and have each production container fetch

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -250,10 +250,21 @@ the champion model from it at startup, instead of
 [baking the model into the image](#bake-the-model-into-the-image-at-build-time).
 
 **Why we rejected it.** It adds runtime moving parts, needs tracking-store access from
-production, and slows cold starts — baking the model in has none of those costs. The idea may
-still return in a stronger form: the **future work** note in the baking section describes
-fetching the champion dynamically once redeploys become frequent, with `load_from_mlflow`'s
-local-disk cache as the production-resilience mechanism.
+production, and slows cold starts — baking the model in has none of those costs. The rejection
+gets stronger under the preferred post-NIA operating model, in which NGED run this code
+themselves (see
+[Requirements → Operating model & handover](../background/requirements.md#operating-model-handover)):
+with the model baked in, NGED never has to run — or depend on — an MLflow tracking server at
+all, and the model simply freezes until a new image arrives. (OCF may well continue developing
+the model post-NIA and release new container images for NGED to test, but that arrangement is
+TBD — and either way it only changes which *image* NGED runs, never whether their production
+runtime needs MLflow.)
+
+The idea may still return in a stronger form: the **future work** note at the end of
+[Bake the model into the image at build time](#bake-the-model-into-the-image-at-build-time) —
+the section describing the accepted design this one lost to — describes fetching the champion
+dynamically once redeploys become frequent, with `load_from_mlflow`'s local-disk cache as the
+production-resilience mechanism.
 
 ## See also
 

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -5,23 +5,135 @@ leaderboard into a running production container — and why. For the step-by-ste
 promote a model, build the image, verify it, push it, and stand up the AWS deployment around
 it — see [Setting up the live service on AWS](../live_service/aws.md).
 
-## Orchestration: an always-on Dagster control plane, not EventBridge
+## Run the Dagster control plane continuously on one small VM
 
-**Decision (July 2026): keep the Dagster control plane — daemon + webserver + code-location
-server — running continuously on one small VM, alongside MLflow and Marimo, managed via Docker
-Compose. Do not adopt AWS EventBridge Scheduler (or the related Step Functions pattern) for
-triggering live forecast runs.** This pressure-tested and confirmed the roadmap's
-[accepted architecture](../roadmap/live-service.md#accepted-option-small-ec2-control-plane-box-ecsrunlauncher-2535month)
-(see [Live service: AWS architecture](../roadmap/live-service.md#aws-architecture) for the costed
-options); the box dispatches every run — live schedules and UI-launched backtests alike — to an
-ephemeral Fargate task via `EcsRunLauncher`.
+The Dagster control plane — daemon + webserver + code-location server — runs continuously on
+one small VM, alongside MLflow and Marimo, managed via Docker Compose. The box does no forecast
+compute of its own: it dispatches every run — live schedules and UI-launched backtests alike —
+to an ephemeral Fargate task via `EcsRunLauncher`. This is the roadmap's
+[accepted architecture](../roadmap/live-service.md#accepted-option-small-ec2-control-plane-box-ecsrunlauncher-2535month);
+see [Live service: AWS architecture](../roadmap/live-service.md#aws-architecture) for the
+costed options.
 
-**The rejected alternative** was a "no control plane" architecture: EventBridge Scheduler fires
-on the 6-hourly cadence and launches an ECS `RunTask` that executes `dagster asset materialize`
-(or `dagster job execute`) directly in the production image. In that pattern, Dagster acts
-purely as the in-process execution framework, EventBridge acts as the scheduler, and compute is
-paid per run with nothing always-on; run history could still be inspected by pointing an
-on-demand `dagster-webserver` at shared Postgres run storage. We rejected it for four reasons:
+Because scheduling lives inside Dagster rather than in any cloud-specific service, the entire
+stack stays portable: the laptop deployment and the cloud deployment are the same artifact,
+started with `docker compose up`. The always-on daemon also provides the cross-run coordination
+that only a daemon can: schedules, sensors, run monitoring, and declarative automation.
+
+The design accepts two trade-offs:
+
+- **Single point of failure.** The daemon on one VM has no managed scheduler watching it; a
+  quiet box failure could silently miss slots. Mitigation: the
+  [missed-check-in alarm](../roadmap/live-service.md#alert-on-absence-the-missed-check-in-alarm)
+  — each successful 6-hourly run checks in with an external monitoring service (Sentry cron
+  monitoring is the planned mechanism), and an alert fires when an expected check-in fails to
+  arrive. The alarm is the only component that lives outside the box, and the stack does not
+  depend on it to function.
+
+- **No run-level auto-retry after a hard crash.** Accepted; covered by the existing
+  replay/backfill mode for missed slots plus the missed-check-in alarm.
+
+Several other orchestration shapes were considered and rejected — see
+[Considered but rejected designs](#considered-but-rejected-designs).
+
+## Bake the model into the image at build time
+
+Production forecasts run as ephemeral Fargate tasks, dispatched by the always-on Dagster
+control plane described [above](#run-the-dagster-control-plane-continuously-on-one-small-vm).
+An ephemeral container has no persistent disk and, for v0.1, no MLflow tracking server to reach
+— so production inference needs some way to get a model without depending on either.
+
+The champion model is therefore baked into the image at build time and loaded via a plain
+`save`/`load` — no MLflow, run ID, or cache involved at runtime. The model directory is
+produced once, out of band (a researcher picks the champion fold from the MLflow leaderboard
+and downloads its artifacts to local disk), then `COPY`'d into the image at build time.
+Promotion becomes rebuild + redeploy, which is auditable (image tags) and keeps MLflow
+completely out of the production runtime. (The rejected alternative — fetching the model from
+MLflow at container startup — is covered in
+[Considered but rejected designs](#fetching-the-champion-model-from-mlflow-at-container-startup).)
+
+This design also serves the preferred post-NIA operating model, in which a non-expert at
+NGED operates the service day to day (see
+[Requirements → Operating model & handover](../background/requirements.md#operating-model-handover)):
+there is no tracking server on the hot path to break, and the model simply freezes between
+OCF's scheduled expert interventions — under a vendor-develops / operator-runs split, that is a
+feature, not a limitation.
+
+This is deliberately simpler than reusing `BaseForecaster.load_from_mlflow`'s cache (the
+mechanism the CV pipeline already uses — see
+[ML orchestration: model artifacts](ml-orchestration.md#model-artifacts-mlflow-artifact-store-immutable-local-cache)):
+v0.1 has no MLflow dependency to cache against in the first place.
+
+**Future work:** once production wants to pick up a new champion without a rebuild + redeploy
+(e.g. after the [XGBoost quick wins](../roadmap/xgboost-improvements.md) start landing
+regularly), switch to fetching the champion model from MLflow dynamically — at that point
+`load_from_mlflow`'s local-disk cache becomes the production-resilience mechanism again (serving
+from disk on a cache hit so the live service survives an MLflow outage), exactly as it does for
+CV today.
+
+## Run live inference in single-run mode, not bulk
+
+The `live_forecasts` asset engineers features in **single-run mode** — an explicit
+`power_fcst_init_time` supplied by the partition, joined across all 51 NWP ensemble members —
+never bulk mode's one-`power_fcst_init_time`-per-NWP-run derivation (see
+[ML orchestration: forecast cadence under-sampling](ml-orchestration.md#known-limitation-forecast-cadence-under-sampling-in-cv)
+for where bulk mode's per-NWP-run derivation matters instead: CV/backtesting, not live inference).
+A production run issues one forecast for one explicit init time every 6 hours; bulk mode's
+derivation has no meaning for a single live materialisation.
+
+## Resolve NWP availability asymmetrically: `live` vs `replay`
+
+`live_forecasts`' `availability_mode` config resolves which NWP run to join against, and the two
+modes are deliberately asymmetric:
+
+- **`"live"`** joins the freshest NWP run actually present in Delta, with **no modelled
+  publication delay** — reality already constrains the table to genuinely published runs, so a
+  faster provider is used automatically without a config change.
+- **`"replay"`** joins the freshest run at least `nwp_publication_delay_hours` old, reconstructing
+  what was genuinely available at that historical init time. Without the delay, a replay would
+  leak NWP runs that only landed after the fact — a lookahead-bias bug, not just an inaccuracy.
+
+The scheduled path always uses `"live"`; backfills of missed or historical partitions use
+`"replay"`. The mode is an explicit, manually-set flag rather than an automatic
+live-iff-recent rule — the ambiguity of "recent" isn't worth resolving for a backfill path that's
+already manually triggered.
+
+## Serve only the trained population
+
+`live_forecasts` forecasts exactly the production model's `trained_time_series_ids` (recorded in
+`meta.json`), never the current day's eligibility set. This is the train==predict population
+invariant: a time series the model never saw during training must never receive a live forecast,
+even if it would otherwise qualify today.
+
+## Promote the champion via a Dagster asset, not a script
+
+The "researcher downloads artifacts" step above is a manually-triggered Dagster asset,
+`promoted_model` (config `mlflow_run_id`), rather than a bare script — promotion becomes a
+materialisation, giving an audit trail and lineage for free. The download logic itself
+(`ml_core._production_helpers.fetch_model_artifacts`) is a pure, asset-independent helper, so
+nothing about this decision couples it to Dagster.
+
+**The Docker build reuses this same asset** (headlessly, via `dagster asset materialize`) — no
+separate fetch script was built, since a bare script would have duplicated the asset's audit
+trail for no benefit. The `docker build` step itself stays outside Dagster: it only ever runs on
+a laptop today, and image build/push becomes a CI-shaped concern once an MLflow tracking server
+and AWS infra exist — not something worth orchestrating through Dagster in the meantime.
+
+## Considered but rejected designs
+
+Each design below was seriously considered for the live service and rejected. Every subsection
+follows the same structure: first it describes the rejected design, then it explains why we
+rejected it.
+
+### No control plane: EventBridge Scheduler launching ECS tasks
+
+**The design.** AWS EventBridge Scheduler fires on the 6-hourly cadence and launches an ECS
+`RunTask` that executes `dagster asset materialize` (or `dagster job execute`) directly in the
+production image. Dagster acts purely as the in-process execution framework, EventBridge acts
+as the scheduler, and compute is paid per run with nothing always-on; run history could still
+be inspected by pointing an on-demand `dagster-webserver` at shared Postgres run storage.
+
+**Why we rejected it (July 2026).** Four reasons:
 
 1. **Portability is a hard requirement.** The entire stack must run on a local laptop (or any
    cloud) without AWS-specific services. Once the schedule lives in EventBridge and run-level
@@ -55,116 +167,33 @@ ordering would have been handled entirely by Dagster within a single self-contai
 full asset selection, and cross-run coordination — sensors, declarative automation,
 freshness-driven materialisation — would not have been available without the daemon.
 
-**Also rejected — a periodically-woken control plane** (running the daemon only, say, hourly to
-save cost): the daemon's schedule catch-up (`max_catchup_runs`, default 5) would technically
-fire missed 6-hourly ticks, but sensors, run monitoring, and retries all assume an always-on
-daemon, the web UI would be unavailable most of the time, and something else would still need
-to reliably wake the daemon — which reintroduces the scheduling problem one level up.
+**Door left open.** EventBridge remains usable later as a *pure trigger* — an external service
+that pokes an otherwise portable stack (e.g. S3 event → EventBridge rule → webhook or task
+launch) — provided the stack never depends on it to run. Event-driven behaviour (e.g. "run when
+NGED drops a new file") can alternatively be handled natively by Dagster sensors, which the
+always-on daemon supports.
 
-### Accepted trade-offs and mitigations
+### A periodically-woken control plane
 
-- **Single point of failure.** The daemon on one VM has no managed scheduler watching it; a
-  quiet box failure could silently miss slots. Mitigation: the
-  [missed-check-in alarm](../roadmap/live-service.md#alert-on-absence-the-missed-check-in-alarm)
-  — each successful 6-hourly run checks in with an external monitoring service (Sentry cron
-  monitoring is the planned mechanism), and an alert fires when an expected check-in fails to
-  arrive. The alarm is the only component that lives outside the box, and the stack does not
-  depend on it to function.
+**The design.** Run the Dagster daemon only periodically (say, hourly) instead of continuously,
+to save cost; on each wake-up, the daemon's schedule catch-up (`max_catchup_runs`, default 5)
+would fire any 6-hourly ticks missed while it slept.
 
-- **No run-level auto-retry after a hard crash.** Accepted; covered by the existing
-  replay/backfill mode for missed slots plus the missed-check-in alarm.
+**Why we rejected it.** Sensors, run monitoring, and retries all assume an always-on daemon;
+the web UI would be unavailable most of the time; and something else would still need to
+reliably wake the daemon — which reintroduces the scheduling problem one level up.
 
-### Door left open
+### Fetching the champion model from MLflow at container startup
 
-EventBridge remains usable later as a *pure trigger* — an external service that pokes an
-otherwise portable stack (e.g. S3 event → EventBridge rule → webhook or task launch) — provided
-the stack never depends on it to run. Event-driven behaviour (e.g. "run when NGED drops a new
-file") can alternatively be handled natively by Dagster sensors, which the always-on daemon
-supports.
+**The design.** Host the MLflow artifact root on S3 and have each production container fetch
+the champion model from it at startup, instead of
+[baking the model into the image](#bake-the-model-into-the-image-at-build-time).
 
-## Baking the model into the image at build time
-
-Production forecasts run as ephemeral Fargate tasks, dispatched by the always-on Dagster
-control plane described [above](#orchestration-an-always-on-dagster-control-plane-not-eventbridge).
-An ephemeral container has no persistent disk and, for v0.1, no MLflow tracking server to reach
-— so production inference needs some way to get a model without depending on either.
-
-**Decision: bake the champion model into the image at build time, loaded via a plain
-`save`/`load` — no MLflow, run ID, or cache involved at runtime.** The model directory is
-produced once, out of band (a researcher picks the champion fold from the MLflow leaderboard and
-downloads its artifacts to local disk), then `COPY`'d into the image at build time. Promotion
-becomes rebuild + redeploy, which is auditable (image tags) and keeps MLflow completely out of
-the production runtime.
-
-**Rejected alternative:** MLflow artifact root on S3 fetched at container startup — more runtime
-moving parts, needs tracking-store access from prod, and slower cold starts.
-
-This decision also serves the preferred post-NIA operating model, in which a non-expert at
-NGED operates the service day to day (see
-[Requirements → Operating model & handover](../background/requirements.md#operating-model-handover)):
-there is no tracking server on the hot path to break, and the model simply freezes between
-OCF's scheduled expert interventions — under a vendor-develops / operator-runs split, that is a
-feature, not a limitation.
-
-This is deliberately simpler than reusing `BaseForecaster.load_from_mlflow`'s cache (the
-mechanism the CV pipeline already uses — see
-[ML orchestration: model artifacts](ml-orchestration.md#model-artifacts-mlflow-artifact-store-immutable-local-cache)):
-v0.1 has no MLflow dependency to cache against in the first place.
-
-**Future work:** once production wants to pick up a new champion without a rebuild + redeploy
-(e.g. after the [XGBoost quick wins](../roadmap/xgboost-improvements.md) start landing
-regularly), switch to fetching the champion model from MLflow dynamically — at that point
-`load_from_mlflow`'s local-disk cache becomes the production-resilience mechanism again (serving
-from disk on a cache hit so the live service survives an MLflow outage), exactly as it does for
-CV today.
-
-## Live inference is single-run, not bulk
-
-The `live_forecasts` asset engineers features in **single-run mode** — an explicit
-`power_fcst_init_time` supplied by the partition, joined across all 51 NWP ensemble members —
-never bulk mode's one-`power_fcst_init_time`-per-NWP-run derivation (see
-[ML orchestration: forecast cadence under-sampling](ml-orchestration.md#known-limitation-forecast-cadence-under-sampling-in-cv)
-for where bulk mode's per-NWP-run derivation matters instead: CV/backtesting, not live inference).
-A production run issues one forecast for one explicit init time every 6 hours; bulk mode's
-derivation has no meaning for a single live materialisation.
-
-## NWP availability: `live` vs `replay` is asymmetric by design
-
-`live_forecasts`' `availability_mode` config resolves which NWP run to join against, and the two
-modes are deliberately asymmetric:
-
-- **`"live"`** joins the freshest NWP run actually present in Delta, with **no modelled
-  publication delay** — reality already constrains the table to genuinely published runs, so a
-  faster provider is used automatically without a config change.
-- **`"replay"`** joins the freshest run at least `nwp_publication_delay_hours` old, reconstructing
-  what was genuinely available at that historical init time. Without the delay, a replay would
-  leak NWP runs that only landed after the fact — a lookahead-bias bug, not just an inaccuracy.
-
-The scheduled path always uses `"live"`; backfills of missed or historical partitions use
-`"replay"`. The mode is an explicit, manually-set flag rather than an automatic
-live-iff-recent rule — the ambiguity of "recent" isn't worth resolving for a backfill path that's
-already manually triggered.
-
-## Serving only the trained population
-
-`live_forecasts` forecasts exactly the production model's `trained_time_series_ids` (recorded in
-`meta.json`), never the current day's eligibility set. This is the train==predict population
-invariant: a time series the model never saw during training must never receive a live forecast,
-even if it would otherwise qualify today.
-
-## Why promotion is a Dagster asset, not a script
-
-The "researcher downloads artifacts" step above is a manually-triggered Dagster asset,
-`promoted_model` (config `mlflow_run_id`), rather than a bare script — promotion becomes a
-materialisation, giving an audit trail and lineage for free. The download logic itself
-(`ml_core._production_helpers.fetch_model_artifacts`) is a pure, asset-independent helper, so
-nothing about this decision couples it to Dagster.
-
-**The Docker build reuses this same asset** (headlessly, via `dagster asset materialize`) — no
-separate fetch script was built, since a bare script would have duplicated the asset's audit
-trail for no benefit. The `docker build` step itself stays outside Dagster: it only ever runs on
-a laptop today, and image build/push becomes a CI-shaped concern once an MLflow tracking server
-and AWS infra exist — not something worth orchestrating through Dagster in the meantime.
+**Why we rejected it.** It adds runtime moving parts, needs tracking-store access from
+production, and slows cold starts — baking the model in has none of those costs. The idea may
+still return in a stronger form: the **future work** note in the baking section describes
+fetching the champion dynamically once redeploys become frequent, with `load_from_mlflow`'s
+local-disk cache as the production-resilience mechanism.
 
 ## See also
 

--- a/docs/background/requirements.md
+++ b/docs/background/requirements.md
@@ -35,10 +35,9 @@ a standing design requirement for everything we build:
   reduced to a dashboard check, a button in the Dagster UI, or a runbook. See
   [Handover to NGED](../roadmap/handover.md) for the engineering consequences and the handover
   workstreams.
-* **Uptime requirements are deliberately lenient.** Nothing very bad happens if the service
-  misses a day: NGED can always read the previous forecasts from S3, and each forecast extends
-  14 days ahead. We still aim for a highly robust service, but recovery is "next business day,
-  via runbook", never a 2am page.
+* **Uptime requirements are deliberately lenient** — recovery is "next business day, via
+  runbook", never a 2am page. See [Uptime: lenient by design](#uptime-lenient-by-design) below
+  for exactly why an outage costs so little.
 
 The phasing:
 
@@ -56,6 +55,36 @@ to develop the code and ML models, and perhaps runs a second service instance of
 adapted for other DNOs, or feeding OCF's substation forecasts into a commercial demand-forecast
 product). This makes account-portable infrastructure doubly valuable — see
 [Handover to NGED](../roadmap/handover.md#4-infrastructure-as-code-portable-to-ngeds-account).
+
+## Uptime: lenient by design
+
+Flexpectation carries **no hard availability target**. We aim for a highly robust service, but
+the requirement when something breaks is recovery "next business day, via runbook" — never a
+2am page, and no on-call rota. This leniency is a property of how NGED consumes the forecasts,
+not an aspiration; three things bound the damage of an outage:
+
+1. **Every forecast extends 14 days ahead**, refreshed every 6 hours, and users mostly act on
+   the forecast roughly 1 to 10 days ahead (see [Core Objectives](#core-objectives)). If the
+   service stops producing new forecasts for a few hours — or even a day — the most recent
+   forecast remains useful; it merely ages, degrading skill gradually rather than cutting NGED
+   off.
+2. **Delivery is decoupled from compute.** Forecasts are delivered as Delta tables on S3 (see
+   [Forecast Delivery](#forecast-delivery) below), so every previously published forecast stays
+   readable even while all of OCF's compute is down — the read path never touches our
+   infrastructure.
+3. **A legacy fallback exists.** In the worst case, NGED can temporarily fall back to their
+   legacy forecasting approach while Flexpectation is fixed.
+
+Missed forecasts are also not lost for evaluation purposes: once the service is back, missed
+slots are backfilled in replay mode, reconstructing what would have been forecast at the time —
+see [Operating the live service: Backfilling a missed slot](../live_service/operations.md#backfilling-a-missed-slot).
+
+This requirement shapes the architecture: it is why a single always-on control-plane VM is an
+acceptable single point of failure (see
+[Production Deployment — Design](../architecture/production-deployment.md#run-the-dagster-control-plane-continuously-on-one-small-vm)),
+and why the primary production alert is a
+[missed-check-in alarm](../roadmap/live-service.md#alert-on-absence-the-missed-check-in-alarm)
+feeding a runbook rather than any paging or failover machinery.
 
 ## Forecast Delivery
 

--- a/docs/background/requirements.md
+++ b/docs/background/requirements.md
@@ -79,6 +79,14 @@ Missed forecasts are also not lost for evaluation purposes: once the service is 
 slots are backfilled in replay mode, reconstructing what would have been forecast at the time —
 see [Operating the live service: Backfilling a missed slot](../live_service/operations.md#backfilling-a-missed-slot).
 
+The same properties give the service **built-in maintenance windows**. New forecasts are
+produced only once every 6 hours, and NGED reads published forecasts directly from S3 rather
+than from any OCF-run service — so the gap between one forecast run and the next is a regular,
+roughly six-hour window in which OCF can stop, patch, upgrade, or even rebuild its compute
+(most notably the always-on control-plane VM) without NGED noticing. No downtime needs to be
+negotiated or announced, and even a maintenance overrun costs only a missed slot, recovered by
+the replay-mode backfill above.
+
 This requirement shapes the architecture: it is why a single always-on control-plane VM is an
 acceptable single point of failure (see
 [Production Deployment — Design](../architecture/production-deployment.md#run-the-dagster-control-plane-continuously-on-one-small-vm)),

--- a/docs/live_service/aws.md
+++ b/docs/live_service/aws.md
@@ -365,9 +365,33 @@ keep the old values until they next start, since injection happens once per cont
 
 ## Step 9 — Create the ECS cluster and Fargate task definition
 
-1. **ECS** → **Clusters** → **Create cluster** → *Networking only* (Fargate; no EC2 — Elastic
-   Compute Cloud, AWS's virtual machines — instances to manage) — a bare cluster is just a
-   namespace, so a single `nged-forecast` cluster is enough for now.
+Two AWS terms do a lot of work in this step, so it's worth being precise about how they relate.
+**ECS** (Elastic Container Service) is AWS's container orchestrator: it takes a **task
+definition** — a recipe naming the container image to run plus the CPU, memory, IAM roles,
+environment variables, and secrets to run it with — and launches and supervises containers from
+that recipe. **Fargate** is one of ECS's two "launch types" — the two ways of providing the
+compute the containers run on. With the other launch type, ECS places containers onto EC2
+(Elastic Compute Cloud — AWS's virtual machines) instances that you provision and patch
+yourself; with Fargate, AWS conjures right-sized compute for each task when it launches and
+tears it down when the task exits, billed by the second. We use ECS on Fargate so that each
+6-hourly forecast run gets a fresh, ephemeral machine and nothing sits idle between runs — the
+ephemeral-worker half of the
+[orchestration design](../architecture/production-deployment.md#orchestration-an-always-on-dagster-control-plane-not-eventbridge)
+(the always-on half is the control-plane box of
+[Step 11](#step-11-launch-the-control-plane-box), which *dispatches* these tasks).
+
+**Why create a "cluster" when nothing here auto-scales?** On the EC2 launch type, a cluster
+really is a fleet — the pool of instances that tasks get placed onto. On Fargate there are no
+instances, so the cluster is purely a **logical namespace for running tasks**, and we need one
+only because every task has to launch *into* a cluster: it's the `--cluster` that
+[Step 10](#step-10-verify-run-a-forecast-task-manually)'s manual `run-task` call targets and the
+`cluster:` the `EcsRunLauncher` config in
+[Step 14](#step-14-configure-dagster-on-the-box) names, and it's where the console groups the
+running tasks you'll watch. An empty cluster manages no capacity and costs nothing, so a single
+`nged-forecast` cluster is all this deployment ever needs.
+
+1. [**ECS**](https://eu-west-2.console.aws.amazon.com/ecs) → **Clusters** → **Create cluster** → name it `nged-forecast` → *Networking only*
+   (i.e. Fargate: no EC2 instances to manage, per the explanation above).
 2. **ECS** → **Task definitions** → **Create new task definition** → *Fargate*:
     - **Task role**: the task role from [Step 7](#step-7-iam-roles-for-the-fargate-task).
     - **Task execution role**: the execution role from

--- a/docs/live_service/aws.md
+++ b/docs/live_service/aws.md
@@ -372,10 +372,18 @@ technologies:
 - The **always-on control plane** — the Dagster daemon, webserver, code-location server, and
   Postgres — runs on a plain **EC2 virtual machine** (EC2 is Elastic Compute Cloud), launched by
   hand in [Step 11](#step-11-launch-the-control-plane-box) and managed with Docker Compose. ECS
-  and Fargate play no part in running it.
+  and Fargate play no part in running it. This is the **only compute in the deployment whose
+  operating system we install and maintain ourselves**: [Step 11](#step-11-launch-the-control-plane-box)
+  chooses its OS image (an Ubuntu Server AMI), and from then on the OS is ours to look after —
+  installing software on it ([Step 12](#step-12-join-the-tailnet) and
+  [Step 13](#step-13-install-docker-and-pull-the-image)) and keeping it patched (Ubuntu's
+  `unattended-upgrades`, checked in [Optional hardening](#optional-hardening)).
 - The **ephemeral forecast worker** — each 6-hourly forecast run — runs as an **ECS task on
   Fargate**: a container that is created for one run and destroyed when it exits. The control
-  plane *dispatches* these tasks but never executes a forecast itself.
+  plane *dispatches* these tasks but never executes a forecast itself. Here there is **no
+  operating system for us to install or maintain**: AWS owns and patches the machines Fargate
+  tasks run on, and everything we are responsible for travels inside the container image from
+  [Step 6](#step-6-push-the-image-to-ecr).
 
 This step builds the scaffolding for the ephemeral half: the cluster its tasks launch into, and
 the task definition describing how to run them. Why the compute is split this way is the

--- a/docs/live_service/aws.md
+++ b/docs/live_service/aws.md
@@ -379,7 +379,7 @@ technologies:
 
 This step builds the scaffolding for the ephemeral half: the cluster its tasks launch into, and
 the task definition describing how to run them. Why the compute is split this way is the
-[orchestration design](../architecture/production-deployment.md#orchestration-an-always-on-dagster-control-plane-not-eventbridge).
+[orchestration design](../architecture/production-deployment.md#run-the-dagster-control-plane-continuously-on-one-small-vm).
 
 Two AWS terms do a lot of work in this step, so it's worth being precise about how they relate.
 **ECS** (Elastic Container Service) is AWS's container orchestrator: it takes a **task definition**
@@ -484,7 +484,7 @@ One small always-on EC2 instance runs the Dagster daemon (schedules, sensors, ru
 the Dagster webserver (the UI), the code-location server, and Postgres (run/event/schedule
 history) — everything except the actual forecast compute, which stays on ephemeral Fargate.
 Why an always-on box at all, and why this shape, is the
-[orchestration decision](../architecture/production-deployment.md#orchestration-an-always-on-dagster-control-plane-not-eventbridge);
+[orchestration decision](../architecture/production-deployment.md#run-the-dagster-control-plane-continuously-on-one-small-vm);
 the sizing and cost are the roadmap's
 [accepted option](../roadmap/live-service.md#accepted-option-small-ec2-control-plane-box-ecsrunlauncher-2535month).
 

--- a/docs/live_service/aws.md
+++ b/docs/live_service/aws.md
@@ -366,19 +366,18 @@ keep the old values until they next start, since injection happens once per cont
 ## Step 9 — Create the ECS cluster and Fargate task definition
 
 Two AWS terms do a lot of work in this step, so it's worth being precise about how they relate.
-**ECS** (Elastic Container Service) is AWS's container orchestrator: it takes a **task
-definition** — a recipe naming the container image to run plus the CPU, memory, IAM roles,
-environment variables, and secrets to run it with — and launches and supervises containers from
-that recipe. **Fargate** is one of ECS's two "launch types" — the two ways of providing the
-compute the containers run on. With the other launch type, ECS places containers onto EC2
-(Elastic Compute Cloud — AWS's virtual machines) instances that you provision and patch
-yourself; with Fargate, AWS conjures right-sized compute for each task when it launches and
-tears it down when the task exits, billed by the second. We use ECS on Fargate so that each
-6-hourly forecast run gets a fresh, ephemeral machine and nothing sits idle between runs — the
-ephemeral-worker half of the
-[orchestration design](../architecture/production-deployment.md#orchestration-an-always-on-dagster-control-plane-not-eventbridge)
-(the always-on half is the control-plane box of
-[Step 11](#step-11-launch-the-control-plane-box), which *dispatches* these tasks).
+**ECS** (Elastic Container Service) is AWS's container orchestrator: it takes a **task definition**
+— a recipe naming the container image to run plus the CPU, memory, IAM roles, environment variables,
+and secrets to run it with — and launches and supervises containers from that recipe. **Fargate** is
+one of ECS's two "launch types" — the two ways of providing the compute the containers run on. The
+other launch type, ECS, places containers onto EC2 (Elastic Compute Cloud — AWS's virtual machines)
+instances that you provision and patch yourself. In contrast, with Fargate, AWS conjures right-sized
+compute for each task when it launches and tears it down when the task exits, billed by the second.
+We use ECS on Fargate so that each 6-hourly forecast run gets a fresh, ephemeral machine and nothing
+sits idle between runs — the ephemeral-worker half of the [orchestration
+design](../architecture/production-deployment.md#orchestration-an-always-on-dagster-control-plane-not-eventbridge)
+(the always-on half is the control-plane box of [Step 11](#step-11-launch-the-control-plane-box),
+which *dispatches* these tasks).
 
 **Why create a "cluster" when nothing here auto-scales?** On the EC2 launch type, a cluster
 really is a fleet — the pool of instances that tasks get placed onto. On Fargate there are no
@@ -390,7 +389,7 @@ only because every task has to launch *into* a cluster: it's the `--cluster` tha
 running tasks you'll watch. An empty cluster manages no capacity and costs nothing, so a single
 `nged-forecast` cluster is all this deployment ever needs.
 
-1. [**ECS**](https://eu-west-2.console.aws.amazon.com/ecs) → **Clusters** → **Create cluster** → name it `nged-forecast` → *Networking only*
+1. [**ECS**](https://eu-west-2.console.aws.amazon.com/ecs?region=eu-west-2) → **Clusters** → **Create cluster** → name it `nged-forecast` → *Networking only*
    (i.e. Fargate: no EC2 instances to manage, per the explanation above).
 2. **ECS** → **Task definitions** → **Create new task definition** → *Fargate*:
     - **Task role**: the task role from [Step 7](#step-7-iam-roles-for-the-fargate-task).

--- a/docs/live_service/aws.md
+++ b/docs/live_service/aws.md
@@ -365,19 +365,31 @@ keep the old values until they next start, since injection happens once per cont
 
 ## Step 9 — Create the ECS cluster and Fargate task definition
 
+First, a reminder of the deployment's shape, because from this step onwards it matters which half
+of it you're building. The stack runs **two different kinds of compute**, on two different AWS
+technologies:
+
+- The **always-on control plane** — the Dagster daemon, webserver, code-location server, and
+  Postgres — runs on a plain **EC2 virtual machine** (EC2 is Elastic Compute Cloud), launched by
+  hand in [Step 11](#step-11-launch-the-control-plane-box) and managed with Docker Compose. ECS
+  and Fargate play no part in running it.
+- The **ephemeral forecast worker** — each 6-hourly forecast run — runs as an **ECS task on
+  Fargate**: a container that is created for one run and destroyed when it exits. The control
+  plane *dispatches* these tasks but never executes a forecast itself.
+
+This step builds the scaffolding for the ephemeral half: the cluster its tasks launch into, and
+the task definition describing how to run them. Why the compute is split this way is the
+[orchestration design](../architecture/production-deployment.md#orchestration-an-always-on-dagster-control-plane-not-eventbridge).
+
 Two AWS terms do a lot of work in this step, so it's worth being precise about how they relate.
 **ECS** (Elastic Container Service) is AWS's container orchestrator: it takes a **task definition**
 — a recipe naming the container image to run plus the CPU, memory, IAM roles, environment variables,
 and secrets to run it with — and launches and supervises containers from that recipe. **Fargate** is
 one of ECS's two "launch types" — the two ways of providing the compute the containers run on. The
-other launch type, ECS, places containers onto EC2 (Elastic Compute Cloud — AWS's virtual machines)
-instances that you provision and patch yourself. In contrast, with Fargate, AWS conjures right-sized
-compute for each task when it launches and tears it down when the task exits, billed by the second.
-We use ECS on Fargate so that each 6-hourly forecast run gets a fresh, ephemeral machine and nothing
-sits idle between runs — the ephemeral-worker half of the [orchestration
-design](../architecture/production-deployment.md#orchestration-an-always-on-dagster-control-plane-not-eventbridge)
-(the always-on half is the control-plane box of [Step 11](#step-11-launch-the-control-plane-box),
-which *dispatches* these tasks).
+other launch type (named "EC2") has ECS place containers onto EC2 instances that you provision and
+patch yourself. In contrast, with Fargate, AWS conjures right-sized compute for each task when it
+launches and tears it down when the task exits, billed by the second. We use ECS on Fargate so that
+each 6-hourly forecast run gets a fresh, ephemeral machine and nothing sits idle between runs.
 
 **Why create a "cluster" when nothing here auto-scales?** On the EC2 launch type, a cluster
 really is a fleet — the pool of instances that tasks get placed onto. On Fargate there are no

--- a/docs/live_service/aws.md
+++ b/docs/live_service/aws.md
@@ -377,7 +377,12 @@ technologies:
   chooses its OS image (an Ubuntu Server AMI), and from then on the OS is ours to look after —
   installing software on it ([Step 12](#step-12-join-the-tailnet) and
   [Step 13](#step-13-install-docker-and-pull-the-image)) and keeping it patched (Ubuntu's
-  `unattended-upgrades`, checked in [Optional hardening](#optional-hardening)).
+  `unattended-upgrades`, checked in [Optional hardening](#optional-hardening)). That
+  maintenance never needs a scheduled outage agreed with NGED: forecasts are produced only
+  every 6 hours, and NGED reads published forecasts straight from S3, so the gap between one
+  forecast run and the next is a built-in maintenance window in which the box can be stopped,
+  patched, and rebooted — see
+  [Requirements → Uptime: lenient by design](../background/requirements.md#uptime-lenient-by-design).
 - The **ephemeral forecast worker** — each 6-hourly forecast run — runs as an **ECS task on
   Fargate**: a container that is created for one run and destroyed when it exits. The control
   plane *dispatches* these tasks but never executes a forecast itself. Here there is **no

--- a/docs/live_service/aws.md
+++ b/docs/live_service/aws.md
@@ -377,8 +377,10 @@ technologies:
   chooses its OS image (an Ubuntu Server AMI), and from then on the OS is ours to look after —
   installing software on it ([Step 12](#step-12-join-the-tailnet) and
   [Step 13](#step-13-install-docker-and-pull-the-image)) and keeping it patched (Ubuntu's
-  `unattended-upgrades`, checked in [Optional hardening](#optional-hardening)). That
-  maintenance never needs a scheduled outage agreed with NGED: forecasts are produced only
+  `unattended-upgrades`, checked in [Optional hardening](#optional-hardening)). (Running the
+  control plane on Fargate too would have removed even that OS burden — why we don't is covered
+  in [Considered but rejected designs](../architecture/production-deployment.md#an-always-on-fargate-service-for-the-control-plane).)
+  That maintenance never needs a scheduled outage agreed with NGED: forecasts are produced only
   every 6 hours, and NGED reads published forecasts straight from S3, so the gap between one
   forecast run and the next is a built-in maintenance window in which the box can be stopped,
   patched, and rebooted — see

--- a/docs/live_service/local.md
+++ b/docs/live_service/local.md
@@ -4,7 +4,7 @@ The entire live service — telemetry ingestion, NWP download, the 6-hourly fore
 and the Dagster UI — runs on a laptop with no AWS involved. This is a deliberate portability
 requirement, not just a development convenience: no cloud-specific service may be load-bearing
 for scheduling or orchestration (see
-[the orchestration decision](../architecture/production-deployment.md#orchestration-an-always-on-dagster-control-plane-not-eventbridge)).
+[the orchestration decision](../architecture/production-deployment.md#run-the-dagster-control-plane-continuously-on-one-small-vm)).
 This page brings the local stack up; once it's running,
 [Operating the live service](operations.md) drives it — promotion, schedules, backfills are
 identical to the AWS deployment.

--- a/docs/roadmap/handover.md
+++ b/docs/roadmap/handover.md
@@ -42,11 +42,11 @@ explicit so we don't accidentally undo them:
   portable application logic over cloud-native glue (e.g. no EventBridge rules) wherever a
   portable option exists. Portability is what makes the service cheap to move into NGED's
   account — or anyone else's.
-- **Lenient uptime requirements**: nothing very bad happens if the service misses a day,
-  because NGED can always read the previous forecasts from S3 (forecasts extend 14 days
-  ahead), and can fall back to their legacy forecasting approach for a few hours while
-  Flexpectation is fixed. Recovery can therefore always be "next business day, via runbook",
-  never "2am page".
+- **Lenient uptime requirements** mean recovery can always be "next business day, via
+  runbook", never "2am page" — see
+  [Requirements → Uptime: lenient by design](../background/requirements.md#uptime-lenient-by-design)
+  for why an outage costs so little (the 14-day forecast horizon, S3 delivery decoupled from
+  compute, and NGED's legacy fallback).
 
 The honest caveat: the failures a non-expert can't handle mostly live at the *boundaries*, not
 in our code — an NWP provider changing formats, NGED SCADA feed schema drift, credential and

--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -44,7 +44,7 @@ plan (phases 0–6.7 complete, PRs #182–#214); its final cleanup phase lives i
   `docker compose up` — no AWS-specific service (EventBridge, Step Functions) may be
   load-bearing for scheduling or orchestration. This is both a development convenience and a
   handover requirement — see
-  [the orchestration decision](../architecture/production-deployment.md#orchestration-an-always-on-dagster-control-plane-not-eventbridge).
+  [the orchestration decision](../architecture/production-deployment.md#run-the-dagster-control-plane-continuously-on-one-small-vm).
 - AWS infrastructure with **no static AWS keys** (IAM roles throughout), basic alerting on task
   failure (SNS → email), and cost-conscious operation (~£25–35/month target).
 
@@ -77,7 +77,7 @@ Issue: [#221](https://github.com/openclimatefix/nged-substation-forecast/issues/
 > [#208](https://github.com/openclimatefix/nged-substation-forecast/issues/208)). The design
 > rationale (single-run vs. bulk mode, the `live`/`replay` asymmetry, the trained-population
 > invariant) now lives at
-> [Production Deployment — Design: Live inference](https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/#live-inference-is-single-run-not-bulk);
+> [Production Deployment — Design: Live inference](https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/#run-live-inference-in-single-run-mode-not-bulk);
 > the operational runbook — promoting a model, running the schedule, backfilling a missed slot —
 > is [Operating the live service](../live_service/operations.md), the permanent home
 > this page's shipped material moves to (and, eventually, this whole page, once every section
@@ -125,7 +125,7 @@ EventBridge Scheduler firing an ECS `RunTask` directly, with no always-on contro
 stands. The durable rationale (portability, NGED handover, illusory cost saving, retry parity)
 and the accepted trade-offs (mitigated by the external
 [missed-check-in alarm](#alert-on-absence-the-missed-check-in-alarm)) are recorded at
-[Production Deployment — Design: Orchestration](../architecture/production-deployment.md#orchestration-an-always-on-dagster-control-plane-not-eventbridge).
+[Production Deployment — Design: Orchestration](../architecture/production-deployment.md#run-the-dagster-control-plane-continuously-on-one-small-vm).
 
 ### Cost summary
 

--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -465,7 +465,9 @@ only fire when something runs and fails. Whole classes of failure are silent: a 
 full disk, an expired credential, a schedule that stopped firing. The **primary** production
 alert is therefore a **missed-check-in alarm** (Sentry's cron-monitoring terminology): it fires
 when **no successful forecast has landed in N hours** (e.g. 8 hours — one missed 6-hourly slot
-plus margin), regardless of cause.
+plus margin), regardless of cause. An alert feeding a runbook — rather than paging or automatic
+failover — is a proportionate response because the project's
+[uptime requirements are lenient by design](../background/requirements.md#uptime-lenient-by-design).
 The accepted option's "daemon silently dead" staleness alarm (mentioned under
 [the architecture options](#accepted-option-small-ec2-control-plane-box-ecsrunlauncher-2535month))
 is this alarm; recording it here makes it a first-class monitoring deliverable rather than a


### PR DESCRIPTION
Two related documentation improvements around the live-service deployment docs.

## AWS runbook — Step 9

[Step 9 of the AWS runbook](https://openclimatefix.github.io/nged-substation-forecast/live_service/aws/#step-9-create-the-ecs-cluster-and-fargate-task-definition) previously jumped straight into console clicks. It now opens with three short explainers:

- **A reminder of the deployment's shape** — the stack runs two different kinds of compute on two different AWS technologies: the always-on Dagster control plane on a plain EC2 virtual machine (Step 11, Docker Compose — no ECS/Fargate involved), and the ephemeral forecast worker as an ECS task on Fargate. Step 9 builds the scaffolding for the ephemeral half only.
- **What ECS and Fargate are and how they relate** — ECS is the orchestrator that launches and supervises containers from a task definition; Fargate is one of its two launch types, providing per-task, per-second-billed compute (versus self-managed EC2 instances).
- **Why a "cluster" is needed when nothing auto-scales** — on Fargate a cluster is a pure logical namespace that every task must launch into: it's the `--cluster` Step 10's manual `run-task` targets and the `cluster:` Step 14's `EcsRunLauncher` config names. Empty, it manages no capacity and costs nothing.

## Production Deployment — Design restructure

[The design page](https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/) now states each decision directly in active present tense, with recipe-like headings ("Bake the model into the image at build time", "Serve only the trained population", …):

- The orchestration section describes only the running design — the Dagster control plane (daemon + webserver + code-location server) running continuously on one small VM alongside MLflow and Marimo, managed via Docker Compose, dispatching every run to ephemeral Fargate via `EcsRunLauncher` — and finishes with a link to the rejected designs.
- A new **Considered but rejected designs** section gathers all the history: one sub-heading per rejected design (EventBridge-no-control-plane, periodically-woken control plane, fetch-model-from-MLflow-at-startup), each with the same structure — the design, then why we rejected it.
- The two renamed heading anchors' inbound links are updated in `live_service/aws.md`, `live_service/local.md`, and `roadmap/live-service.md`.
- The fetch-model-from-MLflow-at-startup rejection now also makes the handover argument (with the model baked in, NGED never has to run or depend on an MLflow tracking server; OCF possibly shipping new images for NGED to test post-NIA is TBD and doesn't change that), and its "future work note in the baking section" phrase is replaced with an explicit link to "Bake the model into the image at build time". It also now draws the R&D-vs-production boundary explicitly: MLflow remains the backbone of ML experimentation (linked to the ML-orchestration artifact-store design and the ML-experimentation workflow docs) — its job ends at promotion, and production's hot path never touches it.

## Lenient uptime requirement — one canonical home

The point that Flexpectation tolerates hours-to-a-day of downtime was scattered across two bullets (in `background/requirements.md` and `roadmap/handover.md`). It now has one rigorous home: [Requirements → Uptime: lenient by design](https://openclimatefix.github.io/nged-substation-forecast/background/requirements/#uptime-lenient-by-design), spelling out the three things that bound the damage of an outage (the 14-day forecast horizon, S3 delivery decoupled from compute, and NGED's legacy-forecast fallback) plus replay-mode backfill. The places where that point is load-bearing now link to it: the single-point-of-failure trade-off in the production-deployment design doc, the handover page, and the missed-check-in-alarm roadmap section.

## Why the control plane isn't an always-on Fargate service

A fourth rejected-design subsection answers the question Step 9 now raises ("Fargate means no OS to maintain — so why does the control plane run on a VM?"): an always-on 2 vCPU / 4 GB Fargate service costs ~2.4× the `t4g.medium` it would replace, the VM is the intended home of the MLflow tracking server and Marimo dashboard too (extra compose entries in paid-for headroom, vs each being another always-on Fargate task), Fargate has no persistent disk for Postgres or MLflow's backend store (forcing RDS or EFS), an ECS-service deployment trades the portable `docker-compose.yml` artifact for AWS-specific glue (plus a Tailscale sidecar), and the OS burden it removes is already small (`unattended-upgrades`, the built-in maintenance windows, the planned rebuild-from-scratch script). Step 9's control-plane bullet links to it.

## Built-in 6-hourly maintenance windows

A consequence of the same properties, now documented: because NGED reads published forecasts directly from S3 and new forecasts are produced only every 6 hours, the gap between forecast runs is a regular maintenance window in which OCF compute (notably the control-plane VM) can be stopped, patched, or rebuilt without NGED noticing. The rigorous statement lives in the canonical uptime section above; Step 9 of the AWS runbook, the orchestration section of the production-deployment design doc, and the "What OCF doesn't have to build or run" list in the forecast-delivery page each repeat it briefly and link back.

## Verification

`pymarkdown scan`, `mkdocs build --strict`, and inspection of the rendered HTML: all new heading anchors resolve, and Step 9's paragraphs, bullet list, and numbered list render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

