### PR TITLE
Score metrics per horizon slice, collapsing the ensemble per forecast run

### DIFF
--- a/docs/roadmap/metrics-and-leaderboard.md
+++ b/docs/roadmap/metrics-and-leaderboard.md
@@ -294,6 +294,18 @@ itself a relevant statistic (visible as the MLflow experiment count).
   candidates (that re-creates the problem); they exist to report honest skill for the chosen
   champion and to detect gross overfitting (final-test NMAE ≫ validation NMAE).
 
+**A multi-fold gotcha to handle when folds proliferate.** The parent-MLflow-run aggregation in
+the `metrics` asset averages each metric key over *only the folds in which that key appears*
+(`exp_metrics.setdefault(key, []).append(value)` then `sum/len` in `defs/cv_assets.py`). Today
+every fold emits the same key set, so this is invisible — but folds with *different horizon
+coverage* (one fold's forecasts stop at 36 h, another's reach day 14) would emit different
+per-horizon-slice keys, and a key like `rmse__all__extended_range` would then silently average
+over a different fold subset than `rmse__all`, with nothing marking the smaller denominator.
+Per-`time_series_type` keys have the same property if fold populations differ. When adding
+folds (the multi-fold epoch below, or the `final_test` fold), either guarantee every
+leaderboard fold emits an identical key set, or make the parent-run aggregation record its
+per-key denominator.
+
 **3. Trade-off (decide at implementation time).** This costs 3 of the 12 validation months, on
 a dataset that is already short. The alternative — accepting documented bias until
 Dynamical.org backfills enable multiple yearly folds — is defensible; if the backfill is

--- a/docs/roadmap/metrics-and-leaderboard.md
+++ b/docs/roadmap/metrics-and-leaderboard.md
@@ -517,9 +517,8 @@ it yields spread from *weather uncertainty only* — no model or observation unc
 ensembles are systematically overconfident, worst at short horizons where members haven't
 diverged. Flexibility procurement is a tails problem (P90+ peaks), so this hits the use case
 directly — yet nothing measures calibration today: `compute_metrics` averages members into a
-deterministic mean (`packages/ml_core/src/ml_core/metrics.py:84-90`) and scores only MAE/NMAE/
-RMSE/MBE on the `"all"` horizon slice (`metrics.py:51`). We pay 51× inference cost and score
-only the mean.
+deterministic ensemble mean per forecast run and scores only MAE/NMAE/RMSE/MBE (now per horizon
+slice, since Phase A landed). We pay 51× inference cost and score only the mean.
 
 The theory behind this diagnosis — the three-term uncertainty decomposition, why a
 deterministic model driven by an NWP ensemble captures only the weather term, and what the
@@ -531,21 +530,11 @@ Fix in four phases, each an independent PR (Phase D is itself several PRs). Phas
 pure evaluation (no model changes) and should land before any further MAE-driven
 experimentation.
 
-### Phase A — horizon-sliced metrics
+### Phase A — horizon-sliced metrics ✅
 
-`HORIZON_SLICES` already exists in `contracts/ml_schemas.py:172` and the
-[time-slices table above](#time-slices-for-performance-evaluation) argues skill drivers differ
-radically by horizon; only `"all"` is computed.
-
-- In `compute_metrics` (`metrics.py`), derive `lead_time = valid_time − power_fcst_init_time`
-  per row (confirm `power_fcst_init_time` survives into the forecast/actuals join; it is a
-  `PowerForecast` primary-key column) and map it onto the `HORIZON_SLICES` bands with
-  `pl.when/then` chains or `cut`.
-- Compute the existing four metrics per `(series, fold, model, horizon_slice)` via one
-  `group_by` including the slice column, plus the existing `"all"` aggregate.
-- `build_mlflow_aggregate_metrics` gains keys like `nmae__all__day_ahead`. Keep the existing
-  key format for `"all"` slices unchanged so historical MLflow runs stay comparable.
-- Schema needs no change (the `Metrics` tall format was designed for this).
+Shipped. `compute_metrics` now scores every metric per `HORIZON_SLICES` band (derived from
+`valid_time − power_fcst_init_time`, with the ensemble collapsed per forecast run), and
+`build_mlflow_aggregate_metrics` logs overall per-slice keys like `nmae__all__day_ahead`.
 
 ### Phase B — probabilistic metrics from the existing ensemble
 

--- a/packages/contracts/src/contracts/ml_schemas.py
+++ b/packages/contracts/src/contracts/ml_schemas.py
@@ -178,11 +178,15 @@ HORIZON_SLICES: Final[tuple[str, ...]] = (
 )
 """Horizon slice labels matching the four forecast ranges from the project report.
 
+Bands are left-closed intervals of lead time (`valid_time − power_fcst_init_time`), as
+implemented by `ml_core.metrics`:
+
 - `"all"`: aggregates over all horizons and is always computed
-- `"intraday"`: 0 – 6 h
-- `"day_ahead"`: 6 – 36 h
-- `"short_medium_range"`: Day 2 – Day 7
-- `"extended_range"`: Day 8 – Day 14
+- `"intraday"`: [0 h, 6 h)
+- `"day_ahead"`: [6 h, 36 h)
+- `"short_medium_range"`: [36 h, 168 h) — day 2 to day 7
+- `"extended_range"`: [168 h, ∞) — day 8 onwards (unbounded above; in practice forecasts
+  stop at the 14-day NWP horizon)
 """
 
 METRIC_NAMES: Final[tuple[str, ...]] = ("mae", "nmae", "rmse", "mbe")

--- a/packages/ml_core/src/ml_core/metrics.py
+++ b/packages/ml_core/src/ml_core/metrics.py
@@ -2,6 +2,7 @@
 
 import re
 from datetime import datetime
+from typing import Final
 
 import patito as pt
 import polars as pl
@@ -22,6 +23,49 @@ from contracts.power_schemas import (
     TimeSeriesMetadata,
 )
 
+_INTRADAY_MAX_HOURS: Final[int] = 6
+"""Exclusive upper bound (hours) of the ``"intraday"`` horizon slice: lead times in [0 h, 6 h)."""
+
+_DAY_AHEAD_MAX_HOURS: Final[int] = 36
+"""Exclusive upper bound (hours) of the ``"day_ahead"`` horizon slice: lead times in [6 h, 36 h)."""
+
+_SHORT_MEDIUM_RANGE_MAX_HOURS: Final[int] = 168
+"""Exclusive upper bound (hours) of the ``"short_medium_range"`` horizon slice.
+
+Lead times in [36 h, 168 h) — day 2 to day 7. Lead times of 168 h and beyond fall in
+``"extended_range"``.
+"""
+
+
+def _horizon_slice_expr() -> pl.Expr:
+    """Map each row's lead time onto the ``HORIZON_SLICES`` bands.
+
+    Lead time is ``valid_time − power_fcst_init_time``. Bands are left-closed:
+    ``"intraday"`` [0 h, 6 h), ``"day_ahead"`` [6 h, 36 h), ``"short_medium_range"``
+    [36 h, 168 h), ``"extended_range"`` [168 h, ∞) — matching the band definitions
+    documented on ``contracts.ml_schemas.HORIZON_SLICES``.
+    """
+    lead_time = pl.col("valid_time") - pl.col("power_fcst_init_time")
+    return (
+        pl.when(lead_time < pl.duration(hours=_INTRADAY_MAX_HOURS))
+        .then(pl.lit("intraday"))
+        .when(lead_time < pl.duration(hours=_DAY_AHEAD_MAX_HOURS))
+        .then(pl.lit("day_ahead"))
+        .when(lead_time < pl.duration(hours=_SHORT_MEDIUM_RANGE_MAX_HOURS))
+        .then(pl.lit("short_medium_range"))
+        .otherwise(pl.lit("extended_range"))
+        .cast(pl.Enum(HORIZON_SLICES))
+    )
+
+
+def _wide_error_metrics(with_error: pl.LazyFrame, group_keys: list[str]) -> pl.LazyFrame:
+    """Aggregate the ``error`` column into wide MAE/RMSE/MBE rows, one per ``group_keys`` group."""
+    return with_error.group_by(group_keys).agg(
+        mae=pl.col("error").abs().mean(),
+        rmse=(pl.col("error").pow(2).mean()).sqrt(),
+        mbe=pl.col("error").mean(),
+    )
+
 
 def compute_metrics(
     cv_forecasts: pt.DataFrame[PowerForecast],
@@ -34,10 +78,16 @@ def compute_metrics(
     For each ``(time_series_id, fold_id, power_fcst_model_name)`` group:
 
     1. Joins predictions to observed ``power`` on ``(time_series_id, valid_time)``.
-    2. Averages across ``ensemble_member`` to form a deterministic ensemble mean.
-    3. Computes MAE, NMAE, RMSE, and MBE.
-    4. Joins ``time_series_type`` from ``metadata`` onto each row.
-    5. Returns one row per ``(time_series_id, fold_id, power_fcst_model_name,
+    2. Assigns each row a ``horizon_slice`` from its lead time
+       (``valid_time − power_fcst_init_time``) — see ``_horizon_slice_expr`` for the bands.
+    3. Averages across ``ensemble_member`` *within each forecast run* (per
+       ``power_fcst_init_time``) to form a deterministic ensemble mean. Each run covering a
+       ``valid_time`` is scored independently, exactly as a production consumer would
+       experience it — runs at different lead times are never pooled.
+    4. Computes MAE, NMAE, RMSE, and MBE per ``horizon_slice``, plus the ``"all"`` aggregate
+       over every lead time.
+    5. Joins ``time_series_type`` from ``metadata`` onto each row.
+    6. Returns one row per ``(time_series_id, fold_id, power_fcst_model_name,
        horizon_slice, metric_name, metric_param)`` in the tall ``Metrics`` format.
 
     NMAE is normalised by the pre-computed full-history ``effective_capacity_mw`` (joined per
@@ -47,8 +97,8 @@ def compute_metrics(
     upgrade makes capacity time-varying (one row per ``(time_series_id,
     time)``), this join must become a temporal as-of join on ``(time_series_id, valid_time)``.
 
-    Currently only the ``"all"`` horizon slice and ``"all"`` metric_param are computed.
-    Horizon-sliced metrics and parametric metrics (Pinball Loss, PICP) can be
+    Currently only the ``"all"`` metric_param is computed. Parametric metrics
+    (Pinball Loss, PICP) and ensemble metrics (CRPS, spread-skill ratio) can be
     added here later without changing the schema.
 
     Args:
@@ -65,9 +115,24 @@ def compute_metrics(
         A validated tall ``Metrics`` DataFrame with ``time_series_type`` populated.
 
     Raises:
-        ValueError: If no rows survive the inner join (forecasts cover a period with no observed
-            data), or if any scored series has no row in ``capacity``.
+        ValueError: If any forecast row has a negative lead time (``valid_time`` before
+            ``power_fcst_init_time`` — an undeliverable hindcast row; see issue #346), if no
+            rows survive the inner join (forecasts cover a period with no observed data), or
+            if any scored series has no row in ``capacity``.
     """
+    # A negative lead time means hindcast rows — valid times already in the past at
+    # power_fcst_init_time, which a live forecast could never deliver. Scoring them would
+    # silently flatter the model (they'd land in "intraday" via the left-closed bands), so
+    # fail loudly. The CV inference pass currently emits such rows for valid times inside
+    # the NWP publication-delay window; issue #346 tracks removing them at the source.
+    n_negative = cv_forecasts.filter(pl.col("valid_time") < pl.col("power_fcst_init_time")).height
+    if n_negative > 0:
+        raise ValueError(
+            f"{n_negative} forecast row(s) have valid_time before power_fcst_init_time "
+            "(negative lead time). These are undeliverable hindcast rows and must not be "
+            "scored — regenerate the forecasts without them (see issue #346)."
+        )
+
     # Join forecasts to actuals; rename power → power_actual to avoid shadowing.
     # Strip the Patito model subclass from actuals so that Polars' cross-subclass
     # type check (assert_same_type) doesn't reject a join between two differently-typed
@@ -80,23 +145,41 @@ def compute_metrics(
         how="inner",
     )
 
-    # Average across ensemble members to produce a deterministic ensemble mean.
-    ensemble_mean = joined.group_by(
-        ["time_series_id", "fold_id", "power_fcst_model_name", "valid_time"]
-    ).agg(
-        power_fcst=pl.col("power_fcst").mean(),
-        power_actual=pl.col("power_actual").first(),
+    # Average across ensemble members to produce a deterministic ensemble mean per forecast
+    # run: power_fcst_init_time is a group key so that runs covering the same valid_time at
+    # different lead times are scored independently, never pooled into a lagged-ensemble blend.
+    # horizon_slice is constant within a (power_fcst_init_time, valid_time) group.
+    ensemble_mean = (
+        joined.with_columns(horizon_slice=_horizon_slice_expr())
+        .group_by(
+            [
+                "time_series_id",
+                "fold_id",
+                "power_fcst_model_name",
+                "power_fcst_init_time",
+                "valid_time",
+            ]
+        )
+        .agg(
+            power_fcst=pl.col("power_fcst").mean(),
+            power_actual=pl.col("power_actual").first(),
+            horizon_slice=pl.col("horizon_slice").first(),
+        )
     )
 
     # Compute error column once, reuse in all aggregations.
     with_error = ensemble_mean.with_columns(error=pl.col("power_fcst") - pl.col("power_actual"))
 
-    # Wide metrics: one row per (time_series_id, fold_id, power_fcst_model_name).
-    metrics_wide = with_error.group_by(["time_series_id", "fold_id", "power_fcst_model_name"]).agg(
-        mae=pl.col("error").abs().mean(),
-        rmse=(pl.col("error").pow(2).mean()).sqrt(),
-        mbe=pl.col("error").mean(),
+    # Wide metrics: one row per (time_series_id, fold_id, power_fcst_model_name, horizon_slice),
+    # where horizon_slice covers the four lead-time bands plus the "all" aggregate over every
+    # lead time.
+    base_keys = ["time_series_id", "fold_id", "power_fcst_model_name"]
+    wide_columns = [*base_keys, "horizon_slice", "mae", "rmse", "mbe"]
+    per_slice = _wide_error_metrics(with_error, [*base_keys, "horizon_slice"])
+    all_slice = _wide_error_metrics(with_error, base_keys).with_columns(
+        horizon_slice=pl.lit("all").cast(pl.Enum(HORIZON_SLICES))
     )
+    metrics_wide = pl.concat([per_slice.select(wide_columns), all_slice.select(wide_columns)])
 
     # Join the pre-computed full-history effective capacity — the NMAE denominator. Strip the
     # Patito model so Polars' cross-subclass join type check doesn't reject the join.
@@ -119,7 +202,7 @@ def compute_metrics(
     metrics_tall = (
         wide.unpivot(
             on=["mae", "nmae", "rmse", "mbe"],
-            index=["time_series_id", "fold_id", "power_fcst_model_name"],
+            index=[*base_keys, "horizon_slice"],
             variable_name="metric_name",
             value_name="metric_value",
         )
@@ -130,7 +213,6 @@ def compute_metrics(
             }
         )
         .with_columns(
-            horizon_slice=pl.lit("all").cast(pl.Enum(HORIZON_SLICES)),
             metric_param=pl.lit("all").cast(pl.Enum(METRIC_PARAMS)),
         )
     )
@@ -166,10 +248,15 @@ def build_mlflow_aggregate_metrics(
 ) -> dict[str, float]:
     """Return a flat ``{metric_key: value}`` dict for ``mlflow.log_metrics``.
 
-    Computes mean ``metric_value`` across all series (``"all"`` aggregate) and per
-    ``time_series_type``, restricted to ``horizon_slice="all"`` and ``metric_param="all"``
-    (the scalar metrics). Key format: ``"{metric_name}__all"`` for the overall aggregate
-    and ``"{metric_name}__{type_slug}"`` for per-type aggregates.
+    Computes mean ``metric_value`` across all series (``"all"`` aggregate), per
+    ``time_series_type``, and per ``horizon_slice``, restricted to ``metric_param="all"``
+    (the scalar metrics). Key formats:
+
+    - ``"{metric_name}__all"`` — overall aggregate (``horizon_slice="all"``).
+    - ``"{metric_name}__{type_slug}"`` — per-type aggregates (``horizon_slice="all"``).
+    - ``"{metric_name}__all__{horizon_slice}"`` — overall aggregate per lead-time band
+      (e.g. ``"nmae__all__day_ahead"``). Per-type sliced aggregates are deliberately not
+      logged — that detail stays queryable in the ``forecast_metrics`` Delta table.
 
     Args:
         metrics_df: Per-series ``Metrics`` rows with ``time_series_type`` populated.
@@ -196,6 +283,15 @@ def build_mlflow_aggregate_metrics(
     overall = base.group_by("metric_name").agg(mean_value=pl.col("metric_value").mean())
     for row in overall.iter_rows(named=True):
         result[f"{row['metric_name']}__all"] = float(row["mean_value"])
+
+    # Overall aggregate per lead-time band (includes all series regardless of type).
+    per_slice = (
+        metrics_df.filter((pl.col("horizon_slice") != "all") & (pl.col("metric_param") == "all"))
+        .group_by(["metric_name", "horizon_slice"])
+        .agg(mean_value=pl.col("metric_value").mean())
+    )
+    for row in per_slice.iter_rows(named=True):
+        result[f"{row['metric_name']}__all__{row['horizon_slice']}"] = float(row["mean_value"])
 
     return result
 

--- a/packages/ml_core/tests/test_metrics.py
+++ b/packages/ml_core/tests/test_metrics.py
@@ -1,7 +1,7 @@
 """Tests for compute_metrics() and build_mlflow_aggregate_metrics()."""
 
 import math
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import patito as pt
 import polars as pl
@@ -41,14 +41,16 @@ def _make_cv_forecasts(
     times: list[datetime],
     power_fcst: list[float],
     fold_id: str = "2022",
+    init_times: list[datetime] | None = None,
 ) -> pt.DataFrame[PowerForecast]:
     n = len(times)
-    init_time = _utc(2022, 1, 1)
+    if init_times is None:
+        init_times = [_utc(2022, 1, 1)] * n
     df = pl.DataFrame(
         {
             "time_series_id": pl.Series([time_series_id] * n, dtype=pl.Int32),
             "valid_time": pl.Series(times, dtype=pl.Datetime("us", "UTC")),
-            "power_fcst_init_time": pl.Series([init_time] * n, dtype=pl.Datetime("us", "UTC")),
+            "power_fcst_init_time": pl.Series(init_times, dtype=pl.Datetime("us", "UTC")),
             "ensemble_member": pl.Series([0] * n, dtype=pl.Int8),
             "nwp_init_time": pl.Series([None] * n, dtype=pl.Datetime("us", "UTC")),
             "power_fcst": pl.Series(power_fcst, dtype=pl.Float32),
@@ -246,6 +248,82 @@ def test_compute_metrics_unknown_series_gets_null_type():
 
 
 # ---------------------------------------------------------------------------
+# horizon-slice tests
+# ---------------------------------------------------------------------------
+
+
+def _slice_mae(result: pl.DataFrame, horizon_slice: str) -> float:
+    """Extract the single MAE value for one horizon slice from a Metrics frame."""
+    rows = result.filter(
+        (pl.col("metric_name") == "mae") & (pl.col("horizon_slice") == horizon_slice)
+    )
+    assert rows.height == 1
+    return float(rows["metric_value"][0])
+
+
+def test_compute_metrics_horizon_slice_band_boundaries():
+    """Lead times land in the correct left-closed bands, including exact boundary values.
+
+    One forecast run (single init time) with valid_times at lead times 0 h and 5.5 h
+    (intraday), 6 h and 35.5 h (day_ahead), 36 h and 167.5 h (short_medium_range), and
+    168 h and 336 h (extended_range). Distinct errors per band make per-slice MAE reveal
+    band membership.
+    """
+    init_time = _utc(2022, 1, 1)
+    leads_hours = [0.0, 5.5, 6.0, 35.5, 36.0, 167.5, 168.0, 336.0]
+    times = [init_time + timedelta(hours=h) for h in leads_hours]
+    # errors: intraday 1, 2 → MAE 1.5; day_ahead 3, 4 → 3.5; smr 5, 6 → 5.5; extended 7, 8 → 7.5
+    errors = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
+    actuals = _make_actuals(1, times, [10.0] * len(times))
+    forecasts = _make_cv_forecasts(1, times, [10.0 + e for e in errors])
+    result = compute_metrics(forecasts, actuals, _make_metadata([1]), _make_capacity([1], [10.0]))
+    assert math.isclose(_slice_mae(result, "intraday"), 1.5, rel_tol=1e-5)
+    assert math.isclose(_slice_mae(result, "day_ahead"), 3.5, rel_tol=1e-5)
+    assert math.isclose(_slice_mae(result, "short_medium_range"), 5.5, rel_tol=1e-5)
+    assert math.isclose(_slice_mae(result, "extended_range"), 7.5, rel_tol=1e-5)
+    assert math.isclose(_slice_mae(result, "all"), 4.5, rel_tol=1e-5)
+
+
+def test_compute_metrics_all_slice_is_row_weighted():
+    """The "all" slice averages over every scored row, not over the per-slice metric values."""
+    init_time = _utc(2022, 1, 1)
+    leads_hours = [0.0, 0.5, 5.5, 6.0, 35.5, 36.0, 168.0]
+    times = [init_time + timedelta(hours=h) for h in leads_hours]
+    # intraday errors 1, 2, 3 → MAE 2; day_ahead 6, 8 → 7; smr 9 → 9; extended 11 → 11.
+    errors = [1.0, 2.0, 3.0, 6.0, 8.0, 9.0, 11.0]
+    actuals = _make_actuals(1, times, [10.0] * len(times))
+    forecasts = _make_cv_forecasts(1, times, [10.0 + e for e in errors])
+    result = compute_metrics(forecasts, actuals, _make_metadata([1]), _make_capacity([1], [10.0]))
+    # Row-weighted mean = 40/7 ≈ 5.714; the mean of the four slice MAEs would be 7.25.
+    assert math.isclose(_slice_mae(result, "all"), 40.0 / 7.0, rel_tol=1e-5)
+
+
+def test_compute_metrics_collapses_ensemble_per_forecast_run():
+    """Runs covering the same valid_time at different lead times are scored independently.
+
+    Two runs forecast the same valid_time: one predicts 8, the other 12, actual is 10.
+    Per-run scoring gives errors −2 and +2 → MAE 2. Pooling the runs into one lagged-ensemble
+    mean would give a single forecast of 10 → MAE 0.
+    """
+    valid_time = _utc(2022, 1, 2)
+    init_times = [_utc(2022, 1, 1, 0), _utc(2022, 1, 1, 6)]  # leads 24 h and 18 h: day_ahead
+    actuals = _make_actuals(1, [valid_time], [10.0])
+    forecasts = _make_cv_forecasts(1, [valid_time, valid_time], [8.0, 12.0], init_times=init_times)
+    result = compute_metrics(forecasts, actuals, _make_metadata([1]), _make_capacity([1], [10.0]))
+    assert math.isclose(_slice_mae(result, "day_ahead"), 2.0, rel_tol=1e-5)
+    assert math.isclose(_slice_mae(result, "all"), 2.0, rel_tol=1e-5)
+
+
+def test_compute_metrics_negative_lead_time_raises():
+    """A valid_time before power_fcst_init_time is corrupted data and must fail loudly."""
+    valid_time = _utc(2022, 1, 1)
+    actuals = _make_actuals(1, [valid_time], [10.0])
+    forecasts = _make_cv_forecasts(1, [valid_time], [10.0], init_times=[_utc(2022, 1, 2)])
+    with pytest.raises(ValueError, match="negative lead time"):
+        compute_metrics(forecasts, actuals, _make_metadata([1]), _make_capacity([1], [10.0]))
+
+
+# ---------------------------------------------------------------------------
 # build_mlflow_aggregate_metrics tests
 # ---------------------------------------------------------------------------
 
@@ -296,6 +374,49 @@ def test_build_mlflow_aggregate_metrics_other_demand_slug():
     df = _make_metrics_df({"Other (Demand)": 3.0})
     result = build_mlflow_aggregate_metrics(df)
     assert "rmse__other_demand" in result
+
+
+def test_build_mlflow_aggregate_metrics_sliced_keys():
+    """Non-"all" horizon slices produce overall {metric}__all__{slice} keys only.
+
+    The "all"-slice keys must ignore sliced rows, and no per-type sliced keys are emitted.
+    """
+    rows = [
+        {
+            "time_series_id": 1,
+            "metric_name": "rmse",
+            "metric_value": 2.0,
+            "time_series_type": "PV",
+            "horizon_slice": "all",
+            "metric_param": "all",
+        },
+        {
+            "time_series_id": 1,
+            "metric_name": "rmse",
+            "metric_value": 4.0,
+            "time_series_type": "PV",
+            "horizon_slice": "day_ahead",
+            "metric_param": "all",
+        },
+        {
+            "time_series_id": 2,
+            "metric_name": "rmse",
+            "metric_value": 6.0,
+            "time_series_type": "Wind",
+            "horizon_slice": "day_ahead",
+            "metric_param": "all",
+        },
+    ]
+    df = pl.DataFrame(rows).cast({"time_series_id": pl.Int32, "metric_value": pl.Float32})
+    result = build_mlflow_aggregate_metrics(df)
+    # Sliced key is the mean over both series' day_ahead rows.
+    assert math.isclose(result["rmse__all__day_ahead"], 5.0, rel_tol=1e-5)
+    # "all"-slice keys ignore the sliced rows.
+    assert math.isclose(result["rmse__all"], 2.0, rel_tol=1e-5)
+    assert math.isclose(result["rmse__pv"], 2.0, rel_tol=1e-5)
+    # No per-type sliced keys.
+    assert "rmse__pv__day_ahead" not in result
+    assert "rmse__wind__day_ahead" not in result
 
 
 def test_build_mlflow_aggregate_metrics_null_type_excluded_from_per_type():

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -346,7 +346,10 @@ def test_metrics_is_idempotent(file_mlflow_env: dict[str, Path]) -> None:
 
 
 def _read_metric(metrics_path: Path, metric_name: str) -> float:
-    fm = pl.read_delta(str(metrics_path)).filter(pl.col("metric_name") == metric_name)
+    """Read the overall (``horizon_slice="all"``) value of one metric for the single test series."""
+    fm = pl.read_delta(str(metrics_path)).filter(
+        (pl.col("metric_name") == metric_name) & (pl.col("horizon_slice") == "all")
+    )
     assert fm.height == 1
     return float(fm["metric_value"][0])
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -193,7 +193,8 @@ def _base_env(
     monkeypatch.setenv("POWER_FORECASTS_DATA_PATH", str(forecasts_path))
     monkeypatch.setenv("FORECAST_METRICS_DATA_PATH", str(metrics_path))
     # Point at a temp path so metrics never reads the repo's real effective_capacity table; the
-    # table is absent until a test materialises it, so NMAE falls back to the window P99 by default.
+    # table is absent until a test materialises it, and the metrics asset fails cleanly without it
+    # (see test_metrics_raises_without_effective_capacity).
     monkeypatch.setenv("EFFECTIVE_CAPACITY_DATA_PATH", str(effective_capacity_path))
 
     _write_power_with_actuals(str(nged_path / "power_time_series.delta"))


### PR DESCRIPTION
Part of #225 (Phase A of the [probabilistic-metrics plan](https://openclimatefix.github.io/nged-substation-forecast/roadmap/metrics-and-leaderboard/#delivering-the-probabilistic-metrics)).

## What changed

- `compute_metrics` derives each row's lead time (`valid_time − power_fcst_init_time`), maps it onto the `HORIZON_SLICES` bands (left-closed: intraday [0 h, 6 h), day_ahead [6 h, 36 h), short_medium_range [36 h, 168 h), extended_range [168 h, ∞)), and scores MAE/NMAE/RMSE/MBE per slice alongside the existing `"all"` aggregate. No schema change — the tall `Metrics` format was designed for this. The `HORIZON_SLICES` contract docstring is aligned with the implemented bands.
- **The ensemble collapse is now per forecast run.** Previously the ensemble mean grouped by `valid_time` only, pooling members across every run covering that valid_time (a lagged-ensemble blend of up to ~14 runs). `power_fcst_init_time` is now a group key, so each run is scored as a production consumer would experience it, and `"all"` is exactly the union of the four slices. Measured consequence on `xgboost_cv_0001` / `mid_2025_to_mid_2026` (all 28 series, real data): `mae__all` shifts from 7.3684 to 7.4308 (**+0.85 %**). Key formats are unchanged, but leaderboard values will shift by about this much on the next scoring run.
- `build_mlflow_aggregate_metrics` gains overall per-slice keys `{metric}__all__{slice}` (e.g. `nmae__all__day_ahead`, 16 new keys). Existing `{metric}__all` and `{metric}__{type_slug}` keys are byte-identical. Per-type sliced detail deliberately stays in the `forecast_metrics` Delta table only.
- **Negative lead times now raise.** While verifying on real data we found every forecast run carries ~6 h of hindcast rows (`valid_time` before `power_fcst_init_time` — the NWP publication-delay window; ~2 % of all rows), which the old code silently scored. `compute_metrics` now raises a `ValueError`; #346 tracks stopping the CV inference pass from emitting them. **Note: re-scoring an existing experiment will fail until its forecasts are regenerated without these rows.**
- The parent-MLflow-run fold-averaging gotcha surfaced by review (sliced keys average over only the folds where they appear, which matters once folds differ in horizon coverage) is recorded in the fold-hygiene plan (#226) in `docs/roadmap/metrics-and-leaderboard.md`.

## Empirical verification (real data, all 28 series)

Re-scored `xgboost_cv_0001` / `mid_2025_to_mid_2026` (370 M forecast rows, chunked by series) with hindcast rows filtered out to simulate the post-#346 pipeline:

- All four slices plus `"all"` populated (112 rows each = 28 series × 4 metrics); `"all"` matches the row-weighted combination of the slices.
- Mean NMAE per slice: short_medium_range 0.1223 · day_ahead 0.1240 · intraday 0.1274 · extended_range 0.1332.
- Notably, **intraday is *not* the best slice** — the current XGBoost has no short-horizon edge, consistent with the design doc's expectation that persistence is hard to beat at 0–6 h (and exactly the signal #147's persistence baseline will quantify). One caveat for interpreting the intraday slice: because `power_fcst_init_time` is always `nwp_init_time + 6 h`, the intraday band only ever covers the same 6 wall-clock hours after each init, so it carries a time-of-day skew.

## Adversarial review

A fresh-context adversarial review found **no correctness bugs**. It empirically refuted the Patito dict-cast trap (the group-by chain drops the model before the `.cast({...})`), proved no `time_series_type` slug can collide with the new key pattern, hand-verified the band-boundary and row-weighting test arithmetic, and confirmed `build_mlflow_aggregate_metrics` output is byte-identical on pre-change frames. It surfaced the `HORIZON_SLICES` docstring divergence (fixed here), the #226 fold-averaging caveat (documented here), and a stale fixture comment describing the removed NMAE window-P99 fallback (fixed here). Its duplicate-actuals concern was checked and dismissed: the contract raises on duplicate `(time_series_id, time)`, the table's only writer filters appends to strictly `time > max_time` per series via `select_new_rows`, and the real table scans clean (0 duplicate pairs).

## Ship-time triage

Phase A's implementation-details bullets, deleted from `docs/roadmap/metrics-and-leaderboard.md` (section now reads "Shipped"):

> - In `compute_metrics` (`metrics.py`), derive `lead_time = valid_time − power_fcst_init_time` per row (confirm `power_fcst_init_time` survives into the forecast/actuals join; it is a `PowerForecast` primary-key column) and map it onto the `HORIZON_SLICES` bands with `pl.when/then` chains or `cut`.
> - Compute the existing four metrics per `(series, fold, model, horizon_slice)` via one `group_by` including the slice column, plus the existing `"all"` aggregate.
> - `build_mlflow_aggregate_metrics` gains keys like `nmae__all__day_ahead`. Keep the existing key format for `"all"` slices unchanged so historical MLflow runs stay comparable.
> - Schema needs no change (the `Metrics` tall format was designed for this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)