### PR TITLE
docs: link infra-as-code mentions to tracking issue #326

### DIFF
--- a/docs/live_service/aws.md
+++ b/docs/live_service/aws.md
@@ -25,7 +25,8 @@ bake the model in at build time, an always-on control plane rather than EventBri
 > (Terraform, or CDK — AWS's Cloud Development Kit) yet.
 > That's deliberate: this is Stage 1 ("solo, Tailscale only") of the
 > [access-phasing plan](../roadmap/live-service.md#access-phasing), and infrastructure-as-code
-> is scheduled to start at Stage 2, when team access adds enough moving parts to justify it.
+> ([#326](https://github.com/openclimatefix/nged-substation-forecast/issues/326)) is scheduled
+> to start at Stage 2, when team access adds enough moving parts to justify it.
 > Alerting (per-task failure emails, the missed-check-in alarm) is also still to come — see
 > [the roadmap](../roadmap/live-service.md#alert-on-absence-the-missed-check-in-alarm).
 

--- a/docs/roadmap/handover.md
+++ b/docs/roadmap/handover.md
@@ -132,8 +132,9 @@ build order:
 ### 4. Infrastructure-as-code, portable to NGED's account
 
 The live-service plan already defers infra-as-code to
-[Access-phasing Stage 2](live-service.md#access-phasing) — that sequencing stands. What the
-handover requirement adds:
+[Access-phasing Stage 2](live-service.md#access-phasing) — that sequencing stands, and the work
+is tracked as [#326](https://github.com/openclimatefix/nged-substation-forecast/issues/326).
+What the handover requirement adds:
 
 - **By handover time, IaC is mandatory, not optional.** The rebuild-from-scratch runbook
   (workstream 3) and the deployment into NGED's account (workstream 5) both depend on it.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -178,13 +178,19 @@ only for first month, then shared with NGED.*
 
 The bucket for **operational improvements to the running live service** — efficiency,
 robustness, and operability polish discovered during early live running, as distinct from the
-forecast-skill milestones above. First item:
+forecast-skill milestones above. Items so far:
 
 - Replace the polling schedules with Dagster sensors
   ([#324](https://github.com/openclimatefix/nged-substation-forecast/issues/324)): cheap
   "is there new data?" detection runs on the control-plane box, and Fargate tasks launch only
   when there is real work to do. Design context:
   [Production Deployment — Design](../architecture/production-deployment.md#running-the-data-ingest-runs-on-the-control-plane-vm).
+- Codify the AWS infrastructure as infra-as-code
+  ([#326](https://github.com/openclimatefix/nged-substation-forecast/issues/326)): the
+  Terraform-vs-CDK question and the sequencing (start at access-phasing Stage 2) are in the
+  [live-service plan](live-service.md#deployment-workstream-3-aws-infrastructure); the
+  account-portability requirement is in
+  [Handover to NGED](handover.md#4-infrastructure-as-code-portable-to-ngeds-account).
 
 ---
 

--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -563,7 +563,8 @@ dress rehearsal above.
 > (steps 5–10). The accepted option's specific pieces below (the always-on EC2 box,
 > `EcsRunLauncher`, scheduling, Tailscale) now have their full bring-up runbook written —
 > [steps 11–16 of the same page](https://openclimatefix.github.io/nged-substation-forecast/live_service/aws/#step-11-launch-the-control-plane-box)
-> — and executing it is in progress; infra-as-code is still 🚧, tracked as follow-up work.
+> — and executing it is in progress; infra-as-code is still 🚧, tracked as
+> [#326](https://github.com/openclimatefix/nged-substation-forecast/issues/326).
 
 Common to all options:
 
@@ -589,7 +590,9 @@ Common to all options:
   failure alerts are necessary but not sufficient — the
   [missed-check-in alarm](#alert-on-absence-the-missed-check-in-alarm) catches the
   silent-failure classes they miss.
-- 🚧 Codify as infra-as-code once there's enough to justify it — per the
+- 🚧 Codify as infra-as-code
+  ([#326](https://github.com/openclimatefix/nged-substation-forecast/issues/326)) once there's
+  enough to justify it — per the
   [Access phasing sequencing note](#access-phasing), that point is Stage 2, not Stage 1.
   **Open question, not yet decided:** this section originally specified a small Terraform
   module (one file), but a later conversation argued for **AWS CDK (Python)** instead —


### PR DESCRIPTION
Infra-as-code now has a tracking issue — [#326](https://github.com/openclimatefix/nged-substation-forecast/issues/326), under epic #323 — so the docs passages that describe the work as still-to-come can point at it. This PR adds that link in the four places that mention the work:

- **`docs/roadmap/live-service.md`** — the Deployment workstream 3 status banner ("infra-as-code is still 🚧") and the 🚧 "Codify as infra-as-code" bullet itself.
- **`docs/roadmap/handover.md`** — the "Infrastructure-as-code, portable to NGED's account" workstream.
- **`docs/roadmap/index.md`** — added #326 to the v0.8 milestone's item list (alongside #324), with pointers to where the Terraform-vs-CDK question and the account-portability requirement live.
- **`docs/live_service/aws.md`** — the "everything here is done by hand" scope note.

No design content changed — links only, plus the new v0.8 list entry summarising where the existing plan lives.

Verified with `pymarkdown scan` and `mkdocs build --strict`, and spot-checked the rendered HTML of the edited lists (per the known Python-Markdown list gotchas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)