### PR TITLE
NWP ensemble panel below the power chart in view_forecasts.py

### DIFF
--- a/packages/dashboard/src/dashboard/forecast_chart.py
+++ b/packages/dashboard/src/dashboard/forecast_chart.py
@@ -1,12 +1,21 @@
-"""Single-panel ensemble forecast chart for the ``view_forecasts.py`` dashboard app.
+"""Chart builders for the ``view_forecasts.py`` dashboard app.
 
-Builds an Altair chart of one forecast run for one ``time_series_id``: every NWP ensemble member
-as a thin grey line, observed power as a thick blue line, a vertical rule at
+``build_view_forecast_chart`` plots one forecast run for one ``time_series_id``: every forecast
+ensemble member as a thin grey line, observed power as a thick blue line, a vertical rule at
 ``power_fcst_init_time``, a faint shaded band behind each weekend (weekday/weekend structure
 dominates demand, so weekends should be findable at a glance), and optional lagged-power lines
 (observed power shifted forward by e.g. 7 days — the raw material of the models' power-lag
-features). A colour legend beside the chart always lists every plottable line — its entry set is
+features). A colour legend above the chart always lists every plottable line — its entry set is
 the shared colour scale's explicit domain, so it never changes as lines are toggled on and off.
+
+``build_nwp_ensemble_chart`` plots the NWP ensemble that fed the forecast (one weather variable
+at the H3 cell containing the series) as a second panel stacked below the power chart.
+
+The two charts are separate Altair specs, so stacking them relies on identical horizontal
+geometry: they share the same pinned x encoding, both pin the y-axis region to ``Y_AXIS_EXTENT``
+pixels, and the power chart's legend sits *above* the plot (``orient="top"``) so it consumes no
+horizontal space that the legend-less NWP panel wouldn't also lose.
+
 The x-axis deliberately overrides Altair's adaptive datetime ticks: labels sit at
 local midnight only (day-of-week first — crucial for demand forecasting), with unlabelled minor
 ticks every 3 hours, all in Europe/London wall time.
@@ -14,6 +23,7 @@ ticks every 3 hours, all in Europe/London wall time.
 
 import calendar
 from collections.abc import Sequence
+from dataclasses import dataclass
 from datetime import datetime, timedelta
 from typing import Any, Final, cast
 
@@ -37,6 +47,57 @@ WEEKEND_SHADE_OPACITY: Final[float] = 0.07
 At this level, ``ocf_theme.MUSTARD`` over the cream theme background reads as a slightly warmer
 cream rather than an orange stripe, so the bands mark weekends without competing with the
 low-opacity grey ensemble lines.
+"""
+
+Y_AXIS_EXTENT: Final[int] = 56
+"""Pinned pixel width of the y-axis region (labels + ticks) on every chart.
+
+The power chart and the NWP subplot are separate stacked charts sharing one container width, so
+their x-axes only align vertically if the space to the left of each plot area is identical.
+Both charts therefore pin the y-axis extent to this constant instead of letting Vega size it to
+the tick labels. Wide enough for the widest expected label (surface pressure, ``100,000``).
+"""
+
+
+@dataclass(frozen=True)
+class NwpPlotVariable:
+    """Display metadata for one NWP variable offered by the NWP-parameter dropdown."""
+
+    label: str
+    """Human-readable name, used in the dropdown, the chart title, and the y-axis title."""
+
+    unit: str
+    """Display unit shown on the y-axis — after ``scale`` is applied."""
+
+    scale: float = 1.0
+    """Display multiplier applied to the stored values (e.g. kg/m²/s → mm/h for precipitation)."""
+
+
+NWP_PLOT_VARIABLES: Final[dict[str, NwpPlotVariable]] = {
+    "temperature_2m": NwpPlotVariable("2 m temperature", "°C"),
+    "dew_point_temperature_2m": NwpPlotVariable("2 m dew-point temperature", "°C"),
+    "wind_speed_10m": NwpPlotVariable("10 m wind speed", "m/s"),
+    "wind_direction_10m": NwpPlotVariable("10 m wind direction", "°"),
+    "wind_speed_100m": NwpPlotVariable("100 m wind speed", "m/s"),
+    "wind_direction_100m": NwpPlotVariable("100 m wind direction", "°"),
+    "pressure_surface": NwpPlotVariable("Surface pressure", "Pa"),
+    "pressure_reduced_to_mean_sea_level": NwpPlotVariable("Mean sea-level pressure", "Pa"),
+    "geopotential_height_500hpa": NwpPlotVariable("500 hPa geopotential height", "m"),
+    "downward_long_wave_radiation_flux_surface": NwpPlotVariable(
+        "Downward long-wave radiation", "W/m²"
+    ),
+    "downward_short_wave_radiation_flux_surface": NwpPlotVariable(
+        "Downward short-wave (solar) radiation", "W/m²"
+    ),
+    # Stored as kg/m²/s (numerically mm/s); ×3600 displays as mm/h, which forecasters expect
+    # and which survives _prepare_for_plot's 3-decimal-place display rounding.
+    "precipitation_surface": NwpPlotVariable("Precipitation rate", "mm/h", scale=3600.0),
+}
+"""The NWP variables the dashboard offers, keyed by ``contracts.weather_schemas.Nwp`` column.
+
+Exactly the *continuous* ``Nwp`` variables (a test guards against drift):
+``categorical_precipitation_type_surface`` is excluded because its values are category codes,
+which a line chart would render as meaningless slopes.
 """
 
 
@@ -83,20 +144,25 @@ is in.
 """
 
 
-def _prepare_for_plot(lf: pl.LazyFrame, time_column: str, power_column: str) -> pl.LazyFrame:
-    """Convert times to naive Europe/London wall time and compact powers for serialisation.
+def _prepare_for_plot(lf: pl.LazyFrame, time_column: str, value_column: str) -> pl.LazyFrame:
+    """Convert times to naive Europe/London wall time and compact values for serialisation.
 
     Naive (zone-stripped) values render identically in any viewer's browser — Vega would
-    otherwise re-localise tz-aware timestamps to the viewer's zone. Powers are rounded to 3
+    otherwise re-localise tz-aware timestamps to the viewer's zone. Values are rounded to 3
     decimal places *as Float64*: a raw ``Float32`` serialises to JSON with ~17 significant
     digits (e.g. ``10.300000190734863``), which roughly triples the inline-data size and pushes
-    the ~34k-row ensemble past marimo's max-output-size guard. 1 W display precision is far
+    the ~34k-row ensemble past marimo's max-output-size guard. 3 d.p. display precision is far
     below forecast error (the stored values are already rounded to a 13-bit significand).
     """
     return lf.with_columns(
         pl.col(time_column).dt.convert_time_zone(DISPLAY_TIME_ZONE).dt.replace_time_zone(None),
-        pl.col(power_column).cast(pl.Float64).round(3),
+        pl.col(value_column).cast(pl.Float64).round(3),
     )
+
+
+def _wall_time(t: datetime) -> datetime:
+    """A tz-aware UTC datetime as naive Europe/London wall time (see ``_prepare_for_plot``)."""
+    return pl.Series([t]).dt.convert_time_zone(DISPLAY_TIME_ZONE).dt.replace_time_zone(None).item()
 
 
 def _weekend_bands(window_start: datetime, window_end: datetime) -> pl.DataFrame:
@@ -154,6 +220,31 @@ def _lagged_power_frame(
         .filter(pl.col("time") >= window_start)
         for lag in lags
     )
+
+
+def _weekend_layer(window_start: datetime, window_end: datetime) -> alt.Chart:
+    """The faint weekend-band layer, drawn first so every other layer sits on top.
+
+    No y encoding, so each band spans the full chart height. Uses the shared x encoding — see
+    ``_x_encoding``'s docstring for why deviating from it would suppress the merged x-axis.
+    """
+    return (
+        alt.Chart(_weekend_bands(window_start, window_end))
+        .mark_rect(color=ocf_theme.MUSTARD, opacity=WEEKEND_SHADE_OPACITY)
+        .encode(
+            x=_x_encoding(window_start, window_end, field="start"),
+            x2="end:T",
+        )
+    )
+
+
+def _y_axis() -> alt.Axis:
+    """A y-axis with its pixel extent pinned so stacked charts align — see ``Y_AXIS_EXTENT``.
+
+    Like the x encoding, the y-axis definition must be identical on every layer that carries a
+    y encoding, or Vega-Lite's axis merge can drop the deviating properties.
+    """
+    return alt.Axis(minExtent=Y_AXIS_EXTENT, maxExtent=Y_AXIS_EXTENT)
 
 
 def _x_axis_ticks(window_start: datetime, window_end: datetime) -> list[datetime]:
@@ -233,28 +324,25 @@ def build_view_forecast_chart(
     # 51 members × 14 days × 48 half-hours ≈ 34k rows exceeds Altair's 5000-row default guard.
     alt.data_transformers.disable_max_rows()
 
-    init_wall = (
-        pl.Series([power_fcst_init_time])
-        .dt.convert_time_zone(DISPLAY_TIME_ZONE)
-        .dt.replace_time_zone(None)
-        .item()
-    )
+    init_wall = _wall_time(power_fcst_init_time)
     window_start = init_wall - PLOT_HISTORY
     window_end = init_wall + PLOT_HORIZON
     x = _x_encoding(window_start, window_end)
 
-    # All power layers share the y title so Vega-Lite merges them into one clean y-axis
-    # whichever subset of lines is toggled on.
+    # All power layers share the y title (and the pinned _y_axis) so Vega-Lite merges them into
+    # one clean y-axis whichever subset of lines is toggled on.
     y_title = f"Power ({units})"
 
     # The shared colour scale's explicit domain drives the legend, so the legend always lists
     # every line — even ones currently toggled off — and colours never reshuffle. The scale and
     # legend definitions ride on the field-encoded layers (lags and the always-present init-time
     # rule); the single-colour layers reference the same scale via datum encodings.
+    # orient="top" keeps the legend out of the plot's horizontal space, so the x-axis aligns
+    # with the legend-less NWP panel stacked below (see the module docstring).
     # (Swatch opacity is pinned to 1 in the OCF theme's legend config — a per-legend
     # ``symbolOpacity`` here would lose to the opacity Vega-Lite derives from the marks.)
     line_color_scale = alt.Scale(domain=list(_LINE_COLORS), range=list(_LINE_COLORS.values()))
-    line_legend = alt.Legend(title=None, symbolType="stroke", symbolStrokeWidth=2)
+    line_legend = alt.Legend(title=None, orient="top", symbolType="stroke", symbolStrokeWidth=2)
 
     # Layers are appended in draw order: weekend bands at the back, then the forecast
     # ensemble, then lagged power (model *inputs*, which must not obscure observations), then
@@ -262,17 +350,7 @@ def build_view_forecast_chart(
     layers: list[alt.Chart] = []
     subtitle_notes: list[str] = []
     if shade_weekends:
-        # Drawn first so every other layer sits on top; no y encoding, so each band spans the
-        # full chart height. Uses the shared x encoding (see _x_encoding's docstring for why
-        # deviating from it would suppress the merged x-axis).
-        layers.append(
-            alt.Chart(_weekend_bands(window_start, window_end))
-            .mark_rect(color=ocf_theme.MUSTARD, opacity=WEEKEND_SHADE_OPACITY)
-            .encode(
-                x=_x_encoding(window_start, window_end, field="start"),
-                x2="end:T",
-            )
-        )
+        layers.append(_weekend_layer(window_start, window_end))
         subtitle_notes.append("Shaded: weekends")
     if show_forecast:
         layers.append(
@@ -280,7 +358,7 @@ def build_view_forecast_chart(
             .mark_line(strokeWidth=1, opacity=0.3)
             .encode(
                 x=x,
-                y=alt.Y("power_fcst:Q", title=y_title),
+                y=alt.Y("power_fcst:Q", title=y_title, axis=_y_axis()),
                 color=alt.ColorDatum(_FORECAST_LABEL),
                 detail="ensemble_member:N",
                 tooltip=["ensemble_member", "valid_time", "power_fcst"],
@@ -301,7 +379,7 @@ def build_view_forecast_chart(
             .mark_line(strokeWidth=1.5, opacity=0.8)
             .encode(
                 x=x,
-                y=alt.Y("power:Q", title=y_title),
+                y=alt.Y("power:Q", title=y_title, axis=_y_axis()),
                 color=alt.Color("lag:N", scale=line_color_scale, legend=line_legend),
                 tooltip=["lag", "valid_time", "power"],
             )
@@ -320,7 +398,7 @@ def build_view_forecast_chart(
             .mark_line(strokeWidth=2.5)
             .encode(
                 x=x,
-                y=alt.Y("power:Q", title=y_title),
+                y=alt.Y("power:Q", title=y_title, axis=_y_axis()),
                 color=alt.ColorDatum(_ACTUALS_LABEL),
                 tooltip=["valid_time", "power"],
             )
@@ -344,4 +422,97 @@ def build_view_forecast_chart(
     )
     # .interactive() on a LayerChart returns a LayerChart; the FacetChart half of the union in
     # its annotation only arises for faceted charts.
+    return cast(alt.LayerChart, chart.interactive())
+
+
+def build_nwp_ensemble_chart(
+    nwp: pl.LazyFrame,
+    *,
+    variable: str,
+    power_fcst_init_time: datetime,
+    nwp_init_time: datetime,
+    shade_weekends: bool = True,
+) -> alt.LayerChart:
+    """Build the NWP-ensemble panel stacked below the power chart, sharing its x-axis.
+
+    Args:
+        nwp: ``Nwp`` rows for one ``(nwp_model_id, init_time, h3_index)`` — the run recorded in
+            the selected forecast's ``nwp_init_time``, at the H3 cell containing this time
+            series (``TimeSeriesMetadata.h3_res_5`` equals ``Nwp.h3_index``; both are resolution
+            5). Every distinct ``ensemble_member`` becomes a thin grey line. Native NWP time
+            steps (3- or 6-hourly) are drawn as-is, not upsampled.
+        variable: The ``Nwp`` column to plot; must be a key of ``NWP_PLOT_VARIABLES``.
+        power_fcst_init_time: The *power* forecast init time (tz-aware UTC). Sets the plotted
+            window and the dashed rule, matching the power chart above exactly.
+        nwp_init_time: When the plotted NWP run was initialised (tz-aware UTC); shown in the
+            subtitle. The lines start here — the run has no earlier data — so the panel is
+            deliberately empty between the window start and the NWP init time.
+        shade_weekends: Whether to draw the same faint weekend bands as the power chart.
+
+    Returns:
+        A layered, zoomable Altair chart in Europe/London wall time whose horizontal geometry
+        matches ``build_view_forecast_chart``'s (same pinned x encoding and y-axis extent), so
+        the two charts' x-axes align when stacked in the dashboard.
+    """
+    var = NWP_PLOT_VARIABLES[variable]
+    init_wall = _wall_time(power_fcst_init_time)
+    window_start = init_wall - PLOT_HISTORY
+    window_end = init_wall + PLOT_HORIZON
+    x = _x_encoding(window_start, window_end)
+
+    # The display scale is applied before _prepare_for_plot so its 3-decimal-place rounding
+    # happens in display units (raw precipitation ~1e-4 kg/m²/s would round to zero).
+    data = _prepare_for_plot(
+        nwp.filter(
+            pl.col("valid_time").is_between(
+                power_fcst_init_time - PLOT_HISTORY, power_fcst_init_time + PLOT_HORIZON
+            )
+        )
+        .select("valid_time", "ensemble_member", variable)
+        .with_columns(pl.col(variable) * var.scale),
+        "valid_time",
+        variable,
+    ).collect()
+
+    layers: list[alt.Chart] = []
+    if shade_weekends:
+        layers.append(_weekend_layer(window_start, window_end))
+    layers.append(
+        alt.Chart(data)
+        .mark_line(strokeWidth=1, opacity=0.3, color=ocf_theme.ENSEMBLE_LINE)
+        .encode(
+            x=x,
+            # zero=False: weather variables have no meaningful zero baseline, and Vega-Lite's
+            # zero default would squash e.g. surface pressure (~101,000 Pa) into a flat sliver
+            # at the top of a zero-based axis.
+            y=alt.Y(
+                f"{variable}:Q",
+                title=f"{var.label} ({var.unit})",
+                axis=_y_axis(),
+                scale=alt.Scale(zero=False),
+            ),
+            detail="ensemble_member:N",
+            tooltip=["ensemble_member", "valid_time", variable],
+        )
+    )
+    # The init-time rule matches the power chart's but takes its colour from the mark: this
+    # panel has no legend (the power chart's legend explains the rule), and a colour encoding
+    # here would conjure one up.
+    layers.append(
+        alt.Chart(pl.DataFrame({"valid_time": [init_wall]}))
+        .mark_rule(strokeWidth=1.5, strokeDash=[6, 4], color=ocf_theme.ORANGE_RED)
+        .encode(x=x, tooltip=[alt.Tooltip("valid_time", title="Forecast init time")])
+    )
+    chart = alt.layer(*layers).properties(
+        title=alt.TitleParams(
+            text=f"NWP ensemble — {var.label}",
+            subtitle=(
+                f"NWP init {nwp_init_time:%a %d %b %Y %H:%M} UTC"
+                " · at the H3 cell containing this series"
+            ),
+        ),
+        width="container",
+        height=220,
+    )
+    # See build_view_forecast_chart for why this cast is safe.
     return cast(alt.LayerChart, chart.interactive())

--- a/packages/dashboard/tests/test_forecast_chart.py
+++ b/packages/dashboard/tests/test_forecast_chart.py
@@ -1,20 +1,27 @@
-"""Tests for the ``view_forecasts.py`` chart builder (``dashboard.forecast_chart``)."""
+"""Tests for the ``view_forecasts.py`` chart builders (``dashboard.forecast_chart``)."""
 
 from collections.abc import Sequence
 from datetime import UTC, datetime, timedelta
 
 import polars as pl
 from altair import LayerChart
+from contracts.weather_schemas import Nwp
 from dashboard.forecast_chart import (
     LAG_OPTIONS,
+    NWP_PLOT_VARIABLES,
     PLOT_HISTORY,
     PLOT_HORIZON,
+    Y_AXIS_EXTENT,
+    build_nwp_ensemble_chart,
     build_view_forecast_chart,
 )
 from plotting import ocf_theme
 
 INIT_TIME = datetime(2026, 7, 4, 6, 0, tzinfo=UTC)
 """During British Summer Time, so wall time is UTC+1 — the axis tests below rely on that."""
+
+NWP_INIT_TIME = INIT_TIME - timedelta(hours=6)
+"""The NWP run feeding the forecast, published 6 h before the power init time."""
 
 
 def _forecasts(members: tuple[int, ...]) -> pl.LazyFrame:
@@ -221,6 +228,95 @@ def test_show_flags_toggle_the_forecast_and_actuals_layers() -> None:
     # weekend bands, lag line, init rule — the y-axis title comes from the lag layer alone.
     assert len(only_lags["layer"]) == 3
     assert only_lags["layer"][1]["encoding"]["y"]["title"] == "Power (MW)"
+
+
+def _nwp(members: tuple[int, ...] = (0, 1, 2)) -> pl.LazyFrame:
+    valid_times = pl.datetime_range(
+        NWP_INIT_TIME,
+        NWP_INIT_TIME + timedelta(days=15),
+        interval="3h",
+        time_zone="UTC",
+        eager=True,
+    )
+    return pl.DataFrame(
+        {
+            "valid_time": pl.concat([valid_times for _ in members]),
+            "ensemble_member": pl.Series(
+                [m for m in members for _ in range(len(valid_times))], dtype=pl.UInt8
+            ),
+            "temperature_2m": pl.Series(
+                [float(m + i % 24) for m in members for i in range(len(valid_times))],
+                dtype=pl.Float32,
+            ),
+            "precipitation_surface": pl.Series(
+                [m * 1e-4 for m in members for _ in range(len(valid_times))], dtype=pl.Float32
+            ),
+        }
+    ).lazy()
+
+
+def _build_nwp(variable: str = "temperature_2m", **kwargs: bool) -> LayerChart:
+    return build_nwp_ensemble_chart(
+        _nwp(),
+        variable=variable,
+        power_fcst_init_time=INIT_TIME,
+        nwp_init_time=NWP_INIT_TIME,
+        **kwargs,
+    )
+
+
+def test_nwp_chart_horizontal_geometry_matches_the_power_chart() -> None:
+    power = _build().to_dict()
+    nwp = _build_nwp().to_dict()
+    assert len(nwp["layer"]) == 3  # weekend bands, ensemble members, init rule
+    # The two charts are stacked in the dashboard, so their x-axes must align: identical x
+    # encoding (same pinned domain, ticks, and labels) and identical pinned y-axis extents.
+    power_x = power["layer"][1]["encoding"]["x"]
+    nwp_x = nwp["layer"][1]["encoding"]["x"]
+    assert nwp_x["axis"] == power_x["axis"]
+    assert nwp_x["scale"] == power_x["scale"]
+    for spec in (power, nwp):
+        y_axis = spec["layer"][1]["encoding"]["y"]["axis"]
+        assert y_axis["minExtent"] == y_axis["maxExtent"] == Y_AXIS_EXTENT
+    # The power chart's legend must sit above the plot — a right-side legend would eat
+    # horizontal plot space that the legend-less NWP panel doesn't lose, breaking alignment.
+    assert power["layer"][-1]["encoding"]["color"]["legend"]["orient"] == "top"
+
+
+def test_nwp_chart_plots_each_member_with_the_units_on_the_y_axis() -> None:
+    spec = _build_nwp().to_dict()
+    ensemble = spec["layer"][1]
+    assert ensemble["encoding"]["y"]["title"] == "2 m temperature (°C)"
+    assert ensemble["encoding"]["detail"]["field"] == "ensemble_member"
+    # Weather variables have no meaningful zero baseline — a zero-based axis would squash
+    # e.g. surface pressure (~101,000 Pa) into a flat sliver.
+    assert ensemble["encoding"]["y"]["scale"]["zero"] is False
+    rows = spec["datasets"][ensemble["data"]["name"]]
+    assert {row["ensemble_member"] for row in rows} == {0, 1, 2}
+
+
+def test_nwp_plot_variables_cover_exactly_the_continuous_nwp_vars() -> None:
+    # Drift guard: adding a variable to the Nwp contract must be mirrored here (or this set
+    # comparison fails), and categorical variables must stay excluded.
+    assert set(NWP_PLOT_VARIABLES) == Nwp.continuous_var_names()
+
+
+def test_precipitation_is_displayed_in_mm_per_hour() -> None:
+    spec = _build_nwp(variable="precipitation_surface").to_dict()
+    assert spec["layer"][1]["encoding"]["y"]["title"] == "Precipitation rate (mm/h)"
+    rows = spec["datasets"][spec["layer"][1]["data"]["name"]]
+    # Stored kg/m²/s values of 0, 1e-4, and 2e-4 (per member) become mm/h on display.
+    assert {row["precipitation_surface"] for row in rows} == {0.0, 0.36, 0.72}
+
+
+def test_nwp_rows_are_clipped_to_the_plotted_window() -> None:
+    spec = _build_nwp().to_dict()
+    rows = spec["datasets"][spec["layer"][1]["data"]["name"]]
+    times = sorted(row["valid_time"] for row in rows)
+    # The run starts 6 h before the power init (01:00 wall time) — the panel is empty before
+    # that — and the run's final day (out to +15 d) is clipped at the window end.
+    assert times[0] == "2026-07-04T01:00:00"
+    assert times[-1] == "2026-07-18T07:00:00"
 
 
 def test_chart_renders_to_html() -> None:

--- a/packages/dashboard/view_forecasts.py
+++ b/packages/dashboard/view_forecasts.py
@@ -11,8 +11,10 @@ with app.setup:
     from dashboard.data_source import settings_for_source, source_status_message
     from dashboard.forecast_chart import (
         LAG_OPTIONS,
+        NWP_PLOT_VARIABLES,
         PLOT_HISTORY,
         PLOT_HORIZON,
+        build_nwp_ensemble_chart,
         build_view_forecast_chart,
     )
     from deltalake import DeltaTable
@@ -25,7 +27,9 @@ def _():
 
     Pick a time series and a forecast run; the plot shows every forecast ensemble member
     (thin grey lines) against the observed power (thick blue line), from 24 hours before
-    the forecast init time to 14 days after it.
+    the forecast init time to 14 days after it. A second panel below shows the NWP ensemble
+    that fed the forecast — pick the weather variable to plot — on the same time axis, at
+    the H3 cell containing the series.
     """)
     return
 
@@ -196,7 +200,14 @@ def _():
     show_lag_7d = mo.ui.checkbox(label="7-day lagged power")
     show_lag_14d = mo.ui.checkbox(label="14-day lagged power")
     weekend_shading = mo.ui.checkbox(value=True, label="Shade weekends")
+    nwp_variable_picker = mo.ui.dropdown(
+        options={v.label: name for name, v in NWP_PLOT_VARIABLES.items()},
+        value=NWP_PLOT_VARIABLES["temperature_2m"].label,
+        label="NWP variable",
+        searchable=True,
+    )
     return (
+        nwp_variable_picker,
         show_actuals,
         show_forecast,
         show_lag_14d,
@@ -212,6 +223,7 @@ def _(
     experiment_picker,
     fold_picker,
     no_runs_message,
+    nwp_variable_picker,
     run_picker,
     series_picker,
     show_actuals,
@@ -230,7 +242,7 @@ def _(
         [mo.md("**Lines**"), show_forecast, show_actuals, show_lag_7d, show_lag_14d],
         gap=0,
     )
-    _pickers += [_lines, weekend_shading]
+    _pickers += [_lines, weekend_shading, nwp_variable_picker]
     _rows = [mo.hstack(_pickers, justify="start", gap=2, wrap=True)]
     if no_runs_message is not None:
         _rows.append(no_runs_message)
@@ -253,7 +265,9 @@ def _(experiment_picker, fold_picker, run_picker, series_picker, settings):
             pl.col("power_fcst_init_time") == init_time,
             pl.col("valid_time") <= init_time + PLOT_HORIZON,
         )
-        .select("valid_time", "power_fcst", "ensemble_member")
+        # nwp_init_time identifies the NWP run for the panel below the power chart; the power
+        # chart cell drops it again so it isn't serialised into the 34k-row chart data.
+        .select("valid_time", "power_fcst", "ensemble_member", "nwp_init_time")
         .collect()
     )
     # History extends max(LAG_OPTIONS) past the plotted window so the lagged-power lines are
@@ -298,7 +312,7 @@ def _(
 ):
     _meta = metadata_df.filter(pl.col("time_series_id") == series_picker.value)
     chart = build_view_forecast_chart(
-        forecasts.lazy(),
+        forecasts.lazy().drop("nwp_init_time"),
         actuals.lazy(),
         power_fcst_init_time=init_time,
         units=_meta["units"].item(),
@@ -326,6 +340,74 @@ def _(
     # the cell output, which would blow marimo's max-output-size guard. Selections are disabled —
     # the chart's own scale-bound zoom/pan is the intended interaction.
     mo.ui.altair_chart(chart, chart_selection=False, legend_selection=False)
+    return
+
+
+@app.cell
+def _(forecasts, metadata_df, series_picker, settings):
+    _nwp_init_times = forecasts.get_column("nwp_init_time").drop_nulls().unique()
+    mo.stop(
+        _nwp_init_times.is_empty(),
+        mo.callout(
+            mo.md(
+                "This forecast records no `nwp_init_time` (e.g. a model that uses no weather "
+                "data), so there is no NWP ensemble to plot."
+            ),
+            kind="info",
+        ),
+    )
+    # A forecast normally comes from a single NWP run; max() picks the freshest if a future
+    # experiment ever grows the ensemble with lagged NWP runs.
+    nwp_init_time = _nwp_init_times.max()
+
+    # All 51 members × ~85 steps × all variables is only ~4k rows, so load every variable for
+    # the run once — switching the NWP-variable dropdown then re-runs only the chart cell,
+    # never this Delta query. init_time is a partition column, so the filter prunes to one
+    # partition; h3_index selects the (resolution 5) cell containing this series.
+    _series_h3 = metadata_df.filter(pl.col("time_series_id") == series_picker.value)[
+        "h3_res_5"
+    ].item()
+    try:
+        nwp = (
+            pl.scan_delta(
+                settings.nwp_data_path,
+                storage_options=typeddict_to_dict(settings.storage_options),
+            )
+            .filter(
+                pl.col("init_time") == nwp_init_time,
+                pl.col("h3_index") == _series_h3,
+            )
+            .drop("nwp_model_id", "init_time", "h3_index")
+            .collect()
+        )
+    except Exception as error:
+        nwp = pl.DataFrame()
+        _load_error = f": `{error}`"
+    else:
+        _load_error = "."
+    mo.stop(
+        nwp.height == 0,
+        mo.callout(
+            mo.md(
+                f"No NWP rows found at `{settings.nwp_data_path}` for the run initialised at "
+                f"{nwp_init_time:%Y-%m-%d %H:%M} UTC at this series' H3 cell{_load_error}"
+            ),
+            kind="warn",
+        ),
+    )
+    return nwp, nwp_init_time
+
+
+@app.cell
+def _(init_time, nwp, nwp_init_time, nwp_variable_picker, weekend_shading):
+    nwp_chart = build_nwp_ensemble_chart(
+        nwp.lazy(),
+        variable=nwp_variable_picker.value,
+        power_fcst_init_time=init_time,
+        nwp_init_time=nwp_init_time,
+        shade_weekends=weekend_shading.value,
+    )
+    mo.ui.altair_chart(nwp_chart, chart_selection=False, legend_selection=False)
     return
 
 


### PR DESCRIPTION
## Summary
- Adds a second panel to the `view_forecasts.py` dashboard showing every ensemble member of the NWP run that fed the selected forecast (`PowerForecast.nwp_init_time`), at the H3 cell containing the series (`TimeSeriesMetadata.h3_res_5 == Nwp.h3_index`, both resolution 5).
- A new "NWP variable" dropdown selects which of the 12 continuous `Nwp` variables to plot, with the display unit on the y-axis; a test guards the variable mapping against drift from the `Nwp` contract. Precipitation is displayed as mm/h (×3600 from the stored kg/m²/s, which would otherwise round to zero at display precision). `categorical_precipitation_type_surface` is excluded — category codes make meaningless line slopes.
- The two charts are separate Altair specs stacked by marimo (switching NWP variable re-runs only the NWP cells, never the power chart or any Delta query). Their x-axes align because both pin the same x encoding and a fixed y-axis pixel extent (`Y_AXIS_EXTENT`), and the power chart's legend moved to `orient="top"` so it no longer consumes horizontal plot space the legend-less NWP panel wouldn't also lose.
- The NWP y scale sets `zero=False`: weather variables have no meaningful zero baseline, and surface pressure (~101,000 Pa) rendered as a flat sliver against the top of a zero-based axis.
- The NWP query loads all variables for one `(init_time, h3_index)` once (~4k rows from one pruned partition, ~0.2 s); forecasts with no `nwp_init_time` (e.g. persistence baselines) get an explanatory callout instead of the panel.

## Test plan
- [x] `uv run pytest packages/` — 204 tests pass (6 new chart tests, including a cross-chart horizontal-geometry guard)
- [x] `uv run ruff check .` / `uv run ruff format --check .` / `uv run ty check` — clean
- [x] `uv run marimo export script packages/dashboard/view_forecasts.py` — cell graph validates
- [x] Rendered both panels from real local data (id 24, live run) and pixel-checked alignment: the init-time rule renders at exactly the same x in both panels, for 2 m temperature and for surface pressure (widest y labels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)