### PR TITLE
Document long-horizon attenuation and add a probabilistic climatology baseline

### DIFF
--- a/docs/roadmap/metrics-and-leaderboard.md
+++ b/docs/roadmap/metrics-and-leaderboard.md
@@ -220,6 +220,11 @@ seasonal/time-of-day distribution of power, with no recency and no weather, whic
   Only a quantile/ensemble climatology answers that, via `crps__all__extended_range` head-to-head
   against the ML models. Like `nged_incumbent`, this baseline owns its own member axis (see the
   `uses_nwp_ensemble` flag in item 5) — it must not be broadcast across the 51 NWP members.
+- **Follow-up once this ships:** overlay the climatology forecast as an always-on reference band
+  in the `view_forecasts` dashboard, so the weather-driven fan can be read against the
+  calendar-only skill floor by eye — the visual twin of the `crps__all__extended_range`
+  comparison above ([#354](https://github.com/openclimatefix/nged-substation-forecast/issues/354),
+  blocked by this work).
 
 **5. Configs and registration.**
 

--- a/docs/roadmap/metrics-and-leaderboard.md
+++ b/docs/roadmap/metrics-and-leaderboard.md
@@ -190,17 +190,36 @@ machinery instead of writing any new time-series logic:
 - Rows where all lags are null (long horizons + data gaps): drop those rows from the output
   (`PowerForecast.power_fcst` presumably non-nullable — check) and log the dropped count.
 
-**4. `ClimatologyForecaster` — diagnostic bookend.**
+**4. `ClimatologyForecaster` — diagnostic bookend, and our *pure* probabilistic climatology
+reference.** `nged_incumbent` is also probabilistic and weather-free, but it is a hybrid —
+persistence-like weekly recency plus climatology-like annual seasonality — so it does not
+isolate the calendar-only distribution. This baseline does: its spread is the unconditional
+seasonal/time-of-day distribution of power, with no recency and no weather, which is exactly the
+"skill floor" the NWP ensemble has to clear at long horizons.
 
-- `train()`: collect `(time_series_id, valid_time, power)` from the features frame and build a
-  lookup table of mean power per `(time_series_id, month, half-hour-of-day, is_weekend)` over
-  the training window. Store as a small Polars frame; `save` writes it as one parquet +
-  `meta.json`.
-- `predict()`: join the lookup onto the prediction rows by the same keys.
+- `train()`: collect `(time_series_id, valid_time, power)` from the features frame and, per
+  `(time_series_id, month, half-hour-of-day, is_weekend)` cell, store the **empirical quantiles**
+  of that cell's training-window power samples at the thirteen NGED delivery quantile levels
+  (`contracts.common.DELIVERY_QUANTILES`) — not just the mean. Store as a small Polars frame;
+  `save` writes it as one parquet + `meta.json`.
+- `predict()`: join the lookup onto the prediction rows by the same keys, then unpivot the
+  thirteen quantile columns into `ensemble_member` rows (member index = quantile index) — the
+  same shape `nged_incumbent` uses. The headline deterministic point forecast is the **median**
+  (the p50 quantile column).
 - `selected_features` needs only the target join — reuse existing time features
   (`local_time_of_day_*` etc.) or derive month/half-hour directly from `valid_time` inside the
   forecaster; prefer deriving directly to keep the feature list empty.
 - `MODEL_NAME = "climatology"`, `MODEL_VERSION = 1`.
+- **Why a distribution, not a mean:** a deterministic climatology forecast collapses CRPS to
+  MAE, so it can only ever be compared against the ML ensemble on point accuracy — exactly the
+  axis a squared-error XGBoost is built to win. The claim we actually need to test is
+  distributional: does the 51-member NWP-driven ensemble know more about day 8–14 power than the
+  plain seasonal/time-of-day distribution does, or is it just dressing up climatology in
+  weather-shaped clothing? (See [Probabilistic forecasting from NWP
+  ensembles](../techniques/probabilistic-forecasting.md#long-horizons-are-not-automatically-safe).)
+  Only a quantile/ensemble climatology answers that, via `crps__all__extended_range` head-to-head
+  against the ML models. Like `nged_incumbent`, this baseline owns its own member axis (see the
+  `uses_nwp_ensemble` flag in item 5) — it must not be broadcast across the 51 NWP members.
 
 **5. Configs and registration.**
 
@@ -209,13 +228,14 @@ machinery instead of writing any new time-series logic:
   following `conf/model/xgboost.yaml`'s `_target_` structure, with `weather_source: "none"`.
 - `PowerForecast.nwp_init_time` is already nullable for exactly this case
   (`power_schemas.py:242`); confirm `cv_power_forecasts` tolerates it end-to-end.
-- **Ensemble members:** for the *deterministic* baselines (persistence, climatology) the CV
+- **Ensemble members:** for the one genuinely *deterministic* baseline (persistence) the CV
   predict path feeds all ~51 members and they produce identical forecasts per member — wasteful
-  but harmless (the ensemble mean is unchanged); v0.3 accepts it. `nged_incumbent` is different:
-  it emits its own 13-member ensemble, so broadcasting it across the 51 NWP members would be wrong,
-  not merely wasteful. A per-forecaster `uses_nwp_ensemble` class flag (default `True`) that
-  `cv_power_forecasts` honours — restricting deterministic baselines to member 0 and letting
-  `nged_incumbent` own the member axis — resolves both at once.
+  but harmless (the ensemble mean is unchanged); v0.3 accepts it. `nged_incumbent` and
+  `climatology` are different: each emits its own 13-member ensemble (analogues and quantiles
+  respectively), so broadcasting either across the 51 NWP members would be wrong, not merely
+  wasteful. A per-forecaster `uses_nwp_ensemble` class flag (default `True`) that
+  `cv_power_forecasts` honours — restricting the deterministic baseline to member 0 and letting
+  `nged_incumbent` and `climatology` each own their member axis — resolves both at once.
 
 **6. Run and publish.** Register each via `register_experiment_job` (`run_mode: smoke_test`
 first, then `full_cv`) and materialise `trained_cv_model` → `cv_power_forecasts` → `metrics`
@@ -234,15 +254,19 @@ so each appears in MLflow as a leaderboard row.
 
 **Verification.** (1) Unit tests in `packages/baseline_forecasters/tests/`: `nged_incumbent`
 unpivots to the expected 13 members and both its **median** (headline) and **P95** (operating-point)
-collapses match hand-computed values; persistence picks the shortest non-null lag; climatology
-lookup round-trips through `save`/`load`; all freeze `trained_time_series_ids`. (2) Smoke-test fold
-end-to-end via the existing integration-test pattern (`tests/test_trained_cv_model.py` fixtures),
-and confirm the incumbent's 13-member ensemble flows through the Phase B probabilistic metrics
-(e.g. CRPS computes over its members). (3) Sanity-check the numbers: persistence NMAE should be
-*worse overall* than XGBoost but plausibly competitive at short horizons; `nged_incumbent`'s median
+collapses match hand-computed values; persistence picks the shortest non-null lag; climatology's
+quantile lookup unpivots to the expected 13 members and matches hand-computed empirical quantiles
+per cell; all three round-trip through `save`/`load` and freeze `trained_time_series_ids`. (2)
+Smoke-test fold end-to-end via the existing integration-test pattern
+(`tests/test_trained_cv_model.py` fixtures), and confirm both `nged_incumbent`'s and
+`climatology`'s member ensembles flow through the Phase B probabilistic metrics (e.g. CRPS
+computes over their members). (3) Sanity-check the numbers: persistence NMAE should be *worse
+overall* than XGBoost but plausibly competitive at short horizons; `nged_incumbent`'s median
 should be a roughly unbiased central estimate while its reported **P95** shows a clear positive MBE
 (the conservative operating point) — even where its CRPS over the 13 members is competitive; don't
-mistake the P95 bias for a bug.
+mistake the P95 bias for a bug. Watch `climatology`'s `crps__all__extended_range` in particular —
+if it comes within noise of the ML ensemble's at day 8–14, that is the quantitative answer to
+"how much is the NWP ensemble actually worth this far out", not a failure to investigate away.
 
 ---
 

--- a/docs/techniques/probabilistic-forecasting.md
+++ b/docs/techniques/probabilistic-forecasting.md
@@ -76,6 +76,34 @@ This matters commercially, not just statistically: flexibility procurement keys 
 **tails** (P90+ peaks), and under-dispersion is precisely the error that makes tails look safer
 than they are.
 
+### Long horizons are not automatically safe
+
+The paragraph above reads as "term 1 shrinks toward zero at short horizons", which invites the
+opposite conclusion at day 8–14: that once weather spread is large, the fan is wide enough on
+its own. That does not follow. A wide NWP ensemble in does not guarantee an honest power fan
+out — the learned weather→power mapping's sensitivity mediates the two, and squared-error
+training damps that sensitivity in a way that grows with lead time.
+
+At day 8–14, ECMWF's individual weather trajectories are themselves close to noise: the model
+was trained on forecast weather as its input, and at long lead times that input is wrong by a
+large, lead-time-dependent amount. Squared-error training responds to noisy inputs by hedging
+toward the mean — attenuating the fitted weather→power sensitivity — and today's model fits one
+sensitivity across all lead times rather than a per-horizon one, because it has no feature that
+tells it how trustworthy the weather input is. The result at day 8–14 can be a fan that is
+merely *wide-looking*: large NWP spread pushed through a damped, horizon-blind sensitivity, with
+the dropped term-2 residual (which is largest exactly where the weather input is least
+trustworthy) never added back in. Wide input spread and honest output spread are not the same
+claim, and only the shipped [spread-skill ratio and PICP](evaluation-metrics.md#probabilistic-metrics)
+computed per horizon slice can tell them apart — don't assume `extended_range` is calibrated
+just because `intraday` is under-dispersed and `extended_range`'s members have visibly fanned
+out.
+
+This is a second, independent reason (beyond the double-counting caveat below) to give the model
+`nwp_lead_time_hours` as a feature ([#230](https://github.com/openclimatefix/nged-substation-forecast/issues/230)):
+it is not only a double-counting mitigation, it is what lets the model learn *how much* to
+attenuate its weather sensitivity per horizon, instead of applying one horizon-averaged
+compromise everywhere.
+
 ## The fix, formally: a mixture of conditional distributions
 
 Ask the model for a full conditional distribution per member — "the distribution of power

--- a/docs/techniques/probabilistic-forecasting.md
+++ b/docs/techniques/probabilistic-forecasting.md
@@ -66,9 +66,10 @@ Total predictive uncertainty decomposes into three terms:
    exactly: meter noise, occupant behaviour, unmodelled local events. Irreducible randomness.
 
 A deterministic model (XGBoost trained with squared error learns the **conditional mean**)
-pushed through 51 members captures term 1 *only*. Terms 2 and 3 are dropped entirely. The
-resulting ensemble is **under-dispersed** — systematically overconfident — and worst at short
-horizons, where term 1 shrinks toward zero while terms 2 and 3 do not. The
+pushed through 51 members captures term 1 *only*. Terms 2 and 3 are dropped entirely, at *every*
+lead time. The resulting ensemble is **under-dispersed** — systematically overconfident — and the
+failure is most conspicuous at short horizons, where term 1 has barely grown, so the fan
+collapses toward the single line of the sketch above while our errors do not. The
 [spread-skill ratio](evaluation-metrics.md#spread-skill-ratio) is the metric
 that catches this: spread ÷ error ≪ 1 means the fan is too thin.
 
@@ -78,31 +79,31 @@ than they are.
 
 ### Long horizons are not automatically safe
 
-The paragraph above reads as "term 1 shrinks toward zero at short horizons", which invites the
-opposite conclusion at day 8–14: that once weather spread is large, the fan is wide enough on
-its own. That does not follow. A wide NWP ensemble in does not guarantee an honest power fan
-out — the learned weather→power mapping's sensitivity mediates the two, and squared-error
-training damps that sensitivity in a way that grows with lead time.
+The long-horizon end looks like the safe one. By day 8–14 the 51 weather stories have diverged
+enormously, so the fan is anything but a thin line — the opposite of the short-horizon failure
+above. But the same two dropped terms still bite here; they just hide better. A wide *input* fan
+does not guarantee an honest *output* fan, because the learned weather→power mapping sits between
+them, and squared-error training quietly narrows what that mapping passes through as lead time
+grows.
 
-At day 8–14, ECMWF's individual weather trajectories are themselves close to noise: the model
-was trained on forecast weather as its input, and at long lead times that input is wrong by a
-large, lead-time-dependent amount. Squared-error training responds to noisy inputs by hedging
-toward the mean — attenuating the fitted weather→power sensitivity — and today's model fits one
-sensitivity across all lead times rather than a per-horizon one, because it has no feature that
-tells it how trustworthy the weather input is. The result at day 8–14 can be a fan that is
-merely *wide-looking*: large NWP spread pushed through a damped, horizon-blind sensitivity, with
-the dropped term-2 residual (which is largest exactly where the weather input is least
-trustworthy) never added back in. Wide input spread and honest output spread are not the same
-claim, and only the shipped [spread-skill ratio and PICP](evaluation-metrics.md#probabilistic-metrics)
-computed per horizon slice can tell them apart — don't assume `extended_range` is calibrated
-just because `intraday` is under-dispersed and `extended_range`'s members have visibly fanned
-out.
+Far out, ECMWF's individual trajectories are themselves close to noise: the model was trained on
+forecast weather as its input, and at long lead times that input is wrong by a large,
+lead-time-dependent amount. Squared-error training responds to noisy inputs by hedging toward the
+mean — attenuating the fitted weather→power sensitivity — and today's model applies one
+sensitivity across all lead times, because it has no feature telling it how trustworthy the
+weather input is. So the day-8–14 fan can be merely *wide-looking*: large NWP spread pushed
+through a damped, horizon-blind sensitivity, with the dropped term-2 residual (largest exactly
+where the weather input is least trustworthy) never added back in. This is why the
+[spread-skill ratio and PICP](evaluation-metrics.md#probabilistic-metrics) are computed per
+horizon slice and not just overall: a visibly fanned-out `extended_range` can still be
+under-dispersed, and only the numbers, not the eye, can say so.
 
-This is a second, independent reason (beyond the double-counting caveat below) to give the model
-`nwp_lead_time_hours` as a feature ([#230](https://github.com/openclimatefix/nged-substation-forecast/issues/230)):
-it is not only a double-counting mitigation, it is what lets the model learn *how much* to
-attenuate its weather sensitivity per horizon, instead of applying one horizon-averaged
-compromise everywhere.
+The mechanism also sharpens the case for giving the model `nwp_lead_time_hours` as a feature
+([#230](https://github.com/openclimatefix/nged-substation-forecast/issues/230)). Beyond the
+double-counting mitigation discussed in the caveat below, the lead-time feature is what lets the
+model learn *how much* to attenuate its weather sensitivity per horizon — narrow when the weather
+input is trustworthy, wide when it isn't — instead of the one horizon-averaged compromise it is
+forced into today.
 
 ## The fix, formally: a mixture of conditional distributions
 


### PR DESCRIPTION
## Summary

Stacked on #352. Jack noticed by eye (via the `view_forecasts` dashboard) that ECMWF ensemble irradiance and wind forecasts beyond ~5 days are close to a shrug, and asked whether our [probabilistic-forecasting plan](https://openclimatefix.github.io/nged-substation-forecast/techniques/probabilistic-forecasting/) actually keeps the service honest about uncertainty at those longer horizons. Reviewing the explainer and the [metrics-and-leaderboard roadmap](https://openclimatefix.github.io/nged-substation-forecast/roadmap/metrics-and-leaderboard/) surfaced two gaps:

- **[probabilistic-forecasting.md](https://openclimatefix.github.io/nged-substation-forecast/techniques/probabilistic-forecasting/#long-horizons-are-not-automatically-safe)** framed underdispersion as a short-horizon-only failure ("term 1 shrinks toward zero at short horizons"), which invites the wrong conclusion that a wide NWP ensemble at day 8–14 is automatically an honest power fan. It isn't: squared-error training on noisy long-lead weather inputs damps the learned weather→power sensitivity, and the model fits one sensitivity across all lead times today (no `nwp_lead_time_hours` feature, #230). Added a new subsection explaining the mechanism and strengthening the case for #230 as a second, independent motivation beyond double-counting.
- The planned `ClimatologyForecaster` baseline (item 4 of the baseline-forecasters plan) was deterministic — a per-cell mean lookup — so its CRPS collapses to MAE and it can never answer the question that matters most at long horizons: does the 51-member NWP ensemble actually know more about day 8–14 power than plain seasonal climatology? Amended it to emit empirical per-cell quantiles as its own 13-member ensemble (same shape as `nged_incumbent`), so `crps__all__extended_range` becomes a real head-to-head comparator. Updated the adjacent `uses_nwp_ensemble` and verification text to match.

Docs-only change; no code or schema touched.

## Test plan

- [x] `uv run pymarkdown scan docs/techniques/probabilistic-forecasting.md docs/roadmap/metrics-and-leaderboard.md` — clean
- [x] `uv run mkdocs build --strict` — clean, cross-doc anchor link resolves
- [x] Manually inspected rendered HTML output for both new sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)