### PR TITLE
docs(roadmap): link Access phasing Stages 2 and 3 to their new issues

### DIFF
--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -334,6 +334,8 @@ something to say "additive on top of."
 
 #### Stage 2 — team gets read-only Dagster access; MLflow stays private
 
+Issue: [#328](https://github.com/openclimatefix/nged-substation-forecast/issues/328)
+
 - A **second** `dagster-webserver --read-only` process on the same box, against the same
   Postgres + code location — cheap: just another process, no new daemon, no new infra beyond
   this.
@@ -363,6 +365,8 @@ something to say "additive on top of."
   pieces Stage 2's proxy needs but also breaks none of them.
 
 #### Stage 3 — public Marimo dashboard, curated public data
+
+Issue: [#329](https://github.com/openclimatefix/nged-substation-forecast/issues/329)
 
 - A **separate** Marimo instance, not the private one — reads only a public-safe subset of data
   (ideally its own S3 prefix), runs as its own ECS Fargate task/service, no ALB.


### PR DESCRIPTION
## What

Adds an `Issue: #NNN` line under the Access phasing **Stage 2** and **Stage 3** headings on the live-service roadmap page, matching the convention every other section on that page already follows.

## Why

An audit of the "Access phasing" and "Production monitoring" sections against GitHub found that the two access-phasing stages were the only planned work on the page with no GitHub issue at all. They are now tracked:

- #328 — Stage 2: read-only Dagster access for the team (Caddy + oauth2-proxy); blocked by #206
- #329 — Stage 3: public Marimo dashboard with scale-to-zero wake-proxy; blocked by #328 and #236

Both are Features, sub-issues of the v0.8 epic #323 (ordered after #326), on the OCF board with Status=Todo / Project=NGED / Area=ML.

The same audit also cross-linked the [missed-check-in alarm](https://openclimatefix.github.io/nged-substation-forecast/roadmap/live-service/#alert-on-absence-the-missed-check-in-alarm) between #224 and #63 (issue-body edits only — no docs change needed, so not part of this diff).

`pymarkdown scan` and `mkdocs build --strict` both pass; the three docs anchors used in the issue bodies were verified against the built HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)