### PR TITLE
Per-line chart toggles, always-shown legend, and theme colour fixes

### DIFF
--- a/packages/dashboard/map_and_timeseries.py
+++ b/packages/dashboard/map_and_timeseries.py
@@ -20,7 +20,7 @@ with app.setup:
     from contracts.power_schemas import PowerTimeSeries, TimeSeriesMetadata
     from contracts.typing_utils import typeddict_to_dict
     from dashboard.data_source import settings_for_source, source_status_message
-    from plotting.ocf_theme import BLUE
+    from plotting.ocf_theme import BLUE, hex_to_rgb
 
 
 @app.cell
@@ -95,7 +95,7 @@ def _(arrow_table):
         pickable=True,
         # Styling
         auto_highlight=True,
-        get_fill_color=[0, 128, 255],
+        get_fill_color=hex_to_rgb(BLUE),
         get_radius=1000,
         radius_units="meters",
         stroked=False,  # No outline

--- a/packages/dashboard/src/dashboard/forecast_chart.py
+++ b/packages/dashboard/src/dashboard/forecast_chart.py
@@ -5,7 +5,9 @@ as a thin grey line, observed power as a thick blue line, a vertical rule at
 ``power_fcst_init_time``, a faint shaded band behind each weekend (weekday/weekend structure
 dominates demand, so weekends should be findable at a glance), and optional lagged-power lines
 (observed power shifted forward by e.g. 7 days — the raw material of the models' power-lag
-features). The x-axis deliberately overrides Altair's adaptive datetime ticks: labels sit at
+features). A colour legend beside the chart always lists every plottable line — its entry set is
+the shared colour scale's explicit domain, so it never changes as lines are toggled on and off.
+The x-axis deliberately overrides Altair's adaptive datetime ticks: labels sit at
 local midnight only (day-of-week first — crucial for demand forecasting), with unlabelled minor
 ticks every 3 hours, all in Europe/London wall time.
 """
@@ -40,7 +42,7 @@ low-opacity grey ensemble lines.
 
 def _lag_label(lag: timedelta) -> str:
     """The display label for a power lag, used in the UI control and the chart legend alike."""
-    return f"{lag.days}-day lag"
+    return f"{lag.days}-day lagged power"
 
 
 LAG_OPTIONS: Final[dict[str, timedelta]] = {
@@ -55,6 +57,22 @@ defaults rather than pretending to read them from the model.
 
 _LAG_COLORS: Final[tuple[str, ...]] = (ocf_theme.PURPLE, ocf_theme.SPRING_GREEN)
 """Line colours assigned to lags in ascending-lag order; must cover ``len(LAG_OPTIONS)``."""
+
+_FORECAST_LABEL: Final[str] = "Forecast power"
+_ACTUALS_LABEL: Final[str] = "Actual power"
+_INIT_TIME_LABEL: Final[str] = "Forecast init time"
+
+_LINE_COLORS: Final[dict[str, str]] = {
+    _FORECAST_LABEL: ocf_theme.ENSEMBLE_LINE,
+    _ACTUALS_LABEL: ocf_theme.BLUE,
+    **dict(zip(LAG_OPTIONS, _LAG_COLORS, strict=True)),
+    _INIT_TIME_LABEL: ocf_theme.ORANGE_RED,
+}
+"""Legend label → line colour for everything the chart can draw, in legend order.
+
+Used as the explicit domain/range of the shared colour scale, so the legend always lists every
+entry — whichever lines are currently toggled on — and each line keeps a stable colour.
+"""
 
 _MIDNIGHT_TEST: Final[str] = "hours(datum.value) == 0"
 """Vega expression: is this tick at (wall-clock) midnight?
@@ -229,11 +247,18 @@ def build_view_forecast_chart(
     # whichever subset of lines is toggled on.
     y_title = f"Power ({units})"
 
+    # The shared colour scale's explicit domain drives the legend, so the legend always lists
+    # every line — even ones currently toggled off — and colours never reshuffle. The scale and
+    # legend definitions ride on the field-encoded layers (lags and the always-present init-time
+    # rule); the single-colour layers reference the same scale via datum encodings.
+    line_color_scale = alt.Scale(domain=list(_LINE_COLORS), range=list(_LINE_COLORS.values()))
+    line_legend = alt.Legend(title=None, symbolType="stroke", symbolStrokeWidth=2, symbolOpacity=1)
+
     # Layers are appended in draw order: weekend bands at the back, then the forecast
     # ensemble, then lagged power (model *inputs*, which must not obscure observations), then
     # observed power, with the init-time rule on top of everything.
     layers: list[alt.Chart] = []
-    legend_parts: list[str] = []
+    subtitle_notes: list[str] = []
     if shade_weekends:
         # Drawn first so every other layer sits on top; no y encoding, so each band spans the
         # full chart height. Uses the shared x encoding (see _x_encoding's docstring for why
@@ -246,22 +271,20 @@ def build_view_forecast_chart(
                 x2="end:T",
             )
         )
-        legend_parts.append("Shaded: weekends")
+        subtitle_notes.append("Shaded: weekends")
     if show_forecast:
         layers.append(
             alt.Chart(_prepare_for_plot(forecasts, "valid_time", "power_fcst").collect())
-            .mark_line(strokeWidth=1, opacity=0.3, color=ocf_theme.ENSEMBLE_LINE)
+            .mark_line(strokeWidth=1, opacity=0.3)
             .encode(
                 x=x,
                 y=alt.Y("power_fcst:Q", title=y_title),
+                color=alt.ColorDatum(_FORECAST_LABEL),
                 detail="ensemble_member:N",
                 tooltip=["ensemble_member", "valid_time", "power_fcst"],
             )
         )
-        legend_parts.append("Grey: ensemble members")
     if lags:
-        # The lag lines' colour legend doubles as the on-chart key, so the subtitle legend
-        # doesn't mention them.
         sorted_lags = sorted(lags)
         layers.append(
             alt.Chart(
@@ -277,14 +300,7 @@ def build_view_forecast_chart(
             .encode(
                 x=x,
                 y=alt.Y("power:Q", title=y_title),
-                color=alt.Color(
-                    "lag:N",
-                    title="Lagged power",
-                    scale=alt.Scale(
-                        domain=[_lag_label(lag) for lag in sorted_lags],
-                        range=list(_LAG_COLORS[: len(sorted_lags)]),
-                    ),
-                ),
+                color=alt.Color("lag:N", scale=line_color_scale, legend=line_legend),
                 tooltip=["lag", "valid_time", "power"],
             )
         )
@@ -299,23 +315,27 @@ def build_view_forecast_chart(
                 .rename({"time": "valid_time"})
                 .collect()
             )
-            .mark_line(strokeWidth=2.5, color=ocf_theme.BLUE)
+            .mark_line(strokeWidth=2.5)
             .encode(
                 x=x,
                 y=alt.Y("power:Q", title=y_title),
+                color=alt.ColorDatum(_ACTUALS_LABEL),
                 tooltip=["valid_time", "power"],
             )
         )
-        legend_parts.append("Blue: observed power")
     layers.append(
-        alt.Chart(pl.DataFrame({"valid_time": [init_wall]}))
-        .mark_rule(strokeWidth=1.5, strokeDash=[6, 4], color=ocf_theme.ORANGE_RED)
-        .encode(x=x, tooltip=[alt.Tooltip("valid_time", title="Forecast init time")])
+        alt.Chart(pl.DataFrame({"valid_time": [init_wall], "series": [_INIT_TIME_LABEL]}))
+        .mark_rule(strokeWidth=1.5, strokeDash=[6, 4])
+        .encode(
+            x=x,
+            color=alt.Color("series:N", scale=line_color_scale, legend=line_legend),
+            tooltip=[alt.Tooltip("valid_time", title="Forecast init time")],
+        )
     )
     chart = alt.layer(*layers).properties(
         title=alt.TitleParams(
             text=title,
-            subtitle=[subtitle, " · ".join(legend_parts)],
+            subtitle=[subtitle, " · ".join(subtitle_notes)] if subtitle_notes else [subtitle],
         ),
         width="container",
         height=400,

--- a/packages/dashboard/src/dashboard/forecast_chart.py
+++ b/packages/dashboard/src/dashboard/forecast_chart.py
@@ -2,14 +2,16 @@
 
 Builds an Altair chart of one forecast run for one ``time_series_id``: every NWP ensemble member
 as a thin grey line, observed power as a thick blue line, a vertical rule at
-``power_fcst_init_time``, and a faint shaded band behind each weekend (weekday/weekend structure
-dominates demand, so weekends should be findable at a glance). The x-axis deliberately overrides
-Altair's adaptive datetime ticks: labels sit at local midnight only (day-of-week first — crucial
-for demand forecasting), with unlabelled minor ticks every 3 hours, all in Europe/London wall
-time.
+``power_fcst_init_time``, a faint shaded band behind each weekend (weekday/weekend structure
+dominates demand, so weekends should be findable at a glance), and optional lagged-power lines
+(observed power shifted forward by e.g. 7 days — the raw material of the models' power-lag
+features). The x-axis deliberately overrides Altair's adaptive datetime ticks: labels sit at
+local midnight only (day-of-week first — crucial for demand forecasting), with unlabelled minor
+ticks every 3 hours, all in Europe/London wall time.
 """
 
 import calendar
+from collections.abc import Sequence
 from datetime import datetime, timedelta
 from typing import Any, Final, cast
 
@@ -34,6 +36,25 @@ At this level, ``ocf_theme.MUSTARD`` over the cream theme background reads as a 
 cream rather than an orange stripe, so the bands mark weekends without competing with the
 low-opacity grey ensemble lines.
 """
+
+
+def _lag_label(lag: timedelta) -> str:
+    """The display label for a power lag, used in the UI control and the chart legend alike."""
+    return f"{lag.days}-day lag"
+
+
+LAG_OPTIONS: Final[dict[str, timedelta]] = {
+    _lag_label(lag): lag for lag in (timedelta(days=7), timedelta(days=14))
+}
+"""The lagged-power lines the dashboard offers, as UI-label → lag.
+
+Hardcoded, illustrative model inputs: the dashboard cannot see which lag features a given
+experiment's model actually used (that config lives in MLflow), so we offer the common
+defaults rather than pretending to read them from the model.
+"""
+
+_LAG_COLORS: Final[tuple[str, ...]] = (ocf_theme.PURPLE, ocf_theme.SPRING_GREEN)
+"""Line colours assigned to lags in ascending-lag order; must cover ``len(LAG_OPTIONS)``."""
 
 _MIDNIGHT_TEST: Final[str] = "hours(datum.value) == 0"
 """Vega expression: is this tick at (wall-clock) midnight?
@@ -88,6 +109,35 @@ def _weekend_bands(window_start: datetime, window_end: datetime) -> pl.DataFrame
     )
 
 
+def _lagged_power_frame(
+    actuals: pl.LazyFrame, power_fcst_init_time: datetime, lags: Sequence[timedelta]
+) -> pl.LazyFrame:
+    """Observed power shifted forward by each lag — the raw material of the power-lag features.
+
+    Only observations at or before ``power_fcst_init_time`` are shifted (the model cannot see
+    later ones), so each line ends at ``power_fcst_init_time + lag`` — precisely where feature
+    engineering nullifies that lag as leaky for longer lead times. The early end of the line is
+    the point, not an artefact.
+
+    Args:
+        actuals: ``PowerTimeSeries`` observations (UTC ``time``), including history at least
+            ``max(lags)`` before the plotted window starts.
+        power_fcst_init_time: The forecast init time (tz-aware UTC).
+        lags: The lags to shift by; one output line (``lag`` label) per element.
+
+    Returns:
+        A frame of (UTC) ``time``, ``power``, and ``lag`` label rows, clipped to start no
+        earlier than the plotted window.
+    """
+    window_start = power_fcst_init_time - PLOT_HISTORY
+    return pl.concat(
+        actuals.filter(pl.col("time") <= power_fcst_init_time)
+        .with_columns(time=pl.col("time") + lag, lag=pl.lit(_lag_label(lag)))
+        .filter(pl.col("time") >= window_start)
+        for lag in lags
+    )
+
+
 def _x_axis_ticks(window_start: datetime, window_end: datetime) -> list[datetime]:
     """Every 3-hourly wall-clock tick across the (naive, wall-time) plotted window."""
     first_tick = window_start.replace(minute=0, second=0, microsecond=0)
@@ -135,20 +185,25 @@ def build_view_forecast_chart(
     title: str,
     subtitle: str,
     shade_weekends: bool = True,
+    lags: Sequence[timedelta] = (),
 ) -> alt.LayerChart:
     """Build the single-panel forecast chart for one series and one forecast run.
 
     Args:
         forecasts: ``PowerForecast`` rows for one ``(time_series_id, power_fcst_init_time)``
             (UTC ``valid_time``); every distinct ``ensemble_member`` becomes a thin grey line.
-        actuals: ``PowerTimeSeries`` observations for the same series (UTC ``time``); plotted
-            wherever available across the whole window, including past the init time.
+        actuals: ``PowerTimeSeries`` observations for the same series (UTC ``time``). The thick
+            blue line plots the window's observations, including past the init time; rows from
+            deeper history (which callers must include when requesting ``lags``) feed only the
+            lagged-power lines.
         power_fcst_init_time: The forecast init time (tz-aware UTC). Sets the plotted window —
             ``PLOT_HISTORY`` before it to ``PLOT_HORIZON`` after it — and the vertical rule.
         units: ``"MW"`` or ``"MVA"``, from this series' ``TimeSeriesMetadata``.
         title: Chart title (the series name / type / id line).
         subtitle: Chart subtitle (the init time / experiment line).
         shade_weekends: Whether to draw a faint background band behind each weekend.
+        lags: Power lags to plot as coloured lines (observed power shifted forward by each lag,
+            using only pre-init observations — see ``_lagged_power_frame``). Empty for none.
 
     Returns:
         A layered, zoomable Altair chart in Europe/London wall time.
@@ -191,9 +246,46 @@ def build_view_forecast_chart(
             tooltip=["ensemble_member", "valid_time", "power_fcst"],
         )
     )
+    lag_layer: alt.Chart | None = None
+    if lags:
+        # Layered between the ensemble (underneath) and the actuals (on top): the lag lines are
+        # model *inputs*, so they must not obscure the observations. Their colour legend doubles
+        # as the on-chart key, so the subtitle legend doesn't mention them.
+        sorted_lags = sorted(lags)
+        lag_layer = (
+            alt.Chart(
+                _prepare_for_plot(
+                    _lagged_power_frame(actuals, power_fcst_init_time, sorted_lags),
+                    "time",
+                    "power",
+                )
+                .rename({"time": "valid_time"})
+                .collect()
+            )
+            .mark_line(strokeWidth=1.5, opacity=0.8)
+            .encode(
+                x=x,
+                y=alt.Y("power:Q"),
+                color=alt.Color(
+                    "lag:N",
+                    title="Lagged power",
+                    scale=alt.Scale(
+                        domain=[_lag_label(lag) for lag in sorted_lags],
+                        range=list(_LAG_COLORS[: len(sorted_lags)]),
+                    ),
+                ),
+                tooltip=["lag", "valid_time", "power"],
+            )
+        )
     actuals_layer = (
         alt.Chart(
-            _prepare_for_plot(actuals, "time", "power").rename({"time": "valid_time"}).collect()
+            _prepare_for_plot(
+                actuals.filter(pl.col("time") >= power_fcst_init_time - PLOT_HISTORY),
+                "time",
+                "power",
+            )
+            .rename({"time": "valid_time"})
+            .collect()
         )
         .mark_line(strokeWidth=2.5, color=ocf_theme.BLUE)
         .encode(
@@ -208,7 +300,10 @@ def build_view_forecast_chart(
         .encode(x=x, tooltip=[alt.Tooltip("valid_time", title="Forecast init time")])
     )
 
-    layers += [ensemble_layer, actuals_layer, init_time_rule]
+    layers.append(ensemble_layer)
+    if lag_layer is not None:
+        layers.append(lag_layer)
+    layers += [actuals_layer, init_time_rule]
     chart = alt.layer(*layers).properties(
         title=alt.TitleParams(
             text=title,

--- a/packages/dashboard/src/dashboard/forecast_chart.py
+++ b/packages/dashboard/src/dashboard/forecast_chart.py
@@ -185,6 +185,8 @@ def build_view_forecast_chart(
     title: str,
     subtitle: str,
     shade_weekends: bool = True,
+    show_forecast: bool = True,
+    show_actuals: bool = True,
     lags: Sequence[timedelta] = (),
 ) -> alt.LayerChart:
     """Build the single-panel forecast chart for one series and one forecast run.
@@ -202,6 +204,8 @@ def build_view_forecast_chart(
         title: Chart title (the series name / type / id line).
         subtitle: Chart subtitle (the init time / experiment line).
         shade_weekends: Whether to draw a faint background band behind each weekend.
+        show_forecast: Whether to draw the grey forecast-ensemble lines.
+        show_actuals: Whether to draw the thick blue observed-power line.
         lags: Power lags to plot as coloured lines (observed power shifted forward by each lag,
             using only pre-init observations — see ``_lagged_power_frame``). Empty for none.
 
@@ -221,8 +225,15 @@ def build_view_forecast_chart(
     window_end = init_wall + PLOT_HORIZON
     x = _x_encoding(window_start, window_end)
 
+    # All power layers share the y title so Vega-Lite merges them into one clean y-axis
+    # whichever subset of lines is toggled on.
+    y_title = f"Power ({units})"
+
+    # Layers are appended in draw order: weekend bands at the back, then the forecast
+    # ensemble, then lagged power (model *inputs*, which must not obscure observations), then
+    # observed power, with the init-time rule on top of everything.
     layers: list[alt.Chart] = []
-    legend_parts = ["Grey: ensemble members", "Blue: observed power"]
+    legend_parts: list[str] = []
     if shade_weekends:
         # Drawn first so every other layer sits on top; no y encoding, so each band spans the
         # full chart height. Uses the shared x encoding (see _x_encoding's docstring for why
@@ -236,23 +247,23 @@ def build_view_forecast_chart(
             )
         )
         legend_parts.append("Shaded: weekends")
-    ensemble_layer = (
-        alt.Chart(_prepare_for_plot(forecasts, "valid_time", "power_fcst").collect())
-        .mark_line(strokeWidth=1, opacity=0.3, color=ocf_theme.ENSEMBLE_LINE)
-        .encode(
-            x=x,
-            y=alt.Y("power_fcst:Q", title=f"Power ({units})"),
-            detail="ensemble_member:N",
-            tooltip=["ensemble_member", "valid_time", "power_fcst"],
+    if show_forecast:
+        layers.append(
+            alt.Chart(_prepare_for_plot(forecasts, "valid_time", "power_fcst").collect())
+            .mark_line(strokeWidth=1, opacity=0.3, color=ocf_theme.ENSEMBLE_LINE)
+            .encode(
+                x=x,
+                y=alt.Y("power_fcst:Q", title=y_title),
+                detail="ensemble_member:N",
+                tooltip=["ensemble_member", "valid_time", "power_fcst"],
+            )
         )
-    )
-    lag_layer: alt.Chart | None = None
+        legend_parts.append("Grey: ensemble members")
     if lags:
-        # Layered between the ensemble (underneath) and the actuals (on top): the lag lines are
-        # model *inputs*, so they must not obscure the observations. Their colour legend doubles
-        # as the on-chart key, so the subtitle legend doesn't mention them.
+        # The lag lines' colour legend doubles as the on-chart key, so the subtitle legend
+        # doesn't mention them.
         sorted_lags = sorted(lags)
-        lag_layer = (
+        layers.append(
             alt.Chart(
                 _prepare_for_plot(
                     _lagged_power_frame(actuals, power_fcst_init_time, sorted_lags),
@@ -265,7 +276,7 @@ def build_view_forecast_chart(
             .mark_line(strokeWidth=1.5, opacity=0.8)
             .encode(
                 x=x,
-                y=alt.Y("power:Q"),
+                y=alt.Y("power:Q", title=y_title),
                 color=alt.Color(
                     "lag:N",
                     title="Lagged power",
@@ -277,33 +288,30 @@ def build_view_forecast_chart(
                 tooltip=["lag", "valid_time", "power"],
             )
         )
-    actuals_layer = (
-        alt.Chart(
-            _prepare_for_plot(
-                actuals.filter(pl.col("time") >= power_fcst_init_time - PLOT_HISTORY),
-                "time",
-                "power",
+    if show_actuals:
+        layers.append(
+            alt.Chart(
+                _prepare_for_plot(
+                    actuals.filter(pl.col("time") >= power_fcst_init_time - PLOT_HISTORY),
+                    "time",
+                    "power",
+                )
+                .rename({"time": "valid_time"})
+                .collect()
             )
-            .rename({"time": "valid_time"})
-            .collect()
+            .mark_line(strokeWidth=2.5, color=ocf_theme.BLUE)
+            .encode(
+                x=x,
+                y=alt.Y("power:Q", title=y_title),
+                tooltip=["valid_time", "power"],
+            )
         )
-        .mark_line(strokeWidth=2.5, color=ocf_theme.BLUE)
-        .encode(
-            x=x,
-            y=alt.Y("power:Q"),
-            tooltip=["valid_time", "power"],
-        )
-    )
-    init_time_rule = (
+        legend_parts.append("Blue: observed power")
+    layers.append(
         alt.Chart(pl.DataFrame({"valid_time": [init_wall]}))
         .mark_rule(strokeWidth=1.5, strokeDash=[6, 4], color=ocf_theme.ORANGE_RED)
         .encode(x=x, tooltip=[alt.Tooltip("valid_time", title="Forecast init time")])
     )
-
-    layers.append(ensemble_layer)
-    if lag_layer is not None:
-        layers.append(lag_layer)
-    layers += [actuals_layer, init_time_rule]
     chart = alt.layer(*layers).properties(
         title=alt.TitleParams(
             text=title,

--- a/packages/dashboard/src/dashboard/forecast_chart.py
+++ b/packages/dashboard/src/dashboard/forecast_chart.py
@@ -251,8 +251,10 @@ def build_view_forecast_chart(
     # every line — even ones currently toggled off — and colours never reshuffle. The scale and
     # legend definitions ride on the field-encoded layers (lags and the always-present init-time
     # rule); the single-colour layers reference the same scale via datum encodings.
+    # (Swatch opacity is pinned to 1 in the OCF theme's legend config — a per-legend
+    # ``symbolOpacity`` here would lose to the opacity Vega-Lite derives from the marks.)
     line_color_scale = alt.Scale(domain=list(_LINE_COLORS), range=list(_LINE_COLORS.values()))
-    line_legend = alt.Legend(title=None, symbolType="stroke", symbolStrokeWidth=2, symbolOpacity=1)
+    line_legend = alt.Legend(title=None, symbolType="stroke", symbolStrokeWidth=2)
 
     # Layers are appended in draw order: weekend bands at the back, then the forecast
     # ensemble, then lagged power (model *inputs*, which must not obscure observations), then

--- a/packages/dashboard/tests/test_forecast_chart.py
+++ b/packages/dashboard/tests/test_forecast_chart.py
@@ -88,7 +88,11 @@ def test_chart_layers_weekends_ensemble_actuals_and_init_rule() -> None:
     assert axes[0] is not None
     assert ensemble["encoding"]["detail"]["field"] == "ensemble_member"
     assert ensemble["encoding"]["y"]["title"] == "Power (MW)"
+    # Single-colour layers take their colour from the shared scale via a datum encoding, so
+    # they participate in the always-shown legend without a constant column in their data.
+    assert ensemble["encoding"]["color"]["datum"] == "Forecast power"
     assert actuals["encoding"]["y"]["field"] == "power"
+    assert actuals["encoding"]["color"]["datum"] == "Actual power"
     assert rule["mark"]["type"] == "rule"
 
 
@@ -155,11 +159,42 @@ def test_lag_lines_end_at_init_plus_lag_and_use_only_pre_init_power() -> None:
     assert first_shifted["power"] == source.filter(pl.col("time") == source_time)["power"].item()
 
 
-def test_lag_colours_assigned_in_ascending_lag_order() -> None:
+def test_legend_always_lists_every_line() -> None:
+    # The always-drawn init-rule layer carries the shared colour scale, whose explicit domain
+    # drives the legend — so the legend is identical whichever lines are toggled on.
+    for spec in (
+        _build().to_dict(),
+        _build(show_forecast=False, show_actuals=False).to_dict(),
+        _build(lags=tuple(LAG_OPTIONS.values())).to_dict(),
+    ):
+        colour = spec["layer"][-1]["encoding"]["color"]
+        assert colour["field"] == "series"
+        assert colour["scale"]["domain"] == [
+            "Forecast power",
+            "Actual power",
+            "7-day lagged power",
+            "14-day lagged power",
+            "Forecast init time",
+        ]
+        assert colour["scale"]["range"] == [
+            ocf_theme.ENSEMBLE_LINE,
+            ocf_theme.BLUE,
+            ocf_theme.PURPLE,
+            ocf_theme.SPRING_GREEN,
+            ocf_theme.ORANGE_RED,
+        ]
+        assert colour["legend"]["symbolType"] == "stroke"
+
+
+def test_lag_lines_share_the_legend_colour_scale() -> None:
     spec = _build(lags=tuple(LAG_OPTIONS.values())).to_dict()
     colour = spec["layer"][2]["encoding"]["color"]
-    assert colour["scale"]["domain"] == ["7-day lag", "14-day lag"]
-    assert colour["scale"]["range"] == [ocf_theme.PURPLE, ocf_theme.SPRING_GREEN]
+    assert colour["field"] == "lag"
+    # Identical scale to the rule layer's, so Vega-Lite merges them without conflict and the
+    # lag lines pick up their (ascending-lag-ordered) colours from the shared domain.
+    assert colour["scale"] == spec["layer"][-1]["encoding"]["color"]["scale"]
+    lag_rows = spec["datasets"][spec["layer"][2]["data"]["name"]]
+    assert {row["lag"] for row in lag_rows} == {"7-day lagged power", "14-day lagged power"}
 
 
 def test_actuals_line_ignores_the_deep_history_loaded_for_lags() -> None:
@@ -174,10 +209,9 @@ def test_actuals_line_ignores_the_deep_history_loaded_for_lags() -> None:
 def test_show_flags_toggle_the_forecast_and_actuals_layers() -> None:
     no_forecast = _build(show_forecast=False).to_dict()
     assert len(no_forecast["layer"]) == 3  # weekend bands, actuals, init rule
-    assert "ensemble members" not in " ".join(no_forecast["title"]["subtitle"])
     no_actuals = _build(show_actuals=False).to_dict()
     assert len(no_actuals["layer"]) == 3  # weekend bands, ensemble, init rule
-    assert "observed power" not in " ".join(no_actuals["title"]["subtitle"])
+    assert no_actuals["layer"][1]["encoding"]["color"]["datum"] == "Forecast power"
     only_lags = _build(
         show_forecast=False,
         show_actuals=False,

--- a/packages/dashboard/tests/test_forecast_chart.py
+++ b/packages/dashboard/tests/test_forecast_chart.py
@@ -1,14 +1,17 @@
 """Tests for the ``view_forecasts.py`` chart builder (``dashboard.forecast_chart``)."""
 
+from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 
 import polars as pl
 from altair import LayerChart
 from dashboard.forecast_chart import (
+    LAG_OPTIONS,
     PLOT_HISTORY,
     PLOT_HORIZON,
     build_view_forecast_chart,
 )
+from plotting import ocf_theme
 
 INIT_TIME = datetime(2026, 7, 4, 6, 0, tzinfo=UTC)
 """During British Summer Time, so wall time is UTC+1 — the axis tests below rely on that."""
@@ -36,9 +39,9 @@ def _forecasts(members: tuple[int, ...]) -> pl.LazyFrame:
     ).lazy()
 
 
-def _actuals() -> pl.LazyFrame:
+def _actuals(history: timedelta = PLOT_HISTORY) -> pl.LazyFrame:
     times = pl.datetime_range(
-        INIT_TIME - PLOT_HISTORY,
+        INIT_TIME - history,
         INIT_TIME + timedelta(days=2),
         interval="30m",
         time_zone="UTC",
@@ -49,15 +52,21 @@ def _actuals() -> pl.LazyFrame:
     ).lazy()
 
 
-def _build(*, shade_weekends: bool = True) -> LayerChart:
+def _build(
+    *,
+    shade_weekends: bool = True,
+    lags: Sequence[timedelta] = (),
+    history: timedelta = PLOT_HISTORY,
+) -> LayerChart:
     return build_view_forecast_chart(
         _forecasts((0, 1, 2)),
-        _actuals(),
+        _actuals(history),
         power_fcst_init_time=INIT_TIME,
         units="MW",
         title="Test series — PV — id 1",
         subtitle="Forecast init Sat 04 Jul 2026 06:00 UTC",
         shade_weekends=shade_weekends,
+        lags=lags,
     )
 
 
@@ -120,6 +129,42 @@ def test_x_axis_has_3_hourly_ticks_labelled_at_midnight_only() -> None:
     assert "%a %d %b" in axis["labelExpr"]
     assert axis["tickSize"]["condition"]["test"] == "hours(datum.value) == 0"
     assert axis["gridOpacity"]["condition"]["test"] == "hours(datum.value) == 0"
+
+
+def test_lag_lines_end_at_init_plus_lag_and_use_only_pre_init_power() -> None:
+    lag = timedelta(days=7)
+    spec = _build(lags=(lag,), history=PLOT_HISTORY + max(LAG_OPTIONS.values())).to_dict()
+    # Layer order: weekend bands, ensemble, lags, actuals, init rule — inputs must not obscure
+    # the observations.
+    assert len(spec["layer"]) == 5
+    lag_rows = spec["datasets"][spec["layer"][2]["data"]["name"]]
+    times = sorted(row["valid_time"] for row in lag_rows)
+    # Wall-time window starts Fri 03 Jul 07:00; only pre-init observations are shifted, so the
+    # line ends exactly at init + lag (Sat 04 Jul 07:00 wall + 7 d) — where feature engineering
+    # nullifies the lag as leaky.
+    assert times[0] == "2026-07-03T07:00:00"
+    assert times[-1] == "2026-07-11T07:00:00"
+    # Shifted values equal the observation lag earlier: both frames index power by row order.
+    source = _actuals(PLOT_HISTORY + max(LAG_OPTIONS.values())).collect()
+    first_shifted = next(row for row in lag_rows if row["valid_time"] == times[0])
+    source_time = datetime(2026, 7, 3, 6, 0, tzinfo=UTC) - lag  # 07:00 wall = 06:00 UTC
+    assert first_shifted["power"] == source.filter(pl.col("time") == source_time)["power"].item()
+
+
+def test_lag_colours_assigned_in_ascending_lag_order() -> None:
+    spec = _build(lags=tuple(LAG_OPTIONS.values())).to_dict()
+    colour = spec["layer"][2]["encoding"]["color"]
+    assert colour["scale"]["domain"] == ["7-day lag", "14-day lag"]
+    assert colour["scale"]["range"] == [ocf_theme.PURPLE, ocf_theme.SPRING_GREEN]
+
+
+def test_actuals_line_ignores_the_deep_history_loaded_for_lags() -> None:
+    spec = _build(history=PLOT_HISTORY + max(LAG_OPTIONS.values())).to_dict()
+    actuals_rows = spec["datasets"][spec["layer"][2]["data"]["name"]]
+    # No lags requested → 4 layers, and the blue line still starts at the window, not at the
+    # start of the deeper history the dashboard now always loads.
+    assert len(spec["layer"]) == 4
+    assert min(row["valid_time"] for row in actuals_rows) == "2026-07-03T07:00:00"
 
 
 def test_chart_renders_to_html() -> None:

--- a/packages/dashboard/tests/test_forecast_chart.py
+++ b/packages/dashboard/tests/test_forecast_chart.py
@@ -55,6 +55,8 @@ def _actuals(history: timedelta = PLOT_HISTORY) -> pl.LazyFrame:
 def _build(
     *,
     shade_weekends: bool = True,
+    show_forecast: bool = True,
+    show_actuals: bool = True,
     lags: Sequence[timedelta] = (),
     history: timedelta = PLOT_HISTORY,
 ) -> LayerChart:
@@ -66,6 +68,8 @@ def _build(
         title="Test series — PV — id 1",
         subtitle="Forecast init Sat 04 Jul 2026 06:00 UTC",
         shade_weekends=shade_weekends,
+        show_forecast=show_forecast,
+        show_actuals=show_actuals,
         lags=lags,
     )
 
@@ -165,6 +169,24 @@ def test_actuals_line_ignores_the_deep_history_loaded_for_lags() -> None:
     # start of the deeper history the dashboard now always loads.
     assert len(spec["layer"]) == 4
     assert min(row["valid_time"] for row in actuals_rows) == "2026-07-03T07:00:00"
+
+
+def test_show_flags_toggle_the_forecast_and_actuals_layers() -> None:
+    no_forecast = _build(show_forecast=False).to_dict()
+    assert len(no_forecast["layer"]) == 3  # weekend bands, actuals, init rule
+    assert "ensemble members" not in " ".join(no_forecast["title"]["subtitle"])
+    no_actuals = _build(show_actuals=False).to_dict()
+    assert len(no_actuals["layer"]) == 3  # weekend bands, ensemble, init rule
+    assert "observed power" not in " ".join(no_actuals["title"]["subtitle"])
+    only_lags = _build(
+        show_forecast=False,
+        show_actuals=False,
+        lags=(timedelta(days=7),),
+        history=PLOT_HISTORY + max(LAG_OPTIONS.values()),
+    ).to_dict()
+    # weekend bands, lag line, init rule — the y-axis title comes from the lag layer alone.
+    assert len(only_lags["layer"]) == 3
+    assert only_lags["layer"][1]["encoding"]["y"]["title"] == "Power (MW)"
 
 
 def test_chart_renders_to_html() -> None:

--- a/packages/dashboard/view_forecasts.py
+++ b/packages/dashboard/view_forecasts.py
@@ -65,9 +65,14 @@ def _(settings):
         ]
         for row in metadata_df.sort("time_series_type", "time_series_name").iter_rows(named=True)
     }
+    # Default to time_series_id 24 rather than the alphabetically-first option — id 20 (a BESS)
+    # sorts first but is mostly garbage data, which makes for a poor first impression.
+    _default_label = next(
+        (label for label, id_ in series_options.items() if id_ == 24), next(iter(series_options))
+    )
     series_picker = mo.ui.dropdown(
         options=series_options,
-        value=next(iter(series_options)),
+        value=_default_label,
         label="Time series",
         searchable=True,
     )

--- a/packages/dashboard/view_forecasts.py
+++ b/packages/dashboard/view_forecasts.py
@@ -184,12 +184,20 @@ def _(available_dates, available_init_times, date_picker):
 
 @app.cell
 def _():
+    show_forecast = mo.ui.checkbox(value=True, label="Forecast power")
+    show_actuals = mo.ui.checkbox(value=True, label="Actual power")
+    # One checkbox per LAG_OPTIONS entry — explicit globals rather than a comprehension,
+    # because marimo only makes UI elements reactive when they are bound to top-level names.
+    show_lag_7d = mo.ui.checkbox(label="7-day lagged power")
+    show_lag_14d = mo.ui.checkbox(label="14-day lagged power")
     weekend_shading = mo.ui.checkbox(value=True, label="Shade weekends")
-    lag_picker = mo.ui.multiselect(
-        options=LAG_OPTIONS,
-        label="Lagged power (illustrative model inputs)",
+    return (
+        show_actuals,
+        show_forecast,
+        show_lag_14d,
+        show_lag_7d,
+        weekend_shading,
     )
-    return lag_picker, weekend_shading
 
 
 @app.cell
@@ -198,10 +206,13 @@ def _(
     experiment_names,
     experiment_picker,
     fold_picker,
-    lag_picker,
     no_runs_message,
     run_picker,
     series_picker,
+    show_actuals,
+    show_forecast,
+    show_lag_14d,
+    show_lag_7d,
     weekend_shading,
 ):
     _pickers = [series_picker, fold_picker]
@@ -210,7 +221,11 @@ def _(
     _pickers.append(date_picker)
     if run_picker is not None:
         _pickers.append(run_picker)
-    _pickers += [lag_picker, weekend_shading]
+    _lines = mo.vstack(
+        [mo.md("**Lines**"), show_forecast, show_actuals, show_lag_7d, show_lag_14d],
+        gap=0,
+    )
+    _pickers += [_lines, weekend_shading]
     _rows = [mo.hstack(_pickers, justify="start", gap=2, wrap=True)]
     if no_runs_message is not None:
         _rows.append(no_runs_message)
@@ -268,9 +283,12 @@ def _(
     fold_picker,
     forecasts,
     init_time,
-    lag_picker,
     metadata_df,
     series_picker,
+    show_actuals,
+    show_forecast,
+    show_lag_14d,
+    show_lag_7d,
     weekend_shading,
 ):
     _meta = metadata_df.filter(pl.col("time_series_id") == series_picker.value)
@@ -288,7 +306,16 @@ def _(
             f" · experiment {experiment_picker.value} · fold {fold_picker.value}"
         ),
         shade_weekends=weekend_shading.value,
-        lags=lag_picker.value,
+        show_forecast=show_forecast.value,
+        show_actuals=show_actuals.value,
+        lags=[
+            lag
+            for box, lag in (
+                (show_lag_7d, LAG_OPTIONS["7-day lag"]),
+                (show_lag_14d, LAG_OPTIONS["14-day lag"]),
+            )
+            if box.value
+        ],
     )
     # mo.ui.altair_chart serves the ~34k data rows as a virtual file instead of inlining them in
     # the cell output, which would blow marimo's max-output-size guard. Selections are disabled —

--- a/packages/dashboard/view_forecasts.py
+++ b/packages/dashboard/view_forecasts.py
@@ -311,8 +311,8 @@ def _(
         lags=[
             lag
             for box, lag in (
-                (show_lag_7d, LAG_OPTIONS["7-day lag"]),
-                (show_lag_14d, LAG_OPTIONS["14-day lag"]),
+                (show_lag_7d, LAG_OPTIONS["7-day lagged power"]),
+                (show_lag_14d, LAG_OPTIONS["14-day lagged power"]),
             )
             if box.value
         ],

--- a/packages/dashboard/view_forecasts.py
+++ b/packages/dashboard/view_forecasts.py
@@ -9,7 +9,12 @@ with app.setup:
     from contracts.power_schemas import TimeSeriesMetadata
     from contracts.typing_utils import typeddict_to_dict
     from dashboard.data_source import settings_for_source, source_status_message
-    from dashboard.forecast_chart import PLOT_HISTORY, PLOT_HORIZON, build_view_forecast_chart
+    from dashboard.forecast_chart import (
+        LAG_OPTIONS,
+        PLOT_HISTORY,
+        PLOT_HORIZON,
+        build_view_forecast_chart,
+    )
     from deltalake import DeltaTable
 
 
@@ -180,7 +185,11 @@ def _(available_dates, available_init_times, date_picker):
 @app.cell
 def _():
     weekend_shading = mo.ui.checkbox(value=True, label="Shade weekends")
-    return (weekend_shading,)
+    lag_picker = mo.ui.multiselect(
+        options=LAG_OPTIONS,
+        label="Lagged power (illustrative model inputs)",
+    )
+    return lag_picker, weekend_shading
 
 
 @app.cell
@@ -189,6 +198,7 @@ def _(
     experiment_names,
     experiment_picker,
     fold_picker,
+    lag_picker,
     no_runs_message,
     run_picker,
     series_picker,
@@ -200,7 +210,7 @@ def _(
     _pickers.append(date_picker)
     if run_picker is not None:
         _pickers.append(run_picker)
-    _pickers.append(weekend_shading)
+    _pickers += [lag_picker, weekend_shading]
     _rows = [mo.hstack(_pickers, justify="start", gap=2, wrap=True)]
     if no_runs_message is not None:
         _rows.append(no_runs_message)
@@ -226,11 +236,17 @@ def _(experiment_picker, fold_picker, run_picker, series_picker, settings):
         .select("valid_time", "power_fcst", "ensemble_member")
         .collect()
     )
+    # History extends max(LAG_OPTIONS) past the plotted window so the lagged-power lines are
+    # loaded whatever the lag picker says — toggling lags then re-runs only the chart cell,
+    # never this Delta query. The extra rows are trivial (one series, 14 more days).
     actuals = (
         pl.scan_delta(settings.power_time_series_data_path, storage_options=_storage)
         .filter(
             pl.col("time_series_id") == series_picker.value,
-            pl.col("time").is_between(init_time - PLOT_HISTORY, init_time + PLOT_HORIZON),
+            pl.col("time").is_between(
+                init_time - PLOT_HISTORY - max(LAG_OPTIONS.values()),
+                init_time + PLOT_HORIZON,
+            ),
         )
         .select("time", "power")
         .collect()
@@ -252,6 +268,7 @@ def _(
     fold_picker,
     forecasts,
     init_time,
+    lag_picker,
     metadata_df,
     series_picker,
     weekend_shading,
@@ -271,6 +288,7 @@ def _(
             f" · experiment {experiment_picker.value} · fold {fold_picker.value}"
         ),
         shade_weekends=weekend_shading.value,
+        lags=lag_picker.value,
     )
     # mo.ui.altair_chart serves the ~34k data rows as a virtual file instead of inlining them in
     # the cell output, which would blow marimo's max-output-size guard. Selections are disabled —

--- a/packages/plotting/src/plotting/ocf_theme.py
+++ b/packages/plotting/src/plotting/ocf_theme.py
@@ -46,6 +46,16 @@ ENSEMBLE_LINE: Final[str] = "#808080"
 _TEXT: Final[str] = "#292B2B"
 
 
+def hex_to_rgb(hex_color: str) -> list[int]:
+    """RGB components of a ``#RRGGBB`` colour, for libraries taking ``[r, g, b]`` lists.
+
+    Lets non-Altair plotting libraries (e.g. lonboard, which styles map layers with RGB
+    lists) use the theme palette rather than hardcoding near-miss colours.
+    """
+    value = hex_color.removeprefix("#")
+    return [int(value[i : i + 2], 16) for i in (0, 2, 4)]
+
+
 @alt.theme.register("ocf", enable=True)
 def _ocf_theme() -> dict[str, Any]:
     palette = list(PALETTE)

--- a/packages/plotting/src/plotting/ocf_theme.py
+++ b/packages/plotting/src/plotting/ocf_theme.py
@@ -81,6 +81,11 @@ def _ocf_theme() -> dict[str, Any]:
             "legend": {
                 "labelColor": _TEXT,
                 "titleColor": _TEXT,
+                # Legend swatches must stay fully opaque whatever opacity the marks draw at.
+                # In a layered chart Vega-Lite derives swatch opacity from the layers' marks
+                # (washing the swatches out) and ignores a per-legend ``symbolOpacity`` — only
+                # this config-level setting wins.
+                "symbolOpacity": 1,
             },
         }
     }

--- a/packages/plotting/tests/test_ocf_theme.py
+++ b/packages/plotting/tests/test_ocf_theme.py
@@ -1,9 +1,15 @@
 """Tests for the OCF Altair theme helpers."""
 
-from plotting.ocf_theme import BLUE, hex_to_rgb
+from plotting.ocf_theme import BLUE, _ocf_theme, hex_to_rgb
 
 
 def test_hex_to_rgb() -> None:
     assert hex_to_rgb(BLUE) == [0x30, 0x6B, 0xFF]
     assert hex_to_rgb("#000000") == [0, 0, 0]
     assert hex_to_rgb("FFFFFF") == [255, 255, 255]  # bare hex (no "#") also accepted
+
+
+def test_legend_swatches_are_fully_opaque() -> None:
+    # Guards against legend swatches washing out: in layered charts Vega-Lite derives swatch
+    # opacity from the layers' marks unless the config pins it.
+    assert _ocf_theme()["config"]["legend"]["symbolOpacity"] == 1

--- a/packages/plotting/tests/test_ocf_theme.py
+++ b/packages/plotting/tests/test_ocf_theme.py
@@ -1,0 +1,9 @@
+"""Tests for the OCF Altair theme helpers."""
+
+from plotting.ocf_theme import BLUE, hex_to_rgb
+
+
+def test_hex_to_rgb() -> None:
+    assert hex_to_rgb(BLUE) == [0x30, 0x6B, 0xFF]
+    assert hex_to_rgb("#000000") == [0, 0, 0]
+    assert hex_to_rgb("FFFFFF") == [255, 255, 255]  # bare hex (no "#") also accepted


### PR DESCRIPTION
## Summary
- Adds per-line checkboxes (Forecast power / Actual power / 7-day and 14-day lagged power) to the `view_forecasts.py` dashboard chart, replacing the earlier lagged-power dropdown.
- The chart legend always lists every plottable line with a stable colour, regardless of which checkboxes are toggled — the shared colour scale's explicit domain drives the legend, riding on the always-drawn forecast-init-time rule layer.
- Fixes legend swatches washing out to a faded grey in layered charts (Vega-Lite derives swatch opacity from the marks unless pinned in the theme config) — pinned `symbolOpacity: 1` in the OCF Altair theme.
- Uses OCF theme colours consistently: the map's scatterplot dots now use `hex_to_rgb(BLUE)` instead of a hardcoded near-miss RGB triple; lag lines use `PURPLE`/`SPRING_GREEN` (palette priorities 3/4, the next available after orange-red and blue).
- Defaults the time-series picker to `time_series_id` 24 instead of the alphabetically-first option (id 20, a BESS with mostly garbage data).

## Test plan
- [x] `uv run pytest` — all tests pass (13 in `packages/dashboard` + `packages/plotting`)
- [x] `uv run ruff check .` / `uv run ruff format --check .` — clean
- [x] `uv run ty check` — clean
- [x] `uv run marimo export script packages/dashboard/view_forecasts.py` — cell graph validates
- [x] Rendered synthetic-data PNGs to confirm: legend lists all five entries with full-opacity swatches in every toggle state; lag lines end at `init + lag`; weekend shading unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)