### PR TITLE
chore: bump version to 0.1.0 for the v0.1 release

### DIFF
--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -59,13 +59,13 @@ GitHub epic issue.
 ## v0.1 — "Naive" MVP (internal only)
 
 *Epic: [#137](https://github.com/openclimatefix/nged-substation-forecast/issues/137) — deploy the
-naive forecast on AWS. **This is the current focus.***
+naive forecast on AWS. **✅ Shipped July 2026** (`v0.1.0`) — running on AWS.*
 
 **Goal**: A simple XGBoost forecast that lets us test infrastructure end-to-end and establish a
 baseline. Intentionally does not detect switching events or estimate effective capacity — hence
 "naive" (assumes the grid is always in perfect health). The data pipeline, per-series XGBoost
-models, and CV leaderboard are already built; the remaining work is deployment — see
-[Live service](live-service.md).
+models, and CV leaderboard were already built; the remaining work was deployment, now running on
+AWS — see [Live service](live-service.md).
 
 ![v0.1 Naive forecast](assets/v0.1_naive_forecast_flow_diagram.png)
 

--- a/packages/contracts/pyproject.toml
+++ b/packages/contracts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "contracts"
-version = "0.0.1"
+version = "0.1.0"
 description = "Data contracts for the NGED substation forecast project"
 requires-python = ">=3.14"
 dependencies = [

--- a/packages/delta_store/pyproject.toml
+++ b/packages/delta_store/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "delta_store"
-version = "0.0.1"
+version = "0.1.0"
 description = "Physical storage policy for the project's Delta tables: parquet writer properties, compression-friendly sort orders, and significand-precision rounding"
 readme = "README.md"
 authors = [

--- a/packages/ml_core/pyproject.toml
+++ b/packages/ml_core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ml_core"
-version = "0.0.1"
+version = "0.1.0"
 description = "Unified ML model interface and shared utilities for substation forecasting."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/nged_data/pyproject.toml
+++ b/packages/nged_data/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nged_data"
-version = "0.0.1"
+version = "0.1.0"
 description = "Package for handling NGED JSON data"
 requires-python = ">=3.14"
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # Metadata (see https://peps.python.org/pep-0621/)
 [project]
 name = "nged-substation-forecast"
-version = "0.0.1"
+version = "0.1.0"
 description = "Forecast net demand at primary, BSP, and GSP substations, and split the forecast into gross demand, solar, and wind per substation for National Grid Electricity Distribution (NGED)"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -688,7 +688,7 @@ wheels = [
 
 [[package]]
 name = "contracts"
-version = "0.0.1"
+version = "0.1.0"
 source = { editable = "packages/contracts" }
 dependencies = [
     { name = "deltalake" },
@@ -1086,7 +1086,7 @@ wheels = [
 
 [[package]]
 name = "delta-store"
-version = "0.0.1"
+version = "0.1.0"
 source = { editable = "packages/delta_store" }
 dependencies = [
     { name = "contracts" },
@@ -2527,7 +2527,7 @@ wheels = [
 
 [[package]]
 name = "ml-core"
-version = "0.0.1"
+version = "0.1.0"
 source = { editable = "packages/ml_core" }
 dependencies = [
     { name = "contracts" },
@@ -2763,7 +2763,7 @@ wheels = [
 
 [[package]]
 name = "nged-data"
-version = "0.0.1"
+version = "0.1.0"
 source = { editable = "packages/nged_data" }
 dependencies = [
     { name = "contracts" },
@@ -2784,7 +2784,7 @@ requires-dist = [
 
 [[package]]
 name = "nged-substation-forecast"
-version = "0.0.1"
+version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "altair" },


### PR DESCRIPTION
v0.1 (the naive XGBoost forecast) is now deployed and running on AWS — closing out epic #137. This marks the release.

## What this does

- Sets **every workspace package** (root + all 10 sub-packages) to `0.1.0`, clearing the existing `0.0.1`/`0.1.0` drift, and updates `uv.lock` to match.
- Flips the **v0.1 milestone status to "shipped"** in the roadmap index.

## Why not keep bumping per-package versions each release?

The package versions are cosmetic: nothing is published to PyPI, and the workspace deps resolve via `{ workspace = true }` (not version). No code reads `__version__` / `importlib.metadata`. So per [#209](https://github.com/openclimatefix/nged-substation-forecast/issues/209) (Peter's steer toward git tags), the durable release marker going forward is an **annotated git tag** (`v0.1.0`) on the merge commit — not per-package version churn. This bump is a one-time normalization to clear the drift.

## Follow-up (not in this PR)

The fuller ship-time triage for the v0.1 roadmap page — retiring `docs/roadmap/live-service.md`, promoting its surviving design decisions to `docs/architecture/`, and resolving the still-open 🚧 threads (alerting, infra-as-code, backtest task definition, SNS-confirm docs) — is substantial and has open threads, so it's deliberately left for a separate change.

Closes #209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)