### PR TITLE
Probabilistic metrics from the existing ensemble (#225 Phase B)

### DIFF
--- a/docs/ml_experimentation/dagster-workflow.md
+++ b/docs/ml_experimentation/dagster-workflow.md
@@ -202,15 +202,25 @@ in the run config dialog before launching.
    need sub-fold chunking — see
    [The other hard ceiling: Polars' 32-bit row index](../architecture/overview.md#the-other-hard-ceiling-polars-32-bit-row-index).)
    For each group:
-   a. Calls `compute_metrics()` — joins observed power, averages ensemble members, computes
-      MAE / NMAE / RMSE / MBE per `(time_series_id, fold_id, power_fcst_model_name)`.
+   a. Calls `compute_metrics()` — joins observed power, collapses each forecast run's ensemble
+      members into per-timestamp quantities, and computes the deterministic metrics
+      (MAE / NMAE / RMSE / MBE on the ensemble mean) plus the probabilistic metrics (fair
+      CRPS, spread-skill ratio, pinball loss at the 13 delivery quantiles, PICP and interval
+      width for the 6 symmetric bands) per
+      `(time_series_id, fold_id, power_fcst_model_name, horizon_slice)` — see the
+      [evaluation-metrics reference](../techniques/evaluation-metrics.md) for definitions.
    b. Enriches rows with scope (`evaluation_scope`), window bounds (`window_start`, `window_end`,
       `window_label`), `computed_at`, and the MLflow fold run id (leaderboard scope only).
    c. Writes to `forecast_metrics` Delta, partitioned by `(experiment_name, fold_id)` with an
       idempotent overwrite predicate — safe to re-run without duplicating rows.
-3. For `evaluation_scope="leaderboard"`: builds a per-type + overall aggregate metric dict (e.g.
-   `rmse__all`, `rmse__disaggregated_demand`) and logs it to the fold's MLflow child run, then
-   averages across folds and logs the mean to the parent run.
+3. For `evaluation_scope="leaderboard"`: builds an aggregate metric dict and logs it to the
+   fold's MLflow child run, then averages across folds and logs the mean to the parent run.
+   The key token is `{metric_name}` for scalar metrics and `{metric_name}_{metric_param}` for
+   parametric ones, in three families: overall (`rmse__all`, `crps__all`), per type
+   (`rmse__disaggregated_demand`), and per horizon slice (`nmae__all__day_ahead`). Parametric
+   metrics are restricted to a headline subset in MLflow (`pinball_loss` at p10/p50/p90;
+   `picp`/`interval_width` at p10_p90) — the full 13-quantile / 6-band detail stays in the
+   `forecast_metrics` Delta table.
 
 After step 8, the MLflow run structure looks like this:
 

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -90,9 +90,10 @@ AWS — see [Live service](live-service.md).
 *Epic: [#6](https://github.com/openclimatefix/nged-substation-forecast/issues/6)*
 
 - Implement the ML energy forecasting "leaderboard" (cross-fold validation metrics in MLflow), ready for systematic ML experimentation ✓ (CV assets added)
-- Metrics: normalised MBE, normalised MAE, RMSE, Pinball loss, PICP, CRPS, Spread-Skill Ratio — the
-  deterministic metrics are ✅; the probabilistic ones are 🚧 (see
-  [Metrics & leaderboard](metrics-and-leaderboard.md))
+- Metrics: MBE, MAE, NMAE, RMSE, Pinball loss, PICP, interval width, CRPS, Spread-Skill Ratio —
+  all ✅ (definitions in the
+  [evaluation-metrics reference](../techniques/evaluation-metrics.md); plan and remaining 🚧
+  items in [Metrics & leaderboard](metrics-and-leaderboard.md))
 - Time-slice filters: nowcasting (0–6 h), day-ahead (6–36 h), medium range (Day 2–7), extended range (Day 8–14), peak events (top 5%)
 - Baseline forecasters (persistence + climatology) so leaderboard scores are interpretable
 - Production monitoring of the live service (`production_monitoring` metrics scope)

--- a/docs/roadmap/metrics-and-leaderboard.md
+++ b/docs/roadmap/metrics-and-leaderboard.md
@@ -3,8 +3,10 @@
 How OCF measures the skill of its forecasts and compares forecasting approaches.
 
 > **Status legend** — ✅ Implemented · 🚧 Planned · 🔬 Research. The `Metrics` schema, the
-> `metrics` Dagster asset, and the deterministic metrics (MAE, NMAE, RMSE, MBE) are ✅
-> implemented. The interactive leaderboard visualisation and probabilistic metrics are 🚧 planned.
+> `metrics` Dagster asset, the deterministic metrics (MAE, NMAE, RMSE, MBE), and the
+> probabilistic metrics (CRPS, spread-skill ratio, pinball loss, PICP, interval width — see the
+> [evaluation-metrics reference](../techniques/evaluation-metrics.md)) are ✅ implemented. The
+> interactive leaderboard visualisation is 🚧 planned.
 > The implemented [cross-validation protocol](../ml_experimentation/cross-validation-folds.md) has
 > moved out of the roadmap. See the [roadmap index](index.md) for status conventions.
 > The 🚧 items are tracked under the v0.3 epic
@@ -331,15 +333,16 @@ and nothing is logged to the leaderboard MLflow runs.
 | Root mean squared error (RMSE) | Deterministic | ✅ | Heavily penalises large misses (one 100 MW error costs more than two 50 MW errors). |
 | Mean bias error (MBE) | Deterministic | ✅ | Systematic over/under-prediction. |
 | Histogram of errors | Deterministic | 🚧 | Visual check that errors are ~Normal. |
-| Pinball loss (quantile loss) | Quantile | 🚧 | Penalises asymmetrically by target quantile. Averaged across quantiles for a single quantile-skill score. |
-| PICP (Prediction Interval Coverage Probability) | Quantile | 🚧 | Of a P10–P90 band, exactly 80% of observations should fall inside. < 80% ⇒ overconfident. |
-| CRPS (Continuous Ranked Probability Score) | Ensemble | 🚧 | Probabilistic equivalent of MAE; rewards both accuracy and sharpness. |
-| Spread-Skill Ratio | Ensemble | 🚧 | Ensemble spread ÷ RMSE of the ensemble mean. 1.0 = well-calibrated; < 1 under-dispersed (overconfident); > 1 over-dispersed (underconfident). |
+| [Pinball loss (quantile loss)](../techniques/evaluation-metrics.md#pinball-loss) | Quantile | ✅ | Penalises asymmetrically by target quantile, at the 13 NGED delivery quantiles. Averaged across quantiles for a single quantile-skill score. |
+| [PICP (Prediction Interval Coverage Probability)](../techniques/evaluation-metrics.md#picp-prediction-interval-coverage-probability) | Quantile | ✅ | Coverage of six symmetric bands (p1–p99 … p35–p65). Judge against the finite-ensemble calibrated reference (≈ 0.769 for p10–p90 at 51 members), not the nominal rate. |
+| [Interval width](../techniques/evaluation-metrics.md#interval-width) | Quantile | ✅ | Mean band width (MW) — the sharpness companion that stops PICP being gamed by over-widening. |
+| [CRPS (Continuous Ranked Probability Score)](../techniques/evaluation-metrics.md#crps-continuous-ranked-probability-score) | Ensemble | ✅ | Probabilistic equivalent of MAE; rewards both accuracy and sharpness. Fair (finite-ensemble-unbiased) form — the one metric comparable across ensemble sizes. |
+| [Spread-Skill Ratio](../techniques/evaluation-metrics.md#spread-skill-ratio) | Ensemble | ✅ | Fortin-corrected RMS ensemble spread ÷ RMSE of the ensemble mean. 1.0 = well-calibrated; < 1 under-dispersed (overconfident); > 1 over-dispersed (underconfident). |
 
 > The `Metrics` schema (`contracts.ml_schemas.Metrics`) stores results as
 > `(time_series_id, power_fcst_model_name, fold_id, horizon_slice, metric_name, metric_param,
 > metric_value)`. `metric_param` carries, e.g., the quantile for Pinball Loss (`p10`) or the band
-> for PICP (`p10_p90`). The `metrics` Dagster asset computes the deterministic metrics ✅ and writes
+> for PICP (`p10_p90`). The `metrics` Dagster asset computes every ✅ metric above and writes
 > per-series rows to `forecast_metrics` Delta (partitioned by `experiment_name, fold_id`), with
 > per-fold and mean-across-folds aggregates logged to MLflow — see
 > [Running an ML experiment end-to-end](../ml_experimentation/dagster-workflow.md#step-8-materialise-metrics).
@@ -528,9 +531,9 @@ the control member (`cv_assets.py:373`) learns a conditional mean, so pushing 51
 it yields spread from *weather uncertainty only* — no model or observation uncertainty. Such
 ensembles are systematically overconfident, worst at short horizons where members haven't
 diverged. Flexibility procurement is a tails problem (P90+ peaks), so this hits the use case
-directly — yet nothing measures calibration today: `compute_metrics` averages members into a
-deterministic ensemble mean per forecast run and scores only MAE/NMAE/RMSE/MBE (now per horizon
-slice, since Phase A landed). We pay 51× inference cost and score only the mean.
+directly. Phases A and B below (both shipped) built the measurement machinery — every metric in
+the [evaluation-metrics reference](../techniques/evaluation-metrics.md), per horizon slice; the
+remaining phases act on what those numbers show.
 
 The theory behind this diagnosis — the three-term uncertainty decomposition, why a
 deterministic model driven by an NWP ensemble captures only the weather term, and what the
@@ -548,30 +551,23 @@ Shipped. `compute_metrics` now scores every metric per `HORIZON_SLICES` band (de
 `valid_time − power_fcst_init_time`, with the ensemble collapsed per forecast run), and
 `build_mlflow_aggregate_metrics` logs overall per-slice keys like `nmae__all__day_ahead`.
 
-### Phase B — probabilistic metrics from the existing ensemble
+### Phase B — probabilistic metrics from the existing ensemble ✅
 
-Compute member-aware metrics *before* the ensemble-mean collapse in `compute_metrics`:
-
-- **Spread-skill ratio**: mean ensemble stddev ÷ RMSE of the ensemble mean, per group. Ratio
-  ≪ 1 confirms underdispersion — this is the headline diagnostic for the finding above.
-- **PICP**: empirical member quantiles per `(series, valid_time)` (`pl.quantile` over members),
-  then coverage of the P10–P90 interval. `metric_param` (currently only `"all"`,
-  `ml_schemas.py:203`) carries the interval label, e.g. `"p10_p90"`.
-- **Pinball loss** at P10/P50/P90 from the same empirical quantiles; `metric_param` = quantile
-  label. (Schema docstrings already anticipate pinball/PICP.)
-- **CRPS** (fair/ensemble form): per timestamp, `mean|xᵢ − y| − ½·mean|xᵢ − xⱼ|`. The pairwise
-  term over 51 members is computable with a self-join on member index within
-  `(series, valid_time)` groups; ~51² × rows is fine at V1 scale. If it's slow, the
-  sorted-member O(m log m) form is a known optimisation — don't start there.
-- Extend `METRIC_NAMES` (`ml_schemas.py:188`) and `METRIC_PARAMS` accordingly. Both are
-  `pl.Enum` columns written to Delta as String (documented gotcha) — additive enum growth is
-  safe for existing data.
-- Flip the statuses in the [metrics table above](#evaluation-metrics) from 🚧 to ✅ as they
-  land.
+Shipped. `compute_metrics` now computes fair CRPS, the Fortin-corrected spread-skill ratio,
+pinball loss at the thirteen NGED delivery quantiles (plus their mean), and PICP and interval
+width for the six symmetric delivery bands — all member-aware, computed before the
+ensemble-mean collapse, per horizon slice. Definitions, equations, and the design decisions
+(fair CRPS divisor, RMS spread, delivery quantiles, MLflow allowlist) live in the
+[evaluation-metrics reference](../techniques/evaluation-metrics.md).
 
 ### Phase C — cheap calibration (after B proves the diagnosis)
 
-Decide based on Phase B's spread-skill numbers. **Post-hoc spread inflation** (EMOS-lite): per
+Decide based on Phase B's spread-skill numbers — and on the **rank (Talagrand) histogram** of
+the observations among the 51 members, computed ad hoc per horizon slice: a U-shape confirms
+plain underdispersion (a single multiplicative inflation can fix it), whereas a sloped or
+asymmetric histogram means bias or shape error, which a symmetric inflation cannot repair and
+which would push toward a rank-dependent correction instead. **Post-hoc spread inflation**
+(EMOS-lite): per
 horizon slice, fit a scalar `s` on the *training* window so that inflating members around the
 ensemble mean (`mean + s·(member − mean)`) makes spread match error. Zero schema change, zero
 new model — implementable as an optional step in `predict` or as a wrapper forecaster. Fit on
@@ -612,14 +608,6 @@ each:
    recalibration hook (fit on train) applied only if the pooled spread-skill/PICP numbers
    demand it. Scored with pinball/PICP/CRPS head-to-head against the Phase-C inflated
    deterministic champion.
-
-### Implementation details — probabilistic metrics (deleted when they ship)
-
-Verification: (1) unit tests in `packages/ml_core/tests/` with hand-computable fixtures — a
-3-member toy ensemble where PICP, spread-skill, pinball, and CRPS are worked out by hand.
-(2) Property check: CRPS of a single-member "ensemble" equals MAE. (3) Re-score an existing
-experiment via the `metrics` asset (`ad_hoc` scope) and eyeball that spread-skill ≪ 1 at short
-horizons — the expected signature of the finding.
 
 ---
 

--- a/docs/techniques/evaluation-metrics.md
+++ b/docs/techniques/evaluation-metrics.md
@@ -172,7 +172,11 @@ true* rather than approximately true:
 
 The variance uses `ddof=1` (the sample variance), and a single-member forecast scores spread 0
 — zero spread is the honest description of a deterministic forecast, and 0/RMSE keeps the
-ratio's meaning (maximally overconfident) rather than becoming null.
+ratio's meaning (maximally overconfident) rather than becoming null. The remaining corner is
+RMSE = 0 (a perfect forecast over the scored group): with zero spread the ratio is defined as
+0 rather than the indeterminate 0/0, and with positive spread (contradictory: claimed
+uncertainty around an error-free mean) the computation refuses to emit a value — NaN or
+infinity in any metric raises rather than silently poisoning the leaderboard aggregates.
 
 ### Pinball loss
 
@@ -239,7 +243,7 @@ $$
 **The calibrated reference is *below* nominal coverage.** Empirical quantiles from a finite
 ensemble sit inside the true ones, so even a perfectly calibrated $m$-member ensemble covers
 less than the nominal rate — approximately
-$\frac{m-1}{m+1}(\tau_{\mathrm{hi}} - \tau_{\mathrm{lo}})$, which we confirmed by simulation.
+$\frac{m-1}{m+1}(\tau_{\mathrm{hi}} - \tau_{\mathrm{lo}})$.
 Judge PICP against these references, not the nominal rates:
 
 | Band | Nominal coverage | Calibrated reference at $m = 51$ |
@@ -254,6 +258,15 @@ Judge PICP against these references, not the nominal rates:
 A p10–p90 PICP of 0.72 at 51 members is therefore mild overconfidence (reference 0.769), not
 the 8-point shortfall a naive comparison with 0.8 would suggest. The gap grows as $m$ shrinks —
 one more reason PICP is not comparable across ensemble sizes.
+
+One caveat on precision: the formula is exact only when the interpolated quantile estimator is
+evaluated on a uniform distribution; for other distribution shapes the interpolation between
+extreme order statistics shifts coverage slightly. We verified by Monte Carlo (1M trials at
+$m = 51$, using the same `quantile(τ, "linear")` estimator as the metrics code) that uniform
+draws reproduce the table to within ±0.001 at every band, while Gaussian draws lift the
+outermost band to ≈ 0.947 (vs the table's 0.942) and leave the rest within noise. So treat the
+p1–p99 reference as accurate to roughly ±0.005 depending on the forecast distribution's shape;
+the central bands are safe as given.
 
 PICP alone is also **gameable**: an absurdly wide band hits any coverage target for free. It
 must always be read alongside a sharpness measure — which is what interval width is for (and
@@ -284,10 +297,13 @@ is `{metric_name}` for scalar metrics and `{metric_name}_{metric_param}` for par
 in three families: `{token}__all` (overall), `{token}__{type_slug}` (per
 `time_series_type`), and `{token}__all__{horizon_slice}` (per lead-time band).
 
-To keep the leaderboard legible (~130 keys rather than ~340), parametric metrics are
+To keep the leaderboard legible, parametric metrics are
 restricted in MLflow to a **headline subset**: `pinball_loss` at p10/p50/p90 and `picp` /
 `interval_width` at p10_p90 (the allowlist is `_MLFLOW_LOGGED_PARAMETRIC` in
-`ml_core.metrics`). Anything not in MLflow is still one Polars filter away in Delta.
+`ml_core.metrics`). The exact key count scales with how many distinct `time_series_type`
+values the scored population spans (each adds a per-type key family): 132 keys for the V1
+trial area's six types, versus roughly 340 if every quantile and band were logged. Anything
+not in MLflow is still one Polars filter away in Delta.
 
 ## What is deliberately *not* here
 

--- a/docs/techniques/evaluation-metrics.md
+++ b/docs/techniques/evaluation-metrics.md
@@ -1,0 +1,301 @@
+# Evaluation metrics
+
+> **Status: durable metric reference.** This page defines every metric computed by
+> `compute_metrics` (`packages/ml_core/src/ml_core/metrics.py`): a plain-language summary of
+> each, the equation, how to interpret the number, and — where the definition involved a real
+> choice — why we chose what we chose. The theory of *why* our ensembles need probabilistic
+> evaluation at all is the companion explainer
+> [Probabilistic forecasting from NWP ensembles](probabilistic-forecasting.md); the plan that
+> delivered these metrics (and the calibration work that builds on them) is
+> [Metrics & leaderboard](../roadmap/metrics-and-leaderboard.md#delivering-the-probabilistic-metrics).
+
+## How scoring works, in brief
+
+Every forecast in this project is an **ensemble**: for each substation (`time_series_id`) and
+each target half-hour (`valid_time`), one forecast *run* (`power_fcst_init_time`) produces $m$
+member forecasts $x_1, \dots, x_m$ (51 members for the NWP-driven ML models; a deterministic
+baseline is simply $m = 1$). Scoring proceeds in two steps:
+
+1. **Per timestamp** — each forecast run's members are collapsed into per-timestamp quantities:
+   the ensemble mean $\bar{x}_t$ (which the deterministic metrics score), plus the member-aware
+   quantities (CRPS, ensemble variance, and the empirical quantiles). Runs that cover the same
+   `valid_time` at different lead times are scored **independently**, exactly as a production
+   consumer would experience each of them — members are never pooled across runs into a
+   lagged-ensemble blend.
+2. **Per group** — the per-timestamp values are averaged within each
+   `(time_series_id, fold_id, power_fcst_model_name, horizon_slice)` group, where
+   `horizon_slice` buckets rows by lead time (`intraday` < 6 h ≤ `day_ahead` < 36 h ≤
+   `short_medium_range` < 168 h ≤ `extended_range`), plus an `"all"` group over every lead
+   time. Dispersion errors are strongly horizon-dependent, so the per-slice view is usually
+   the one to read.
+
+Results land in two places: the `forecast_metrics` Delta table holds the **full** detail (one
+row per `(time_series_id, fold_id, horizon_slice, metric_name, metric_param)`), and MLflow
+receives per-experiment aggregates under a
+[restricted headline subset](#where-the-numbers-live-delta-vs-mlflow).
+
+Notation below: $y_t$ is the observed power at valid time $t$; $x_{t,1}, \dots, x_{t,m}$ are
+the ensemble members of the run being scored; $\bar{x}_t$ is their mean; $T$ is the number of
+timestamps in the group; $\hat{q}_t(\tau)$ is the empirical quantile of the members at level
+$\tau$ (linear interpolation between order statistics).
+
+## Deterministic metrics
+
+These score the **ensemble mean** — a single number per timestamp — and say nothing about
+whether the forecast's claimed uncertainty was honest.
+
+### Mean absolute error (MAE)
+
+**MW; smaller is better.** the typical size of the miss. An MAE of 3 MW means the forecast is off by
+about 3 MW on an average half-hour, in one direction or the other.
+
+$$
+\mathrm{MAE} = \frac{1}{T} \sum_t \left| \bar{x}_t - y_t \right|
+$$
+
+Every MW of error costs the same, so MAE is not distorted by a few bad hours — but for the same
+reason it cannot tell you whether errors are steady or spiky (that is RMSE's job), nor whether
+they lean high or low (MBE's job).
+
+### Normalised MAE (NMAE)
+
+**Dimensionless; smaller is better.** MAE expressed as a fraction of the substation's size, so a 200 MW BSP and a
+5 MW primary can be compared on one axis. NMAE ≈ 0.03 means typical errors are about 3% of the
+series' effective capacity. This is the **headline cross-series metric**.
+
+$$
+\mathrm{NMAE} = \frac{\mathrm{MAE}}{\text{effective capacity}}
+$$
+
+**Why a capacity denominator, not the mean:** intermittent generators (PV, wind) spend much of
+their time near zero output, so normalising by *mean* power would inflate their NMAE relative
+to a demand substation of similar peak size. The denominator is the series' full-history
+effective capacity (P99 of |power|), computed over the full history so that it stays stable
+across CV folds — see
+[Normalising NMAE by effective_capacity](../roadmap/metrics-and-leaderboard.md#normalising-nmae-by-effective_capacity).
+
+### Root mean squared error (RMSE)
+
+**MW; smaller is better.** like MAE, but big misses count disproportionately — one 100 MW error hurts
+more than two 50 MW errors. If RMSE is much larger than MAE, the model's errors are spiky: it
+is usually fine and occasionally very wrong.
+
+$$
+\mathrm{RMSE} = \sqrt{ \frac{1}{T} \sum_t \left( \bar{x}_t - y_t \right)^2 }
+$$
+
+### Mean bias error (MBE)
+
+**MW; zero is best.** does the forecast lean high or low? Positive MBE means systematic
+over-prediction. A model can have MBE ≈ 0 and still be terrible (large errors that cancel), so
+MBE is a diagnosis of *direction*, never of *size*.
+
+$$
+\mathrm{MBE} = \frac{1}{T} \sum_t \left( \bar{x}_t - y_t \right)
+$$
+
+## Probabilistic metrics
+
+These score the ensemble **before** the mean collapse, and are the reason we pay 51× inference
+cost. A recurring caveat: of everything below, **only CRPS is fair across ensemble sizes** —
+PICP, pinball loss, interval width, and (residually) the spread-skill ratio all shift with the
+member count $m$, because empirical quantiles from few members are systematically too narrow.
+When comparing models with different ensemble sizes (e.g. the 51-member ML models against
+`nged_incumbent`'s 13 historical analogues), lean on CRPS.
+
+### CRPS (continuous ranked probability score)
+
+**MW; smaller is better.** MAE for a whole probability forecast. CRPS asks "how far was the forecast
+*distribution* from what happened?" — it rewards being right, and being *confidently* right,
+in one number. For a deterministic forecast ($m = 1$) CRPS literally equals MAE, so CRPS values
+sit on the same MW scale as MAE and the two are directly comparable: an ensemble whose CRPS
+beats its own MAE is extracting real value from its spread.
+
+We compute the **fair** (finite-ensemble-unbiased) form of Ferro (2014), per timestamp:
+
+$$
+\mathrm{CRPS}_t = \frac{1}{m} \sum_{i} \left| x_{t,i} - y_t \right|
+\;-\; \frac{1}{m(m-1)} \sum_{i<j} \left| x_{t,i} - x_{t,j} \right|
+$$
+
+with the second (spread) term defined as 0 when $m = 1$, and the group value being the mean of
+$\mathrm{CRPS}_t$ over the group's timestamps. The first term is accuracy (how far members sit
+from reality); the subtracted term is a reward for spread — hedging across the members' honest
+disagreement is scored better than betting everything on their mean.
+
+**Why the fair form:** the textbook ensemble estimator divides the spread term by $m^2$ rather
+than $m(m-1)$, which under-credits small ensembles — a *perfectly calibrated* 2-member ensemble
+scores ~50% worse than its true CRPS, shrinking to ~3% at 13 members (we verified this by
+Monte Carlo). Since we will compare ensembles of different sizes, we use the unbiased divisor;
+the $m = 1$ convention then makes "CRPS = MAE for deterministic forecasts" exact.
+
+**How it is computed:** the naive pairwise sum is $O(m^2)$ per timestamp and, at fold scale,
+would require a members self-join materialising billions of pair rows. We instead use the
+sorted-member identity
+$\sum_{i<j} |x_i - x_j| = \sum_{k=1}^{m} (2k - m - 1)\, x_{(k)}$ (for ascending order
+statistics $x_{(k)}$), which is a single $O(m \log m)$ aggregation expression. The sum is
+accumulated in Float64: its terms are as large as $\pm m \cdot |x|$ while the result is only
+spread-sized, and that cancellation loses percent-level accuracy in Float32 when members are
+near-identical (precisely the underdispersed-intraday case we most care about).
+
+### Spread-skill ratio
+
+**Dimensionless; 1.0 is best.** is the fan the right width? The ratio compares how uncertain the forecast
+*claims* to be (the spread of its members) against how wrong it *actually* is (the RMSE of its
+mean). A ratio of 1.0 means the claimed uncertainty matches the realised error — the fan can be
+trusted. Below 1 the model is overconfident (**underdispersed**: the fan is too thin, and
+reality keeps landing outside it); above 1 it is underconfident. This is the headline
+diagnostic for the
+[underdispersion this project expects](probabilistic-forecasting.md#where-forecast-uncertainty-actually-comes-from).
+
+$$
+\mathrm{SSR} = \frac{ \sqrt{ \dfrac{1}{T} \sum_t \dfrac{m+1}{m}\, s_t^2 } }{ \mathrm{RMSE} },
+\qquad
+s_t^2 = \frac{1}{m-1} \sum_i \left( x_{t,i} - \bar{x}_t \right)^2
+$$
+
+Two definitional choices matter here, both made so that "1.0 = well-calibrated" is *literally
+true* rather than approximately true:
+
+- **RMS spread, not mean-of-stddev.** Averaging per-timestamp standard deviations and dividing
+  by RMSE looks natural but is biased low by Jensen's inequality whenever spread varies across
+  timestamps — and power-forecast spread varies strongly (diurnally and synoptically). In a
+  simulation of a *perfectly calibrated* heteroscedastic 51-member ensemble, the mean-of-stddev
+  form read 0.80 while the RMS form read 0.99. We therefore aggregate variances and take one
+  square root ("RMS spread"), so a calibrated model cannot be misdiagnosed as underdispersed.
+- **The Fortin $(m+1)/m$ factor.** Even with RMS spread, a calibrated $m$-member ensemble
+  satisfies $\mathrm{RMSE}^2 = \frac{m+1}{m} \times$ (mean ensemble variance) — the truth
+  behaves like one extra draw from the same distribution (Fortin et al. 2014). Folding
+  $(m+1)/m$ into the numerator makes the calibrated target exactly 1.0 at *any* ensemble size,
+  instead of ~0.99 at 51 members and ~0.96 at 13 — where the uncorrected form would read as
+  spurious underdispersion.
+
+The variance uses `ddof=1` (the sample variance), and a single-member forecast scores spread 0
+— zero spread is the honest description of a deterministic forecast, and 0/RMSE keeps the
+ratio's meaning (maximally overconfident) rather than becoming null.
+
+### Pinball loss
+
+**MW; smaller is better.** the score for a single quantile forecast, with a deliberately lopsided
+penalty that matches what the quantile *claims*. A p90 forecast claims "only a 10% chance power
+exceeds this", so when power does exceed it the loss is steep (weight 0.9), and when power
+falls below it the loss is shallow (weight 0.1). A forecaster minimises expected pinball loss
+at level $\tau$ by reporting the true $\tau$-quantile — bluffing wide or narrow both cost — so
+pinball loss is the honest scorecard for each individual quantile.
+
+For the empirical member quantile $\hat{q}_t(\tau)$:
+
+$$
+L_\tau
+= \frac{1}{T} \sum_t
+\begin{cases}
+\tau \, \left( y_t - \hat{q}_t(\tau) \right) & \text{if } y_t \ge \hat{q}_t(\tau) \\[2pt]
+(1 - \tau) \, \left( \hat{q}_t(\tau) - y_t \right) & \text{otherwise.}
+\end{cases}
+$$
+
+**Which quantiles — the NGED delivery thirteen.** Pinball loss is computed at exactly the
+levels agreed with NGED for the [delivery tables](../roadmap/delivery-tables.md) (p1, p2, p5,
+p10, p20, p35, p50, p65, p80, p90, p95, p98, p99; the single source of truth is
+`contracts.common.DELIVERY_QUANTILES`), one `metric_param` row per level. Three reasons:
+evaluation should measure what we sell; the tails *are* the product (NGED is far more
+interested in the tails than the shoulders); and the
+[Phase D quantile pipeline](../roadmap/metrics-and-leaderboard.md#phase-d-ensemble-of-quantile-forecasts-representation-3-pooled-representation-2)
+will be scored head-to-head at these same levels, so today's numbers are directly the baseline
+it must beat.
+
+**Finite-ensemble tail caveat:** from 51 members, $\hat{q}(0.01)$ interpolates between the two
+lowest members — the raw ensemble simply cannot represent its own far tails well, so its tail
+pinball losses are partly a representational limit rather than pure skill. That is not a reason
+to skip them (the product needs tails scored); it is the quantitative motivation for Phase D's
+per-member quantile models.
+
+### Mean pinball loss
+
+**MW; smaller is better.** the thirteen pinball losses averaged into one quantile-skill scalar, for
+leaderboard ranking. Because six of the thirteen delivery levels sit at or beyond p10/p90, this
+average is deliberately **tail-weighted** — a model that nails the median but botches the tails
+scores poorly, which matches NGED's priorities.
+
+$$
+\overline{L} = \frac{1}{13} \sum_{\tau \in Q} L_\tau ,
+\qquad Q = \{0.01, 0.02, 0.05, 0.10, 0.20, 0.35, 0.50, 0.65, 0.80, 0.90, 0.95, 0.98, 0.99\}
+$$
+
+### PICP (prediction interval coverage probability)
+
+**Dimensionless; aim for the calibrated reference below.** how often reality actually lands inside the claimed band. For the p10–p90
+band, roughly 80% of observations should fall inside; markedly less means the band is too
+narrow (overconfident), markedly more means too wide. PICP is scored for every symmetric pair
+of delivery quantiles — six bands from p35–p65 (30%) out to p1–p99 (98%) — so together the six
+values trace a **coverage curve** across the whole distribution.
+
+$$
+\mathrm{PICP}_{[\tau_{\mathrm{lo}}, \tau_{\mathrm{hi}}]}
+= \frac{1}{T} \sum_t
+\mathbf{1}\!\left[ \hat{q}_t(\tau_{\mathrm{lo}}) \le y_t \le \hat{q}_t(\tau_{\mathrm{hi}}) \right]
+$$
+
+**The calibrated reference is *below* nominal coverage.** Empirical quantiles from a finite
+ensemble sit inside the true ones, so even a perfectly calibrated $m$-member ensemble covers
+less than the nominal rate — approximately
+$\frac{m-1}{m+1}(\tau_{\mathrm{hi}} - \tau_{\mathrm{lo}})$, which we confirmed by simulation.
+Judge PICP against these references, not the nominal rates:
+
+| Band | Nominal coverage | Calibrated reference at $m = 51$ |
+|---|---|---|
+| p1–p99 | 0.98 | ≈ 0.942 |
+| p2–p98 | 0.96 | ≈ 0.923 |
+| p5–p95 | 0.90 | ≈ 0.865 |
+| p10–p90 | 0.80 | ≈ 0.769 |
+| p20–p80 | 0.60 | ≈ 0.577 |
+| p35–p65 | 0.30 | ≈ 0.288 |
+
+A p10–p90 PICP of 0.72 at 51 members is therefore mild overconfidence (reference 0.769), not
+the 8-point shortfall a naive comparison with 0.8 would suggest. The gap grows as $m$ shrinks —
+one more reason PICP is not comparable across ensemble sizes.
+
+PICP alone is also **gameable**: an absurdly wide band hits any coverage target for free. It
+must always be read alongside a sharpness measure — which is what interval width is for (and
+the proper scores, CRPS and pinball, punish over-widening automatically).
+
+### Interval width
+
+**MW; narrower is better *given* coverage.** how wide the claimed band is, on average — the sharpness companion to PICP.
+On its own, narrower is not better (a zero-width band is maximally sharp and maximally
+useless); the pair to optimise is *coverage at the reference, at the smallest width*. Reading
+PICP and interval width together makes the coverage-vs-sharpness trade-off legible — in
+particular, a calibration step that "fixes" coverage by inflating spread will visibly pay for
+it here.
+
+$$
+\mathrm{Width}_{[\tau_{\mathrm{lo}}, \tau_{\mathrm{hi}}]}
+= \frac{1}{T} \sum_t \left( \hat{q}_t(\tau_{\mathrm{hi}}) - \hat{q}_t(\tau_{\mathrm{lo}}) \right)
+$$
+
+It is computed for the same six bands as PICP.
+
+## Where the numbers live: Delta vs MLflow
+
+The `forecast_metrics` Delta table always holds the complete detail: all thirteen pinball
+levels, all six bands, every horizon slice, per series. MLflow — the leaderboard — receives
+per-experiment aggregates (unweighted means across series) under keys built from a token that
+is `{metric_name}` for scalar metrics and `{metric_name}_{metric_param}` for parametric ones,
+in three families: `{token}__all` (overall), `{token}__{type_slug}` (per
+`time_series_type`), and `{token}__all__{horizon_slice}` (per lead-time band).
+
+To keep the leaderboard legible (~130 keys rather than ~340), parametric metrics are
+restricted in MLflow to a **headline subset**: `pinball_loss` at p10/p50/p90 and `picp` /
+`interval_width` at p10_p90 (the allowlist is `_MLFLOW_LOGGED_PARAMETRIC` in
+`ml_core.metrics`). Anything not in MLflow is still one Polars filter away in Delta.
+
+## What is deliberately *not* here
+
+- **Rank (Talagrand) histograms** — the most direct picture of *how* an ensemble is
+  miscalibrated (U-shaped = underdispersed, domed = overdispersed). A histogram is not a scalar,
+  so it does not fit the tall metrics schema; it is computed in ad-hoc analyses (e.g. when
+  choosing the
+  [Phase C calibration](../roadmap/metrics-and-leaderboard.md#phase-c-cheap-calibration-after-b-proves-the-diagnosis)
+  approach) rather than stored per experiment.
+- **Histogram of errors** — same reason; planned as a visual check on the
+  [roadmap](../roadmap/metrics-and-leaderboard.md#evaluation-metrics).

--- a/docs/techniques/index.md
+++ b/docs/techniques/index.md
@@ -23,6 +23,13 @@ docstrings) as the work that applies them ships.
   caveat. Applied by the
   [probabilistic evaluation & calibration plan](../roadmap/metrics-and-leaderboard.md#delivering-the-probabilistic-metrics)
   and the [delivery tables](../roadmap/delivery-tables.md#table-1-power_forecast).
+- [Evaluation metrics](evaluation-metrics.md) — every metric `compute_metrics` produces, each
+  with a plain-language summary, the equation, and the design decisions behind it: the
+  deterministic four (MAE, NMAE, RMSE, MBE), fair CRPS, the Fortin-corrected spread-skill
+  ratio, pinball loss at the NGED delivery quantiles, PICP with its finite-ensemble calibrated
+  references, and interval width. Applied by the
+  [metrics & leaderboard plan](../roadmap/metrics-and-leaderboard.md) and computed by the
+  `metrics` Dagster asset.
 - [Differentiable physics](differentiable-physics.md) — inversion through differentiable forward
   models: the single-site solar plant and the aggregate fleet node. Applied by the
   [capacity-estimation](../roadmap/capacity-estimation.md) and

--- a/docs/techniques/probabilistic-forecasting.md
+++ b/docs/techniques/probabilistic-forecasting.md
@@ -69,7 +69,7 @@ A deterministic model (XGBoost trained with squared error learns the **condition
 pushed through 51 members captures term 1 *only*. Terms 2 and 3 are dropped entirely. The
 resulting ensemble is **under-dispersed** — systematically overconfident — and worst at short
 horizons, where term 1 shrinks toward zero while terms 2 and 3 do not. The
-[spread-skill ratio](../roadmap/metrics-and-leaderboard.md#evaluation-metrics) is the metric
+[spread-skill ratio](evaluation-metrics.md#spread-skill-ratio) is the metric
 that catches this: spread ÷ error ≪ 1 means the fan is too thin.
 
 This matters commercially, not just statistically: flexibility procurement keys off the
@@ -157,7 +157,7 @@ Mitigations, in order of practicality:
   isn't, rather than one horizon-averaged width.
 - **Train on many ensemble members, not just the control** (planned in [#148](https://github.com/openclimatefix/nged-substation-forecast/issues/148)) — the model then sees "one plausible
   scenario" as its actual input distribution, which is what a member is at inference time.
-- **Measure, then correct**: check the spread-skill ratio and PICP (planned in [#225](https://github.com/openclimatefix/nged-substation-forecast/issues/225)) of the *pooled* forecast per
+- **Measure, then correct**: check the [spread-skill ratio and PICP](evaluation-metrics.md#probabilistic-metrics) of the *pooled* forecast per
   horizon slice, and apply a per-horizon affine recalibration of the pooled quantiles (fit on
   the training window) only if the numbers demand it.
 
@@ -168,7 +168,8 @@ over-stated risk) is a far safer failure mode than the under-dispersion it repla
 ## How this maps onto the project
 
 - **Diagnose first**: the spread-skill / PICP / pinball / CRPS metrics that quantify all of the
-  above are Phases A–B of the
+  above are implemented — see the [evaluation-metrics reference](evaluation-metrics.md) — as
+  Phases A–B of the
   [probabilistic evaluation plan](../roadmap/metrics-and-leaderboard.md#delivering-the-probabilistic-metrics).
 - **Cheap stopgap**: post-hoc spread inflation of the existing deterministic ensemble ([Phase C
   of the probabilistic evaluation plan](../roadmap/metrics-and-leaderboard.md#phase-c-cheap-calibration-after-b-proves-the-diagnosis)) buys calibration without any of this machinery — the full mixture pipeline must beat

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
       - Overview: techniques/index.md
       - Convex Optimisation: techniques/convex-optimisation.md
       - Probabilistic Forecasting: techniques/probabilistic-forecasting.md
+      - Evaluation Metrics: techniques/evaluation-metrics.md
       - Differentiable Physics: techniques/differentiable-physics.md
       - Encoders: techniques/encoders.md
       - Disaggregation Evaluation: techniques/disaggregation-evaluation.md

--- a/packages/contracts/src/contracts/common.py
+++ b/packages/contracts/src/contracts/common.py
@@ -1,4 +1,4 @@
-from typing import Any, Type
+from typing import Any, Final, Type
 
 import patito as pt
 import polars as pl
@@ -11,6 +11,38 @@ from patito.exceptions import (
 
 # Define our standard datetime type for all schemas
 UTC_DATETIME_DTYPE = pl.Datetime(time_unit="us", time_zone="UTC")
+
+DELIVERY_QUANTILES: Final[tuple[float, ...]] = (
+    0.01,
+    0.02,
+    0.05,
+    0.10,
+    0.20,
+    0.35,
+    0.50,
+    0.65,
+    0.80,
+    0.90,
+    0.95,
+    0.98,
+    0.99,
+)
+"""The thirteen quantile levels agreed with NGED for the delivery tables.
+
+Deliberately tail-heavy: NGED is far more interested in the tails than the shoulders. This
+tuple is the single source of truth for every quantile-indexed artefact — the pinball-loss
+``metric_param`` labels today, and the percentile columns of the delivery-table
+representations (Representations 2 and 3) when those land in v0.5.
+"""
+
+
+def quantile_label(quantile: float) -> str:
+    """Return the canonical ``p{level}`` label for a quantile, e.g. ``0.05`` → ``"p5"``.
+
+    The label format matches the percentile column names agreed with NGED for the delivery
+    tables (see ``DELIVERY_QUANTILES``).
+    """
+    return f"p{round(quantile * 100)}"
 
 
 def _get_time_series_id_dtype(**kwargs) -> Any:

--- a/packages/contracts/src/contracts/ml_schemas.py
+++ b/packages/contracts/src/contracts/ml_schemas.py
@@ -7,7 +7,12 @@ from typing_extensions import Self
 
 from contracts.power_schemas import LIST_OF_TIME_SERIES_TYPES
 
-from .common import UTC_DATETIME_DTYPE, _get_time_series_id_dtype
+from .common import (
+    DELIVERY_QUANTILES,
+    UTC_DATETIME_DTYPE,
+    _get_time_series_id_dtype,
+    quantile_label,
+)
 
 _FEATURE_DTYPE = pt.Field(dtype=pl.Float32, allow_missing=True)
 
@@ -189,27 +194,73 @@ implemented by `ml_core.metrics`:
   stop at the 14-day NWP horizon)
 """
 
-METRIC_NAMES: Final[tuple[str, ...]] = ("mae", "nmae", "rmse", "mbe")
+METRIC_NAMES: Final[tuple[str, ...]] = (
+    "mae",
+    "nmae",
+    "rmse",
+    "mbe",
+    "crps",
+    "spread_skill_ratio",
+    "pinball_loss",
+    "mean_pinball_loss",
+    "picp",
+    "interval_width",
+)
 """Metric names currently implemented.
 
+Full definitions, equations, and design rationale:
+https://openclimatefix.github.io/nged-substation-forecast/techniques/evaluation-metrics/
+
+Deterministic (scored on the per-run ensemble mean):
+
 - `"mae"`: mean absolute error (MW)
-- `"nmae"`: normalised MAE (dimensionless; normalised by mean |power|)
+- `"nmae"`: normalised MAE (dimensionless; normalised by full-history effective capacity)
 - `"rmse"`: root mean squared error (MW)
 - `"mbe"`: mean bias error (MW; positive = over-prediction)
 
-Extend as new metrics are added:
+Probabilistic (scored on the ensemble members before the mean collapse):
 
-- ensemble: `"crps"`, `"spread_skill_ratio"`;
-- quantile: `"pinball_loss"`, `"mean_pinball_loss"`;
-- calibration: `"picp"`.
+- `"crps"`: fair (finite-ensemble-unbiased) continuous ranked probability score (MW). The only
+  metric here that is comparable across models with different ensemble sizes.
+- `"spread_skill_ratio"`: Fortin-corrected RMS ensemble spread ÷ RMSE of the ensemble mean
+  (dimensionless; 1.0 = well-calibrated, < 1 = underdispersed/overconfident).
+- `"pinball_loss"`: quantile loss (MW) at the quantile named by `metric_param`.
+- `"mean_pinball_loss"`: unweighted mean of `"pinball_loss"` over the thirteen
+  `DELIVERY_QUANTILES` (MW). Tail-heavy by construction, matching NGED's priorities.
+- `"picp"`: prediction-interval coverage probability of the band named by `metric_param`
+  (dimensionless fraction). The calibrated reference for empirical quantiles from a finite
+  ensemble sits *below* the nominal coverage — e.g. ≈ 0.769, not 0.8, for `p10_p90` at 51
+  members.
+- `"interval_width"`: mean width (MW) of the band named by `metric_param` — the sharpness
+  companion to `"picp"` (coverage is only impressive if the band is also narrow).
 """
 
-METRIC_PARAMS: Final[tuple[str, ...]] = ("all",)
-"""Parameter values for parametric metrics (e.g. Pinball Loss at a specific quantile).
+QUANTILE_METRIC_PARAMS: Final[tuple[str, ...]] = tuple(
+    quantile_label(q) for q in DELIVERY_QUANTILES
+)
+"""`metric_param` labels for quantile-indexed metrics (pinball loss), e.g. `"p1"` … `"p99"`.
 
-- `"all"` is used for all scalar metrics with no extra parameter dimension.
-- When Pinball Loss is added, extend with `"p10"`, `"p20"`, …, `"p90"`.
-- When PICP is added, extend with `"p10_p90"`, `"p20_p80"`, etc.
+Derived from `DELIVERY_QUANTILES` so that evaluation is always scored at exactly the quantile
+levels the product delivers.
+"""
+
+BAND_METRIC_PARAMS: Final[tuple[str, ...]] = tuple(
+    f"{quantile_label(q)}_{quantile_label(1 - q)}" for q in DELIVERY_QUANTILES if q < 0.5
+)
+"""`metric_param` labels for the symmetric prediction-interval bands (PICP, interval width).
+
+One band per symmetric pair of `DELIVERY_QUANTILES`: `"p1_p99"`, `"p2_p98"`, `"p5_p95"`,
+`"p10_p90"`, `"p20_p80"`, `"p35_p65"`. Together they trace a coverage curve from the 30%
+band to the 98% band.
+"""
+
+METRIC_PARAMS: Final[tuple[str, ...]] = ("all", *QUANTILE_METRIC_PARAMS, *BAND_METRIC_PARAMS)
+"""Parameter values for parametric metrics.
+
+- `"all"`: all scalar metrics with no extra parameter dimension (MAE, NMAE, RMSE, MBE, CRPS,
+  spread-skill ratio, mean pinball loss).
+- Quantile labels (`"p1"` … `"p99"`, from `QUANTILE_METRIC_PARAMS`): pinball loss.
+- Band labels (`"p1_p99"` … `"p35_p65"`, from `BAND_METRIC_PARAMS`): PICP and interval width.
 """
 
 EVALUATION_SCOPES: Final[tuple[str, ...]] = ("leaderboard", "production_monitoring", "ad_hoc")
@@ -287,9 +338,9 @@ class Metrics(pt.Model):
         dtype=pl.Enum(METRIC_PARAMS),
         description=(
             "Extra parameter dimension for parametric metrics.  "
-            "'all' for scalar metrics (MAE, RMSE, MBE, NMAE).  "
-            "For Pinball Loss: 'p10', 'p50', etc.  "
-            "For PICP: 'p10_p90', 'p20_p80', etc."
+            "'all' for scalar metrics (MAE, NMAE, RMSE, MBE, CRPS, spread-skill ratio, mean"
+            " pinball loss).  For pinball loss: a DELIVERY_QUANTILES label ('p1' … 'p99').  "
+            "For PICP and interval width: a symmetric band label ('p1_p99' … 'p35_p65')."
         ),
     )
 

--- a/packages/ml_core/src/ml_core/metrics.py
+++ b/packages/ml_core/src/ml_core/metrics.py
@@ -6,7 +6,7 @@ from typing import Final
 
 import patito as pt
 import polars as pl
-from contracts.common import UTC_DATETIME_DTYPE
+from contracts.common import DELIVERY_QUANTILES, UTC_DATETIME_DTYPE, quantile_label
 from contracts.ml_schemas import (
     EVALUATION_SCOPES,
     HORIZON_SLICES,
@@ -69,12 +69,137 @@ def _horizon_slice_expr() -> pl.Expr:
     )
 
 
-def _wide_error_metrics(with_error: pl.LazyFrame, group_keys: list[str]) -> pl.LazyFrame:
-    """Aggregate the ``error`` column into wide MAE/RMSE/MBE rows, one per ``group_keys`` group."""
-    return with_error.group_by(group_keys).agg(
-        mae=pl.col("error").abs().mean(),
-        rmse=(pl.col("error").pow(2).mean()).sqrt(),
-        mbe=pl.col("error").mean(),
+_BAND_LOWER_QUANTILES: Final[tuple[float, ...]] = tuple(q for q in DELIVERY_QUANTILES if q < 0.5)
+"""Lower quantile of each symmetric prediction-interval band scored by PICP/interval width.
+
+Each lower quantile ``q`` pairs with ``1 − q`` to form a band (e.g. 0.1 → the p10–p90 band),
+matching ``contracts.ml_schemas.BAND_METRIC_PARAMS``.
+"""
+
+_MLFLOW_LOGGED_PARAMETRIC: Final[frozenset[tuple[str, str]]] = frozenset(
+    {
+        ("pinball_loss", "p10"),
+        ("pinball_loss", "p50"),
+        ("pinball_loss", "p90"),
+        ("picp", "p10_p90"),
+        ("interval_width", "p10_p90"),
+    }
+)
+"""The parametric ``(metric_name, metric_param)`` pairs logged to MLflow.
+
+Metrics with ``metric_param="all"`` are always logged; parametric metrics are restricted to
+this headline subset to keep the MLflow leaderboard legible (~130 keys instead of ~340). The
+full 13-quantile / 6-band detail is always queryable in the ``forecast_metrics`` Delta table.
+"""
+
+
+def _band_label(lower_quantile: float) -> str:
+    """Return the band ``metric_param`` label for a lower quantile, e.g. ``0.1`` → ``"p10_p90"``."""
+    return f"{quantile_label(lower_quantile)}_{quantile_label(1 - lower_quantile)}"
+
+
+def _quantile_column(quantile: float) -> str:
+    """Name of the per-timestamp empirical-quantile column for ``quantile``, e.g. ``"q_p10"``."""
+    return f"q_{quantile_label(quantile)}"
+
+
+def _fair_crps_expr() -> pl.Expr:
+    """Per-timestamp fair CRPS over the ensemble members of one forecast-run group.
+
+    Evaluated inside the per-run collapse ``group_by``, where each group holds the ``m``
+    members forecasting one ``(time_series_id, power_fcst_init_time, valid_time)``. The fair
+    (finite-ensemble-unbiased, Ferro 2014) form is::
+
+        CRPS = mean_i |x_i − y|  −  Σ_{i<j} |x_i − x_j| / (m(m−1))
+
+    with the pairwise term defined as 0 when ``m = 1`` (so a single-member "ensemble" scores
+    its absolute error, and group means reduce to MAE). The pairwise sum uses the sorted-member
+    identity ``Σ_{i<j}(x_(j) − x_(i)) = Σ_k (2k − m − 1)·x_(k)`` — O(m log m) instead of a
+    member self-join — computed in Float64 because the identity's large cancelling terms (up
+    to ±m·|power|) lose percent-level accuracy in Float32 when members are near-identical.
+
+    See
+    <https://openclimatefix.github.io/nged-substation-forecast/techniques/evaluation-metrics/>
+    for the full rationale.
+    """
+    m = pl.len()
+    members = pl.col("power_fcst").cast(pl.Float64)
+    mean_member_ae = (members - pl.col("power_actual").cast(pl.Float64)).abs().mean()
+    rank = pl.int_range(1, m + 1)
+    pairwise_sum = (members.sort() * (2 * rank - m - 1)).sum()
+    pairwise_mean = pl.when(m > 1).then(pairwise_sum / (m * (m - 1))).otherwise(0.0)
+    return mean_member_ae - pairwise_mean
+
+
+def _corrected_variance_expr() -> pl.Expr:
+    """Per-timestamp Fortin-corrected ensemble variance, ``((m+1)/m)·Var(members)``.
+
+    Evaluated inside the per-run collapse ``group_by``. For a calibrated ensemble the RMSE of
+    the ensemble mean equals ``sqrt((m+1)/m)`` times the RMS ensemble spread (Fortin et
+    al. 2014), so folding the factor in here makes the spread-skill ratio's calibrated target
+    exactly 1.0 at any ensemble size. Uses the sample variance (``ddof=1``), guarded to 0 for
+    single-member groups where ``.var()`` would return null (``metric_value`` is
+    non-nullable, and zero spread is the honest description of a deterministic forecast).
+    """
+    m = pl.len()
+    variance = pl.col("power_fcst").cast(pl.Float64).var()
+    return pl.when(m > 1).then(variance * (m + 1) / m).otherwise(0.0)
+
+
+def _wide_metric_columns() -> list[str]:
+    """Ordered names of the wide metric columns produced by ``_wide_metrics``.
+
+    Parametric metrics encode their ``metric_param`` after a ``":"`` separator (e.g.
+    ``"pinball_loss:p10"``); ``compute_metrics`` splits the encoding apart again after the
+    unpivot to tall format. ``"nmae"`` is absent — it is derived from ``"mae"`` after the
+    capacity join.
+    """
+    columns = ["mae", "rmse", "mbe", "crps", "spread_skill_ratio", "mean_pinball_loss"]
+    columns += [f"pinball_loss:{quantile_label(q)}" for q in DELIVERY_QUANTILES]
+    for lower in _BAND_LOWER_QUANTILES:
+        columns += [f"picp:{_band_label(lower)}", f"interval_width:{_band_label(lower)}"]
+    return columns
+
+
+def _wide_metrics(per_run: pl.LazyFrame, group_keys: list[str]) -> pl.LazyFrame:
+    """Aggregate per-timestamp values into one wide row of metrics per ``group_keys`` group.
+
+    ``per_run`` is the per-forecast-run frame built by ``compute_metrics``: one row per
+    ``(time_series_id, power_fcst_init_time, valid_time)`` carrying the ensemble-mean
+    ``error``, per-timestamp ``crps`` and ``corrected_var``, and the empirical
+    ``DELIVERY_QUANTILES`` columns. Emits the columns listed by ``_wide_metric_columns``.
+    """
+    actual = pl.col("power_actual")
+    aggs: dict[str, pl.Expr] = {
+        "mae": pl.col("error").abs().mean(),
+        "rmse": (pl.col("error").pow(2).mean()).sqrt(),
+        "mbe": pl.col("error").mean(),
+        "crps": pl.col("crps").mean(),
+        # RMS spread, not mean-of-std: Jensen's inequality drags mean-of-std well below the
+        # RMS form whenever spread varies across timestamps, which would fake underdispersion
+        # for a calibrated ensemble. The (m+1)/m factor is already folded into corrected_var.
+        "_rms_spread": pl.col("corrected_var").mean().sqrt(),
+    }
+    for q in DELIVERY_QUANTILES:
+        diff = actual - pl.col(_quantile_column(q))
+        aggs[f"pinball_loss:{quantile_label(q)}"] = (
+            pl.when(diff >= 0).then(diff * q).otherwise(diff * (q - 1)).mean()
+        )
+    for lower in _BAND_LOWER_QUANTILES:
+        low_col = pl.col(_quantile_column(lower))
+        high_col = pl.col(_quantile_column(1 - lower))
+        aggs[f"picp:{_band_label(lower)}"] = actual.is_between(low_col, high_col).mean()
+        aggs[f"interval_width:{_band_label(lower)}"] = (high_col - low_col).mean()
+    return (
+        per_run.group_by(group_keys)
+        .agg(**aggs)
+        .with_columns(
+            spread_skill_ratio=pl.col("_rms_spread") / pl.col("rmse"),
+            mean_pinball_loss=pl.mean_horizontal(
+                [f"pinball_loss:{quantile_label(q)}" for q in DELIVERY_QUANTILES]
+            ),
+        )
+        .drop("_rms_spread")
     )
 
 
@@ -86,17 +211,24 @@ def compute_metrics(
 ) -> pt.DataFrame[Metrics]:
     """Compute evaluation metrics from CV predictions and observed power.
 
+    Full metric definitions, equations, and design rationale:
+    <https://openclimatefix.github.io/nged-substation-forecast/techniques/evaluation-metrics/>
+
     For each ``(time_series_id, fold_id, power_fcst_model_name)`` group:
 
     1. Joins predictions to observed ``power`` on ``(time_series_id, valid_time)``.
     2. Assigns each row a ``horizon_slice`` from its lead time
        (``valid_time − power_fcst_init_time``) — see ``_horizon_slice_expr`` for the bands.
-    3. Averages across ``ensemble_member`` *within each forecast run* (per
-       ``power_fcst_init_time``) to form a deterministic ensemble mean. Each run covering a
-       ``valid_time`` is scored independently, exactly as a production consumer would
-       experience it — runs at different lead times are never pooled.
-    4. Computes MAE, NMAE, RMSE, and MBE per ``horizon_slice``, plus the ``"all"`` aggregate
-       over every lead time.
+    3. Collapses the ensemble members *within each forecast run* (per
+       ``power_fcst_init_time``) into per-timestamp quantities: the deterministic ensemble
+       mean, the fair CRPS, the Fortin-corrected ensemble variance, and the empirical
+       ``DELIVERY_QUANTILES``. Each run covering a ``valid_time`` is scored independently,
+       exactly as a production consumer would experience it — runs at different lead times
+       are never pooled.
+    4. Aggregates per ``horizon_slice``, plus the ``"all"`` aggregate over every lead time:
+       MAE, NMAE, RMSE, and MBE on the ensemble mean; CRPS and the spread-skill ratio from
+       the member-aware quantities; pinball loss at each delivery quantile (plus their
+       mean); and PICP and interval width for each symmetric quantile band.
     5. Joins ``time_series_type`` from ``metadata`` onto each row.
     6. Returns one row per ``(time_series_id, fold_id, power_fcst_model_name,
        horizon_slice, metric_name, metric_param)`` in the tall ``Metrics`` format.
@@ -108,9 +240,10 @@ def compute_metrics(
     upgrade makes capacity time-varying (one row per ``(time_series_id,
     time)``), this join must become a temporal as-of join on ``(time_series_id, valid_time)``.
 
-    Currently only the ``"all"`` metric_param is computed. Parametric metrics
-    (Pinball Loss, PICP) and ensemble metrics (CRPS, spread-skill ratio) can be
-    added here later without changing the schema.
+    Single-member "ensembles" (e.g. a deterministic baseline forecaster) are scored
+    unconditionally: their fair CRPS equals their MAE, their spread-skill ratio is 0, and
+    their quantile bands are degenerate (all quantiles coincide, so PICP ≈ 0 and interval
+    width = 0). Those are honest descriptions of a deterministic forecast, not errors.
 
     Args:
         cv_forecasts: CV predictions to evaluate.
@@ -157,11 +290,17 @@ def compute_metrics(
         how="inner",
     )
 
-    # Average across ensemble members to produce a deterministic ensemble mean per forecast
-    # run: power_fcst_init_time is a group key so that runs covering the same valid_time at
-    # different lead times are scored independently, never pooled into a lagged-ensemble blend.
-    # horizon_slice is constant within a (power_fcst_init_time, valid_time) group.
-    ensemble_mean = (
+    # Collapse the ensemble members of each forecast run into per-timestamp quantities: the
+    # deterministic ensemble mean plus the member-aware values (fair CRPS, Fortin-corrected
+    # variance, empirical delivery quantiles). power_fcst_init_time is a group key so that
+    # runs covering the same valid_time at different lead times are scored independently,
+    # never pooled into a lagged-ensemble blend. horizon_slice is constant within a
+    # (power_fcst_init_time, valid_time) group.
+    quantile_aggs = {
+        _quantile_column(q): pl.col("power_fcst").cast(pl.Float64).quantile(q, "linear")
+        for q in DELIVERY_QUANTILES
+    }
+    per_run = (
         joined.with_columns(horizon_slice=_horizon_slice_expr())
         .group_by(
             [
@@ -176,19 +315,22 @@ def compute_metrics(
             power_fcst=pl.col("power_fcst").mean(),
             power_actual=pl.col("power_actual").first(),
             horizon_slice=pl.col("horizon_slice").first(),
+            crps=_fair_crps_expr(),
+            corrected_var=_corrected_variance_expr(),
+            **quantile_aggs,
         )
     )
 
-    # Compute error column once, reuse in all aggregations.
-    with_error = ensemble_mean.with_columns(error=pl.col("power_fcst") - pl.col("power_actual"))
+    # Compute the ensemble-mean error column once, reuse in all aggregations.
+    with_error = per_run.with_columns(error=pl.col("power_fcst") - pl.col("power_actual"))
 
     # Wide metrics: one row per (time_series_id, fold_id, power_fcst_model_name, horizon_slice),
     # where horizon_slice covers the four lead-time bands plus the "all" aggregate over every
     # lead time.
     base_keys = ["time_series_id", "fold_id", "power_fcst_model_name"]
-    wide_columns = [*base_keys, "horizon_slice", "mae", "rmse", "mbe"]
-    per_slice = _wide_error_metrics(with_error, [*base_keys, "horizon_slice"])
-    all_slice = _wide_error_metrics(with_error, base_keys).with_columns(
+    wide_columns = [*base_keys, "horizon_slice", *_wide_metric_columns()]
+    per_slice = _wide_metrics(with_error, [*base_keys, "horizon_slice"])
+    all_slice = _wide_metrics(with_error, base_keys).with_columns(
         horizon_slice=pl.lit("all").cast(pl.Enum(HORIZON_SLICES))
     )
     metrics_wide = pl.concat([per_slice.select(wide_columns), all_slice.select(wide_columns)])
@@ -210,22 +352,28 @@ def compute_metrics(
         )
     wide = wide.with_columns(nmae=pl.col("mae") / pl.col("effective_capacity_mw"))
 
-    # Pivot to tall format. The leftover effective_capacity_mw column is dropped by the unpivot.
+    # Pivot to tall format, then split the "name:param" encoding of the parametric wide
+    # columns into (metric_name, metric_param); scalar metrics have no separator, so their
+    # split field_1 is null and fills to "all". The leftover effective_capacity_mw column is
+    # dropped by the unpivot.
+    name_parts = pl.col("metric_name").str.split_exact(":", 1)
     metrics_tall = (
         wide.unpivot(
-            on=["mae", "nmae", "rmse", "mbe"],
+            on=[*_wide_metric_columns(), "nmae"],
             index=[*base_keys, "horizon_slice"],
             variable_name="metric_name",
             value_name="metric_value",
         )
+        .with_columns(
+            metric_name=name_parts.struct.field("field_0"),
+            metric_param=name_parts.struct.field("field_1").fill_null("all"),
+        )
         .cast(
             {
                 "metric_name": pl.Enum(METRIC_NAMES),
+                "metric_param": pl.Enum(METRIC_PARAMS),
                 "metric_value": pl.Float32,
             }
-        )
-        .with_columns(
-            metric_param=pl.lit("all").cast(pl.Enum(METRIC_PARAMS)),
         )
     )
 
@@ -255,20 +403,49 @@ def _type_slug(type_str: str) -> str:
     return re.sub(r"[^a-z0-9]+", "_", type_str.lower()).strip("_")
 
 
+def _mlflow_logged_expr() -> pl.Expr:
+    """Predicate selecting the metric rows logged to MLflow.
+
+    Every ``metric_param="all"`` metric is logged; parametric metrics are restricted to the
+    ``_MLFLOW_LOGGED_PARAMETRIC`` headline subset.
+    """
+    logged = pl.col("metric_param") == "all"
+    for name, param in sorted(_MLFLOW_LOGGED_PARAMETRIC):
+        logged = logged | ((pl.col("metric_name") == name) & (pl.col("metric_param") == param))
+    return logged
+
+
+def _metric_key_token_expr() -> pl.Expr:
+    """MLflow key token for a metric row: ``{metric_name}`` or ``{metric_name}_{metric_param}``.
+
+    ``metric_param="all"`` metrics keep the bare name (so the pre-probabilistic key formats
+    are unchanged); parametric metrics append the param, e.g. ``"pinball_loss_p10"``.
+    """
+    name = pl.col("metric_name").cast(pl.String)
+    return (
+        pl.when(pl.col("metric_param") == "all")
+        .then(name)
+        .otherwise(name + "_" + pl.col("metric_param").cast(pl.String))
+    )
+
+
 def build_mlflow_aggregate_metrics(
     metrics_df: pl.DataFrame,
 ) -> dict[str, float]:
     """Return a flat ``{metric_key: value}`` dict for ``mlflow.log_metrics``.
 
     Computes mean ``metric_value`` across all series (``"all"`` aggregate), per
-    ``time_series_type``, and per ``horizon_slice``, restricted to ``metric_param="all"``
-    (the scalar metrics). Key formats:
+    ``time_series_type``, and per ``horizon_slice``. The key token is ``{metric_name}`` for
+    ``metric_param="all"`` metrics and ``{metric_name}_{metric_param}`` for parametric ones
+    (e.g. ``pinball_loss_p10``, ``picp_p10_p90``); parametric metrics are restricted to the
+    ``_MLFLOW_LOGGED_PARAMETRIC`` headline subset. Key formats:
 
-    - ``"{metric_name}__all"`` — overall aggregate (``horizon_slice="all"``).
-    - ``"{metric_name}__{type_slug}"`` — per-type aggregates (``horizon_slice="all"``).
-    - ``"{metric_name}__all__{horizon_slice}"`` — overall aggregate per lead-time band
+    - ``"{token}__all"`` — overall aggregate (``horizon_slice="all"``).
+    - ``"{token}__{type_slug}"`` — per-type aggregates (``horizon_slice="all"``).
+    - ``"{token}__all__{horizon_slice}"`` — overall aggregate per lead-time band
       (e.g. ``"nmae__all__day_ahead"``). Per-type sliced aggregates are deliberately not
-      logged — that detail stays queryable in the ``forecast_metrics`` Delta table.
+      logged — that detail stays queryable in the ``forecast_metrics`` Delta table, as does
+      the full 13-quantile / 6-band parametric detail.
 
     Args:
         metrics_df: Per-series ``Metrics`` rows with ``time_series_type`` populated.
@@ -276,7 +453,10 @@ def build_mlflow_aggregate_metrics(
     Returns:
         Flat dict of MLflow metric key → mean float value.
     """
-    base = metrics_df.filter((pl.col("horizon_slice") == "all") & (pl.col("metric_param") == "all"))
+    logged = metrics_df.filter(_mlflow_logged_expr()).with_columns(
+        metric_key=_metric_key_token_expr()
+    )
+    base = logged.filter(pl.col("horizon_slice") == "all")
 
     result: dict[str, float] = {}
 
@@ -284,26 +464,26 @@ def build_mlflow_aggregate_metrics(
     if "time_series_type" in base.columns:
         per_type = (
             base.filter(pl.col("time_series_type").is_not_null())
-            .group_by(["metric_name", "time_series_type"])
+            .group_by(["metric_key", "time_series_type"])
             .agg(mean_value=pl.col("metric_value").mean())
         )
         for row in per_type.iter_rows(named=True):
-            key = f"{row['metric_name']}__{_type_slug(str(row['time_series_type']))}"
+            key = f"{row['metric_key']}__{_type_slug(str(row['time_series_type']))}"
             result[key] = float(row["mean_value"])
 
     # Overall "all" aggregate (includes all series regardless of type).
-    overall = base.group_by("metric_name").agg(mean_value=pl.col("metric_value").mean())
+    overall = base.group_by("metric_key").agg(mean_value=pl.col("metric_value").mean())
     for row in overall.iter_rows(named=True):
-        result[f"{row['metric_name']}__all"] = float(row["mean_value"])
+        result[f"{row['metric_key']}__all"] = float(row["mean_value"])
 
     # Overall aggregate per lead-time band (includes all series regardless of type).
     per_slice = (
-        metrics_df.filter((pl.col("horizon_slice") != "all") & (pl.col("metric_param") == "all"))
-        .group_by(["metric_name", "horizon_slice"])
+        logged.filter(pl.col("horizon_slice") != "all")
+        .group_by(["metric_key", "horizon_slice"])
         .agg(mean_value=pl.col("metric_value").mean())
     )
     for row in per_slice.iter_rows(named=True):
-        result[f"{row['metric_name']}__all__{row['horizon_slice']}"] = float(row["mean_value"])
+        result[f"{row['metric_key']}__all__{row['horizon_slice']}"] = float(row["mean_value"])
 
     return result
 

--- a/packages/ml_core/src/ml_core/metrics.py
+++ b/packages/ml_core/src/ml_core/metrics.py
@@ -88,8 +88,11 @@ _MLFLOW_LOGGED_PARAMETRIC: Final[frozenset[tuple[str, str]]] = frozenset(
 """The parametric ``(metric_name, metric_param)`` pairs logged to MLflow.
 
 Metrics with ``metric_param="all"`` are always logged; parametric metrics are restricted to
-this headline subset to keep the MLflow leaderboard legible (~130 keys instead of ~340). The
-full 13-quantile / 6-band detail is always queryable in the ``forecast_metrics`` Delta table.
+this headline subset to keep the MLflow leaderboard legible. The key count depends on how
+many distinct ``time_series_type`` values the scored population spans (each adds a per-type
+key family): 132 keys for the V1 trial area's ~6 types, versus ~340 if every parametric
+metric were logged. The full 13-quantile / 6-band detail is always queryable in the
+``forecast_metrics`` Delta table.
 """
 
 
@@ -190,11 +193,20 @@ def _wide_metrics(per_run: pl.LazyFrame, group_keys: list[str]) -> pl.LazyFrame:
         high_col = pl.col(_quantile_column(1 - lower))
         aggs[f"picp:{_band_label(lower)}"] = actual.is_between(low_col, high_col).mean()
         aggs[f"interval_width:{_band_label(lower)}"] = (high_col - low_col).mean()
+    # A perfect forecast group (rmse == 0) with zero spread would score 0/0 = NaN — which is
+    # not null, so it would sail through Metrics.validate and poison every downstream MLflow
+    # mean. Define that corner as 0.0 (consistent with "a deterministic forecast's
+    # spread-skill ratio is 0"). Zero rmse with *positive* spread divides to +inf, which the
+    # finiteness check in compute_metrics turns into a loud error.
+    rmse = pl.col("rmse")
+    rms_spread = pl.col("_rms_spread")
     return (
         per_run.group_by(group_keys)
         .agg(**aggs)
         .with_columns(
-            spread_skill_ratio=pl.col("_rms_spread") / pl.col("rmse"),
+            spread_skill_ratio=pl.when((rmse == 0) & (rms_spread == 0))
+            .then(0.0)
+            .otherwise(rms_spread / rmse),
             mean_pinball_loss=pl.mean_horizontal(
                 [f"pinball_loss:{quantile_label(q)}" for q in DELIVERY_QUANTILES]
             ),
@@ -250,6 +262,8 @@ def compute_metrics(
             Currently only CV fold rows are handled; ``fold_id="live"`` support will
             be added with the ``production_monitoring`` scope in Phase 8.
         actuals: Observed half-hourly power (lazy — only the joined subset is collected).
+            Deduplicated on ``(time_series_id, time)`` before the join — a duplicated actual
+            would otherwise double the ensemble members and corrupt the member-aware metrics.
         metadata: Substation metadata used to join ``time_series_type`` onto each metric row.
             Series absent from ``metadata`` receive a null ``time_series_type``.
         capacity: Pre-computed per-series effective capacity; ``effective_capacity_mw`` is the
@@ -262,8 +276,10 @@ def compute_metrics(
         NoOverlappingActualsError: If no rows survive the inner join (forecasts cover a
             period with no observed data).
         ValueError: If any forecast row has a negative lead time (``valid_time`` before
-            ``power_fcst_init_time`` — an undeliverable hindcast row; see issue #346), or if
-            any scored series has no row in ``capacity``.
+            ``power_fcst_init_time`` — an undeliverable hindcast row; see issue #346), if
+            any scored series has no row in ``capacity``, or if any computed metric value is
+            non-finite (NaN/inf — which ``Metrics.validate`` would otherwise accept, since
+            NaN is not null, and which would poison the MLflow aggregate means).
     """
     # A negative lead time means hindcast rows — valid times already in the past at
     # power_fcst_init_time, which a live forecast could never deliver. Scoring them would
@@ -282,9 +298,15 @@ def compute_metrics(
     # Strip the Patito model subclass from actuals so that Polars' cross-subclass
     # type check (assert_same_type) doesn't reject a join between two differently-typed
     # pt.LazyFrame objects.
+    # Dedupe actuals on the join key: a duplicated (time_series_id, time) row would double
+    # every ensemble member through the join, silently corrupting the member-aware metrics
+    # (CRPS, spread, quantiles) while leaving the deterministic ones — which only see the
+    # mean — untouched. Nothing enforces this uniqueness upstream, so guard it here.
     actuals_plain = pl.LazyFrame._from_pyldf(actuals._ldf)
     joined = cv_forecasts.lazy().join(
-        actuals_plain.select(["time_series_id", "time", "power"]).rename({"power": "power_actual"}),
+        actuals_plain.select(["time_series_id", "time", "power"])
+        .unique(subset=["time_series_id", "time"], keep="any")
+        .rename({"power": "power_actual"}),
         left_on=["time_series_id", "valid_time"],
         right_on=["time_series_id", "time"],
         how="inner",
@@ -381,6 +403,18 @@ def compute_metrics(
         raise NoOverlappingActualsError(
             "No rows in the joined forecast/actuals data. "
             "Check that cv_forecasts and actuals overlap in time."
+        )
+
+    # NaN/inf are not null, so Metrics.validate would accept them — and a single non-finite
+    # value poisons every downstream MLflow mean. Fail loudly instead, naming the offenders.
+    non_finite = metrics_tall.filter(~pl.col("metric_value").is_finite())
+    if not non_finite.is_empty():
+        offenders = non_finite.select(
+            ["time_series_id", "horizon_slice", "metric_name", "metric_param", "metric_value"]
+        )
+        raise ValueError(
+            f"{non_finite.height} metric row(s) have a non-finite metric_value, which would "
+            f"silently poison the MLflow aggregate means. First offenders:\n{offenders.head(10)}"
         )
 
     # Join time_series_type from metadata (left — keeps all metric rows; unmatched → null).

--- a/packages/ml_core/tests/test_metrics.py
+++ b/packages/ml_core/tests/test_metrics.py
@@ -261,7 +261,9 @@ def test_compute_metrics_per_series_batching_is_equivalent():
         ]
     )
 
-    sort_keys = ["time_series_id", "horizon_slice", "metric_name"]
+    # metric_param must be a sort key: each group has 13 pinball_loss rows (one per
+    # quantile), so sorting by metric_name alone leaves ties in non-deterministic order.
+    sort_keys = ["time_series_id", "horizon_slice", "metric_name", "metric_param"]
     assert whole.sort(sort_keys).equals(batched.sort(sort_keys))
 
 
@@ -389,6 +391,193 @@ def test_power_forecast_contract_rejects_hindcast_rows():
 
 
 # ---------------------------------------------------------------------------
+# probabilistic-metric tests
+# ---------------------------------------------------------------------------
+
+
+def _make_ensemble_forecasts(
+    time_series_id: int,
+    times: list[datetime],
+    member_values: list[list[float]],
+    init_times: list[datetime] | None = None,
+) -> pt.DataFrame[PowerForecast]:
+    """Build forecasts with one row per (valid_time, ensemble_member).
+
+    ``member_values[i]`` lists the ensemble-member forecasts for ``times[i]``. Two rows with
+    the same ``valid_time`` but different ``init_times`` entries form two separate forecast
+    runs, each with its own members.
+    """
+    if init_times is None:
+        init_times = [_utc(2021, 12, 31, 23, 30)] * len(times)
+    valid_times: list[datetime] = []
+    run_init_times: list[datetime] = []
+    members: list[int] = []
+    values: list[float] = []
+    for valid_time, init_time, run_members in zip(times, init_times, member_values, strict=True):
+        for member, value in enumerate(run_members):
+            valid_times.append(valid_time)
+            run_init_times.append(init_time)
+            members.append(member)
+            values.append(value)
+    n = len(values)
+    df = pl.DataFrame(
+        {
+            "time_series_id": pl.Series([time_series_id] * n, dtype=pl.Int32),
+            "valid_time": pl.Series(valid_times, dtype=pl.Datetime("us", "UTC")),
+            "power_fcst_init_time": pl.Series(run_init_times, dtype=pl.Datetime("us", "UTC")),
+            "ensemble_member": pl.Series(members, dtype=pl.Int8),
+            "nwp_init_time": pl.Series([None] * n, dtype=pl.Datetime("us", "UTC")),
+            "power_fcst": pl.Series(values, dtype=pl.Float32),
+            "power_fcst_model_name": pl.Series(["stub"] * n, dtype=pl.String),
+            "power_fcst_model_version": pl.Series([1] * n, dtype=pl.Int16),
+            "ml_flow_experiment_id": pl.Series([None] * n, dtype=pl.Int32),
+            "experiment_name": pl.Series(["stub_exp"] * n, dtype=pl.String),
+            "fold_id": pl.Series(["2022"] * n, dtype=pl.String),
+        }
+    )
+    return PowerForecast.validate(df, allow_superfluous_columns=True)
+
+
+def _metric_value(
+    result: pl.DataFrame,
+    metric_name: str,
+    horizon_slice: str = "all",
+    metric_param: str = "all",
+) -> float:
+    """Extract the single value of one (metric_name, horizon_slice, metric_param) row."""
+    rows = result.filter(
+        (pl.col("metric_name") == metric_name)
+        & (pl.col("horizon_slice") == horizon_slice)
+        & (pl.col("metric_param") == metric_param)
+    )
+    assert rows.height == 1
+    return float(rows["metric_value"][0])
+
+
+def test_compute_metrics_probabilistic_three_member_toy():
+    """Every probabilistic metric matches hand computation on a 3-member toy ensemble.
+
+    Members [1, 2, 4] forecast an actual of 2.5 (one timestamp, one run, m = 3):
+
+    - Fair CRPS = mean|xᵢ − y| − Σᵢ<ⱼ|xᵢ − xⱼ| / (m(m−1))
+      = (1.5 + 0.5 + 1.5)/3 − (1 + 3 + 2)/6 = 7/6 − 1 = 1/6.
+    - Ensemble mean = 7/3 → error = 7/3 − 2.5 = −1/6, so RMSE = 1/6. Sample variance
+      (ddof=1) = 7/3; Fortin-corrected variance = (m+1)/m · 7/3 = 28/9;
+      spread_skill_ratio = √(28/9) / (1/6) = 6·√(28/9).
+    - Linear empirical quantiles interpolate at position (m−1)·τ: p10 → 1.2, p50 → 2,
+      p90 → 3.6, p99 → 3.96.
+    - Pinball loss (y = 2.5): p10 → 0.1·1.3 = 0.13; p50 → 0.5·0.5 = 0.25;
+      p90 → 0.1·1.1 = 0.11; p99 → 0.01·1.46 = 0.0146.
+    - p10–p90 band = [1.2, 3.6] contains 2.5 → PICP = 1.0, interval width = 2.4.
+    """
+    times = [_utc(2022, 1, 1, 0, 0)]
+    actuals = _make_actuals(1, times, [2.5])
+    forecasts = _make_ensemble_forecasts(1, times, [[1.0, 2.0, 4.0]])
+    result = compute_metrics(forecasts, actuals, _make_metadata([1]), _make_capacity([1], [10.0]))
+
+    assert math.isclose(_metric_value(result, "crps"), 1.0 / 6.0, rel_tol=1e-5)
+    assert math.isclose(
+        _metric_value(result, "spread_skill_ratio"), 6.0 * math.sqrt(28.0 / 9.0), rel_tol=1e-5
+    )
+    assert math.isclose(
+        _metric_value(result, "pinball_loss", metric_param="p10"), 0.13, rel_tol=1e-5
+    )
+    assert math.isclose(
+        _metric_value(result, "pinball_loss", metric_param="p50"), 0.25, rel_tol=1e-5
+    )
+    assert math.isclose(
+        _metric_value(result, "pinball_loss", metric_param="p90"), 0.11, rel_tol=1e-5
+    )
+    assert math.isclose(
+        _metric_value(result, "pinball_loss", metric_param="p99"), 0.0146, rel_tol=1e-4
+    )
+    assert math.isclose(_metric_value(result, "picp", metric_param="p10_p90"), 1.0, rel_tol=1e-5)
+    assert math.isclose(
+        _metric_value(result, "interval_width", metric_param="p10_p90"), 2.4, rel_tol=1e-5
+    )
+    # mean_pinball_loss is the unweighted mean over all 13 delivery quantiles.
+    pinball_rows = result.filter(
+        (pl.col("metric_name") == "pinball_loss") & (pl.col("horizon_slice") == "all")
+    )
+    assert pinball_rows.height == 13
+    mean_of_quantile_pinballs = pinball_rows["metric_value"].mean()
+    assert isinstance(mean_of_quantile_pinballs, float)
+    assert math.isclose(
+        _metric_value(result, "mean_pinball_loss"), mean_of_quantile_pinballs, rel_tol=1e-5
+    )
+    # Pinball loss is non-negative at every quantile.
+    assert (pinball_rows["metric_value"] >= 0).all()
+
+
+def test_compute_metrics_single_member_ensemble_degenerates_gracefully():
+    """A deterministic (single-member) forecast is scored honestly, with no null values.
+
+    Fair CRPS reduces to MAE (the pairwise term is defined as 0 at m = 1), the spread-skill
+    ratio is 0 (zero spread, not null — ``.var(ddof=1)`` alone would return null), every
+    quantile coincides with the forecast so interval widths are 0, and PICP is 0 whenever the
+    actual differs from the forecast.
+    """
+    times = [_utc(2022, 1, 1, 0, 0), _utc(2022, 1, 1, 0, 30)]
+    actuals = _make_actuals(1, times, [10.0, 10.0])
+    forecasts = _make_cv_forecasts(1, times, [12.0, 8.0])  # single member; MAE = 2
+    result = compute_metrics(forecasts, actuals, _make_metadata([1]), _make_capacity([1], [10.0]))
+
+    assert result["metric_value"].is_not_null().all()
+    assert math.isclose(_metric_value(result, "crps"), _metric_value(result, "mae"), rel_tol=1e-6)
+    assert _metric_value(result, "spread_skill_ratio") == 0.0
+    assert _metric_value(result, "interval_width", metric_param="p10_p90") == 0.0
+    assert _metric_value(result, "picp", metric_param="p10_p90") == 0.0
+
+
+def test_compute_metrics_fair_crps_handles_duplicate_members():
+    """The sorted-member pairwise identity is exact when members tie.
+
+    Members [2, 2, 5], actual 3.5: CRPS = (1.5 + 1.5 + 1.5)/3 − (0 + 3 + 3)/6 = 1.5 − 1 = 0.5.
+    """
+    times = [_utc(2022, 1, 1, 0, 0)]
+    actuals = _make_actuals(1, times, [3.5])
+    forecasts = _make_ensemble_forecasts(1, times, [[2.0, 2.0, 5.0]])
+    result = compute_metrics(forecasts, actuals, _make_metadata([1]), _make_capacity([1], [10.0]))
+    assert math.isclose(_metric_value(result, "crps"), 0.5, rel_tol=1e-5)
+
+
+def test_compute_metrics_crps_scored_per_forecast_run():
+    """CRPS pools members within a run, never across runs covering the same valid_time.
+
+    Two 2-member runs forecast the same valid_time (actual 10): members [7, 9] give
+    CRPS = (3 + 1)/2 − 2/2 = 1, and members [11, 13] likewise give 1, so per-run scoring
+    averages to 1. Pooling all four members into one lagged ensemble would instead give
+    (3 + 1 + 1 + 3)/4 − 20/12 = 1/3.
+    """
+    valid_time = _utc(2022, 1, 2)
+    init_times = [_utc(2022, 1, 1, 0), _utc(2022, 1, 1, 6)]  # leads 24 h and 18 h: day_ahead
+    actuals = _make_actuals(1, [valid_time], [10.0])
+    forecasts = _make_ensemble_forecasts(
+        1, [valid_time, valid_time], [[7.0, 9.0], [11.0, 13.0]], init_times=init_times
+    )
+    result = compute_metrics(forecasts, actuals, _make_metadata([1]), _make_capacity([1], [10.0]))
+    assert math.isclose(_metric_value(result, "crps"), 1.0, rel_tol=1e-5)
+
+
+def test_compute_metrics_probabilistic_metrics_per_slice():
+    """Probabilistic metrics are aggregated per horizon slice, with "all" as the row mean.
+
+    One run: an intraday timestamp with members [7, 9] (CRPS 1) and a day_ahead timestamp
+    with members [4, 8] (CRPS = (6 + 2)/2 − 4/2 = 2), both against an actual of 10.
+    """
+    init_time = _utc(2022, 1, 1)
+    times = [init_time + timedelta(hours=0.5), init_time + timedelta(hours=24)]
+    actuals = _make_actuals(1, times, [10.0, 10.0])
+    forecasts = _make_ensemble_forecasts(
+        1, times, [[7.0, 9.0], [4.0, 8.0]], init_times=[init_time] * 2
+    )
+    result = compute_metrics(forecasts, actuals, _make_metadata([1]), _make_capacity([1], [10.0]))
+    assert math.isclose(_metric_value(result, "crps", horizon_slice="intraday"), 1.0, rel_tol=1e-5)
+    assert math.isclose(_metric_value(result, "crps", horizon_slice="day_ahead"), 2.0, rel_tol=1e-5)
+    assert math.isclose(_metric_value(result, "crps"), 1.5, rel_tol=1e-5)
+
+
+# ---------------------------------------------------------------------------
 # build_mlflow_aggregate_metrics tests
 # ---------------------------------------------------------------------------
 
@@ -511,3 +700,63 @@ def test_build_mlflow_aggregate_metrics_null_type_excluded_from_per_type():
     assert all("__none" not in k and "null" not in k for k in result)
     # "all" includes both series
     assert math.isclose(result["rmse__all"], 3.0, rel_tol=1e-5)
+
+
+def _parametric_metrics_row(
+    metric_name: str,
+    metric_param: str,
+    metric_value: float,
+    horizon_slice: str = "all",
+    time_series_id: int = 1,
+    time_series_type: str = "PV",
+) -> dict[str, object]:
+    """One Metrics-shaped row for parametric-key MLflow tests."""
+    return {
+        "time_series_id": time_series_id,
+        "metric_name": metric_name,
+        "metric_value": metric_value,
+        "time_series_type": time_series_type,
+        "horizon_slice": horizon_slice,
+        "metric_param": metric_param,
+    }
+
+
+def test_build_mlflow_aggregate_metrics_parametric_key_tokens():
+    """Parametric metrics use {name}_{param} key tokens, restricted to the headline allowlist.
+
+    metric_param="all" metrics keep the bare-name token (existing key formats unchanged);
+    pinball_loss is logged at p10/p50/p90 only and picp/interval_width at p10_p90 only —
+    the full 13-quantile / 6-band detail stays in the Delta table.
+    """
+    rows = [
+        _parametric_metrics_row("crps", "all", 1.5),
+        _parametric_metrics_row("pinball_loss", "p10", 2.0),
+        _parametric_metrics_row("pinball_loss", "p1", 3.0),  # not in the allowlist
+        _parametric_metrics_row("picp", "p10_p90", 0.7),
+        _parametric_metrics_row("picp", "p5_p95", 0.8),  # not in the allowlist
+        _parametric_metrics_row("interval_width", "p10_p90", 5.0),
+    ]
+    df = pl.DataFrame(rows).cast({"time_series_id": pl.Int32, "metric_value": pl.Float32})
+    result = build_mlflow_aggregate_metrics(df)
+
+    assert math.isclose(result["crps__all"], 1.5, rel_tol=1e-5)
+    assert math.isclose(result["pinball_loss_p10__all"], 2.0, rel_tol=1e-5)
+    assert math.isclose(result["picp_p10_p90__all"], 0.7, rel_tol=1e-5)
+    assert math.isclose(result["interval_width_p10_p90__all"], 5.0, rel_tol=1e-5)
+    # The allowlist also applies to the per-type key family.
+    assert math.isclose(result["pinball_loss_p10__pv"], 2.0, rel_tol=1e-5)
+    # Non-allowlisted params are absent from every key family.
+    assert not any(key.startswith("pinball_loss_p1_") for key in result)
+    assert not any(key.startswith("picp_p5_p95") for key in result)
+
+
+def test_build_mlflow_aggregate_metrics_parametric_sliced_keys():
+    """Allowlisted parametric metrics get per-slice keys; non-allowlisted ones do not."""
+    rows = [
+        _parametric_metrics_row("pinball_loss", "p10", 2.0, horizon_slice="day_ahead"),
+        _parametric_metrics_row("pinball_loss", "p1", 3.0, horizon_slice="day_ahead"),
+    ]
+    df = pl.DataFrame(rows).cast({"time_series_id": pl.Int32, "metric_value": pl.Float32})
+    result = build_mlflow_aggregate_metrics(df)
+    assert math.isclose(result["pinball_loss_p10__all__day_ahead"], 2.0, rel_tol=1e-5)
+    assert not any(key.startswith("pinball_loss_p1_") for key in result)

--- a/packages/ml_core/tests/test_metrics.py
+++ b/packages/ml_core/tests/test_metrics.py
@@ -7,6 +7,7 @@ import patito as pt
 import polars as pl
 import pytest
 from contracts.ml_schemas import Metrics
+from polars.testing import assert_frame_equal
 from contracts.power_schemas import (
     LIST_OF_TIME_SERIES_TYPES,
     EffectiveCapacity,
@@ -180,10 +181,15 @@ def test_compute_metrics_raises_when_series_missing_capacity():
 
 
 def test_compute_metrics_ensemble_averaging():
-    """Ensemble mean should be taken before computing metrics."""
+    """Ensemble mean should be taken before computing the deterministic metrics.
+
+    Members 8 and 12 against an actual of 11: the ensemble mean is 10, so MAE = 1 — whereas
+    scoring the members individually would give (3 + 1)/2 = 2. (The actual deliberately
+    differs from the ensemble mean: an exact hit with positive spread is the contradictory
+    zero-RMSE corner that ``compute_metrics`` rejects as non-finite.)
+    """
     time = _utc(2022, 1, 1, 0, 0)
     init_time = _utc(2021, 12, 31, 23, 30)
-    # Two ensemble members: forecasts 8 and 12 → ensemble mean = 10 → error = 0
     df = pl.DataFrame(
         {
             "time_series_id": pl.Series([1, 1], dtype=pl.Int32),
@@ -202,10 +208,10 @@ def test_compute_metrics_ensemble_averaging():
         }
     )
     forecasts = PowerForecast.validate(df, allow_superfluous_columns=True)
-    actuals = _make_actuals(1, [time], [10.0])
+    actuals = _make_actuals(1, [time], [11.0])
     result = compute_metrics(forecasts, actuals, _make_metadata([1]), _make_capacity([1], [10.0]))
     mae_row = result.filter(pl.col("metric_name") == "mae")
-    assert math.isclose(mae_row["metric_value"][0], 0.0, abs_tol=1e-5)
+    assert math.isclose(mae_row["metric_value"][0], 1.0, abs_tol=1e-5)
 
 
 def test_compute_metrics_multiple_folds():
@@ -527,6 +533,56 @@ def test_compute_metrics_single_member_ensemble_degenerates_gracefully():
     assert _metric_value(result, "spread_skill_ratio") == 0.0
     assert _metric_value(result, "interval_width", metric_param="p10_p90") == 0.0
     assert _metric_value(result, "picp", metric_param="p10_p90") == 0.0
+
+
+def test_compute_metrics_perfect_forecast_scores_finite_zero_spread_skill():
+    """A perfect deterministic forecast (RMSE = 0, spread = 0) scores 0, never NaN.
+
+    The unguarded ratio would be 0/0 = NaN — which is not null, so it would pass
+    ``Metrics.validate`` and silently poison every downstream MLflow mean. Realistically
+    reachable: a persistence baseline forecasting a flat series.
+    """
+    times = [_utc(2022, 1, 1, 0, 0), _utc(2022, 1, 1, 0, 30)]
+    actuals = _make_actuals(1, times, [10.0, 10.0])
+    forecasts = _make_cv_forecasts(1, times, [10.0, 10.0])  # exact hit at every timestamp
+    result = compute_metrics(forecasts, actuals, _make_metadata([1]), _make_capacity([1], [10.0]))
+
+    assert _metric_value(result, "spread_skill_ratio") == 0.0
+    assert result["metric_value"].is_finite().all()
+
+
+def test_compute_metrics_zero_rmse_with_positive_spread_raises():
+    """Positive spread around an error-free ensemble mean fails loudly, not as inf.
+
+    Members [8, 12] against an actual of 10: the ensemble mean is exact (RMSE = 0) but the
+    spread is positive, so the spread-skill ratio divides to infinity — the finiteness check
+    must refuse to emit it.
+    """
+    times = [_utc(2022, 1, 1, 0, 0)]
+    actuals = _make_actuals(1, times, [10.0])
+    forecasts = _make_ensemble_forecasts(1, times, [[8.0, 12.0]])
+    with pytest.raises(ValueError, match="non-finite"):
+        compute_metrics(forecasts, actuals, _make_metadata([1]), _make_capacity([1], [10.0]))
+
+
+def test_compute_metrics_deduplicates_actuals():
+    """A duplicated (time_series_id, time) actuals row leaves every metric unchanged.
+
+    Without the dedupe, the join would double the ensemble members — doubling m and silently
+    corrupting the member-aware metrics (CRPS, spread, quantiles) while the deterministic
+    ones, which only see the mean, stay untouched.
+    """
+    times = [_utc(2022, 1, 1, 0, 0)]
+    forecasts = _make_ensemble_forecasts(1, times, [[1.0, 2.0, 4.0]])
+    metadata, capacity = _make_metadata([1]), _make_capacity([1], [10.0])
+
+    clean = compute_metrics(forecasts, _make_actuals(1, times, [2.5]), metadata, capacity)
+    duplicated = compute_metrics(
+        forecasts, _make_actuals(1, times * 2, [2.5, 2.5]), metadata, capacity
+    )
+
+    sort_keys = ["horizon_slice", "metric_name", "metric_param"]
+    assert_frame_equal(clean.sort(sort_keys), duplicated.sort(sort_keys))
 
 
 def test_compute_metrics_fair_crps_handles_duplicate_members():

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -895,10 +895,12 @@ def _score_forecast_group(
 def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     """Compute evaluation metrics and write to ``forecast_metrics``.
 
-    Reads the filtered ``power_forecasts`` Delta, joins observed power, computes MAE/NMAE/RMSE/MBE
-    per series (via ``compute_metrics()``), enriches each row with scope and evaluation-window
-    provenance, and writes to the ``forecast_metrics`` Delta table partitioned by
-    ``(experiment_name, fold_id)``.
+    Reads the filtered ``power_forecasts`` Delta, joins observed power, computes the
+    deterministic and probabilistic metrics per series and horizon slice (via
+    ``compute_metrics()`` — see
+    <https://openclimatefix.github.io/nged-substation-forecast/techniques/evaluation-metrics/>),
+    enriches each row with scope and evaluation-window provenance, and writes to the
+    ``forecast_metrics`` Delta table partitioned by ``(experiment_name, fold_id)``.
 
     For ``evaluation_scope="leaderboard"``, also logs per-type + overall aggregate metrics to each
     fold's MLflow child run and the mean-across-folds aggregates to the experiment's parent run.

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -532,12 +532,23 @@ def test_score_forecast_group_per_series_batches(
     )
     assert n_rows == expected.height
 
-    compare_cols = ["time_series_id", "horizon_slice", "metric_name", "metric_value"]
-    sort_keys = ["time_series_id", "horizon_slice", "metric_name"]
+    # metric_param must be in both the sort keys and the compared columns: each group has 13
+    # pinball_loss rows (one per quantile), so without it tied metric_name rows sort
+    # non-deterministically and a p10 value could be compared against a p90 row.
+    compare_cols = [
+        "time_series_id",
+        "horizon_slice",
+        "metric_name",
+        "metric_param",
+        "metric_value",
+    ]
+    sort_keys = ["time_series_id", "horizon_slice", "metric_name", "metric_param"]
     # Delta stores the Enum columns as String, so compare in String space. Expression casts
     # (not a {column: dtype} dict-cast) because `expected` is a model-bearing Patito frame.
     expected_str = expected.select(compare_cols).with_columns(
-        pl.col("horizon_slice").cast(pl.String), pl.col("metric_name").cast(pl.String)
+        pl.col("horizon_slice").cast(pl.String),
+        pl.col("metric_name").cast(pl.String),
+        pl.col("metric_param").cast(pl.String),
     )
     assert written.select(compare_cols).sort(sort_keys).equals(expected_str.sort(sort_keys))
 


### PR DESCRIPTION
Part of #225 — **Phase B: probabilistic metrics from the existing ensemble**. Do not close #225 on merge (Phases C and D remain).

## What this adds

`compute_metrics` now computes member-aware metrics from the ensemble *before* the per-run mean collapse, per horizon slice, alongside the existing deterministic metrics (whose values are unchanged — verified bit-identical on real data, see below):

- **Fair CRPS** (Ferro 2014, `1/(m(m−1))` divisor) — computed via the sorted-member identity (`O(m log m)`, no member self-join) in Float64, with the pairwise term defined as 0 at `m = 1` so a deterministic forecast's CRPS equals its MAE exactly. The only metric that is comparable across ensemble sizes — this matters for the future 13-member `nged_incumbent` comparison (#147).
- **Spread-skill ratio** — Fortin-corrected RMS spread ÷ RMSE of the ensemble mean, so the calibrated target is exactly 1.0 at any ensemble size. RMS spread (not mean-of-stddev, which Jensen's inequality biases to ~0.80 for a calibrated heteroscedastic ensemble) and the `(m+1)/m` factor are deliberate deviations from the roadmap sketch; rationale in the new docs page.
- **Pinball loss at the thirteen NGED delivery quantiles** (p1 … p99; single source of truth `contracts.common.DELIVERY_QUANTILES`, which Phase D's Representation 2/3 schemas will reuse), plus **`mean_pinball_loss`** — deliberately tail-weighted, matching NGED's priorities.
- **PICP and interval width** for the six symmetric delivery bands (p1–p99 … p35–p65) — a coverage curve plus its sharpness companion. PICP is judged against the finite-ensemble calibrated reference (≈ 0.769 for p10–p90 at 51 members), not the nominal rate.

MLflow keys: parametric metrics get a `{metric_name}_{metric_param}` token (e.g. `pinball_loss_p10__all__day_ahead`); every pre-existing key format is byte-identical. To keep the leaderboard legible, parametric metrics are restricted in MLflow to a headline allowlist (`pinball_loss` p10/p50/p90; `picp`/`interval_width` p10_p90) — the full 13-quantile / 6-band detail is always in the `forecast_metrics` Delta table. No production-logic changes in `cv_assets.py` (the fold averaging and Delta write paths are key-generic).

**New durable docs page: [Evaluation metrics](https://openclimatefix.github.io/nged-substation-forecast/techniques/evaluation-metrics/)** — every metric with a plain-language summary ("MW; smaller is better" level), the equation, interpretation guidance, and the rationale for each design decision.

## Design provenance

The plan was adversarially reviewed by a clean-context agent before implementation; its two substantive findings (RMS spread instead of mean-of-stddev; the null single-member `ens_std` guard) are incorporated, as are two suggestions from the community comment on #225 (the Fortin `√((m+1)/m)` factor and pairing PICP with a sharpness measure — adopted as `interval_width`). The rank/Talagrand histogram suggestion is deliberately *not* a stored metric (a histogram doesn't fit the tall schema); it is computed in the verification below and noted on the roadmap as an input to the Phase C calibration decision.

## Verification on real data (`xgboost_cv_0001` / `mid_2025_to_mid_2026`)

Scored in the same per-series batches as the `metrics` asset, no writes:

- **Deterministic values bit-identical**: all 560 `(time_series_id, horizon_slice, metric_name)` rows match the existing Delta partition exactly, 0 mismatches.
- **Per-slice signature** (unweighted means across the 28 series). The expected underdispersion is confirmed, and it is severe — spread-skill ≈ 0.10–0.14 against a calibrated target of 1.0, worst at intraday exactly as predicted; CRPS beats MAE by only ~4–6%, consistent with a fan far too thin to add value:

| slice | nmae | mae | crps | spread-skill | picp p10–p90 | width p10–p90 (MW) |
|---|---|---|---|---|---|---|
| intraday | 0.1305 | 7.209 | 6.843 | **0.098** | 0.073 | 1.785 |
| day_ahead | 0.1240 | 7.132 | 6.700 | 0.120 | 0.087 | 2.142 |
| short_medium_range | 0.1223 | 7.191 | 6.692 | 0.138 | 0.107 | 2.456 |
| extended_range | 0.1332 | 7.659 | 7.161 | 0.121 | 0.106 | 2.377 |
| all | 0.1284 | 7.433 | 6.942 | 0.127 | 0.104 | 2.377 |

- **Coverage curve** (horizon = all; reference = finite-ensemble calibrated coverage at m = 51):

| band | PICP | calibrated ref | nominal |
|---|---|---|---|
| p1–p99 | 0.174 | 0.942 | 0.98 |
| p2–p98 | 0.157 | 0.923 | 0.96 |
| p5–p95 | 0.131 | 0.865 | 0.90 |
| p10–p90 | 0.104 | 0.769 | 0.80 |
| p20–p80 | 0.070 | 0.577 | 0.60 |
| p35–p65 | 0.032 | 0.288 | 0.30 |

- **Talagrand rank histograms** (13 condensed bins of 4 ranks; uniform = 7.7% per bin): an extreme U at every horizon. The two outermost bins hold 87–91% of observations (uniform: 15.4%) — ~44% of observations fall **below every member** and ~47% **above every member**, i.e. the observation escapes the entire 51-member envelope on roughly 9 in 10 half-hours. The U is symmetric with no strong slope, which supports Phase C's simple multiplicative inflation as the first calibration attempt (though inflation factors implied by spread-skill ≈ 0.1 are large — the Phase D quantile pipeline is clearly needed).

```text
intraday             [44.0  1.1  0.8  0.7  0.6  0.6  0.6  0.6  0.6  0.8  0.9  1.2  47.3]%
day_ahead            [41.9  1.3  1.0  0.8  0.8  0.7  0.7  0.7  0.8  0.9  1.1  1.6  47.7]%
short_medium_range   [40.5  1.6  1.1  1.0  0.9  0.9  0.8  0.9  1.0  1.1  1.3  1.9  47.0]%
extended_range       [40.1  1.7  1.2  1.0  0.9  0.8  0.8  0.8  0.9  1.0  1.3  1.9  47.4]%
```

- **Runtime / memory**: 84 s, 18.6 GB peak RSS for the whole fold including the rank-histogram pass (previous deterministic-only asset run: 42 s, 14.6 GB peak; the documented batch-size measurement was ~50 s, ~18 GB) — the sorted-identity CRPS stays comfortably inside the per-batch memory budget.
- **MLflow key count**: 132, as designed.

## Ship-time triage (done in this PR)

- Roadmap metric table flipped to ✅ (with links into the new reference page); Phase B section replaced by a shipped summary; "Implementation details — probabilistic metrics" section deleted (content preserved above); rank-histogram note added to Phase C.
- Stale metric lists updated in `docs/roadmap/index.md`, `docs/ml_experimentation/dagster-workflow.md` (Step 8 + MLflow key tree), `docs/techniques/probabilistic-forecasting.md`, and the `metrics` asset docstring.

Deleted roadmap "Implementation details" section (verbatim):

> Verification: (1) unit tests in `packages/ml_core/tests/` with hand-computable fixtures — a 3-member toy ensemble where PICP, spread-skill, pinball, and CRPS are worked out by hand. (2) Property check: CRPS of a single-member "ensemble" equals MAE. (3) Re-score an existing experiment via the `metrics` asset (`ad_hoc` scope) and eyeball that spread-skill ≪ 1 at short horizons — the expected signature of the finding.

All three verification items were done (the third against the real fold, above).

## After merge

Re-materialise leaderboard metrics for `xgboost_cv_0001` so Delta/MLflow gain the probabilistic rows and keys — deterministic values will not move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
