### PR TITLE
Score metrics folds in per-series batches to bound the asset's memory

### DIFF
--- a/packages/ml_core/src/ml_core/metrics.py
+++ b/packages/ml_core/src/ml_core/metrics.py
@@ -23,6 +23,17 @@ from contracts.power_schemas import (
     TimeSeriesMetadata,
 )
 
+
+class NoOverlappingActualsError(ValueError):
+    """Raised by ``compute_metrics`` when no forecast row joins to any observed actual.
+
+    A distinct subclass so callers that score a fold in per-series batches can treat "this
+    batch's series have no overlapping actuals" as skippable — mirroring how such series
+    silently vanish from the inner join when the whole fold is scored in one call — while
+    every other ``ValueError`` (negative lead times, missing capacity) still propagates.
+    """
+
+
 _INTRADAY_MAX_HOURS: Final[int] = 6
 """Exclusive upper bound (hours) of the ``"intraday"`` horizon slice: lead times in [0 h, 6 h)."""
 
@@ -115,10 +126,11 @@ def compute_metrics(
         A validated tall ``Metrics`` DataFrame with ``time_series_type`` populated.
 
     Raises:
+        NoOverlappingActualsError: If no rows survive the inner join (forecasts cover a
+            period with no observed data).
         ValueError: If any forecast row has a negative lead time (``valid_time`` before
-            ``power_fcst_init_time`` — an undeliverable hindcast row; see issue #346), if no
-            rows survive the inner join (forecasts cover a period with no observed data), or
-            if any scored series has no row in ``capacity``.
+            ``power_fcst_init_time`` — an undeliverable hindcast row; see issue #346), or if
+            any scored series has no row in ``capacity``.
     """
     # A negative lead time means hindcast rows — valid times already in the past at
     # power_fcst_init_time, which a live forecast could never deliver. Scoring them would
@@ -218,7 +230,7 @@ def compute_metrics(
     )
 
     if metrics_tall.is_empty():
-        raise ValueError(
+        raise NoOverlappingActualsError(
             "No rows in the joined forecast/actuals data. "
             "Check that cv_forecasts and actuals overlap in time."
         )

--- a/packages/ml_core/tests/test_metrics.py
+++ b/packages/ml_core/tests/test_metrics.py
@@ -14,7 +14,11 @@ from contracts.power_schemas import (
     PowerTimeSeries,
     TimeSeriesMetadata,
 )
-from ml_core.metrics import build_mlflow_aggregate_metrics, compute_metrics
+from ml_core.metrics import (
+    NoOverlappingActualsError,
+    build_mlflow_aggregate_metrics,
+    compute_metrics,
+)
 
 
 def _utc(year: int, month: int, day: int, hour: int = 0, minute: int = 0) -> datetime:
@@ -217,13 +221,46 @@ def test_compute_metrics_multiple_folds():
 
 
 def test_compute_metrics_raises_on_no_join():
-    """If forecasts and actuals have no overlapping times, raise ValueError."""
+    """No overlapping times raises the dedicated (batch-skippable) ValueError subclass."""
     actuals = _make_actuals(1, [_utc(2022, 6, 1)], [10.0])
     forecasts = PowerForecast.validate(
         _make_cv_forecasts(1, [_utc(2023, 6, 1)], [10.0]), allow_superfluous_columns=True
     )
-    with pytest.raises(ValueError, match="No rows"):
+    with pytest.raises(NoOverlappingActualsError, match="No rows"):
         compute_metrics(forecasts, actuals, _make_metadata([1]), _make_capacity([1], [10.0]))
+
+
+def test_compute_metrics_per_series_batching_is_equivalent():
+    """Scoring series separately and concatenating equals scoring them in one call.
+
+    This property is what lets the metrics asset score a fold in per-series batches
+    (bounded memory) without changing any metric value.
+    """
+    times = [_utc(2022, 1, 1, 0, 0), _utc(2022, 1, 1, 0, 30)]
+    actuals = pt.LazyFrame.from_existing(
+        pl.concat(
+            [
+                _make_actuals(1, times, [10.0, 10.0]).collect().lazy(),
+                _make_actuals(2, times, [20.0, 20.0]).collect().lazy(),
+            ]
+        )
+    ).set_model(PowerTimeSeries)
+    fcst_1 = _make_cv_forecasts(1, times, [12.0, 8.0])
+    fcst_2 = _make_cv_forecasts(2, times, [25.0, 19.0])
+    both = PowerForecast.validate(pl.concat([fcst_1, fcst_2]), allow_superfluous_columns=True)
+    metadata = _make_metadata([1, 2])
+    capacity = _make_capacity([1, 2], [10.0, 20.0])
+
+    whole = compute_metrics(both, actuals, metadata, capacity)
+    batched = pl.concat(
+        [
+            compute_metrics(fcst_1, actuals, metadata, capacity),
+            compute_metrics(fcst_2, actuals, metadata, capacity),
+        ]
+    )
+
+    sort_keys = ["time_series_id", "horizon_slice", "metric_name"]
+    assert whole.sort(sort_keys).equals(batched.sort(sort_keys))
 
 
 def test_compute_metrics_populates_time_series_type():

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -804,10 +804,15 @@ def _score_forecast_group(
     The group is scored in per-series batches of ``_METRICS_SERIES_BATCH_SIZE`` so that peak
     memory is one batch, never the whole fold (a single V1 fold is already too big to
     materialise). ``compute_metrics`` is independent per ``time_series_id``, so concatenating
-    the per-batch ``Metrics`` frames is exactly equivalent to scoring the group in one call.
-    A batch whose series have no overlapping actuals is skipped — mirroring how such series
-    silently vanish from the inner join in a whole-group call — but a group where *no* batch
-    overlaps raises, exactly as the whole-group call would.
+    the per-batch ``Metrics`` frames produces exactly the metric values a whole-group call
+    would. A batch whose series have no overlapping actuals is skipped — mirroring how such
+    series silently vanish from the inner join in a whole-group call — but a group where *no*
+    batch overlaps raises, exactly as the whole-group call would.
+
+    One deliberate divergence from whole-group scoring: error messages from
+    ``compute_metrics`` (missing capacity, negative lead times) describe only the first
+    offending *batch* — at most ``_METRICS_SERIES_BATCH_SIZE`` series — rather than the
+    whole group, since the raise aborts the loop before later batches load.
 
     Args:
         exp_name: Experiment name for this group.

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -43,7 +43,12 @@ from ml_core._cv_helpers import (
     eligible_time_series_ids,
     parse_cv_partition_key,
 )
-from ml_core.metrics import build_mlflow_aggregate_metrics, compute_metrics, enrich_metrics_rows
+from ml_core.metrics import (
+    NoOverlappingActualsError,
+    build_mlflow_aggregate_metrics,
+    compute_metrics,
+    enrich_metrics_rows,
+)
 from ml_core._mlflow_runs import (
     get_or_create_experiment,
     get_or_create_fold_run,
@@ -642,7 +647,7 @@ class MetricsConfig(Config):
 def _resolve_eval_window(
     evaluation_scope: EvalScopeType,
     fold_id: str,
-    group_df: pt.DataFrame[PowerForecast],
+    group_scan: pl.LazyFrame,
 ) -> tuple[datetime, datetime, str]:
     """Return ``(window_start, window_end, window_label)`` for a metrics group.
 
@@ -653,8 +658,9 @@ def _resolve_eval_window(
         evaluation_scope: ``"leaderboard"`` uses fold-config dates; ``"ad_hoc"`` uses the
             observed ``valid_time`` range of the forecast group.
         fold_id: Fold identifier; only used when ``evaluation_scope == "leaderboard"``.
-        group_df: Validated ``PowerForecast`` rows for this ``(experiment_name, fold_id)``
-            group. Only ``valid_time`` is accessed, and only for the ``"ad_hoc"`` branch.
+        group_scan: Lazy scan of this ``(experiment_name, fold_id)`` group's forecast rows.
+            Only a streaming min/max over ``valid_time`` is computed, and only for the
+            ``"ad_hoc"`` branch — the group is never materialised here.
 
     Returns:
         ``(window_start, window_end, window_label)`` — the inclusive evaluation window bounds
@@ -667,9 +673,12 @@ def _resolve_eval_window(
             date_to_utc_datetime(fold.val_end, end_of_day=True),
             fold_id,
         )
-    # groups is derived from a non-empty forecasts_df, so min/max are always non-null datetimes.
-    window_start = group_df["valid_time"].min()
-    window_end = group_df["valid_time"].max()
+    bounds = group_scan.select(
+        window_start=pl.col("valid_time").min(), window_end=pl.col("valid_time").max()
+    ).collect(engine="streaming")
+    window_start = bounds["window_start"][0]
+    window_end = bounds["window_end"][0]
+    # groups is derived from a non-empty forecast scan, so min/max are always non-null datetimes.
     assert isinstance(window_start, datetime) and isinstance(window_end, datetime)
     return window_start, window_end, "ad_hoc"
 
@@ -710,36 +719,77 @@ def _write_metrics_to_delta(
     )
 
 
-def _load_forecast_group(
-    pruned_scan: pt.LazyFrame[PowerForecast], exp_name: str, fold_id: str
-) -> pt.DataFrame[PowerForecast]:
-    """Collect and validate a single ``(experiment_name, fold_id)`` group.
+_METRICS_SERIES_BATCH_SIZE: Final[int] = 4
+"""How many ``time_series_id`` values to materialise per scoring batch in the ``metrics`` asset.
 
-    Narrows the already-pruned scan to one partition. This extra ``.filter()`` on the String
-    partition columns pushes down into the Delta scan, so only this partition's Parquet files are
-    read. Peak memory is therefore a single fold, regardless of how many groups the population
-    filter matched.
+A single V1 fold is far too big to collect whole (~370M rows with the full ``PowerForecast``
+schema OOM-kills a 29 GB machine), but ``compute_metrics`` is independent per
+``time_series_id`` — every group key includes it — so scoring per-series batches and
+concatenating the tall ``Metrics`` results is exactly equivalent to one big call.
+
+Measured on the V1 fold (28 series, ~13M rows each): batch size 4 completes in ~50 s with
+~18 GB peak process RSS, dominated by the streaming Delta scan (each batch re-scans the
+partition; the materialised batch frame itself is a few GB). Batch size 2 measured only
+~2 GB lower, so shrinking the batch buys little — the scan overhead is roughly constant in
+fold size, which is what keeps this workable at V2 scale.
+"""
+
+
+def _group_scan(
+    pruned_scan: pt.LazyFrame[PowerForecast], exp_name: str, fold_id: str
+) -> pl.LazyFrame:
+    """Narrow the already-pruned scan to a single ``(experiment_name, fold_id)`` partition.
+
+    The ``.filter()`` on the String partition columns pushes down into the Delta scan, so
+    downstream collects read only this partition's Parquet files.
 
     Args:
         pruned_scan: The ``pt.LazyFrame[PowerForecast]`` returned by ``PopulationFilter.apply``
             (partition predicates already applied).
-        exp_name: Experiment name of the group to load.
-        fold_id: Fold identifier of the group to load.
+        exp_name: Experiment name of the group.
+        fold_id: Fold identifier of the group.
 
     Returns:
-        The validated ``PowerForecast`` rows for this one group.
+        A lazy scan of this one group's rows (a plain ``pl.LazyFrame`` — ``.filter()`` drops
+        the Patito subclass; the per-batch loader re-validates on collect).
     """
-    group_scan = pruned_scan.filter(
+    return pruned_scan.filter(
         (pl.col("experiment_name") == exp_name) & (pl.col("fold_id") == fold_id)
     )
-    collected = pt.LazyFrame.from_existing(group_scan).set_model(PowerForecast).collect()
+
+
+def _series_ids_in_group(group_scan: pl.LazyFrame) -> list[int]:
+    """Return the sorted ``time_series_id`` values present in one forecast group.
+
+    A streaming single-column aggregation — cheap relative to the row data.
+    """
+    return sorted(
+        group_scan.select("time_series_id").unique().collect(engine="streaming")["time_series_id"]
+    )
+
+
+def _load_series_batch(
+    group_scan: pl.LazyFrame, series_ids: list[int]
+) -> pt.DataFrame[PowerForecast]:
+    """Collect and validate one batch of series from a single-group forecast scan.
+
+    Args:
+        group_scan: Lazy scan of one ``(experiment_name, fold_id)`` group's rows.
+        series_ids: The ``time_series_id`` values to materialise.
+
+    Returns:
+        The validated ``PowerForecast`` rows for these series.
+    """
+    collected = group_scan.filter(pl.col("time_series_id").is_in(series_ids)).collect(
+        engine="streaming"
+    )
     return PowerForecast.validate(collected, allow_superfluous_columns=True)
 
 
 def _score_forecast_group(
     exp_name: str,
     fold_id: str,
-    group_forecasts: pt.DataFrame[PowerForecast],
+    group_scan: pl.LazyFrame,
     actuals_lf: pt.LazyFrame[PowerTimeSeries],
     metadata_df: pt.DataFrame[TimeSeriesMetadata],
     capacity_df: pt.DataFrame[EffectiveCapacity],
@@ -751,11 +801,19 @@ def _score_forecast_group(
     """Score one ``(experiment_name, fold_id)`` group, write ``Metrics`` to Delta, and
     optionally log to MLflow.
 
+    The group is scored in per-series batches of ``_METRICS_SERIES_BATCH_SIZE`` so that peak
+    memory is one batch, never the whole fold (a single V1 fold is already too big to
+    materialise). ``compute_metrics`` is independent per ``time_series_id``, so concatenating
+    the per-batch ``Metrics`` frames is exactly equivalent to scoring the group in one call.
+    A batch whose series have no overlapping actuals is skipped — mirroring how such series
+    silently vanish from the inner join in a whole-group call — but a group where *no* batch
+    overlaps raises, exactly as the whole-group call would.
+
     Args:
         exp_name: Experiment name for this group.
         fold_id: Fold identifier for this group.
-        group_forecasts: The already-sliced, validated ``PowerForecast`` rows for this single
-            ``(exp_name, fold_id)`` group (loaded by ``_load_forecast_group``).
+        group_scan: Lazy scan of this single ``(exp_name, fold_id)`` group's forecast rows
+            (from ``_group_scan``); materialised one series batch at a time.
         actuals_lf: Lazy observed power scan (only the joined subset is collected inside
             ``compute_metrics()``).
         metadata_df: Substation metadata used to join ``time_series_type`` onto each metric row.
@@ -776,11 +834,30 @@ def _score_forecast_group(
         - ``fold_metric_dict`` — flat ``{mlflow_metric_key: mean_value}`` dict logged to the
           fold's MLflow child run (e.g. ``{"rmse__all": 0.42, "rmse__pv": 0.31}``). ``None``
           for ``"ad_hoc"`` scope, where no MLflow run exists.
+
+    Raises:
+        NoOverlappingActualsError: If no series in the group has any overlapping actuals.
     """
-    per_series_metrics = compute_metrics(group_forecasts, actuals_lf, metadata_df, capacity_df)
+    series_ids = _series_ids_in_group(group_scan)
+    batch_metrics: list[pt.DataFrame[Metrics]] = []
+    for start in range(0, len(series_ids), _METRICS_SERIES_BATCH_SIZE):
+        batch_ids = series_ids[start : start + _METRICS_SERIES_BATCH_SIZE]
+        batch_forecasts = _load_series_batch(group_scan, batch_ids)
+        try:
+            batch_metrics.append(
+                compute_metrics(batch_forecasts, actuals_lf, metadata_df, capacity_df)
+            )
+        except NoOverlappingActualsError:
+            continue
+    if not batch_metrics:
+        raise NoOverlappingActualsError(
+            f"No rows in the joined forecast/actuals data for group ({exp_name}, {fold_id}). "
+            "Check that cv_forecasts and actuals overlap in time."
+        )
+    per_series_metrics = Metrics.validate(pl.concat(batch_metrics), allow_superfluous_columns=True)
 
     window_start, window_end, window_label = _resolve_eval_window(
-        evaluation_scope, fold_id, group_forecasts
+        evaluation_scope, fold_id, group_scan
     )
     mlflow_run_id: str | None = None
     if evaluation_scope == "leaderboard":
@@ -844,7 +921,7 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
 
     # Discover the matching groups from the pruned scan — projecting to only the two partition
     # columns keeps this collect cheap (partition metadata, not row data). Each group is then
-    # loaded and scored one at a time, so peak memory is a single fold.
+    # scored in per-series batches, so peak memory is one batch, never a whole fold.
     groups = (
         pruned_scan.select(["experiment_name", "fold_id"])
         .unique()
@@ -891,11 +968,10 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     experiment_fold_metrics: dict[str, dict[str, list[float]]] = {}
 
     for exp_name, fold_id in groups:
-        group_forecasts = _load_forecast_group(pruned_scan, exp_name, fold_id)
         n_rows, fold_metric_dict = _score_forecast_group(
             exp_name,
             fold_id,
-            group_forecasts,
+            _group_scan(pruned_scan, exp_name, fold_id),
             actuals_lf,
             metadata_df,
             capacity_df,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -388,6 +388,142 @@ def test_metrics_nmae_denominator_is_effective_capacity(
     assert nmae == pytest.approx(mae / capacity, rel=1e-5)
 
 
+def _batch_forecast_frame(
+    time_series_id: int, times: list[datetime], power_fcst: list[float]
+) -> pl.DataFrame:
+    """One-member PowerForecast rows for the per-series-batching test."""
+    n = len(times)
+    return pl.DataFrame(
+        {
+            "time_series_id": pl.Series([time_series_id] * n, dtype=pl.Int32),
+            "valid_time": pl.Series(times, dtype=pl.Datetime("us", "UTC")),
+            "power_fcst_init_time": pl.Series([min(times)] * n, dtype=pl.Datetime("us", "UTC")),
+            "ensemble_member": pl.Series([0] * n, dtype=pl.Int8),
+            "nwp_init_time": pl.Series([None] * n, dtype=pl.Datetime("us", "UTC")),
+            "power_fcst": pl.Series(power_fcst, dtype=pl.Float32),
+            "power_fcst_model_name": pl.Series(["stub"] * n, dtype=pl.String),
+            "power_fcst_model_version": pl.Series([1] * n, dtype=pl.Int16),
+            "ml_flow_experiment_id": pl.Series([None] * n, dtype=pl.Int32),
+            "experiment_name": pl.Series(["exp_batch"] * n, dtype=pl.String),
+            "fold_id": pl.Series(["2025"] * n, dtype=pl.String),
+        }
+    )
+
+
+def test_score_forecast_group_per_series_batches(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Per-series batching writes exactly the rows a whole-group call would.
+
+    With the batch size forced to 1, three series exercise the multi-batch path; the series
+    with no overlapping actuals is skipped (as it silently vanishes from the inner join in a
+    whole-group call) and the written Delta rows match ``compute_metrics`` on the overlapping
+    series.
+    """
+    from contracts.power_schemas import EffectiveCapacity, PowerTimeSeries
+    from ml_core.metrics import compute_metrics
+
+    from nged_substation_forecast.defs import cv_assets
+
+    times = [
+        datetime(2025, 8, 1, 6, 0, tzinfo=timezone.utc),
+        datetime(2025, 8, 1, 6, 30, tzinfo=timezone.utc),
+    ]
+    # Series 1 and 2 overlap the actuals below; series 3's valid times are a year later.
+    far_times = [t.replace(year=2026) for t in times]
+    group = PowerForecast.validate(
+        pl.concat(
+            [
+                _batch_forecast_frame(1, times, [12.0, 8.0]),
+                _batch_forecast_frame(2, times, [25.0, 19.0]),
+                _batch_forecast_frame(3, far_times, [1.0, 1.0]),
+            ]
+        )
+    )
+    actuals = pt.LazyFrame.from_existing(
+        pl.LazyFrame(
+            {
+                "time_series_id": pl.Series([1, 1, 2, 2], dtype=pl.Int32),
+                "time": pl.Series(times * 2, dtype=pl.Datetime("us", "UTC")),
+                "power": pl.Series([10.0, 10.0, 20.0, 20.0], dtype=pl.Float32),
+            }
+        )
+    ).set_model(PowerTimeSeries)
+    metadata_df = TimeSeriesMetadata.validate(
+        pl.DataFrame(
+            {
+                "time_series_id": pl.Series([1, 2, 3], dtype=pl.Int32),
+                "time_series_name": [f"Substation {i}" for i in (1, 2, 3)],
+                "time_series_type": pl.Series(["Disaggregated Demand"] * 3).cast(
+                    pl.Enum(LIST_OF_TIME_SERIES_TYPES)
+                ),
+                "units": pl.Series(["MW"] * 3).cast(pl.Enum(["MW", "MVA"])),
+                "licence_area": pl.Series(["EMids"] * 3).cast(pl.Enum(["EMids"])),
+                "substation_number": pl.Series([1, 2, 3], dtype=pl.Int32),
+                "substation_type": pl.Series(["Primary"] * 3).cast(
+                    pl.Enum(["BSP", "EHV Customer", "GSP", "HV Customer", "Primary"])
+                ),
+                "latitude": pl.Series([53.0] * 3, dtype=pl.Float32),
+                "longitude": pl.Series([-0.5] * 3, dtype=pl.Float32),
+                "h3_res_5": pl.Series([_TS1_CELL] * 3, dtype=pl.UInt64),
+            }
+        ),
+        allow_superfluous_columns=True,
+    )
+    capacity_df = EffectiveCapacity.validate(
+        pl.DataFrame(
+            {
+                "time_series_id": pl.Series([1, 2, 3], dtype=pl.Int32),
+                "time": pl.Series([times[0]] * 3, dtype=pl.Datetime("us", "UTC")),
+                "effective_capacity_mw": pl.Series([10.0, 20.0, 5.0], dtype=pl.Float32),
+            }
+        )
+    )
+
+    monkeypatch.setattr(cv_assets, "_METRICS_SERIES_BATCH_SIZE", 1)
+    metrics_path = tmp_path / "forecast_metrics"
+    n_rows, fold_metric_dict = cv_assets._score_forecast_group(
+        "exp_batch",
+        "2025",
+        group.lazy(),
+        actuals,
+        metadata_df,
+        capacity_df,
+        "ad_hoc",
+        str(metrics_path),
+        datetime.now(timezone.utc),
+        None,
+    )
+
+    assert fold_metric_dict is None  # ad_hoc scope never logs to MLflow
+    written = pl.read_delta(str(metrics_path))
+    assert set(written["time_series_id"].to_list()) == {1, 2}
+
+    expected = compute_metrics(
+        PowerForecast.validate(
+            pl.concat(
+                [
+                    _batch_forecast_frame(1, times, [12.0, 8.0]),
+                    _batch_forecast_frame(2, times, [25.0, 19.0]),
+                ]
+            )
+        ),
+        actuals,
+        metadata_df,
+        capacity_df,
+    )
+    assert n_rows == expected.height
+
+    compare_cols = ["time_series_id", "horizon_slice", "metric_name", "metric_value"]
+    sort_keys = ["time_series_id", "horizon_slice", "metric_name"]
+    # Delta stores the Enum columns as String, so compare in String space. Expression casts
+    # (not a {column: dtype} dict-cast) because `expected` is a model-bearing Patito frame.
+    expected_str = expected.select(compare_cols).with_columns(
+        pl.col("horizon_slice").cast(pl.String), pl.col("metric_name").cast(pl.String)
+    )
+    assert written.select(compare_cols).sort(sort_keys).equals(expected_str.sort(sort_keys))
+
+
 def test_metrics_ad_hoc_no_mlflow_logging(file_mlflow_env: dict[str, Path]) -> None:
     instance = DagsterInstance.ephemeral()
     _run_cv_pipeline(instance)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -481,6 +481,18 @@ def test_score_forecast_group_per_series_batches(
     )
 
     monkeypatch.setattr(cv_assets, "_METRICS_SERIES_BATCH_SIZE", 1)
+    # Spy on the batch loader so the test fails loudly if a refactor ever defeats the
+    # batch-size monkeypatch (which would silently collapse this back to one batch).
+    batch_calls: list[list[int]] = []
+    real_load_series_batch = cv_assets._load_series_batch
+
+    def _spy_load_series_batch(
+        group_scan: pl.LazyFrame, series_ids: list[int]
+    ) -> pt.DataFrame[PowerForecast]:
+        batch_calls.append(series_ids)
+        return real_load_series_batch(group_scan, series_ids)
+
+    monkeypatch.setattr(cv_assets, "_load_series_batch", _spy_load_series_batch)
     metrics_path = tmp_path / "forecast_metrics"
     n_rows, fold_metric_dict = cv_assets._score_forecast_group(
         "exp_batch",
@@ -496,6 +508,8 @@ def test_score_forecast_group_per_series_batches(
     )
 
     assert fold_metric_dict is None  # ad_hoc scope never logs to MLflow
+    # The multi-batch and skip paths were genuinely exercised: one single-series batch each.
+    assert batch_calls == [[1], [2], [3]]
     written = pl.read_delta(str(metrics_path))
     assert set(written["time_series_id"].to_list()) == {1, 2}
 


### PR DESCRIPTION
Closes #348. (Was stacked on #347, since merged; this PR is now based on `main`.)

## What changed

- **`_score_forecast_group` now scores a fold in per-series batches** (`_METRICS_SERIES_BATCH_SIZE = 4`) instead of receiving the whole materialised group. `compute_metrics` is independent per `time_series_id` — every group key includes it — so concatenating the per-batch tall `Metrics` frames is exactly equivalent to one big call. `_load_forecast_group` is replaced by `_group_scan` + `_series_ids_in_group` + `_load_series_batch` (streaming collects).
- **`NoOverlappingActualsError`** (a `ValueError` subclass, raised by `compute_metrics` for the empty-join case) lets the batch loop skip series with no overlapping actuals — mirroring how such series silently vanish from the inner join in a whole-group call — while a group where *no* series overlaps still raises, and every other `ValueError` (negative leads, missing capacity) still propagates.
- The `ad_hoc` evaluation window is resolved with a streaming min/max over the group scan instead of the materialised frame.

## Empirical verification (real data)

Ran the real `_score_forecast_group` over the actual `xgboost_cv_0001` / `mid_2025_to_mid_2026` partition (370,467,468 rows; hindcast rows filtered in the scan to satisfy the #346 guard):

- **Before**: an equivalent whole-fold eager collect was OOM-killed on the 29 GB dev machine.
- **After**: completes in **51 s** at **17.5 GB peak RSS**, and the written 560 `Metrics` rows match the independently-computed Phase A verification **exactly** (`mae__all` = 7.4308; all per-slice NMAEs identical to 6 decimal places).
- Batch size 2 measured only ~2 GB lower peak (15.8 GB) at the same runtime — the peak is dominated by the streaming Delta scan, not the batch frame, so it stays roughly constant as folds grow. That constant-in-fold-size behaviour is what makes this workable at V2 scale (~80× more series); the measured numbers are recorded on the constant's docstring.

## Tests

- Unit: per-series batching equivalence property (`compute_metrics` whole vs per-series concat), and the no-overlap case now asserts the dedicated exception type.
- Integration: new `test_score_forecast_group_per_series_batches` forces batch size 1 over three series (one with no overlapping actuals) and checks the written Delta rows equal a whole-group `compute_metrics` call; the existing end-to-end asset suite runs through the batched path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Adversarial review

A fresh-context adversarial review of the stacked diff found **no correctness bugs**. It empirically confirmed the batching-equivalence claim (mixed overlap/non-overlap batches produce byte-equal Delta rows to a whole-group call), verified the full skip-semantics truth table against the old behaviour, proved `NoOverlappingActualsError` cannot mask negative-lead or missing-capacity errors (both repro'd propagating from a later batch), and checked the Patito-concat, 2³²-row, stale-caller, and write-once-per-group concerns clean. It also noted the batch `is_in` filter can skip Parquet row groups because `POWER_FORECASTS_SORT_COLS` leads with `time_series_id`. Two low-severity findings, both addressed in a follow-up commit: the missing-capacity error now documents that it describes only the first offending batch (a deliberate divergence — the raise aborts the loop before later batches load), and the batching test gained a spy on `_load_series_batch` asserting the exact single-series batch calls, so a refactor that defeats the batch-size monkeypatch fails loudly instead of silently collapsing the test to one batch.

