### PR TITLE
Stop CV emitting undeliverable hindcast rows: enforce valid_time > power_fcst_init_time

### DIFF
--- a/packages/contracts/src/contracts/power_schemas.py
+++ b/packages/contracts/src/contracts/power_schemas.py
@@ -219,7 +219,15 @@ class PowerForecast(pt.Model):
 
     valid_time: datetime = pt.Field(
         dtype=UTC_DATETIME_DTYPE,
-        description="The target time this forecast is valid for.",
+        constraints=pl.col("valid_time") > pl.col("power_fcst_init_time"),
+        description=(
+            "The target time this forecast is valid for. Constrained to be strictly after"
+            " power_fcst_init_time: a row targeting a valid time at or before its own"
+            " initialisation is an undeliverable hindcast row — at power_fcst_init_time that"
+            " valid time is already observed. The live service only forecasts strictly future"
+            " valid times and bulk-mode feature engineering drops hindcast rows at source, so"
+            " a constraint violation here indicates a pipeline regression."
+        ),
     )
 
     time_series_id: int = _get_time_series_id_dtype()
@@ -304,57 +312,6 @@ class PowerForecast(pt.Model):
             "filter on this column to select the population you need."
         ),
     )
-
-    @classmethod
-    def validate(  # ty: ignore[invalid-method-override]
-        cls,
-        dataframe: pl.DataFrame,
-        columns: Sequence[str] | None = None,
-        allow_missing_columns: bool = False,
-        allow_superfluous_columns: bool = False,
-        drop_superfluous_columns: bool = False,
-    ) -> pt.DataFrame[Self]:
-        """Validate the given dataframe, ensuring every row is a deliverable forecast.
-
-        Beyond the per-column checks, enforce ``valid_time > power_fcst_init_time`` (strictly):
-        a row targeting a valid_time at or before its own initialisation time is a hindcast row.
-        The live service never delivers one (``live_forecasts`` forecasts strictly future valid
-        times), and bulk-mode feature engineering drops them at source, so their presence here
-        indicates a pipeline regression.
-
-        Args:
-            dataframe: The Polars DataFrame to validate.
-            columns: Optional list of columns to validate against.
-            allow_missing_columns: Whether to allow missing columns.
-            allow_superfluous_columns: Whether to allow extra columns.
-            drop_superfluous_columns: Whether to drop extra columns.
-
-        Returns:
-            A validated Patito DataFrame.
-
-        Raises:
-            ValueError: If any row has ``valid_time <= power_fcst_init_time``.
-        """
-        validated_df = super().validate(
-            dataframe=dataframe,
-            columns=columns,
-            allow_missing_columns=allow_missing_columns,
-            allow_superfluous_columns=allow_superfluous_columns,
-            drop_superfluous_columns=drop_superfluous_columns,
-        )
-
-        n_hindcast: int = validated_df.select(
-            (pl.col("valid_time") <= pl.col("power_fcst_init_time")).sum()
-        ).item()
-        if n_hindcast > 0:
-            raise ValueError(
-                f"Found {n_hindcast} hindcast row(s) with valid_time <= power_fcst_init_time. "
-                "Every forecast row must target a strictly future valid_time — at "
-                "power_fcst_init_time those valid times are already observed, so such rows can "
-                "never be delivered."
-            )
-
-        return validated_df
 
 
 class EffectiveCapacity(pt.Model):

--- a/packages/contracts/src/contracts/power_schemas.py
+++ b/packages/contracts/src/contracts/power_schemas.py
@@ -305,6 +305,57 @@ class PowerForecast(pt.Model):
         ),
     )
 
+    @classmethod
+    def validate(  # ty: ignore[invalid-method-override]
+        cls,
+        dataframe: pl.DataFrame,
+        columns: Sequence[str] | None = None,
+        allow_missing_columns: bool = False,
+        allow_superfluous_columns: bool = False,
+        drop_superfluous_columns: bool = False,
+    ) -> pt.DataFrame[Self]:
+        """Validate the given dataframe, ensuring every row is a deliverable forecast.
+
+        Beyond the per-column checks, enforce ``valid_time > power_fcst_init_time`` (strictly):
+        a row targeting a valid_time at or before its own initialisation time is a hindcast row.
+        The live service never delivers one (``live_forecasts`` forecasts strictly future valid
+        times), and bulk-mode feature engineering drops them at source, so their presence here
+        indicates a pipeline regression.
+
+        Args:
+            dataframe: The Polars DataFrame to validate.
+            columns: Optional list of columns to validate against.
+            allow_missing_columns: Whether to allow missing columns.
+            allow_superfluous_columns: Whether to allow extra columns.
+            drop_superfluous_columns: Whether to drop extra columns.
+
+        Returns:
+            A validated Patito DataFrame.
+
+        Raises:
+            ValueError: If any row has ``valid_time <= power_fcst_init_time``.
+        """
+        validated_df = super().validate(
+            dataframe=dataframe,
+            columns=columns,
+            allow_missing_columns=allow_missing_columns,
+            allow_superfluous_columns=allow_superfluous_columns,
+            drop_superfluous_columns=drop_superfluous_columns,
+        )
+
+        n_hindcast: int = validated_df.select(
+            (pl.col("valid_time") <= pl.col("power_fcst_init_time")).sum()
+        ).item()
+        if n_hindcast > 0:
+            raise ValueError(
+                f"Found {n_hindcast} hindcast row(s) with valid_time <= power_fcst_init_time. "
+                "Every forecast row must target a strictly future valid_time — at "
+                "power_fcst_init_time those valid times are already observed, so such rows can "
+                "never be delivered."
+            )
+
+        return validated_df
+
 
 class EffectiveCapacity(pt.Model):
     """Effective capacity of each time series at each half-hourly timestep.

--- a/packages/ml_core/src/ml_core/features/_nwp.py
+++ b/packages/ml_core/src/ml_core/features/_nwp.py
@@ -31,6 +31,10 @@ def _join_nwp_bulk_mode(
 
     Produces one row per (time_series_id, nwp_init_time, valid_time, ensemble_member) with
     power_fcst_init_time derived per-row as nwp_init_time + nwp_publication_delay_hours.
+    Each NWP run's first nwp_publication_delay_hours of valid times therefore precede the
+    derived power_fcst_init_time; those hindcast rows are kept here so that window features
+    (e.g. weather rolling means) see the same predecessor rows as single-run mode, and are
+    dropped by ``_engineer_features`` after feature computation.
     """
     if processed_nwp is None:
         result = power_with_metadata.with_columns(

--- a/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py
+++ b/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py
@@ -214,7 +214,10 @@ def _engineer_features(
         # on the full frame and lets the caller filter before predicting. The strict `>`
         # mirrors what the live service delivers. The no-NWP bulk branch is exempt: it sets
         # power_fcst_init_time = valid_time (lead 0 by construction), so this filter would
-        # drop every row.
+        # drop every row. That exemption makes the no-NWP branch training-only: predict
+        # output built from it is all-lead-0 and always fails PowerForecast.validate, so a
+        # power-only forecaster (e.g. a persistence baseline) must synthesise genuine
+        # power_fcst_init_times for inference rather than predict through this branch.
         engineered_lf = engineered_lf.filter(pl.col("valid_time") > pl.col("power_fcst_init_time"))
     final_lf = _select_output_columns(engineered_lf, selected_features)
     return pt.LazyFrame.from_existing(final_lf).set_model(AllFeatures)

--- a/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py
+++ b/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py
@@ -117,10 +117,12 @@ def _engineer_features(
             The function is NWP-centric. It produces one row per
             (time_series_id, nwp_init_time, valid_time, ensemble_member), and derives
             power_fcst_init_time = nwp_init_time + nwp_publication_delay_hours per-row.
-            Leaky power lags are nullified relative to each row's power_fcst_init_time,
-            so the resulting dataset is safe for training. For backtesting, pass the full
-            historical dataset here and filter the output to valid_time >= power_fcst_init_time
-            before evaluating.
+            Hindcast rows (valid_time at or before the derived power_fcst_init_time — each
+            NWP run's first nwp_publication_delay_hours of valid times) are dropped, so both
+            training and backtesting see only rows the live service could deliver
+            (valid_time > power_fcst_init_time, strictly). Leaky power lags are nullified
+            relative to each row's power_fcst_init_time, so the resulting dataset is safe
+            for training.
 
             **Single datetime — real-time production inference or backfilling:**
             A constant power_fcst_init_time is stamped onto every row, and the NWP join
@@ -204,6 +206,16 @@ def _engineer_features(
         processed_nwp=processed_nwp,
         historical_weather=historical_weather,
     )
+    if power_fcst_init_time is None and nwp_lf is not None:
+        # Bulk mode with NWP: drop hindcast rows (each NWP run's first
+        # nwp_publication_delay_hours of valid times, which precede the derived
+        # power_fcst_init_time). Filtering *after* feature computation keeps window features
+        # (e.g. weather rolling means) identical to single-run mode, which likewise computes
+        # on the full frame and lets the caller filter before predicting. The strict `>`
+        # mirrors what the live service delivers. The no-NWP bulk branch is exempt: it sets
+        # power_fcst_init_time = valid_time (lead 0 by construction), so this filter would
+        # drop every row.
+        engineered_lf = engineered_lf.filter(pl.col("valid_time") > pl.col("power_fcst_init_time"))
     final_lf = _select_output_columns(engineered_lf, selected_features)
     return pt.LazyFrame.from_existing(final_lf).set_model(AllFeatures)
 

--- a/packages/ml_core/tests/test_cross_mode_equivalence.py
+++ b/packages/ml_core/tests/test_cross_mode_equivalence.py
@@ -72,13 +72,16 @@ _SORT_COLS = ["time_series_id", "power_fcst_init_time", "valid_time", "ensemble_
 
 
 def _run_valid_times(run_init: datetime) -> list[datetime]:
-    """A non-overlapping 06:00–12:00 half-hourly window for each daily run.
+    """A non-overlapping 00:00–12:00 half-hourly window for each daily run.
 
-    Non-overlapping windows mean each (time_series_id, valid_time) appears in exactly one run,
-    which keeps the bulk and single-run row sets directly comparable.
+    Starting at the run's own init_time (like real ECMWF ENS) gives every run a full
+    ``_DELAY_HOURS`` of hindcast valid times before its derived power_fcst_init_time. Those
+    rows must feed window features (weather rolling means) as predecessors on both sides even
+    though they are dropped from the compared output. Non-overlapping windows mean each
+    (time_series_id, valid_time) appears in exactly one run, which keeps the bulk and
+    single-run row sets directly comparable.
     """
-    start = run_init + timedelta(hours=_DELAY_HOURS)
-    return [start + timedelta(minutes=30 * i) for i in range(13)]  # 06:00 .. 12:00 inclusive
+    return [run_init + timedelta(minutes=30 * i) for i in range(25)]  # 00:00 .. 12:00 inclusive
 
 
 def _power_observation_times(run_init: datetime) -> list[datetime]:
@@ -167,12 +170,25 @@ def test_bulk_and_single_run_features_are_identical() -> None:
         )
     single_run = pl.concat(single_run_parts)
 
-    # 12, not 13: each run's window is 13 half-hourly steps, but the first lands exactly on
-    # power_fcst_init_time (lead 0), which bulk mode drops as an undeliverable hindcast row.
+    # 12 of each run's 25 half-hourly steps survive: the 12 negative-lead steps and the lead-0
+    # step land at or before the derived power_fcst_init_time, and bulk mode drops those
+    # undeliverable hindcast rows after computing features on the full window.
     assert len(bulk) == len(_NWP_RUNS) * len(_MEMBERS) * 12
     # Guard: the power lag must actually resolve to non-null observed values for some rows,
     # otherwise "identical" would be a vacuous all-null match on both sides.
     assert bulk["power_lag_3h"].is_not_null().any()
+    # Guard: at the first deliverable step (init + 6.5 h) the 3 h rolling window reaches back
+    # into the dropped hindcast steps. If bulk mode filtered *before* computing window
+    # features, the window would hold only the row itself and the mean would collapse to the
+    # row's own temperature — so equality with single-run alone would not catch a matched
+    # regression on both sides.
+    first_deliverable = bulk.filter(
+        (pl.col("valid_time") == _NWP_RUNS[0] + timedelta(hours=_DELAY_HOURS, minutes=30))
+        & (pl.col("ensemble_member") == 0)
+    )
+    assert first_deliverable.height == 1
+    row = first_deliverable.row(0, named=True)
+    assert row["temperature_2m_rolling_mean_3h"] != row["temperature_2m"]
     assert_frame_equal(
         bulk.select(_COMPARE_COLS).sort(_SORT_COLS),
         single_run.select(_COMPARE_COLS).sort(_SORT_COLS),

--- a/packages/ml_core/tests/test_cross_mode_equivalence.py
+++ b/packages/ml_core/tests/test_cross_mode_equivalence.py
@@ -10,8 +10,11 @@ the *same* ``_engineer_features()``, differing only in operating mode:
 This test takes a fixture spanning several **daily** NWP runs (real ECMWF ENS is issued once
 per day at 00 UTC), runs bulk mode, then *replays* each NWP run in single-run mode with
 ``power_fcst_init_time = nwp_init_time + delay`` and asserts the rows match exactly on the
-primary key and on every requested feature column. If a future change diverges the two modes,
-this fails.
+primary key and on every requested feature column. The comparison is over **deliverable** rows
+(``valid_time > power_fcst_init_time``): bulk mode drops hindcast rows at source, while
+single-run mode keeps them for its caller to filter before predicting (as ``live_forecasts``
+does), so the replay side applies that same filter here. If a future change diverges the two
+modes, this fails.
 
 Scope note: this test exercises the **weather, time, power-lag, and weather-rolling** features.
 Weather/time features depend on the bulk-vs-single-run NWP join; power lags are included because
@@ -152,11 +155,21 @@ def test_bulk_and_single_run_features_are_identical() -> None:
             nwp_init_time=run,
         ).collect()
         # Keep only rows the NWP run actually covers (single-run mode is power-centric and
-        # emits null-weather rows for valid_times outside this run's window).
-        single_run_parts.append(replay.filter(pl.col("nwp_lead_time_hours").is_not_null()))
+        # emits null-weather rows for valid_times outside this run's window), and only
+        # deliverable rows (valid_time strictly after power_fcst_init_time) — single-run mode
+        # keeps history rows for the production caller to filter before predicting, whereas
+        # bulk mode drops them at source.
+        single_run_parts.append(
+            replay.filter(
+                pl.col("nwp_lead_time_hours").is_not_null()
+                & (pl.col("valid_time") > run + timedelta(hours=_DELAY_HOURS))
+            )
+        )
     single_run = pl.concat(single_run_parts)
 
-    assert len(bulk) == len(_NWP_RUNS) * len(_MEMBERS) * 13
+    # 12, not 13: each run's window is 13 half-hourly steps, but the first lands exactly on
+    # power_fcst_init_time (lead 0), which bulk mode drops as an undeliverable hindcast row.
+    assert len(bulk) == len(_NWP_RUNS) * len(_MEMBERS) * 12
     # Guard: the power lag must actually resolve to non-null observed values for some rows,
     # otherwise "identical" would be a vacuous all-null match on both sides.
     assert bulk["power_lag_3h"].is_not_null().any()

--- a/packages/ml_core/tests/test_features.py
+++ b/packages/ml_core/tests/test_features.py
@@ -662,6 +662,60 @@ def test_engineer_features_multi_run_backtest_uses_bulk_mode():
     assert nwp_init_times == {nwp_init_time_1, nwp_init_time_2}
 
 
+def test_engineer_features_bulk_mode_drops_hindcast_rows():
+    """Bulk mode emits only deliverable rows: valid_time strictly after power_fcst_init_time.
+
+    Each NWP run's valid times start at its own init_time, but the derived
+    power_fcst_init_time is init_time + nwp_publication_delay_hours — so the run's first
+    delay-hours of valid times are hindcast rows that a live forecast could never deliver.
+    They must not appear in the output; the earliest emitted valid_time is the first
+    half-hourly step strictly after power_fcst_init_time.
+    """
+    delay_hours = 6
+    nwp_init_time = datetime(2023, 1, 1, 0, 0)
+    power_fcst_init_time = nwp_init_time + timedelta(hours=delay_hours)
+    # Half-hourly valid times from the NWP init through 2 h past the publication delay.
+    valid_times = [nwp_init_time + timedelta(minutes=30 * i) for i in range(17)]
+
+    nwp_df = pl.DataFrame(
+        {
+            "time_series_id": ["ts1"] * len(valid_times),
+            "valid_time": valid_times,
+            "ensemble_member": [0] * len(valid_times),
+            "init_time": [nwp_init_time] * len(valid_times),
+            "temperature_2m": [10.0] * len(valid_times),
+        }
+    )
+    power_df = pl.DataFrame(
+        {
+            "time_series_id": ["ts1"] * len(valid_times),
+            "time": valid_times,
+            "power": [100.0] * len(valid_times),
+        }
+    )
+    metadata_df = pl.DataFrame({"time_series_id": ["ts1"], "time_series_type": ["substation"]})
+
+    result = (
+        _engineer_features(
+            power_time_series=pt.LazyFrame.from_existing(power_df.lazy()).set_model(
+                PowerTimeSeries
+            ),
+            time_series_metadata=pt.DataFrame(metadata_df).set_model(TimeSeriesMetadata),
+            nwp=nwp_df.lazy(),
+            selected_features={"temperature_2m"},
+            power_fcst_init_time=None,  # bulk mode
+            nwp_publication_delay_hours=delay_hours,
+        )
+        .collect()
+        .sort("valid_time")
+    )
+
+    # 17 half-hourly steps: 12 hindcast (leads −6 h .. −30 min), 1 at lead 0, 4 deliverable.
+    assert len(result) == 4
+    assert (result["valid_time"] > result["power_fcst_init_time"]).all()
+    assert result["valid_time"][0] == power_fcst_init_time + timedelta(minutes=30)
+
+
 def test_engineer_features_raises_when_nwp_init_time_given_without_power_fcst_init_time():
     power_df = pl.DataFrame(
         {"time_series_id": ["ts1"], "time": [datetime(2023, 1, 1, 12)], "power": [100.0]}

--- a/packages/ml_core/tests/test_metrics.py
+++ b/packages/ml_core/tests/test_metrics.py
@@ -49,7 +49,9 @@ def _make_cv_forecasts(
 ) -> pt.DataFrame[PowerForecast]:
     n = len(times)
     if init_times is None:
-        init_times = [_utc(2022, 1, 1)] * n
+        # 30 min before the fixtures' customary first valid_time (2022-01-01 00:00): the
+        # PowerForecast contract requires valid_time strictly after power_fcst_init_time.
+        init_times = [_utc(2021, 12, 31, 23, 30)] * n
     df = pl.DataFrame(
         {
             "time_series_id": pl.Series([time_series_id] * n, dtype=pl.Int32),
@@ -180,7 +182,7 @@ def test_compute_metrics_raises_when_series_missing_capacity():
 def test_compute_metrics_ensemble_averaging():
     """Ensemble mean should be taken before computing metrics."""
     time = _utc(2022, 1, 1, 0, 0)
-    init_time = _utc(2022, 1, 1)
+    init_time = _utc(2021, 12, 31, 23, 30)
     # Two ensemble members: forecasts 8 and 12 → ensemble mean = 10 → error = 0
     df = pl.DataFrame(
         {
@@ -301,18 +303,21 @@ def _slice_mae(result: pl.DataFrame, horizon_slice: str) -> float:
 def test_compute_metrics_horizon_slice_band_boundaries():
     """Lead times land in the correct left-closed bands, including exact boundary values.
 
-    One forecast run (single init time) with valid_times at lead times 0 h and 5.5 h
+    One forecast run (single init time) with valid_times at lead times 0.5 h and 5.5 h
     (intraday), 6 h and 35.5 h (day_ahead), 36 h and 167.5 h (short_medium_range), and
     168 h and 336 h (extended_range). Distinct errors per band make per-slice MAE reveal
-    band membership.
+    band membership. 0.5 h is the shortest deliverable lead: the PowerForecast contract
+    requires valid_time strictly after power_fcst_init_time, so lead 0 cannot occur.
     """
     init_time = _utc(2022, 1, 1)
-    leads_hours = [0.0, 5.5, 6.0, 35.5, 36.0, 167.5, 168.0, 336.0]
+    leads_hours = [0.5, 5.5, 6.0, 35.5, 36.0, 167.5, 168.0, 336.0]
     times = [init_time + timedelta(hours=h) for h in leads_hours]
     # errors: intraday 1, 2 → MAE 1.5; day_ahead 3, 4 → 3.5; smr 5, 6 → 5.5; extended 7, 8 → 7.5
     errors = [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]
     actuals = _make_actuals(1, times, [10.0] * len(times))
-    forecasts = _make_cv_forecasts(1, times, [10.0 + e for e in errors])
+    forecasts = _make_cv_forecasts(
+        1, times, [10.0 + e for e in errors], init_times=[init_time] * len(times)
+    )
     result = compute_metrics(forecasts, actuals, _make_metadata([1]), _make_capacity([1], [10.0]))
     assert math.isclose(_slice_mae(result, "intraday"), 1.5, rel_tol=1e-5)
     assert math.isclose(_slice_mae(result, "day_ahead"), 3.5, rel_tol=1e-5)
@@ -324,12 +329,14 @@ def test_compute_metrics_horizon_slice_band_boundaries():
 def test_compute_metrics_all_slice_is_row_weighted():
     """The "all" slice averages over every scored row, not over the per-slice metric values."""
     init_time = _utc(2022, 1, 1)
-    leads_hours = [0.0, 0.5, 5.5, 6.0, 35.5, 36.0, 168.0]
+    leads_hours = [0.5, 1.0, 5.5, 6.0, 35.5, 36.0, 168.0]
     times = [init_time + timedelta(hours=h) for h in leads_hours]
     # intraday errors 1, 2, 3 → MAE 2; day_ahead 6, 8 → 7; smr 9 → 9; extended 11 → 11.
     errors = [1.0, 2.0, 3.0, 6.0, 8.0, 9.0, 11.0]
     actuals = _make_actuals(1, times, [10.0] * len(times))
-    forecasts = _make_cv_forecasts(1, times, [10.0 + e for e in errors])
+    forecasts = _make_cv_forecasts(
+        1, times, [10.0 + e for e in errors], init_times=[init_time] * len(times)
+    )
     result = compute_metrics(forecasts, actuals, _make_metadata([1]), _make_capacity([1], [10.0]))
     # Row-weighted mean = 40/7 ≈ 5.714; the mean of the four slice MAEs would be 7.25.
     assert math.isclose(_slice_mae(result, "all"), 40.0 / 7.0, rel_tol=1e-5)
@@ -352,12 +359,28 @@ def test_compute_metrics_collapses_ensemble_per_forecast_run():
 
 
 def test_compute_metrics_negative_lead_time_raises():
-    """A valid_time before power_fcst_init_time is corrupted data and must fail loudly."""
+    """A valid_time before power_fcst_init_time is corrupted data and must fail loudly.
+
+    ``PowerForecast.validate`` rejects hindcast rows at construction, so to exercise
+    ``compute_metrics``' own defence-in-depth guard we corrupt the frame *after* validation
+    (``with_columns`` does not re-validate).
+    """
     valid_time = _utc(2022, 1, 1)
     actuals = _make_actuals(1, [valid_time], [10.0])
-    forecasts = _make_cv_forecasts(1, [valid_time], [10.0], init_times=[_utc(2022, 1, 2)])
+    forecasts = _make_cv_forecasts(1, [valid_time], [10.0]).with_columns(
+        power_fcst_init_time=pl.lit(_utc(2022, 1, 2)).cast(pl.Datetime("us", "UTC"))
+    )
     with pytest.raises(ValueError, match="negative lead time"):
         compute_metrics(forecasts, actuals, _make_metadata([1]), _make_capacity([1], [10.0]))
+
+
+def test_power_forecast_contract_rejects_hindcast_rows():
+    """The PowerForecast contract itself refuses valid_time at or before power_fcst_init_time."""
+    valid_time = _utc(2022, 1, 1)
+    with pytest.raises(ValueError, match="hindcast"):
+        _make_cv_forecasts(1, [valid_time], [10.0], init_times=[valid_time])  # lead 0
+    with pytest.raises(ValueError, match="hindcast"):
+        _make_cv_forecasts(1, [valid_time], [10.0], init_times=[_utc(2022, 1, 2)])
 
 
 # ---------------------------------------------------------------------------

--- a/packages/ml_core/tests/test_metrics.py
+++ b/packages/ml_core/tests/test_metrics.py
@@ -375,11 +375,16 @@ def test_compute_metrics_negative_lead_time_raises():
 
 
 def test_power_forecast_contract_rejects_hindcast_rows():
-    """The PowerForecast contract itself refuses valid_time at or before power_fcst_init_time."""
+    """The PowerForecast contract itself refuses valid_time at or before power_fcst_init_time.
+
+    Enforced declaratively via the ``valid_time`` field's Patito constraint;
+    ``DataFrameValidationError`` is a ``ValueError`` subclass, so callers treating validation
+    failures as ``ValueError`` keep working.
+    """
     valid_time = _utc(2022, 1, 1)
-    with pytest.raises(ValueError, match="hindcast"):
+    with pytest.raises(pt.exceptions.DataFrameValidationError, match="valid_time"):
         _make_cv_forecasts(1, [valid_time], [10.0], init_times=[valid_time])  # lead 0
-    with pytest.raises(ValueError, match="hindcast"):
+    with pytest.raises(pt.exceptions.DataFrameValidationError, match="valid_time"):
         _make_cv_forecasts(1, [valid_time], [10.0], init_times=[_utc(2022, 1, 2)])
 
 

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -924,14 +924,16 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     ).set_model(PowerForecast)
     pruned_scan = config.population_filter.apply(scan)
 
-    # Discover the matching groups from the pruned scan — projecting to only the two partition
-    # columns keeps this collect cheap (partition metadata, not row data). Each group is then
-    # scored in per-series batches, so peak memory is one batch, never a whole fold.
+    # Discover the matching groups from the pruned scan. The streaming engine is essential
+    # here even though only the two partition columns are projected: the in-memory engine
+    # materialises them at full row length before the unique (measured: OOM-killed on the
+    # 364M-row fold vs 0.3 GB peak streaming). Each group is then scored in per-series
+    # batches, so peak memory is one batch, never a whole fold.
     groups = (
         pruned_scan.select(["experiment_name", "fold_id"])
         .unique()
         .sort(["experiment_name", "fold_id"])
-        .collect()
+        .collect(engine="streaming")
         .rows()
     )
     if not groups:

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -19,7 +19,7 @@ import subprocess
 import time
 import urllib.error
 import urllib.request
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import mlflow
@@ -397,7 +397,11 @@ def _batch_forecast_frame(
         {
             "time_series_id": pl.Series([time_series_id] * n, dtype=pl.Int32),
             "valid_time": pl.Series(times, dtype=pl.Datetime("us", "UTC")),
-            "power_fcst_init_time": pl.Series([min(times)] * n, dtype=pl.Datetime("us", "UTC")),
+            # 30 min before the earliest valid_time: the PowerForecast contract requires
+            # valid_time strictly after power_fcst_init_time.
+            "power_fcst_init_time": pl.Series(
+                [min(times) - timedelta(minutes=30)] * n, dtype=pl.Datetime("us", "UTC")
+            ),
             "ensemble_member": pl.Series([0] * n, dtype=pl.Int8),
             "nwp_init_time": pl.Series([None] * n, dtype=pl.Datetime("us", "UTC")),
             "power_fcst": pl.Series(power_fcst, dtype=pl.Float32),

--- a/tests/test_s3_data_paths.py
+++ b/tests/test_s3_data_paths.py
@@ -135,7 +135,9 @@ def _make_forecasts(experiment_name: str, power_fcst: list[float]) -> pt.DataFra
                 "power_fcst_model_name": ["xgboost"] * n,
                 "experiment_name": [experiment_name] * n,
                 "power_fcst_model_version": [1] * n,
-                "power_fcst_init_time": [_T0] * n,
+                # 30 min before the earliest valid_time (_T0): the PowerForecast contract
+                # requires valid_time strictly after power_fcst_init_time.
+                "power_fcst_init_time": [_T0 - timedelta(minutes=30)] * n,
                 "power_fcst": power_fcst,
                 "fold_id": ["s3_test"] * n,
             }


### PR DESCRIPTION
Fixes #346.

## What changed

- **Bulk-mode feature engineering drops hindcast rows.** In bulk mode, `power_fcst_init_time` is derived as `nwp_init_time + nwp_publication_delay_hours`, but each NWP run's valid times start at `nwp_init_time` — so every run's first 6 h of valid times land at or before the derived `power_fcst_init_time`. These rows can never be delivered, yet CV training and inference were both consuming them (~2% of all rows, and until the horizon-sliced-metrics PR they were silently *scored*, flattering every model). `_engineer_features` now filters them out — strictly (`valid_time > power_fcst_init_time`), mirroring the filter `live_forecasts` already applies before predicting.
- **The filter runs *after* feature computation, at the end of the bulk branch** — not in the NWP join. Window features (weather rolling means) must see the hindcast rows as predecessors, exactly as single-run mode does (it computes on the full frame and lets the production caller filter before predict). Filtering in the join diverged the cross-mode rolling-mean values; the cross-mode equivalence test caught it and now locks the invariant in over deliverable rows.
- **Training drops the rows too, deliberately.** Hindcast rows carry feature combinations (fresh 0–6 h NWP plus fully-populated short power lags) that never occur at any deliverable lead, so they are unrepresentative training samples. Existing saved models are untouched; future retrains see ~2% fewer rows.
- **The `PowerForecast` contract now enforces the invariant**: `validate()` rejects any row with `valid_time <= power_fcst_init_time`, so a regression fails loudly at predict time (before writing) and at the metrics asset's per-series batch loads. The `compute_metrics` negative-lead guard stays as defence in depth.
- The no-NWP bulk branch is exempt from the filter: it sets `power_fcst_init_time = valid_time` by construction (lead 0 on every row), so the strict filter would empty it.

## Empirical verification (real data)

Engineered features for a real NWP run (2025-10-01 00Z, series 1–4, control member) through the fixed bulk pipeline and compared against the existing `power_forecasts` rows for the same run:

- 2,832 rows engineered; **minimum lead +30 min**, no `valid_time <= power_fcst_init_time` rows.
- The engineered keys are **exactly** the old rows minus their 52 hindcast rows (old: 2,884) — confirming the filter is purely row-subtractive, so surviving forecasts are unchanged.

Existing damage measured across `power_forecasts` (to be repaired after merge with a per-partition `DeltaTable.delete("... AND valid_time <= power_fcst_init_time")`, then re-scored):

| partition | rows | negative lead | lead 0 |
|---|---|---|---|
| `xgboost_cv_0001 / mid_2025_to_mid_2026` | 370,467,468 | 6,168,960 | 514,080 |
| `xgboost_smoke_test_3 / smoke_test` | 1,941,927 | 35,496 | 2,958 |
| `xgboost_smoke_test_4 / smoke_test` | 31,199,454 | 512,244 | 42,687 |
| `xgboost_cv_0001 / live` | 10,195,920 | 0 | 0 |

The `live` partition is clean — `live_forecasts` always filtered strictly — which is also why strict `>` is the right semantics for CV to mirror.

## Tests

- New bulk-mode test: each NWP run's earliest emitted valid time is `power_fcst_init_time + 30 min`; hindcast and lead-0 steps are absent.
- Cross-mode equivalence now compares deliverable rows (12 per run/member, not 13) and asserts bulk == single-run including rolling weather means.
- New contract test: lead-0 and negative-lead rows fail `PowerForecast.validate`.
- Metrics fixtures move their default `power_fcst_init_time` 30 min before the earliest valid time; the horizon-band boundary test's lead-0 row becomes 0.5 h (the shortest deliverable lead — band expectations unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Repair executed (2026-07-17)

The data repair has now been run (it is git-independent, so it did not wait for merge):

1. **Delete**: per-partition `DeltaTable.delete(... AND valid_time <= power_fcst_init_time)` removed exactly the predicted counts — 6,683,040 / 38,454 / 554,931 rows; the `live` partition was untouched and zero violating rows remain anywhere.
2. **Storage-policy restore**: the delete rewrote files with delta-rs default writer properties (partition grew 0.68 → 0.85 GB), so each repaired partition was rewritten through `write_power_forecasts` (reading from the pinned post-delete version, per-series batches). Per-series row counts and `power_fcst` checksums verified identical; the partition landed at 0.666 GB — smaller than the original, since the hindcast rows are gone and series-batched writes align with `POWER_FORECASTS_SORT_COLS`. **Lesson for future repairs: pass `writer_properties=POWER_FORECASTS_WRITER_PROPERTIES` to `DeltaTable.delete`.**
3. **Re-score**: `metrics` re-materialised for `xgboost_cv_0001 / mid_2025_to_mid_2026` (leaderboard scope): `mae__all` **7.4333** (vs 7.4308 when lead-0 rows were still scored — the easiest rows are gone, so error nudges up), intraday NMAE 0.1274 → **0.1305**; per-slice ordering now short_medium_range 0.1223 < day_ahead 0.1240 < intraday 0.1305 < extended_range 0.1332. Fold run and `cv_summary` parent updated in MLflow.
4. **Vacuum**: 110 stale files removed; table directory back to 708 MB; all four partitions verified readable.

Re-scoring was also the first end-to-end run of the metrics **asset** on real data since #349 (which had only exercised `_score_forecast_group` directly) — and it OOM'd in the asset's group-discovery `collect()`, which materialises the projected partition columns at full row length in the in-memory engine (comment claimed it was metadata-cheap; measured: killed at >24 GB vs 0.3 GB streaming). Fixed in the third commit by collecting with the streaming engine.
