### PR TITLE
docs(architecture): explain why ingest runs aren't executed on the control-plane VM

### DIFF
--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -22,8 +22,15 @@ costed options.
 
 Because scheduling lives inside Dagster rather than in any cloud-specific service, the entire
 stack stays portable: the laptop deployment and the cloud deployment are the same artifact,
-started with `docker compose up`. The always-on daemon also provides the cross-run coordination
-that only a daemon can: schedules, sensors, run monitoring, and declarative automation.
+started with `docker compose up`. What switches a deployment between local and Fargate
+execution is not code but **Dagster instance configuration**: the run launcher is declared in
+`dagster.yaml`, which lives outside the image. The laptop's `dagster.yaml` declares no run
+launcher, so runs execute as local subprocesses (Dagster's `DefaultRunLauncher`); the box's
+declares `EcsRunLauncher`
+([Step 14 of the runbook](../live_service/aws.md#step-14-configure-dagster-on-the-box)), so
+runs launch as Fargate tasks. The code and image are byte-identical either way. The always-on
+daemon also provides the cross-run coordination that only a daemon can: schedules, sensors, run
+monitoring, and declarative automation.
 
 The design accepts two trade-offs:
 
@@ -256,6 +263,14 @@ directly on the always-on box instead of each being dispatched to its own Fargat
 would save the per-run Fargate cost and the minute or so of task-provisioning latency each
 dispatch pays.
 
+One sizing fact frames the whole question: Dagster launches **runs, not assets**, onto Fargate.
+A schedule tick launches one job run, which becomes one Fargate task, and every asset in that
+job's selection executes inside that single task — so a tiny asset only pays for a task of its
+own if it has a schedule of its own (the one-off `h3_grid_weights`, materialised by hand, never
+does). The question is therefore about the recurring scheduled runs, and only one of them is
+genuinely tiny: the hourly NGED telemetry poll — which, because NGED publishes new files only
+roughly every 5 hours, spends most of its ticks discovering there is nothing to do.
+
 **Why we rejected it.** Five reasons:
 
 1. **Dagster has one run launcher per instance.** The `EcsRunLauncher` configured in
@@ -289,16 +304,35 @@ dispatch pays.
    that is a task-size change; on the box it is another round of resizing the component that
    is hardest to touch.
 
-**What the accepted design costs, and the door left open.** Every ingest run currently
-inherits the task definition's 4 vCPU / 16 GB — sized for inference's ~9 GB peak, and
-oversized for an hourly telemetry pull. At the `eu-west-2` ARM rates in the
-[region price table](forecast-delivery.md#securing-it) (~\$0.21/hour for that task size),
-~720 hourly runs of a few minutes each come to on the order of **\$5–10/month** — the same
-magnitude of saving the [EventBridge rejection](#no-control-plane-eventbridge-scheduler-launching-ecs-tasks)
-dismissed as "not real for this workload". If that figure ever starts to matter, the fix is a
-config change, not an architecture change: `EcsRunLauncher` supports per-run `ecs/cpu` and
-`ecs/memory` tags, so the ingest jobs can declare a small task size while forecasts keep
-4 vCPU / 16 GB. Shrink the ingest tasks; don't move the work onto the box.
+**What the accepted design costs.** Every ingest run currently inherits the task definition's
+4 vCPU / 16 GB — sized for inference's ~9 GB peak, and oversized for an hourly telemetry pull.
+At the `eu-west-2` ARM rates in the [region price table](forecast-delivery.md#securing-it)
+(~\$0.21/hour for that task size), ~720 hourly runs of a few minutes each — most of them the
+no-ops described above — come to on the order of **\$5–10/month**: the same magnitude of saving
+the [EventBridge rejection](#no-control-plane-eventbridge-scheduler-launching-ecs-tasks)
+dismissed as "not real for this workload". A second, quieter cost: `ecmwf_ens`'s
+not-yet-published retry loop (`RetryRequested`, 30-minute waits) retries *inside the same run*,
+so on a late-publication day its 16 GB task sits idle for up to 4 hours, billed the whole time
+(still well under \$1).
+
+**Door left open.** If those figures ever start to matter, two fixes exist inside the accepted
+architecture, and neither moves work onto the box:
+
+- **Right-size the ingest tasks.** `EcsRunLauncher` supports per-run `ecs/cpu` and `ecs/memory`
+  tags, so the ingest jobs can declare a small task size while forecasts keep 4 vCPU / 16 GB —
+  a config change, not an architecture change.
+- **Replace polling schedules with Dagster sensors**
+  ([#324](https://github.com/openclimatefix/nged-substation-forecast/issues/324)). Sensor
+  evaluation functions run **on the daemon** — that is, on the always-on box — while only
+  genuine *runs* go through the launcher. A sensor that cheaply lists NGED's bucket every few
+  minutes and fires the ingest job only when new files actually exist puts the seconds-of-work
+  detection on the box, where Dagster runs it natively, and launches Fargate only for the ~5
+  real ingests a day; the same pattern lets a sensor watch for NWP publication instead of
+  holding a Fargate task idle through the retry loop. This is the hybrid that reason 1 said
+  would need a custom launcher — except Dagster already ships it, because the tiny recurring
+  work here is *detection*, and detection is what sensors are for.
+
+Either way: shrink or skip the ingest tasks; don't move the work onto the box.
 
 ### Fetching the champion model from MLflow at container startup
 

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -13,7 +13,9 @@ responsible for the entire recurring pipeline, not just the forecasts: pulling f
 from NGED's bucket (hourly), downloading the ECMWF ensemble NWP from Dynamical.org (daily), and
 issuing the forecasts themselves (6-hourly). The box does none of that pipeline compute of its
 own, though: it dispatches every run — those schedules and UI-launched backtests alike — to an
-ephemeral Fargate task via `EcsRunLauncher`. This is the roadmap's
+ephemeral Fargate task via `EcsRunLauncher`. Even the light data-ingest runs go to Fargate;
+the reasoning is in
+[Running the data-ingest runs on the control-plane VM](#running-the-data-ingest-runs-on-the-control-plane-vm). This is the roadmap's
 [accepted architecture](../roadmap/live-service.md#accepted-option-small-ec2-control-plane-box-ecsrunlauncher-2535month);
 see [Live service: AWS architecture](../roadmap/live-service.md#aws-architecture) for the
 costed options.
@@ -245,6 +247,58 @@ hosts), so the one piece of self-maintained OS in the deployment would disappear
    tested rebuild-from-scratch script (see
    [Handover: de-pet the control-plane box](../roadmap/handover.md#3-de-pet-the-control-plane-box))
    so that the answer to a sick box is *destroy and recreate*, never *diagnose*.
+
+### Running the data-ingest runs on the control-plane VM
+
+**The design.** The recurring data-ingest jobs — the hourly NGED telemetry pull and the daily
+Dynamical.org NWP download — are deliberately much lighter than inference, so they could run
+directly on the always-on box instead of each being dispatched to its own Fargate task. That
+would save the per-run Fargate cost and the minute or so of task-provisioning latency each
+dispatch pays.
+
+**Why we rejected it.** Five reasons:
+
+1. **Dagster has one run launcher per instance.** The `EcsRunLauncher` configured in
+   `dagster.yaml` applies to *every* run the daemon launches — there is no per-job "run this
+   one locally" switch. "Ingest on the box, forecasts on Fargate" would therefore mean writing
+   a custom hybrid launcher that reads a run tag and delegates to one of two launchers. That is
+   only a few dozen lines, but it is bespoke glue on the critical path of every run — exactly
+   what the [handover constraint](../roadmap/handover.md) says to avoid.
+
+2. **Blast-radius isolation.** The box's only job is to always be up, and it is deliberately
+   tiny: a `t4g.medium` whose 4 GB is shared by the daemon, webserver, code-location server,
+   and Postgres, with MLflow and Marimo planned on top. The ingest jobs are lighter than
+   inference but not negligible — the NWP ingest decodes a full daily ENS run (~7 million
+   rows) and is CPU-hungry enough that its download once starved *itself* through thread
+   contention ([#276](https://github.com/openclimatefix/nged-substation-forecast/issues/276)).
+   Several busy worker threads on a 2-vCPU box would starve daemon heartbeats and the UI, and
+   a memory spike (upstream format drift, an unusually large file) risks the OOM killer taking
+   out Postgres or the daemon. A bad data file killing an ephemeral task is a shrug; killing
+   the control plane is the exact failure this architecture exists to avoid.
+
+3. **The box would have to grow.** Hosting ingest means sizing the box for ingest peaks rather
+   than for coordination — realistically a `t4g.large` at roughly double the `t4g.medium`'s
+   ~\$27/month, which roughly cancels the Fargate saving.
+
+4. **One execution path.** With everything on Fargate, every run has the same image, the same
+   log destination (CloudWatch), the same IAM story (the task role), and the same debugging
+   experience. Two execution environments means two sets of failure modes for an operator who
+   is, post-NIA, a non-expert at NGED.
+
+5. **V2 scaling.** At ~2,500 time series the ingest workload grows roughly 78×. On Fargate
+   that is a task-size change; on the box it is another round of resizing the component that
+   is hardest to touch.
+
+**What the accepted design costs, and the door left open.** Every ingest run currently
+inherits the task definition's 4 vCPU / 16 GB — sized for inference's ~9 GB peak, and
+oversized for an hourly telemetry pull. At the `eu-west-2` ARM rates in the
+[region price table](forecast-delivery.md#securing-it) (~\$0.21/hour for that task size),
+~720 hourly runs of a few minutes each come to on the order of **\$5–10/month** — the same
+magnitude of saving the [EventBridge rejection](#no-control-plane-eventbridge-scheduler-launching-ecs-tasks)
+dismissed as "not real for this workload". If that figure ever starts to matter, the fix is a
+config change, not an architecture change: `EcsRunLauncher` supports per-run `ecs/cpu` and
+`ecs/memory` tags, so the ingest jobs can declare a small task size while forecasts keep
+4 vCPU / 16 GB. Shrink the ingest tasks; don't move the work onto the box.
 
 ### Fetching the champion model from MLflow at container startup
 

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -172,13 +172,29 @@ only for first month, then shared with NGED.*
 
 ---
 
+## v0.8 — Improve Live Service
+
+*Epic: [#323](https://github.com/openclimatefix/nged-substation-forecast/issues/323)*
+
+The bucket for **operational improvements to the running live service** — efficiency,
+robustness, and operability polish discovered during early live running, as distinct from the
+forecast-skill milestones above. First item:
+
+- Replace the polling schedules with Dagster sensors
+  ([#324](https://github.com/openclimatefix/nged-substation-forecast/issues/324)): cheap
+  "is there new data?" detection runs on the control-plane box, and Fargate tasks launch only
+  when there is real work to do. Design context:
+  [Production Deployment — Design](../architecture/production-deployment.md#running-the-data-ingest-runs-on-the-control-plane-vm).
+
+---
+
 ## v1.0 — Stable Live Service for NGED's Trial Area
 
 *Epic: [#133](https://github.com/openclimatefix/nged-substation-forecast/issues/133)*
 
 Target: **January 2027**
 
-- All features listed above (v0.1–v0.7), plus fixes discovered during live running
+- All features listed above (v0.1–v0.8), plus fixes discovered during live running
 - 32 time series in the NGED trial area: 16 primary substations, 6 solar PV farms, 3 wind farms, 2 GSPs, 2 BSPs, 1 biofuel generator, 1 BESS, 1 reciprocating gas generator
 - Five Delta Lake output tables delivered to NGED every 6 hours:
     1. `power_forecast` — [−1, +1] ensemble power forecasts


### PR DESCRIPTION
Adds a fourth subsection to [Considered but rejected designs](https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/#considered-but-rejected-designs): **Running the data-ingest runs on the control-plane VM**. The question it answers: the hourly NGED telemetry pull and daily Dynamical.org NWP download are deliberately light, so why dispatch each one to its own Fargate task instead of running them on the always-on box?

Following the section's established structure (the design, then why we rejected it), the five reasons:

1. **Dagster OSS has one run launcher per instance** — "ingest locally, forecasts on Fargate" would need a custom hybrid launcher: bespoke glue on the critical path of every run, contra the handover constraint.
2. **Blast-radius isolation** — ingest is lighter than inference but not negligible ([#276](https://github.com/openclimatefix/nged-substation-forecast/issues/276)'s CPU self-contention is cited as evidence); a memory or CPU spike on the shared 4 GB box risks starving daemon heartbeats or OOM-killing Postgres — killing the control plane is the exact failure the architecture exists to avoid.
3. **The box would have to grow** — sizing for ingest peaks (~2× the `t4g.medium` cost) roughly cancels the Fargate saving.
4. **One execution path** — same image, log destination, IAM story, and debugging experience for every run; two environments is two sets of failure modes for a non-expert post-NIA operator.
5. **V2 scaling** — a task-size change on Fargate vs another resize of the hardest-to-touch component.

It closes honestly with what the accepted design costs (~\$5–10/month of ingest runs inheriting the inference-sized 4 vCPU / 16 GB task — the same magnitude the EventBridge rejection dismissed as "not real") and the door left open: per-run `ecs/cpu`/`ecs/memory` tags to shrink ingest task sizes, rather than ever moving the work onto the box.

The orchestration section's "dispatches every run" sentence now links to the new subsection at the point where a reader would ask the question.

## Follow-up commit: mechanism, granularity, and the sensor escape hatch

- The orchestration section now explains **how a deployment picks its launcher**: the run launcher is Dagster *instance* configuration (`dagster.yaml`, outside the image) — the laptop declares none (`DefaultRunLauncher` subprocesses), the box declares `EcsRunLauncher` (linked to Step 14 of the runbook). Code and image are byte-identical either way, which is what makes the "same artifact" portability claim true.
- The new rejected-design subsection gains the framing fact that **Dagster launches runs, not assets, onto Fargate** — a tiny asset only pays for a task if it has a schedule of its own — and notes the two real inefficiencies: most hourly telemetry polls are no-ops (NGED publishes ~5-hourly), and `ecmwf_ens`'s `RetryRequested` loop holds its 16 GB task idle for up to 4 h on late-publication days.
- Its closing "Door left open" now has two options, neither of which moves work onto the box: per-run `ecs/cpu`/`ecs/memory` tags, and **Dagster sensors** ([#324](https://github.com/openclimatefix/nged-substation-forecast/issues/324)) — sensor evaluation runs on the daemon (the box), so cheap "is there new data?" detection lives there natively while only genuine runs launch Fargate tasks. This is the hybrid reason 1 said would need a custom launcher, shipped by Dagster itself.
- New **v0.8 — Improve Live Service** roadmap milestone (epic [#323](https://github.com/openclimatefix/nged-substation-forecast/issues/323), first sub-task #324), keeping the epics-map-1:1-to-milestones convention; v1.0's feature range updated to v0.1–v0.8.

## Verification

`pymarkdown scan`, `mkdocs build --strict`, and rendered-HTML inspection: the new heading anchor exists, the five reasons render as an ordered list, and all cross-links (issue #276, handover page, region price table, EventBridge subsection, and the inbound link from the orchestration section) resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
