### PR TITLE
Shade weekends in the view_forecasts chart, with an on/off checkbox

### DIFF
--- a/packages/dashboard/src/dashboard/forecast_chart.py
+++ b/packages/dashboard/src/dashboard/forecast_chart.py
@@ -96,18 +96,23 @@ def _x_axis_ticks(window_start: datetime, window_end: datetime) -> list[datetime
     return pl.datetime_range(first_tick, window_end, interval="3h", eager=True).to_list()
 
 
-def _x_encoding(window_start: datetime, window_end: datetime) -> alt.X:
+def _x_encoding(window_start: datetime, window_end: datetime, field: str = "valid_time") -> alt.X:
     """The shared x encoding: explicit 3-hourly ticks, labels at midnight only.
 
     Altair's adaptive datetime ticks are hard to read; instead every property is pinned. Labelled
     major ticks (with gridlines) sit at each local midnight, formatted ``Mon 06 Jul``; shorter
     minor ticks every 3 hours carry no label and no gridline. The conditional-axis-property
     dicts are Vega-Lite's native encoding for "major vs minor tick" styling.
+
+    Every layer must use this same encoding (via ``field`` when its time column isn't
+    ``valid_time``): the x scale is shared across layers, so Vega-Lite merges the layers' axis
+    definitions, and one deviating definition (e.g. ``axis=None``) can suppress the merged axis
+    — labels, ticks, and gridlines — for the whole chart.
     """
     tick_size: dict[str, Any] = {"condition": {"test": _MIDNIGHT_TEST, "value": 7}, "value": 3}
     grid_opacity: dict[str, Any] = {"condition": {"test": _MIDNIGHT_TEST, "value": 1}, "value": 0}
     return alt.X(
-        "valid_time:T",
+        f"{field}:T",
         title=f"Time ({DISPLAY_TIME_ZONE})",
         scale=alt.Scale(domain=[window_start, window_end]),
         axis=alt.Axis(
@@ -160,16 +165,13 @@ def build_view_forecast_chart(
     x = _x_encoding(window_start, window_end)
 
     # Drawn first so every other layer sits on top; no y encoding, so each band spans the full
-    # chart height. The other layers carry the labelled x-axis, hence axis=None here.
+    # chart height. Uses the shared x encoding (see _x_encoding's docstring for why deviating
+    # from it would suppress the merged x-axis).
     weekend_layer = (
         alt.Chart(_weekend_bands(window_start, window_end))
         .mark_rect(color=ocf_theme.MUSTARD, opacity=WEEKEND_SHADE_OPACITY)
         .encode(
-            x=alt.X(
-                "start:T",
-                scale=alt.Scale(domain=[window_start, window_end]),
-                axis=None,
-            ),
+            x=_x_encoding(window_start, window_end, field="start"),
             x2="end:T",
         )
     )

--- a/packages/dashboard/src/dashboard/forecast_chart.py
+++ b/packages/dashboard/src/dashboard/forecast_chart.py
@@ -1,12 +1,15 @@
 """Single-panel ensemble forecast chart for the ``view_forecasts.py`` dashboard app.
 
 Builds an Altair chart of one forecast run for one ``time_series_id``: every NWP ensemble member
-as a thin grey line, observed power as a thick blue line, and a vertical rule at
-``power_fcst_init_time``. The x-axis deliberately overrides Altair's adaptive datetime ticks:
-labels sit at local midnight only (day-of-week first — crucial for demand forecasting), with
-unlabelled minor ticks every 3 hours, all in Europe/London wall time.
+as a thin grey line, observed power as a thick blue line, a vertical rule at
+``power_fcst_init_time``, and a faint shaded band behind each weekend (weekday/weekend structure
+dominates demand, so weekends should be findable at a glance). The x-axis deliberately overrides
+Altair's adaptive datetime ticks: labels sit at local midnight only (day-of-week first — crucial
+for demand forecasting), with unlabelled minor ticks every 3 hours, all in Europe/London wall
+time.
 """
 
+import calendar
 from datetime import datetime, timedelta
 from typing import Any, Final, cast
 
@@ -23,6 +26,14 @@ PLOT_HORIZON: Final[timedelta] = timedelta(days=14)
 DISPLAY_TIME_ZONE: Final[str] = "Europe/London"
 """All plotted times are converted to this zone's wall time (demand shape follows the local
 clock, so midnight ticks and day-of-week labels must be local, not UTC)."""
+
+WEEKEND_SHADE_OPACITY: Final[float] = 0.07
+"""Opacity of the weekend background bands.
+
+At this level, ``ocf_theme.MUSTARD`` over the cream theme background reads as a slightly warmer
+cream rather than an orange stripe, so the bands mark weekends without competing with the
+low-opacity grey ensemble lines.
+"""
 
 _MIDNIGHT_TEST: Final[str] = "hours(datum.value) == 0"
 """Vega expression: is this tick at (wall-clock) midnight?
@@ -46,6 +57,34 @@ def _prepare_for_plot(lf: pl.LazyFrame, time_column: str, power_column: str) -> 
     return lf.with_columns(
         pl.col(time_column).dt.convert_time_zone(DISPLAY_TIME_ZONE).dt.replace_time_zone(None),
         pl.col(power_column).cast(pl.Float64).round(3),
+    )
+
+
+def _weekend_bands(window_start: datetime, window_end: datetime) -> pl.DataFrame:
+    """Weekend intervals (Saturday 00:00 to Monday 00:00 wall time) overlapping the window.
+
+    Args:
+        window_start: Start of the plotted window (naive Europe/London wall time).
+        window_end: End of the plotted window (naive wall time).
+
+    Returns:
+        One row per weekend, with naive wall-time ``start``/``end`` columns clipped to the
+        window (possibly zero rows). Bands sit at wall-clock midnights, matching the labelled
+        midnight gridlines.
+    """
+    # Scan from two days before the window so a window that opens mid-weekend still picks up
+    # the enclosing band's Saturday.
+    day = (window_start - timedelta(days=2)).replace(hour=0, minute=0, second=0, microsecond=0)
+    bands: list[tuple[datetime, datetime]] = []
+    while day < window_end:
+        if day.weekday() == calendar.SATURDAY:
+            band = (max(day, window_start), min(day + timedelta(days=2), window_end))
+            if band[0] < band[1]:
+                bands.append(band)
+        day += timedelta(days=1)
+    return pl.DataFrame(
+        {"start": [b[0] for b in bands], "end": [b[1] for b in bands]},
+        schema={"start": pl.Datetime("us"), "end": pl.Datetime("us")},
     )
 
 
@@ -120,6 +159,20 @@ def build_view_forecast_chart(
     window_end = init_wall + PLOT_HORIZON
     x = _x_encoding(window_start, window_end)
 
+    # Drawn first so every other layer sits on top; no y encoding, so each band spans the full
+    # chart height. The other layers carry the labelled x-axis, hence axis=None here.
+    weekend_layer = (
+        alt.Chart(_weekend_bands(window_start, window_end))
+        .mark_rect(color=ocf_theme.MUSTARD, opacity=WEEKEND_SHADE_OPACITY)
+        .encode(
+            x=alt.X(
+                "start:T",
+                scale=alt.Scale(domain=[window_start, window_end]),
+                axis=None,
+            ),
+            x2="end:T",
+        )
+    )
     ensemble_layer = (
         alt.Chart(_prepare_for_plot(forecasts, "valid_time", "power_fcst").collect())
         .mark_line(strokeWidth=1, opacity=0.3, color=ocf_theme.ENSEMBLE_LINE)
@@ -147,10 +200,10 @@ def build_view_forecast_chart(
         .encode(x=x, tooltip=[alt.Tooltip("valid_time", title="Forecast init time")])
     )
 
-    chart = alt.layer(ensemble_layer, actuals_layer, init_time_rule).properties(
+    chart = alt.layer(weekend_layer, ensemble_layer, actuals_layer, init_time_rule).properties(
         title=alt.TitleParams(
             text=title,
-            subtitle=[subtitle, "Grey: ensemble members · Blue: observed power"],
+            subtitle=[subtitle, "Grey: ensemble members · Blue: observed power · Shaded: weekends"],
         ),
         width="container",
         height=400,

--- a/packages/dashboard/src/dashboard/forecast_chart.py
+++ b/packages/dashboard/src/dashboard/forecast_chart.py
@@ -134,6 +134,7 @@ def build_view_forecast_chart(
     units: str,
     title: str,
     subtitle: str,
+    shade_weekends: bool = True,
 ) -> alt.LayerChart:
     """Build the single-panel forecast chart for one series and one forecast run.
 
@@ -147,6 +148,7 @@ def build_view_forecast_chart(
         units: ``"MW"`` or ``"MVA"``, from this series' ``TimeSeriesMetadata``.
         title: Chart title (the series name / type / id line).
         subtitle: Chart subtitle (the init time / experiment line).
+        shade_weekends: Whether to draw a faint background band behind each weekend.
 
     Returns:
         A layered, zoomable Altair chart in Europe/London wall time.
@@ -164,17 +166,21 @@ def build_view_forecast_chart(
     window_end = init_wall + PLOT_HORIZON
     x = _x_encoding(window_start, window_end)
 
-    # Drawn first so every other layer sits on top; no y encoding, so each band spans the full
-    # chart height. Uses the shared x encoding (see _x_encoding's docstring for why deviating
-    # from it would suppress the merged x-axis).
-    weekend_layer = (
-        alt.Chart(_weekend_bands(window_start, window_end))
-        .mark_rect(color=ocf_theme.MUSTARD, opacity=WEEKEND_SHADE_OPACITY)
-        .encode(
-            x=_x_encoding(window_start, window_end, field="start"),
-            x2="end:T",
+    layers: list[alt.Chart] = []
+    legend_parts = ["Grey: ensemble members", "Blue: observed power"]
+    if shade_weekends:
+        # Drawn first so every other layer sits on top; no y encoding, so each band spans the
+        # full chart height. Uses the shared x encoding (see _x_encoding's docstring for why
+        # deviating from it would suppress the merged x-axis).
+        layers.append(
+            alt.Chart(_weekend_bands(window_start, window_end))
+            .mark_rect(color=ocf_theme.MUSTARD, opacity=WEEKEND_SHADE_OPACITY)
+            .encode(
+                x=_x_encoding(window_start, window_end, field="start"),
+                x2="end:T",
+            )
         )
-    )
+        legend_parts.append("Shaded: weekends")
     ensemble_layer = (
         alt.Chart(_prepare_for_plot(forecasts, "valid_time", "power_fcst").collect())
         .mark_line(strokeWidth=1, opacity=0.3, color=ocf_theme.ENSEMBLE_LINE)
@@ -202,10 +208,11 @@ def build_view_forecast_chart(
         .encode(x=x, tooltip=[alt.Tooltip("valid_time", title="Forecast init time")])
     )
 
-    chart = alt.layer(weekend_layer, ensemble_layer, actuals_layer, init_time_rule).properties(
+    layers += [ensemble_layer, actuals_layer, init_time_rule]
+    chart = alt.layer(*layers).properties(
         title=alt.TitleParams(
             text=title,
-            subtitle=[subtitle, "Grey: ensemble members · Blue: observed power · Shaded: weekends"],
+            subtitle=[subtitle, " · ".join(legend_parts)],
         ),
         width="container",
         height=400,

--- a/packages/dashboard/tests/test_forecast_chart.py
+++ b/packages/dashboard/tests/test_forecast_chart.py
@@ -60,28 +60,42 @@ def _build() -> LayerChart:
     )
 
 
-def test_chart_layers_ensemble_actuals_and_init_rule() -> None:
+def test_chart_layers_weekends_ensemble_actuals_and_init_rule() -> None:
     spec = _build().to_dict()
-    assert len(spec["layer"]) == 3  # ensemble members, actuals, init-time rule
-    ensemble, actuals, rule = spec["layer"]
+    assert len(spec["layer"]) == 4  # weekend bands, ensemble members, actuals, init-time rule
+    weekends, ensemble, actuals, rule = spec["layer"]
+    assert weekends["mark"]["type"] == "rect"  # drawn first, so every line sits on top of it
+    assert weekends["encoding"]["x2"]["field"] == "end"
     assert ensemble["encoding"]["detail"]["field"] == "ensemble_member"
     assert ensemble["encoding"]["y"]["title"] == "Power (MW)"
     assert actuals["encoding"]["y"]["field"] == "power"
     assert rule["mark"]["type"] == "rule"
 
 
+def test_weekend_bands_sit_at_wall_midnights_clipped_to_window() -> None:
+    spec = _build().to_dict()
+    bands = spec["datasets"][spec["layer"][0]["data"]["name"]]
+    # Window is Fri 03 Jul 07:00 → Sat 18 Jul 07:00 wall time: two full weekends plus the
+    # opening hours of a third, clipped at the window's end.
+    assert [(b["start"], b["end"]) for b in bands] == [
+        ("2026-07-04T00:00:00", "2026-07-06T00:00:00"),
+        ("2026-07-11T00:00:00", "2026-07-13T00:00:00"),
+        ("2026-07-18T00:00:00", "2026-07-18T07:00:00"),
+    ]
+
+
 def test_times_are_rendered_as_europe_london_wall_time() -> None:
     spec = _build().to_dict()
     # 06:00 UTC during BST is 07:00 wall time; the rule layer's single datum carries it, naive.
-    (rule_datum,) = spec["datasets"][spec["layer"][2]["data"]["name"]]
+    (rule_datum,) = spec["datasets"][spec["layer"][3]["data"]["name"]]
     assert rule_datum["valid_time"].startswith("2026-07-04T07:00:00")
     assert "+" not in rule_datum["valid_time"]  # naive — no zone for Vega to re-localise
-    assert spec["layer"][0]["encoding"]["x"]["title"] == "Time (Europe/London)"
+    assert spec["layer"][1]["encoding"]["x"]["title"] == "Time (Europe/London)"
 
 
 def test_x_axis_has_3_hourly_ticks_labelled_at_midnight_only() -> None:
     spec = _build().to_dict()
-    axis = spec["layer"][0]["encoding"]["x"]["axis"]
+    axis = spec["layer"][1]["encoding"]["x"]["axis"]
     # Altair omits an all-zero time-of-day, so a midnight tick has no "hours" key at all.
     tick_hours = [tick.get("hours", 0) for tick in axis["values"]]
     assert all(hour % 3 == 0 for hour in tick_hours)

--- a/packages/dashboard/tests/test_forecast_chart.py
+++ b/packages/dashboard/tests/test_forecast_chart.py
@@ -49,7 +49,7 @@ def _actuals() -> pl.LazyFrame:
     ).lazy()
 
 
-def _build() -> LayerChart:
+def _build(*, shade_weekends: bool = True) -> LayerChart:
     return build_view_forecast_chart(
         _forecasts((0, 1, 2)),
         _actuals(),
@@ -57,6 +57,7 @@ def _build() -> LayerChart:
         units="MW",
         title="Test series — PV — id 1",
         subtitle="Forecast init Sat 04 Jul 2026 06:00 UTC",
+        shade_weekends=shade_weekends,
     )
 
 
@@ -76,6 +77,13 @@ def test_chart_layers_weekends_ensemble_actuals_and_init_rule() -> None:
     assert ensemble["encoding"]["y"]["title"] == "Power (MW)"
     assert actuals["encoding"]["y"]["field"] == "power"
     assert rule["mark"]["type"] == "rule"
+
+
+def test_shade_weekends_false_omits_the_band_layer() -> None:
+    spec = _build(shade_weekends=False).to_dict()
+    assert len(spec["layer"]) == 3  # ensemble members, actuals, init-time rule
+    assert all(layer["mark"]["type"] != "rect" for layer in spec["layer"])
+    assert "weekends" not in " ".join(spec["title"]["subtitle"])
 
 
 def test_weekend_bands_sit_at_wall_midnights_clipped_to_window() -> None:

--- a/packages/dashboard/tests/test_forecast_chart.py
+++ b/packages/dashboard/tests/test_forecast_chart.py
@@ -66,6 +66,12 @@ def test_chart_layers_weekends_ensemble_actuals_and_init_rule() -> None:
     weekends, ensemble, actuals, rule = spec["layer"]
     assert weekends["mark"]["type"] == "rect"  # drawn first, so every line sits on top of it
     assert weekends["encoding"]["x2"]["field"] == "end"
+    # Layers share the x scale, so Vega-Lite merges their axis definitions — one deviating
+    # definition (e.g. axis=None) suppresses labels, ticks, and gridlines for the whole chart.
+    # Guard that every layer carries the identical axis definition.
+    axes = [layer["encoding"]["x"].get("axis") for layer in spec["layer"]]
+    assert all(axis == axes[0] for axis in axes)
+    assert axes[0] is not None
     assert ensemble["encoding"]["detail"]["field"] == "ensemble_member"
     assert ensemble["encoding"]["y"]["title"] == "Power (MW)"
     assert actuals["encoding"]["y"]["field"] == "power"

--- a/packages/dashboard/view_forecasts.py
+++ b/packages/dashboard/view_forecasts.py
@@ -178,6 +178,12 @@ def _(available_dates, available_init_times, date_picker):
 
 
 @app.cell
+def _():
+    weekend_shading = mo.ui.checkbox(value=True, label="Shade weekends")
+    return (weekend_shading,)
+
+
+@app.cell
 def _(
     date_picker,
     experiment_names,
@@ -186,6 +192,7 @@ def _(
     no_runs_message,
     run_picker,
     series_picker,
+    weekend_shading,
 ):
     _pickers = [series_picker, fold_picker]
     if len(experiment_names) > 1:
@@ -193,6 +200,7 @@ def _(
     _pickers.append(date_picker)
     if run_picker is not None:
         _pickers.append(run_picker)
+    _pickers.append(weekend_shading)
     _rows = [mo.hstack(_pickers, justify="start", gap=2, wrap=True)]
     if no_runs_message is not None:
         _rows.append(no_runs_message)
@@ -246,6 +254,7 @@ def _(
     init_time,
     metadata_df,
     series_picker,
+    weekend_shading,
 ):
     _meta = metadata_df.filter(pl.col("time_series_id") == series_picker.value)
     chart = build_view_forecast_chart(
@@ -261,6 +270,7 @@ def _(
             f"Forecast init {init_time:%a %d %b %Y %H:%M} UTC"
             f" · experiment {experiment_picker.value} · fold {fold_picker.value}"
         ),
+        shade_weekends=weekend_shading.value,
     )
     # mo.ui.altair_chart serves the ~34k data rows as a virtual file instead of inlining them in
     # the cell output, which would blow marimo's max-output-size guard. Selections are disabled —


### PR DESCRIPTION
Adds a faint mustard background band (Saturday 00:00 → Monday 00:00, Europe/London wall time) behind each weekend in the `view_forecasts` chart, so the weekday/weekend demand structure is findable at a glance. A "Shade weekends" checkbox in the controls row toggles it (default on); toggling only re-runs the chart cell, not the Delta queries.

Details:

- `_weekend_bands()` computes the bands clipped to the plotted window, so a window opening or closing mid-weekend gets a correctly truncated band. Bands sit at wall-clock midnights, aligned with the labelled midnight gridlines.
- The band layer uses the shared x encoding (`_x_encoding`, now parameterised over the field name). The first attempt used `axis=None`, which suppressed the merged x-axis — labels, ticks, and gridlines — for the whole chart, because Vega-Lite merges layers' axis definitions on a shared scale. The gotcha is documented in `_x_encoding`'s docstring and guarded by a test asserting every layer carries the identical axis definition.
- `build_view_forecast_chart(shade_weekends=False)` omits the layer and its subtitle legend entry entirely, restoring the exact pre-shading chart.

First of the chart-enhancement follow-ons discussed after #339.

🤖 Generated with [Claude Code](https://claude.com/claude-code)