### PR TITLE
docs: how-to for connecting to the AWS control plane over Tailscale

### DIFF
--- a/docs/live_service/connecting.md
+++ b/docs/live_service/connecting.md
@@ -1,0 +1,102 @@
+# Connecting to the AWS control plane
+
+Once the service is set up on AWS ([Setting up the live service on AWS](aws.md)) and running, this
+is how a laptop reaches it — both the Dagster UI and a shell on the always-on control-plane box —
+over Tailscale.
+
+Everything routes through the OCF tailnet. The control-plane box has **no publicly-reachable
+ports** (its security group allows no inbound traffic except Postgres from the Fargate workers),
+and the Dagster webserver has **no login of its own**, so joining the tailnet is what grants — and
+gates — access. Anyone on the OCF tailnet can reach the UI and, via Tailscale SSH, a shell as
+`ubuntu`; that is intended for this box. See
+[the access-phasing plan](../roadmap/live-service.md#access-phasing) for why the security model is
+"tailnet membership is the authentication" at this stage.
+
+This page is the client-laptop counterpart to [Step 12](aws.md#step-12-join-the-tailnet) of the
+AWS runbook: that step joins the *box* to the tailnet, once; this page gets *your* laptop onto the
+same tailnet so it can see the box.
+
+## Prerequisites
+
+- **The AWS stack is set up and running** — [Setting up the live service on AWS](aws.md) has been
+  completed. In particular the control-plane box `nged-forecast-ctrl` has joined the OCF tailnet
+  with Tailscale SSH enabled ([Step 12](aws.md#step-12-join-the-tailnet)), and the Dagster stack is
+  up ([Step 15](aws.md#step-15-start-the-stack-and-connect-over-tailscale)).
+- **An OCF Google Workspace account** (`…@openclimatefix.org`). The tailnet is org-scoped, so a
+  personal Google account cannot join it — and only devices on the OCF tailnet can see
+  `nged-forecast-ctrl`.
+
+## Step 1 — Install Tailscale on your laptop
+
+- **macOS / Windows**: install the GUI client from
+  [tailscale.com/download](https://tailscale.com/download) (on macOS, `brew install --cask
+  tailscale` works too).
+- **Linux**: use the same install script the box uses in
+  [Step 12](aws.md#step-12-join-the-tailnet) — it adds Tailscale's own APT repository so the client
+  keeps getting the current stable release through `apt upgrade`:
+
+    ```bash
+    curl -fsSL https://tailscale.com/install.sh | sh
+    ```
+
+## Step 2 — Join the OCF tailnet
+
+Sign in **with your OCF Google Workspace account** (`…@openclimatefix.org`) so your laptop joins
+the shared OCF org tailnet rather than a personal one:
+
+- **GUI client**: launch Tailscale, choose **Log in**, then **Sign in with Google**, and pick your
+  `…@openclimatefix.org` account.
+- **CLI (Linux)**: run `sudo tailscale up`, open the URL it prints, and sign in with the OCF Google
+  account.
+
+A device is on **one tailnet at a time**. If your laptop is already signed into a personal
+Tailscale account, switch it to the OCF account first — the account menu in the GUI client, or
+`sudo tailscale switch` / `sudo tailscale login` on the CLI — otherwise `nged-forecast-ctrl` will
+not appear.
+
+## Step 3 — Confirm you can reach the box
+
+```bash
+tailscale status                     # nged-forecast-ctrl should appear in the list
+tailscale ping nged-forecast-ctrl
+```
+
+`nged-forecast-ctrl` is the box's stable MagicDNS name (set by `--hostname` in
+[Step 12](aws.md#step-12-join-the-tailnet)). If the name ever fails to resolve — MagicDNS is off on
+your client, say — read the box's raw Tailscale IP (a `100.x` address) from the `tailscale status`
+output and use that instead.
+
+## Step 4 — Open the Dagster UI
+
+In a browser, open **`http://nged-forecast-ctrl:3000`** (plain `http`, MagicDNS name; the raw
+`100.x` Tailscale IP works too). There is no login prompt — that is by design (see the security
+note at the top of this page).
+
+From here, driving the running service — promoting a champion, materialising or backfilling a slot,
+inspecting a forecast — is [Operating the live service](operations.md).
+
+## Step 5 — SSH into the box
+
+```bash
+ssh ubuntu@nged-forecast-ctrl
+```
+
+No SSH key and no key management: the box runs **Tailscale SSH** (the `--ssh` flag in
+[Step 12](aws.md#step-12-join-the-tailnet)), so access is governed by the tailnet's ACLs rather
+than a key file, and the login user is `ubuntu`. Use this shell for the box-side `docker compose`
+operations — checking service health, tailing logs, restarting the stack — that live in
+[Step 15](aws.md#step-15-start-the-stack-and-connect-over-tailscale), for example:
+
+```bash
+cd ~/nged-forecast
+docker compose ps                    # all four services should be Up
+docker compose logs -f daemon
+```
+
+## See also
+
+- [Setting up the live service on AWS](aws.md) — the one-time bring-up this page assumes is done,
+  including [Step 12](aws.md#step-12-join-the-tailnet) (joining the box to the tailnet) and
+  [Step 15](aws.md#step-15-start-the-stack-and-connect-over-tailscale) (starting the stack).
+- [Operating the live service](operations.md) — what to do once you are connected: promotion, the
+  6-hourly schedule, inspecting forecasts, backfilling missed slots.

--- a/docs/live_service/index.md
+++ b/docs/live_service/index.md
@@ -38,6 +38,9 @@ driving is identical in both environments, so it lives on one shared page:
   spelled out on first use there), promote a champion and build/verify/push its image, the
   Fargate task, the always-on control-plane box, and connecting to the Dagster UI over
   Tailscale.
+- [Connecting to the AWS control plane](connecting.md) — get a laptop onto the OCF tailnet to
+  reach an already-running deployment: install Tailscale, view the Dagster UI, and SSH into the
+  always-on box.
 - [Operating the live service](operations.md) — driving a running stack day to day: promote a
   champion model, let the 6-hourly `live_forecasts` schedule run (or materialise a slot by
   hand), inspect a forecast, and backfill a missed slot in replay mode.

--- a/docs/live_service/operations.md
+++ b/docs/live_service/operations.md
@@ -25,7 +25,8 @@ the stack runs in — bring one up first:
   `http://localhost:3000` and runs execute on your machine.
 - **Deployed on AWS** — [Setting up the live service on AWS](aws.md); the UI is at
   `http://nged-forecast-ctrl:3000` over Tailscale, and each run executes on an ephemeral
-  Fargate task.
+  Fargate task. To get your laptop onto the tailnet and reach that UI, see
+  [Connecting to the AWS control plane](connecting.md).
 
 ## Step 1 — Pick a champion model
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ nav:
       - Overview: live_service/index.md
       - Running the whole stack locally: live_service/local.md
       - Setting up the live service on AWS: live_service/aws.md
+      - Connecting to the AWS control plane: live_service/connecting.md
       - Operating the live service: live_service/operations.md
       - Configuration reference: live_service/setup.md
   - Roadmap:


### PR DESCRIPTION
## What

Adds [`docs/live_service/connecting.md`](https://github.com/openclimatefix/nged-substation-forecast/blob/docs-connect-tailscale-336/docs/live_service/connecting.md) — a brief how-to for connecting a laptop to the always-on Dagster control plane, assuming the AWS bring-up in `aws.md` is complete and the service is running. It covers:

1. Installing Tailscale on the laptop (macOS/Windows GUI, Linux install script).
2. Joining the **OCF** tailnet by signing in with an `@openclimatefix.org` Google Workspace account (with the one-tailnet-per-device switching caveat).
3. Confirming reachability (`tailscale status` / `ping`), with the MagicDNS-off fallback to the raw `100.x` IP.
4. Opening the Dagster UI at `http://nged-forecast-ctrl:3000`.
5. SSH into the box via Tailscale SSH (`ssh ubuntu@nged-forecast-ctrl`, no key management).

Also wires the page into the nav (`mkdocs.yml`) and cross-links it from the live-service index and the `operations.md` prerequisites.

## Why

Closes #336. The existing `aws.md` runbook documents joining the *box* to the tailnet (Step 12) from the setup operator's side, but nothing documented the *client-laptop* side — how a second operator (or the same operator on a fresh machine) gets onto the OCF tailnet to reach an already-running deployment. This page is that counterpart.

## Reviewer notes

- Kept deliberately non-duplicative of `aws.md`: this page assumes the box-side setup is done and links back to Steps 12 and 15 rather than repeating them.
- Frames the security model up front (tailnet membership *is* the authentication; no public inbound ports; the Dagster UI has no login of its own), consistent with `aws.md` and the access-phasing plan.
- Verified with `uv run pymarkdown scan` (clean) and `uv run mkdocs build --strict` (passes — all internal anchor links resolve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)