### PR TITLE
Add a stitched NWP proxy-analysis line to the view_forecasts NWP panel

### DIFF
--- a/packages/dashboard/src/dashboard/forecast_chart.py
+++ b/packages/dashboard/src/dashboard/forecast_chart.py
@@ -137,7 +137,7 @@ _LAG_COLORS: Final[tuple[str, ...]] = (ocf_theme.PURPLE, ocf_theme.SPRING_GREEN)
 
 _FORECAST_LABEL: Final[str] = "Forecast power"
 _ACTUALS_LABEL: Final[str] = "Actual power"
-_INIT_TIME_LABEL: Final[str] = "Forecast init time"
+_INIT_TIME_LABEL: Final[str] = "Power forecast init time"
 _NWP_ENSEMBLE_LABEL: Final[str] = "NWP ensemble"
 _NWP_ANALYSIS_LABEL: Final[str] = "NWP proxy analysis"
 
@@ -439,7 +439,7 @@ def build_view_forecast_chart(
         .encode(
             x=x,
             color=alt.Color("series:N", scale=line_color_scale, legend=line_legend),
-            tooltip=[alt.Tooltip("valid_time", title="Forecast init time")],
+            tooltip=[alt.Tooltip("valid_time", title="Power forecast init time")],
         )
     )
     chart = alt.layer(*layers).properties(
@@ -577,7 +577,7 @@ def build_nwp_ensemble_chart(
         .encode(
             x=x,
             color=alt.Color("series:N", scale=nwp_color_scale, legend=nwp_legend),
-            tooltip=[alt.Tooltip("valid_time", title="Forecast init time")],
+            tooltip=[alt.Tooltip("valid_time", title="Power forecast init time")],
         )
     )
     subtitle = (

--- a/packages/dashboard/src/dashboard/forecast_chart.py
+++ b/packages/dashboard/src/dashboard/forecast_chart.py
@@ -100,6 +100,22 @@ Exactly the *continuous* ``Nwp`` variables (a test guards against drift):
 which a line chart would render as meaningless slopes.
 """
 
+NWP_ANALYSIS_LEAD: Final[timedelta] = timedelta(hours=24)
+"""How much of each NWP run's start feeds the stitched proxy-analysis line.
+
+We hold no weather observations, so the closest available proxy for the *true* weather over
+historical times is each run's shortest-lead forecasts: the first day of every run across the
+window, stitched into one line. 24 hours matches the daily-00Z run cadence, so consecutive
+chunks tile into a continuous line with no gaps and no overlaps.
+"""
+
+NWP_ANALYSIS_MEMBER: Final[int] = 0
+"""The ensemble member the proxy-analysis line uses.
+
+Member 0 of ECMWF ENS is the control run — the unperturbed forecast started from the analysis
+itself — so its shortest leads are the closest thing to the analysis that the ensemble holds.
+"""
+
 
 def _lag_label(lag: timedelta) -> str:
     """The display label for a power lag, used in the UI control and the chart legend alike."""
@@ -431,6 +447,7 @@ def build_nwp_ensemble_chart(
     variable: str,
     power_fcst_init_time: datetime,
     nwp_init_time: datetime,
+    analysis: pl.LazyFrame | None = None,
     shade_weekends: bool = True,
 ) -> alt.LayerChart:
     """Build the NWP-ensemble panel stacked below the power chart, sharing its x-axis.
@@ -447,6 +464,12 @@ def build_nwp_ensemble_chart(
         nwp_init_time: When the plotted NWP run was initialised (tz-aware UTC); shown in the
             subtitle. The lines start here — the run has no earlier data — so the panel is
             deliberately empty between the window start and the NWP init time.
+        analysis: Short-lead ``Nwp`` rows from *every* run overlapping the window — the first
+            ``NWP_ANALYSIS_LEAD`` of each run, ``NWP_ANALYSIS_MEMBER`` only — with ``init_time``
+            and ``valid_time`` alongside the variable columns. Stitched (freshest run wins where
+            runs overlap a ``valid_time``) into a single thick blue line: our closest proxy for
+            the true weather, since we hold no weather observations. ``None``, or no rows in the
+            window, omits the line.
         shade_weekends: Whether to draw the same faint weekend bands as the power chart.
 
     Returns:
@@ -459,22 +482,44 @@ def build_nwp_ensemble_chart(
     window_start = init_wall - PLOT_HISTORY
     window_end = init_wall + PLOT_HORIZON
     x = _x_encoding(window_start, window_end)
+    plot_window = pl.col("valid_time").is_between(
+        power_fcst_init_time - PLOT_HISTORY, power_fcst_init_time + PLOT_HORIZON
+    )
+    # zero=False: weather variables have no meaningful zero baseline, and Vega-Lite's zero
+    # default would squash e.g. surface pressure (~101,000 Pa) into a flat sliver at the top of
+    # a zero-based axis. Shared by every value-carrying layer so the axis definitions merge.
+    y = alt.Y(
+        f"{variable}:Q",
+        title=f"{var.label} ({var.unit})",
+        axis=_y_axis(),
+        scale=alt.Scale(zero=False),
+    )
 
     # The display scale is applied before _prepare_for_plot so its 3-decimal-place rounding
     # happens in display units (raw precipitation ~1e-4 kg/m²/s would round to zero).
     data = _prepare_for_plot(
-        nwp.filter(
-            pl.col("valid_time").is_between(
-                power_fcst_init_time - PLOT_HISTORY, power_fcst_init_time + PLOT_HORIZON
-            )
-        )
+        nwp.filter(plot_window)
         .select("valid_time", "ensemble_member", variable)
         .with_columns(pl.col(variable) * var.scale),
         "valid_time",
         variable,
     ).collect()
+    analysis_data = (
+        None
+        if analysis is None
+        else _prepare_for_plot(
+            analysis.filter(plot_window)
+            # Where runs overlap a valid_time, keep the freshest run — the shortest lead.
+            .filter(pl.col("init_time") == pl.col("init_time").max().over("valid_time"))
+            .select("valid_time", variable)
+            .with_columns(pl.col(variable) * var.scale),
+            "valid_time",
+            variable,
+        ).collect()
+    )
 
     layers: list[alt.Chart] = []
+    subtitle_notes: list[str] = []
     if shade_weekends:
         layers.append(_weekend_layer(window_start, window_end))
     layers.append(
@@ -482,19 +527,23 @@ def build_nwp_ensemble_chart(
         .mark_line(strokeWidth=1, opacity=0.3, color=ocf_theme.ENSEMBLE_LINE)
         .encode(
             x=x,
-            # zero=False: weather variables have no meaningful zero baseline, and Vega-Lite's
-            # zero default would squash e.g. surface pressure (~101,000 Pa) into a flat sliver
-            # at the top of a zero-based axis.
-            y=alt.Y(
-                f"{variable}:Q",
-                title=f"{var.label} ({var.unit})",
-                axis=_y_axis(),
-                scale=alt.Scale(zero=False),
-            ),
+            y=y,
             detail="ensemble_member:N",
             tooltip=["ensemble_member", "valid_time", variable],
         )
     )
+    if analysis_data is not None and analysis_data.height > 0:
+        # BLUE deliberately matches the power panel's observed-truth colour; the stroke width
+        # matches the actual-power line's for the same reason.
+        layers.append(
+            alt.Chart(analysis_data)
+            .mark_line(strokeWidth=2.5, color=ocf_theme.BLUE)
+            .encode(x=x, y=y, tooltip=["valid_time", variable])
+        )
+        analysis_hours = int(NWP_ANALYSIS_LEAD.total_seconds() // 3600)
+        subtitle_notes.append(
+            f"Blue: proxy analysis (each NWP run's first {analysis_hours} h, stitched)"
+        )
     # The init-time rule matches the power chart's but takes its colour from the mark: this
     # panel has no legend (the power chart's legend explains the rule), and a colour encoding
     # here would conjure one up.
@@ -503,13 +552,13 @@ def build_nwp_ensemble_chart(
         .mark_rule(strokeWidth=1.5, strokeDash=[6, 4], color=ocf_theme.ORANGE_RED)
         .encode(x=x, tooltip=[alt.Tooltip("valid_time", title="Forecast init time")])
     )
+    subtitle = (
+        f"NWP init {nwp_init_time:%a %d %b %Y %H:%M} UTC · at the H3 cell containing this series"
+    )
     chart = alt.layer(*layers).properties(
         title=alt.TitleParams(
             text=f"NWP ensemble — {var.label}",
-            subtitle=(
-                f"NWP init {nwp_init_time:%a %d %b %Y %H:%M} UTC"
-                " · at the H3 cell containing this series"
-            ),
+            subtitle=[subtitle, *subtitle_notes],
         ),
         width="container",
         height=220,

--- a/packages/dashboard/src/dashboard/forecast_chart.py
+++ b/packages/dashboard/src/dashboard/forecast_chart.py
@@ -13,8 +13,8 @@ at the H3 cell containing the series) as a second panel stacked below the power 
 
 The two charts are separate Altair specs, so stacking them relies on identical horizontal
 geometry: they share the same pinned x encoding, both pin the y-axis region to ``Y_AXIS_EXTENT``
-pixels, and the power chart's legend sits *above* the plot (``orient="top"``) so it consumes no
-horizontal space that the legend-less NWP panel wouldn't also lose.
+pixels, and both charts' legends sit *above* the plot (``orient="top"``) so neither consumes
+horizontal plot space.
 
 The x-axis deliberately overrides Altair's adaptive datetime ticks: labels sit at
 local midnight only (day-of-week first — crucial for demand forecasting), with unlabelled minor
@@ -138,6 +138,8 @@ _LAG_COLORS: Final[tuple[str, ...]] = (ocf_theme.PURPLE, ocf_theme.SPRING_GREEN)
 _FORECAST_LABEL: Final[str] = "Forecast power"
 _ACTUALS_LABEL: Final[str] = "Actual power"
 _INIT_TIME_LABEL: Final[str] = "Forecast init time"
+_NWP_ENSEMBLE_LABEL: Final[str] = "NWP ensemble"
+_NWP_ANALYSIS_LABEL: Final[str] = "NWP proxy analysis"
 
 _LINE_COLORS: Final[dict[str, str]] = {
     _FORECAST_LABEL: ocf_theme.ENSEMBLE_LINE,
@@ -145,10 +147,21 @@ _LINE_COLORS: Final[dict[str, str]] = {
     **dict(zip(LAG_OPTIONS, _LAG_COLORS, strict=True)),
     _INIT_TIME_LABEL: ocf_theme.ORANGE_RED,
 }
-"""Legend label → line colour for everything the chart can draw, in legend order.
+"""Legend label → line colour for everything the power chart can draw, in legend order.
 
 Used as the explicit domain/range of the shared colour scale, so the legend always lists every
 entry — whichever lines are currently toggled on — and each line keeps a stable colour.
+"""
+
+_NWP_LINE_COLORS: Final[dict[str, str]] = {
+    _NWP_ENSEMBLE_LABEL: ocf_theme.ENSEMBLE_LINE,
+    _NWP_ANALYSIS_LABEL: ocf_theme.BLUE,
+    _INIT_TIME_LABEL: ocf_theme.ORANGE_RED,
+}
+"""Legend label → line colour for the NWP panel — the counterpart of ``_LINE_COLORS``.
+
+The colours deliberately rhyme with the power chart's: grey for the model's view (ensemble),
+blue for the closest-to-truth line, orange-red for the shared init-time rule.
 """
 
 _MIDNIGHT_TEST: Final[str] = "hours(datum.value) == 0"
@@ -354,7 +367,8 @@ def build_view_forecast_chart(
     # legend definitions ride on the field-encoded layers (lags and the always-present init-time
     # rule); the single-colour layers reference the same scale via datum encodings.
     # orient="top" keeps the legend out of the plot's horizontal space, so the x-axis aligns
-    # with the legend-less NWP panel stacked below (see the module docstring).
+    # with the NWP panel stacked below, whose legend sits on top for the same reason (see the
+    # module docstring).
     # (Swatch opacity is pinned to 1 in the OCF theme's legend config — a per-legend
     # ``symbolOpacity`` here would lose to the opacity Vega-Lite derives from the marks.)
     line_color_scale = alt.Scale(domain=list(_LINE_COLORS), range=list(_LINE_COLORS.values()))
@@ -518,39 +532,53 @@ def build_nwp_ensemble_chart(
         ).collect()
     )
 
+    # The same always-shown-legend construction as the power chart: the shared colour scale's
+    # explicit domain drives the legend (so it lists every entry whatever is toggled on), the
+    # scale and legend ride on the always-drawn init-time rule, and the single-colour layers
+    # join via datum encodings. orient="top" keeps both charts' plot areas the same width.
+    nwp_color_scale = alt.Scale(
+        domain=list(_NWP_LINE_COLORS), range=list(_NWP_LINE_COLORS.values())
+    )
+    nwp_legend = alt.Legend(title=None, orient="top", symbolType="stroke", symbolStrokeWidth=2)
+
     layers: list[alt.Chart] = []
     subtitle_notes: list[str] = []
     if shade_weekends:
         layers.append(_weekend_layer(window_start, window_end))
     layers.append(
         alt.Chart(data)
-        .mark_line(strokeWidth=1, opacity=0.3, color=ocf_theme.ENSEMBLE_LINE)
+        .mark_line(strokeWidth=1, opacity=0.3)
         .encode(
             x=x,
             y=y,
+            color=alt.ColorDatum(_NWP_ENSEMBLE_LABEL),
             detail="ensemble_member:N",
             tooltip=["ensemble_member", "valid_time", variable],
         )
     )
     if analysis_data is not None and analysis_data.height > 0:
-        # BLUE deliberately matches the power panel's observed-truth colour; the stroke width
-        # matches the actual-power line's for the same reason.
+        # BLUE (via the shared scale) deliberately matches the power panel's observed-truth
+        # colour; the stroke width matches the actual-power line's for the same reason.
         layers.append(
             alt.Chart(analysis_data)
-            .mark_line(strokeWidth=2.5, color=ocf_theme.BLUE)
-            .encode(x=x, y=y, tooltip=["valid_time", variable])
+            .mark_line(strokeWidth=2.5)
+            .encode(
+                x=x,
+                y=y,
+                color=alt.ColorDatum(_NWP_ANALYSIS_LABEL),
+                tooltip=["valid_time", variable],
+            )
         )
         analysis_hours = int(NWP_ANALYSIS_LEAD.total_seconds() // 3600)
-        subtitle_notes.append(
-            f"Blue: proxy analysis (each NWP run's first {analysis_hours} h, stitched)"
-        )
-    # The init-time rule matches the power chart's but takes its colour from the mark: this
-    # panel has no legend (the power chart's legend explains the rule), and a colour encoding
-    # here would conjure one up.
+        subtitle_notes.append(f"Proxy analysis: each NWP run's first {analysis_hours} h, stitched")
     layers.append(
-        alt.Chart(pl.DataFrame({"valid_time": [init_wall]}))
-        .mark_rule(strokeWidth=1.5, strokeDash=[6, 4], color=ocf_theme.ORANGE_RED)
-        .encode(x=x, tooltip=[alt.Tooltip("valid_time", title="Forecast init time")])
+        alt.Chart(pl.DataFrame({"valid_time": [init_wall], "series": [_INIT_TIME_LABEL]}))
+        .mark_rule(strokeWidth=1.5, strokeDash=[6, 4])
+        .encode(
+            x=x,
+            color=alt.Color("series:N", scale=nwp_color_scale, legend=nwp_legend),
+            tooltip=[alt.Tooltip("valid_time", title="Forecast init time")],
+        )
     )
     subtitle = (
         f"NWP init {nwp_init_time:%a %d %b %Y %H:%M} UTC · at the H3 cell containing this series"

--- a/packages/dashboard/tests/test_forecast_chart.py
+++ b/packages/dashboard/tests/test_forecast_chart.py
@@ -8,6 +8,7 @@ from altair import LayerChart
 from contracts.weather_schemas import Nwp
 from dashboard.forecast_chart import (
     LAG_OPTIONS,
+    NWP_ANALYSIS_LEAD,
     NWP_PLOT_VARIABLES,
     PLOT_HISTORY,
     PLOT_HORIZON,
@@ -255,12 +256,49 @@ def _nwp(members: tuple[int, ...] = (0, 1, 2)) -> pl.LazyFrame:
     ).lazy()
 
 
-def _build_nwp(variable: str = "temperature_2m", **kwargs: bool) -> LayerChart:
+def _nwp_analysis(inits: Sequence[datetime]) -> pl.LazyFrame:
+    """The first ``NWP_ANALYSIS_LEAD`` of one run per element of ``inits``, control member only
+    — what the dashboard feeds ``build_nwp_ensemble_chart``'s ``analysis`` argument. The
+    temperature encodes the run's index so tests can see which run each plotted point came from.
+    """
+    frames = []
+    for index, run_init in enumerate(inits):
+        valid_times = pl.datetime_range(
+            run_init,
+            run_init + NWP_ANALYSIS_LEAD,
+            interval="3h",
+            closed="left",
+            time_zone="UTC",
+            eager=True,
+        )
+        frames.append(
+            pl.DataFrame(
+                {
+                    "init_time": [run_init] * len(valid_times),
+                    "valid_time": valid_times,
+                    "temperature_2m": pl.Series(
+                        [float(index)] * len(valid_times), dtype=pl.Float32
+                    ),
+                    "precipitation_surface": pl.Series(
+                        [1e-4 * (index + 1)] * len(valid_times), dtype=pl.Float32
+                    ),
+                }
+            )
+        )
+    return pl.concat(frames).lazy()
+
+
+def _build_nwp(
+    variable: str = "temperature_2m",
+    analysis: pl.LazyFrame | None = None,
+    **kwargs: bool,
+) -> LayerChart:
     return build_nwp_ensemble_chart(
         _nwp(),
         variable=variable,
         power_fcst_init_time=INIT_TIME,
         nwp_init_time=NWP_INIT_TIME,
+        analysis=analysis,
         **kwargs,
     )
 
@@ -307,6 +345,57 @@ def test_precipitation_is_displayed_in_mm_per_hour() -> None:
     rows = spec["datasets"][spec["layer"][1]["data"]["name"]]
     # Stored kg/m²/s values of 0, 1e-4, and 2e-4 (per member) become mm/h on display.
     assert {row["precipitation_surface"] for row in rows} == {0.0, 0.36, 0.72}
+
+
+def test_nwp_analysis_is_a_single_blue_line_over_the_ensemble() -> None:
+    spec = _build_nwp(
+        analysis=_nwp_analysis([NWP_INIT_TIME + timedelta(days=d) for d in range(3)])
+    ).to_dict()
+    assert len(spec["layer"]) == 4  # weekend bands, ensemble members, analysis line, init rule
+    analysis = spec["layer"][2]
+    # Blue and thick, deliberately matching the power panel's observed-truth line.
+    assert analysis["mark"]["color"] == ocf_theme.BLUE
+    assert analysis["mark"]["strokeWidth"] == 2.5
+    # Identical y encoding to the ensemble layer's, so the axis definitions merge cleanly.
+    assert analysis["encoding"]["y"] == spec["layer"][1]["encoding"]["y"]
+    assert "detail" not in analysis["encoding"]  # one stitched line, not a line per member
+    assert any("proxy analysis" in line for line in spec["title"]["subtitle"])
+
+
+def test_nwp_analysis_keeps_the_freshest_run_where_runs_overlap() -> None:
+    # Two runs 12 h apart, each contributing NWP_ANALYSIS_LEAD (24 h) of rows, so the second
+    # run's first 12 h of valid times appear in both — the freshest (shortest-lead) run must
+    # win there, collapsing each overlapped valid_time to a single point.
+    spec = _build_nwp(
+        analysis=_nwp_analysis([NWP_INIT_TIME, NWP_INIT_TIME + timedelta(hours=12)])
+    ).to_dict()
+    rows = spec["datasets"][spec["layer"][2]["data"]["name"]]
+    by_time = {row["valid_time"]: row["temperature_2m"] for row in rows}
+    assert len(by_time) == len(rows) == 12  # 8 + 8 rows, 4 of them at shared valid times
+    # NWP_INIT_TIME is 04 Jul 00:00 UTC = 01:00 wall time (BST); the runs overlap from 13:00.
+    assert by_time["2026-07-04T04:00:00"] == 0.0  # before the overlap: only the first run
+    assert by_time["2026-07-04T16:00:00"] == 1.0  # inside the overlap: the second run wins
+    assert by_time["2026-07-05T10:00:00"] == 1.0  # after the first run's 24 h end
+
+
+def test_nwp_analysis_line_is_omitted_when_absent_or_outside_the_window() -> None:
+    assert len(_build_nwp().to_dict()["layer"]) == 3  # no analysis passed
+    # A run whose whole first 24 h predate the window contributes no rows, so the layer and
+    # the subtitle note both vanish rather than advertising a line that isn't drawn.
+    stale = _build_nwp(
+        analysis=_nwp_analysis([INIT_TIME - PLOT_HISTORY - timedelta(days=2)])
+    ).to_dict()
+    assert len(stale["layer"]) == 3
+    assert not any("proxy analysis" in line for line in stale["title"]["subtitle"])
+
+
+def test_nwp_analysis_uses_the_same_display_units_as_the_ensemble() -> None:
+    spec = _build_nwp(
+        variable="precipitation_surface", analysis=_nwp_analysis([NWP_INIT_TIME])
+    ).to_dict()
+    rows = spec["datasets"][spec["layer"][2]["data"]["name"]]
+    # The stored 1e-4 kg/m²/s becomes 0.36 mm/h — same ×3600 display scale as the grey lines.
+    assert {row["precipitation_surface"] for row in rows} == {0.36}
 
 
 def test_nwp_rows_are_clipped_to_the_plotted_window() -> None:

--- a/packages/dashboard/tests/test_forecast_chart.py
+++ b/packages/dashboard/tests/test_forecast_chart.py
@@ -316,9 +316,9 @@ def test_nwp_chart_horizontal_geometry_matches_the_power_chart() -> None:
     for spec in (power, nwp):
         y_axis = spec["layer"][1]["encoding"]["y"]["axis"]
         assert y_axis["minExtent"] == y_axis["maxExtent"] == Y_AXIS_EXTENT
-    # The power chart's legend must sit above the plot — a right-side legend would eat
-    # horizontal plot space that the legend-less NWP panel doesn't lose, breaking alignment.
-    assert power["layer"][-1]["encoding"]["color"]["legend"]["orient"] == "top"
+        # Both legends must sit above their plot — a right-side legend would eat horizontal
+        # plot space and break the vertical alignment of the two stacked x-axes.
+        assert spec["layer"][-1]["encoding"]["color"]["legend"]["orient"] == "top"
 
 
 def test_nwp_chart_plots_each_member_with_the_units_on_the_y_axis() -> None:
@@ -326,6 +326,8 @@ def test_nwp_chart_plots_each_member_with_the_units_on_the_y_axis() -> None:
     ensemble = spec["layer"][1]
     assert ensemble["encoding"]["y"]["title"] == "2 m temperature (°C)"
     assert ensemble["encoding"]["detail"]["field"] == "ensemble_member"
+    # The grey takes its colour from the shared scale via a datum encoding, joining the legend.
+    assert ensemble["encoding"]["color"]["datum"] == "NWP ensemble"
     # Weather variables have no meaningful zero baseline — a zero-based axis would squash
     # e.g. surface pressure (~101,000 Pa) into a flat sliver.
     assert ensemble["encoding"]["y"]["scale"]["zero"] is False
@@ -353,13 +355,14 @@ def test_nwp_analysis_is_a_single_blue_line_over_the_ensemble() -> None:
     ).to_dict()
     assert len(spec["layer"]) == 4  # weekend bands, ensemble members, analysis line, init rule
     analysis = spec["layer"][2]
-    # Blue and thick, deliberately matching the power panel's observed-truth line.
-    assert analysis["mark"]["color"] == ocf_theme.BLUE
+    # Thick, and blue via the shared scale — deliberately matching the power panel's
+    # observed-truth line.
+    assert analysis["encoding"]["color"]["datum"] == "NWP proxy analysis"
     assert analysis["mark"]["strokeWidth"] == 2.5
     # Identical y encoding to the ensemble layer's, so the axis definitions merge cleanly.
     assert analysis["encoding"]["y"] == spec["layer"][1]["encoding"]["y"]
     assert "detail" not in analysis["encoding"]  # one stitched line, not a line per member
-    assert any("proxy analysis" in line for line in spec["title"]["subtitle"])
+    assert any("Proxy analysis" in line for line in spec["title"]["subtitle"])
 
 
 def test_nwp_analysis_keeps_the_freshest_run_where_runs_overlap() -> None:
@@ -386,7 +389,7 @@ def test_nwp_analysis_line_is_omitted_when_absent_or_outside_the_window() -> Non
         analysis=_nwp_analysis([INIT_TIME - PLOT_HISTORY - timedelta(days=2)])
     ).to_dict()
     assert len(stale["layer"]) == 3
-    assert not any("proxy analysis" in line for line in stale["title"]["subtitle"])
+    assert not any("Proxy analysis" in line for line in stale["title"]["subtitle"])
 
 
 def test_nwp_analysis_uses_the_same_display_units_as_the_ensemble() -> None:
@@ -396,6 +399,29 @@ def test_nwp_analysis_uses_the_same_display_units_as_the_ensemble() -> None:
     rows = spec["datasets"][spec["layer"][2]["data"]["name"]]
     # The stored 1e-4 kg/m²/s becomes 0.36 mm/h — same ×3600 display scale as the grey lines.
     assert {row["precipitation_surface"] for row in rows} == {0.36}
+
+
+def test_nwp_legend_always_lists_every_line() -> None:
+    # Same construction as the power chart's legend: the always-drawn init-rule layer carries
+    # the shared colour scale, whose explicit domain drives the legend — so the legend is
+    # identical whether or not the analysis line is currently drawn.
+    for spec in (
+        _build_nwp().to_dict(),
+        _build_nwp(analysis=_nwp_analysis([NWP_INIT_TIME])).to_dict(),
+    ):
+        colour = spec["layer"][-1]["encoding"]["color"]
+        assert colour["field"] == "series"
+        assert colour["scale"]["domain"] == [
+            "NWP ensemble",
+            "NWP proxy analysis",
+            "Forecast init time",
+        ]
+        assert colour["scale"]["range"] == [
+            ocf_theme.ENSEMBLE_LINE,
+            ocf_theme.BLUE,
+            ocf_theme.ORANGE_RED,
+        ]
+        assert colour["legend"]["symbolType"] == "stroke"
 
 
 def test_nwp_rows_are_clipped_to_the_plotted_window() -> None:

--- a/packages/dashboard/tests/test_forecast_chart.py
+++ b/packages/dashboard/tests/test_forecast_chart.py
@@ -182,7 +182,7 @@ def test_legend_always_lists_every_line() -> None:
             "Actual power",
             "7-day lagged power",
             "14-day lagged power",
-            "Forecast init time",
+            "Power forecast init time",
         ]
         assert colour["scale"]["range"] == [
             ocf_theme.ENSEMBLE_LINE,
@@ -414,7 +414,7 @@ def test_nwp_legend_always_lists_every_line() -> None:
         assert colour["scale"]["domain"] == [
             "NWP ensemble",
             "NWP proxy analysis",
-            "Forecast init time",
+            "Power forecast init time",
         ]
         assert colour["scale"]["range"] == [
             ocf_theme.ENSEMBLE_LINE,

--- a/packages/dashboard/view_forecasts.py
+++ b/packages/dashboard/view_forecasts.py
@@ -331,7 +331,7 @@ def _(
             f" — id {series_picker.value}"
         ),
         subtitle=(
-            f"Forecast init {init_time:%a %d %b %Y %H:%M} UTC"
+            f"Power forecast init {init_time:%a %d %b %Y %H:%M} UTC"
             f" · experiment {experiment_picker.value} · fold {fold_picker.value}"
         ),
         shade_weekends=weekend_shading.value,

--- a/packages/dashboard/view_forecasts.py
+++ b/packages/dashboard/view_forecasts.py
@@ -11,6 +11,8 @@ with app.setup:
     from dashboard.data_source import settings_for_source, source_status_message
     from dashboard.forecast_chart import (
         LAG_OPTIONS,
+        NWP_ANALYSIS_LEAD,
+        NWP_ANALYSIS_MEMBER,
         NWP_PLOT_VARIABLES,
         PLOT_HISTORY,
         PLOT_HORIZON,
@@ -206,12 +208,14 @@ def _():
         label="NWP variable",
         searchable=True,
     )
+    show_nwp_analysis = mo.ui.checkbox(value=True, label="NWP proxy analysis")
     return (
         nwp_variable_picker,
         show_actuals,
         show_forecast,
         show_lag_14d,
         show_lag_7d,
+        show_nwp_analysis,
         weekend_shading,
     )
 
@@ -230,6 +234,7 @@ def _(
     show_forecast,
     show_lag_14d,
     show_lag_7d,
+    show_nwp_analysis,
     weekend_shading,
 ):
     # The run selectors (which forecast to look at) stack vertically as one visual unit;
@@ -248,7 +253,7 @@ def _(
         mo.vstack(_run_selectors, gap=0.5),
         _lines,
         weekend_shading,
-        nwp_variable_picker,
+        mo.vstack([nwp_variable_picker, show_nwp_analysis], gap=0.5),
     ]
     _rows = [mo.hstack(_pickers, justify="start", gap=2, wrap=True)]
     if no_runs_message is not None:
@@ -351,7 +356,7 @@ def _(
 
 
 @app.cell
-def _(forecasts, metadata_df, series_picker, settings):
+def _(forecasts, init_time, metadata_df, series_picker, settings):
     _nwp_init_times = forecasts.get_column("nwp_init_time").drop_nulls().unique()
     mo.stop(
         _nwp_init_times.is_empty(),
@@ -387,8 +392,31 @@ def _(forecasts, metadata_df, series_picker, settings):
             .drop("nwp_model_id", "init_time", "h3_index")
             .collect()
         )
+        # The proxy-analysis line stitches the first NWP_ANALYSIS_LEAD of every run overlapping
+        # the plotted window (control member only) — see the constants' docstrings. Loading it
+        # here, unconditionally, keeps the "NWP proxy analysis" checkbox instant: toggling it
+        # re-runs only the chart cell, never this Delta query (~0.2 s across the ~17 pruned
+        # init_time partitions). Runs older than window_start − NWP_ANALYSIS_LEAD cannot reach
+        # the window, so the init_time filter starts there.
+        nwp_analysis = (
+            pl.scan_delta(
+                settings.nwp_data_path,
+                storage_options=typeddict_to_dict(settings.storage_options),
+            )
+            .filter(
+                pl.col("init_time").is_between(
+                    init_time - PLOT_HISTORY - NWP_ANALYSIS_LEAD, init_time + PLOT_HORIZON
+                ),
+                pl.col("h3_index") == _series_h3,
+                pl.col("ensemble_member") == NWP_ANALYSIS_MEMBER,
+                pl.col("valid_time") < pl.col("init_time") + NWP_ANALYSIS_LEAD,
+            )
+            .drop("nwp_model_id", "h3_index", "ensemble_member")
+            .collect()
+        )
     except Exception as error:
         nwp = pl.DataFrame()
+        nwp_analysis = pl.DataFrame()
         _load_error = f": `{error}`"
     else:
         _load_error = "."
@@ -402,16 +430,25 @@ def _(forecasts, metadata_df, series_picker, settings):
             kind="warn",
         ),
     )
-    return nwp, nwp_init_time
+    return nwp, nwp_analysis, nwp_init_time
 
 
 @app.cell
-def _(init_time, nwp, nwp_init_time, nwp_variable_picker, weekend_shading):
+def _(
+    init_time,
+    nwp,
+    nwp_analysis,
+    nwp_init_time,
+    nwp_variable_picker,
+    show_nwp_analysis,
+    weekend_shading,
+):
     nwp_chart = build_nwp_ensemble_chart(
         nwp.lazy(),
         variable=nwp_variable_picker.value,
         power_fcst_init_time=init_time,
         nwp_init_time=nwp_init_time,
+        analysis=nwp_analysis.lazy() if show_nwp_analysis.value else None,
         shade_weekends=weekend_shading.value,
     )
     mo.ui.altair_chart(nwp_chart, chart_selection=False, legend_selection=False)

--- a/packages/dashboard/view_forecasts.py
+++ b/packages/dashboard/view_forecasts.py
@@ -227,18 +227,17 @@ def _(
     experiment_picker,
     fold_picker,
     no_runs_message,
-    nwp_variable_picker,
     run_picker,
     series_picker,
     show_actuals,
     show_forecast,
     show_lag_14d,
     show_lag_7d,
-    show_nwp_analysis,
     weekend_shading,
 ):
     # The run selectors (which forecast to look at) stack vertically as one visual unit;
-    # the display toggles (how to draw it) sit beside them.
+    # the display toggles (how to draw it) sit beside them. The NWP controls live with the
+    # NWP panel itself (see the NWP chart cell), not here.
     _run_selectors = [series_picker, fold_picker]
     if len(experiment_names) > 1:
         _run_selectors.append(experiment_picker)
@@ -253,7 +252,6 @@ def _(
         mo.vstack(_run_selectors, gap=0.5),
         _lines,
         weekend_shading,
-        mo.vstack([nwp_variable_picker, show_nwp_analysis], gap=0.5),
     ]
     _rows = [mo.hstack(_pickers, justify="start", gap=2, wrap=True)]
     if no_runs_message is not None:
@@ -451,7 +449,14 @@ def _(
         analysis=nwp_analysis.lazy() if show_nwp_analysis.value else None,
         shade_weekends=weekend_shading.value,
     )
-    mo.ui.altair_chart(nwp_chart, chart_selection=False, legend_selection=False)
+    # The NWP controls sit directly above the panel they affect (when the upstream cells stop
+    # because there is no NWP to plot, the controls rightly disappear with the panel).
+    mo.vstack(
+        [
+            mo.hstack([nwp_variable_picker, show_nwp_analysis], justify="start", gap=2),
+            mo.ui.altair_chart(nwp_chart, chart_selection=False, legend_selection=False),
+        ]
+    )
     return
 
 


### PR DESCRIPTION
## What

Three additions to the `view_forecasts.py` dashboard's NWP panel:

1. **NWP proxy-analysis line** — we hold no weather observations, so the closest available proxy for the true weather over historical times is each NWP run's shortest-lead forecasts. The new line stitches the first 24 h of every run overlapping the plotted window (`NWP_ANALYSIS_LEAD`), control member only (`NWP_ANALYSIS_MEMBER = 0` — the unperturbed ECMWF ENS run started from the analysis itself), into a single thick blue line drawn over the grey ensemble. Where runs overlap a `valid_time`, the freshest run wins. An "NWP proxy analysis" checkbox (default on) toggles the line; the stitched rows load unconditionally alongside the ensemble (~0.2 s across the pruned `init_time` partitions), so toggling re-runs only the chart cell.

2. **Always-shown legend on the NWP panel**, mirroring the power chart's construction: an explicit-domain colour scale rides on the always-drawn init-time rule (so the legend lists *NWP ensemble / NWP proxy analysis / Forecast init time* whatever is toggled on), the single-colour layers join via datum encodings, and `orient="top"` keeps the legend out of the plot's horizontal space so the stacked x-axes stay aligned (re-verified pixel-exact against the power chart's init rule: 0.00 px difference).

3. **NWP controls moved next to their panel** — the "NWP variable" dropdown and the new checkbox now sit directly above the NWP chart instead of in the top controls block, and disappear with the panel when a forecast has no NWP to plot.

## Notes for review

- The blue analysis line deliberately reuses the power panel's observed-truth colour and stroke width (`ocf_theme.BLUE`, 2.5 px).
- Since the legend names the blue line, the subtitle note carries only the construction detail: "Proxy analysis: each NWP run's first 24 h, stitched".
- New tests cover the layer structure and colour, freshest-run-wins stitching, omission when the analysis is absent or outside the window, mm/h display scaling, and the legend's stable domain/range across toggle states.
- **Not included:** linked zoom across the two panels was investigated and deliberately rolled back — it requires merging the panels into a single vconcat spec and stacks several fragile mechanisms (Altair param deduplication + a silenced warning, param-placement rules, a vega-embed `usermeta` JSON-patch for container sizing) while costing the between-panel controls placement and fine-grained reactivity. The axes remain pixel-aligned at rest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)