### PR TITLE
Rewrite orchestrator page as "Why Dagster, not Airflow?"; refresh facts against Airflow 3.3.0

### DIFF
--- a/docs/architecture/airflow-portability.md
+++ b/docs/architecture/airflow-portability.md
@@ -3,27 +3,141 @@
 OCF's existing production services are orchestrated with Apache Airflow, as a fleet of
 micro-services (each service in its own git repository, running in its own container). Since
 Flexpectation orchestrates with Dagster instead, the question naturally arises whether this
-project could — or should — converge on Airflow. This page records the assessment (July 2026) so
-the reasoning stays auditable, in the same spirit as the
+project could — or should — converge on Airflow. This page records the assessment so the
+reasoning stays auditable, in the same spirit as the
 [rejected designs in Production Deployment](production-deployment.md#considered-but-rejected-designs).
 
-The short answer:
+The page answers three questions in turn:
 
-- **A port is technically possible, and deliberately so.** The codebase keeps orchestrator
-  lock-in shallow: all real logic lives in `packages/` with no Dagster imports, and the Dagster
-  surface is a handful of thin files. Nothing about the data or ML design depends on Dagster.
-- **A full port would cost day-to-day ML R&D some capabilities we lean on heavily** —
-  runtime-minted partitions, per-partition observability and backfill — which Airflow does not
-  currently replicate.
-- **Porting only the live service is the most promising variant** — the R&D/production seam
-  already drawn by our architecture is exactly where an orchestrator boundary could sit —
-  though it would mean running two orchestrators side by side, an ongoing cost weighed up
-  below.
+1. **Why did we choose Dagster when we designed the system (August 2025)?** At the time the
+   choice was clear-cut: Airflow could not support the experiment workflow we wanted.
+2. **Would it be possible to migrate to Airflow today?** Yes — and it is a closer call than it
+   was at design time, because Airflow 3.2 and 3.3 (April–July 2026) closed several of the
+   gaps. The remaining gap is day-to-day experiment observability, not the data model.
+3. **What would a port actually look like?** The mechanics, the trickiest parts, where Airflow
+   would be genuinely better, and the options — ending with our recommendation to stay put
+   for now.
 
-Airflow claims on this page were verified against Airflow 3.3.0 in July 2026 and are dated where
-they may drift.
+Airflow claims on this page were verified against Airflow 3.3.0 (released 6 July 2026) on
+19 July 2026, and are dated where they may drift.
 
-## Why a port is mechanically straightforward
+## Why we chose Dagster (August 2025)
+
+The ML R&D side of this project was designed around a specific workflow: mint an
+`{experiment_name}__{fold_id}` partition key per cross-validation cell at runtime, and get
+individually addressable, retryable, observable materialisations per key — with a UI that shows
+at a glance which (experiment, fold) cells exist, succeeded, or failed, across every experiment
+ever run. Dagster's `DynamicPartitionsDefinition` provides exactly this;
+[ML Orchestration Design](ml-orchestration.md) documents the layer built on it.
+
+When the system was designed in August 2025, the current Airflow release was 3.0.4 (released
+8 August 2025; Airflow 3.1.0 did not arrive until 25 September 2025). At that point in time:
+
+- **Airflow had no asset partitioning of any kind.** Partitions were the time axis of a DAG,
+  full stop. [AIP-76 (Asset Partitions)](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=311626969)
+  was an unshipped proposal; it did not begin landing until Airflow 3.2.0 in April 2026. The
+  experiment×fold dynamic-partition design simply had no Airflow analogue.
+- **The fallback pattern was compromised in the then-current release.** The natural Airflow
+  shape for cross-validation — dynamic task mapping, one mapped task instance per fold — was
+  undermined by a live regression in the 3.0.x series
+  ([#54779](https://github.com/apache/airflow/issues/54779)): clearing a single mapped
+  instance restarted *all* of its siblings, so one failed fold could not be retried alone. The
+  fix shipped in 3.1.4, and the REST API could not target a single map index at all until
+  October 2025 ([#43635](https://github.com/apache/airflow/issues/43635)).
+- **Backfill run-config was fresh out of a bug.** Backfills silently failing to pass their
+  `conf` to runs ([#51439](https://github.com/apache/airflow/issues/51439)) had been fixed
+  only days earlier, in 3.0.4 itself — and a second variant (conf not applied to runs whose
+  logical dates already existed,
+  [#59043](https://github.com/apache/airflow/issues/59043)) survived until Airflow 3.2.2 in
+  May 2026. Run-config correctness matters unusually much to us because replay-mode backfills
+  guard against [lookahead bias](production-deployment.md#resolve-nwp-availability-asymmetrically-live-vs-replay).
+- **Airflow could not run our Python.** Python 3.14 support arrived in Airflow 3.2.0
+  (April 2026); this project is 3.14-only.
+
+So the design-time claim is straightforward: in August 2025, Airflow could not deliver the
+per-cell experiment workflow this project was built around, and its nearest substitute had a
+broken per-fold retry story in the release we would have deployed. Choosing Dagster was not a
+matter of taste.
+
+## Could we migrate today? (assessed July 2026)
+
+### What has changed since the design was made
+
+Airflow 3.2.0 (April 2026) and 3.3.0 (July 2026) closed several of the gaps above:
+
+- **Asset partitions shipped, including runtime-minted keys.** 3.2.0 introduced partitioned
+  assets and partitioned DAG runs ([AIP-76](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=311626969));
+  [3.3.0 added](https://airflow.apache.org/blog/airflow-3.3.0/) the `PartitionedAtRuntime`
+  timetable and `outlet_events[asset].add_partitions(...)`, which lets a task mint arbitrary
+  string partition keys decided in code — the direct conceptual analogue of Dagster's
+  `DynamicPartitionsDefinition`. An `{experiment}__{fold}` key scheme is directly expressible.
+- **The backfill-conf bug class is fixed.** [#59043](https://github.com/apache/airflow/issues/59043)
+  (conf silently not applied to runs with existing logical dates) was fixed in Airflow 3.2.2,
+  released 29 May 2026. No open issues in that class remain. One live caveat: AWS MWAA's
+  newest supported version is 3.2.1, which predates the fix.
+- **Retry policies became pluggable** (AIP-105, in 3.3.0) — "retry only on
+  `NwpRunNotYetAvailable`, fail fast on genuine bugs" is now expressible directly.
+- **Airflow runs Python 3.14** (since 3.2.0).
+
+### What an Airflow-native experiment workflow would look like
+
+A fair assessment has to judge Airflow's *native* redesign, not a mechanical translation of
+our Dagster code. That redesign is well established in the Airflow world: one triggered DAG
+run per experiment, carrying the experiment config as `conf` (with a meaningful `run_id` — the
+trigger UI, CLI, and `TriggerDagRunOperator` all support custom run IDs), and one dynamically
+mapped task instance per fold (`.expand()` over a fold list computed from `conf`). Astronomer's
+[MLOps guidance](https://www.astronomer.io/docs/learn/airflow-mlops) documents exactly this
+pattern, with MLflow as the system of record for experiment results.
+
+This gets further than one might expect — in particular, **per-fold observability and retry
+are not lost**:
+
+- Each mapped instance has its own state, logs, and XCom, visible in the Grid view one click
+  below the task row; a failed fold auto-retries alone.
+- A single map index can be cleared and re-run from the UI (and via the REST API since late
+  2025) without touching its siblings — on current Airflow versions.
+- `map_index_template` (Airflow 2.9+) displays a rendered fold name (e.g. `fold_2024_q3`)
+  instead of an integer index.
+
+Note that this is *not* the fold-loop-inside-one-run design that
+[ML Orchestration — rejected designs](ml-orchestration.md#rejected-designs) rules out: mapped
+task instances keep per-fold state and retry, which is what that rejection was protecting.
+
+### What is still missing
+
+Three gaps remain, and they are affordances we use daily rather than blockers in principle:
+
+- **No all-time experiment×fold status catalog.** Airflow's history is run-oriented: the Grid
+  view is a date-ordered run×task matrix, with fold status collapsed one click deep and
+  expandable only per run, and mapped instances are not searchable by rendered name
+  ([#45100](https://github.com/apache/airflow/issues/45100)). The new AIP-76 partitions have
+  the right data model but no partition-status UI — nothing shows "which keys exist /
+  succeeded / failed, all time"; AIP-76 lists partition observability as future work, and the
+  feature is weeks old versus Dagster partitions' years of production maturity. Dagster's
+  at-a-glance partition grid has no Airflow surface today.
+- **Extending a past experiment is structurally awkward.** A run's `conf` is immutable, so
+  "add one more fold to last month's experiment" means triggering a second run under a second
+  run ID, and nothing native re-aggregates the two. In Dagster, the new fold is one more key
+  minted into the same partition set, with unified status.
+- **Materialisation metadata is raw JSON.** Since Airflow 2.10 a task can attach an `extra`
+  dict to an asset event, visible in the UI's asset-events list and readable downstream — a
+  genuine partial equivalent of Dagster's `add_output_metadata`. But there is no rendered
+  table or per-asset history plot; for human-facing metrics the standard Airflow-world answer
+  is MLflow, which matches where our metrics already live but loses the per-materialisation
+  summaries the Dagster UI renders on every run.
+
+### Verdict
+
+A migration is possible today, and the case against it is narrower than it was in August 2025.
+The honest framing is no longer "Airflow can't do ML R&D" — it demonstrably can, and its data
+model closed the dynamic-partition gap in July 2026. The framing is: **Airflow can run the
+workload; what it lacks is the catalog** — the persistent per-cell status surface and in-place
+experiment extension that Dagster gives us for free — and re-platforming to chase a weeks-old
+partition feature whose observability UI is still on the roadmap would be premature.
+
+## What would a port look like?
+
+### Why a port is mechanically straightforward
 
 The orchestration layer was built thin on purpose, and three properties make it portable:
 
@@ -40,18 +154,14 @@ The orchestration layer was built thin on purpose, and three properties make it 
 - **Every write is an idempotent partition overwrite**, so retry semantics do not depend on
   orchestrator guarantees.
 
-The Dagster-specific surface is roughly 1,600 lines across five files
+The Dagster-specific surface is roughly 1,900 lines across five files
 (`defs/assets.py`, `defs/cv_assets.py`, `defs/production_assets.py`, `defs/jobs.py`,
 `defs/schedules.py`) plus `definitions.py`, `dagster.yaml`, and the Docker Compose control
 plane. Beyond code, a dozen docs pages — most of `docs/live_service/` and
 [Running an experiment end-to-end](../ml_experimentation/dagster-workflow.md) — are written
 around the Dagster UI and would need rewriting.
 
-## What we actually use from Dagster, and how it maps
-
-Airflow 3 is a much closer match than Airflow 2 was: it supports Python 3.14 (since 3.2.0),
-schedules around data intervals, runs event-driven asset scheduling, and ships an ECS executor.
-The mapping is uneven, though:
+### What we actually use from Dagster, and how it maps
 
 | Dagster feature in use | Where | Airflow 3 equivalent | Fit |
 |---|---|---|---|
@@ -60,61 +170,50 @@ The mapping is uneven, though:
 | Concurrency pool (`pool="ECMWF"`) | `ecmwf_ens` | Airflow pools | Direct equivalent |
 | In-run retry-with-wait (`RetryRequested`) | `ecmwf_ens` NWP wait | Deferrable sensor | Airflow is **better** (see below) |
 | Typed run config + Launchpad | `availability_mode`, `MetricsConfig`, `PromotedModelConfig` | DAG `params` with schema-validated trigger forms | Workable; less strongly typed |
-| `DynamicPartitionsDefinition` (`{experiment}__{fold}`) | CV layer | No direct equivalent yet | The main gap (see below) |
-| Per-partition backfills with run config | `live_forecasts` replay | Backfills take `--dag-run-conf`, but with open correctness bugs | Needs careful verification (see below) |
-| `add_output_metadata` tables, asset catalog, lineage | every asset | Task logs / XCom; Airflow assets carry no materialisation metadata | A loss we would feel day to day |
+| `DynamicPartitionsDefinition` (`{experiment}__{fold}`) | CV layer | `PartitionedAtRuntime` + `add_partitions` (3.3.0), or run-per-experiment + mapped folds | Data model now matches; the status-grid UI does not (see above) |
+| Per-fold retry and observability | CV layer | Dynamic task mapping (per-instance state, logs, clear; `map_index_template`) | Good on ≥3.1.4 |
+| Per-partition backfills with run config | `live_forecasts` replay | Backfills take `--dag-run-conf`; conf-dropped bug fixed in 3.2.2 | Good on ≥3.2.2; MWAA (3.2.1) still affected |
+| `add_output_metadata` tables, asset catalog, lineage | every asset | Asset-event `extra` JSON (2.10+) in the events list | Partial — raw JSON, no rendered tables or history plots |
 | `EcsRunLauncher` (laptop = subprocess, cloud = Fargate, switched by `dagster.yaml`) | control plane | ECS executor (Amazon provider, Fargate launch type) | Exists; per-*task* rather than per-run granularity |
 | Sensors / run-status coordination (planned, [#324](https://github.com/openclimatefix/nged-substation-forecast/issues/324)) | ingest → forecast ordering | Asset-triggered DAGs, event-driven scheduling | Parity, arguably cleaner in Airflow |
 
-A note on Airflow's asset partitioning: Airflow 3.2 introduced partitioned assets and
-[3.3.0 expanded them](https://airflow.apache.org/blog/airflow-3.3.0/) (time-window partitions,
-mappers, wait policies). This strengthens the *time*-partitioned story, but partitions remain
-configuration-defined — there is no equivalent of minting new partition keys at runtime — and
-the feature is months old versus Dagster partitions' years of production maturity. Worth a
-fresh look whenever this page is revisited.
+### The three trickiest parts of a full port
 
-## The three trickiest parts of a full port
+#### The CV layer: right data model, missing status surface
 
-### Runtime-minted experiment×fold partitions have no direct equivalent yet
+A port of the CV layer would face a choice between two imperfect shapes. Adopting AIP-76
+runtime partitions keeps the `{experiment}__{fold}` key scheme but stakes the daily workflow
+on a weeks-old feature with no partition-status UI. Remodelling as run-per-experiment with
+mapped folds is mature and keeps per-fold retry, but fragments the catalog: "which cells have
+been materialised, ever" would have to be answered by MLflow (which becomes the system of
+record for experiment progress) or a hand-rolled query over Airflow's task-instance table,
+and extending a past experiment becomes a second, disconnected run. Either way, the
+at-a-glance grid we use daily is gone until Airflow ships partition observability.
 
-The CV layer's core mechanic is that `register_experiment_job` mints
-`{experiment_name}__{fold_id}` partition keys at runtime, and `trained_cv_model` /
-`cv_power_forecasts` become individually addressable, retryable, observable materialisations
-per key — the Dagster UI shows exactly which (experiment, fold) cells exist, succeeded, or
-failed. Airflow's partitioning is fundamentally the time axis of a DAG; a port would remodel
-each (experiment, fold) as a triggered DAG run carrying `conf`, and "which cells have been
-materialised" would have to be tracked elsewhere — realistically MLflow becomes the system of
-record for experiment progress, and the at-a-glance grid is gone.
-
-[ML Orchestration — rejected designs](ml-orchestration.md#rejected-designs) already records
-that a fold-loop-inside-one-run design was rejected precisely for losing per-fold observability
-and retry. A full Airflow port would steer us back toward the design we had rejected.
-
-### Replay backfills would need especially careful verification
+#### Replay backfills: fixed upstream, still deserving of explicit verification
 
 Recovering missed `live_forecasts` slots means backfilling selected 6-hourly partitions with
-`availability_mode="replay"` — and replay exists to prevent
+`availability_mode="replay"`, which guards against
 [lookahead bias](production-deployment.md#resolve-nwp-availability-asymmetrically-live-vs-replay).
-Airflow backfills do accept a per-backfill `--dag-run-conf` (CLI and UI), but as of July 2026
-there are open bugs where that conf is silently not applied to runs whose logical dates already
-exist ([#52622](https://github.com/apache/airflow/issues/52622),
-[#59043](https://github.com/apache/airflow/issues/59043)). A silently dropped
-`availability_mode="replay"` does not fail — it produces subtly lookahead-contaminated
-forecasts. Any port would need this path explicitly verified, or redesigned (e.g. a dedicated
-replay DAG) so the mode cannot be dropped.
+The bug class where backfill conf was silently dropped is fixed as of Airflow 3.2.2 (see
+above), but its history is instructive: a silently dropped `availability_mode="replay"` does
+not fail — it produces subtly lookahead-contaminated forecasts. A port should still verify
+this path end-to-end on the deployed version (MWAA's 3.2.1 predates the fix), or redesign it
+(e.g. a dedicated replay DAG) so the mode cannot be dropped at all.
 
-### Materialisation metadata and lineage
+#### Materialisation metadata and lineage
 
 Every asset attaches summary tables and row counts to its materialisation
 (`context.add_output_metadata`), which the Dagster UI renders per run and plots over time; the
 asset catalog gives lineage from ingest through forecasts, and `promoted_model` exists
 specifically so that
 [promotion is an audited materialisation](production-deployment.md#promote-the-champion-via-a-dagster-asset-not-a-script).
-Airflow has no per-materialisation metadata surface; the equivalents are structured logs or a
-hand-rolled reporting table. This loss is diffuse rather than blocking, but it would be felt on
-every run.
+Airflow's asset-event extras cover the storage half of this (the metadata travels and is
+queryable) but not the presentation half: no rendered tables, no per-asset metadata history.
+The equivalents are structured logs, MLflow, or a hand-rolled reporting table. This loss is
+diffuse rather than blocking, but it would be felt on every run.
 
-## Where Airflow would be genuinely better
+### Where Airflow would be genuinely better
 
 The assessment cuts both ways — Airflow would bring some genuine improvements:
 
@@ -132,7 +231,7 @@ The assessment cuts both ways — Airflow would bring some genuine improvements:
   heavy tasks on Fargate" natively — the hybrid that
   [would need a custom Dagster launcher](production-deployment.md#running-the-data-ingest-runs-on-the-control-plane-vm).
   The trade is ~1 minute of task provisioning latency per *task* instead of per *run*.
-- **Pluggable retry policies** (Airflow 3.3) map cleanly onto "retry only on
+- **Pluggable retry policies** (AIP-105, Airflow 3.3) map cleanly onto "retry only on
   `NwpRunNotYetAvailable`, fail fast on genuine bugs".
 - **Organisational familiarity and managed hosting.** Airflow is what OCF already runs in
   production, so a port buys shared operational knowledge, shared tooling, and a hiring pool.
@@ -140,20 +239,21 @@ The assessment cuts both ways — Airflow would bring some genuine improvements:
   pins Python 3.12, so this project's 3.14-only packages could not be imported by MWAA workers
   directly; the standard escape is thin DAGs of `EcsRunTaskOperator` calls launching our own
   container image, which decouples the DAG environment from the project environment entirely.
+  (Note that MWAA's 3.2.1 also predates the 3.2.2 backfill-conf fix discussed above.)
 
-## Three options
+### Three options
 
-### Option A: full port — possible, but the hardest path
+#### Option A: full port — possible, but the hardest path
 
 Everything above applies. The translation itself is not the cost — assets are thin shells with
-their intended behaviour documented, so rewriting them as DAGs is days of work. The cost is the
-redesign of the CV layer around the missing dynamic partitions, the verification of
+their intended behaviour documented, so rewriting them as DAGs is days of work. The cost is
+the redesign of the CV layer around the missing partition-status surface, the verification of
 orchestration behaviour (schedules ticking, backfills replaying without lookahead leakage, ECS
 dispatch — inherently wall-clock-bound), the docs rewrite, and the deployment cutover.
 Realistically several weeks end-to-end, landing on an experimentation workflow with fewer of
 the affordances we rely on today.
 
-### Option B: port only the live service — promising, with a real two-orchestrator cost
+#### Option B: port only the live service — promising, with a real two-orchestrator cost
 
 Move the production side to Airflow — `power_time_series_and_metadata`, `ecmwf_ens`,
 `live_forecasts`, `h3_grid_weights`, and their schedules — and keep everything
@@ -199,10 +299,11 @@ Against (the cost of a second orchestrator, which is ongoing rather than one-off
   developer.
 - The audit trail fragments: production run history in Airflow, promotion and experiment
   history in Dagster/MLflow.
-- The Airflow backfill-conf bugs above sit exactly on the ported surface (replay mode), the
-  most correctness-critical operation being moved.
+- If the deployment target were MWAA at its current version (3.2.1), the backfill-conf bug
+  would sit exactly on the ported surface (replay mode), the most correctness-critical
+  operation being moved.
 
-### Option C: stay on Dagster, keep the seam documented — our recommendation for now
+#### Option C: stay on Dagster, keep the seam documented — our recommendation for now
 
 We have not yet found a technical problem in this project that a port would solve, and either
 port lands somewhere between "equivalent" and "a little worse" for the people using the
@@ -219,8 +320,12 @@ We would happily revisit this page if any of the following happens:
   points at Option B, not Option A.
 - **An OCF platform decision** that all production services must run on the shared Airflow
   infrastructure. Also points at Option B.
-- **Airflow's asset partitioning maturing** to cover runtime-minted partition keys with
-  per-partition observability — this would remove the main blocker to Option A.
+- **AIP-76 partition observability shipping** — a per-partition status surface (which keys
+  exist, succeeded, failed, over all time) for runtime-minted partitions. The data model
+  arrived in Airflow 3.3.0; the UI is the remaining blocker to Option A, and it is explicitly
+  on Airflow's roadmap, so this trigger is plausible rather than theoretical.
+- **MWAA catching up** to Airflow ≥3.2.2 (the backfill-conf fix) and ideally 3.3+, which
+  would remove the last correctness caveat on the managed-hosting path.
 - **Dagster itself becoming harder to sustain** (maintenance burden, licensing or
   project-direction concerns).
 

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -378,5 +378,5 @@ production-resilience mechanism.
   artifacts live, and how to point `Settings` at S3.
 - [ML Orchestration Design](ml-orchestration.md) — why production inference doesn't reuse the
   CV pipeline's MLflow-artifact cache.
-- [Porting to Airflow](airflow-portability.md) — what moving this orchestration to Airflow
-  would take, and why Dagster remains the better fit today.
+- [Why Dagster, not Airflow?](why-dagster-not-airflow.md) — why Dagster was chosen at design
+  time, whether a migration to Airflow would be possible today, and what a port would take.

--- a/docs/architecture/why-dagster-not-airflow.md
+++ b/docs/architecture/why-dagster-not-airflow.md
@@ -34,7 +34,12 @@ running **on the order of hundreds of ML experiments per month**, make each run 
 crucially, each *re-run*, when an inevitable bug fix invalidates earlier results — as
 frictionless as possible, and land every result on a standardised leaderboard. Orchestrator
 ergonomics for experimentation are not a nice-to-have here; they are load-bearing for the
-project's core output.
+project's core output. And conducting experiments is only half the loop: a winning experiment
+must then move into production as easily and as safely as possible, which is why R&D and
+production share a single unified codebase — promotion is an
+[audited materialisation](production-deployment.md#promote-the-champion-via-a-dagster-asset-not-a-script),
+not a rewrite — and why anything that splits the R&D and production worlds apart carries an
+ongoing cost (a tension Option B below has to price in).
 
 Concretely, the workflow we designed for this is: mint an
 `{experiment_name}__{fold_id}` partition key per cross-validation cell at runtime, and get

--- a/docs/architecture/why-dagster-not-airflow.md
+++ b/docs/architecture/why-dagster-not-airflow.md
@@ -1,10 +1,13 @@
-# Porting to Airflow — What It Would Take
+# Why Dagster, not Airflow?
 
-OCF's existing production services are orchestrated with Apache Airflow, as a fleet of
-micro-services (each service in its own git repository, running in its own container). Since
-Flexpectation orchestrates with Dagster instead, the question naturally arises whether this
-project could — or should — converge on Airflow. This page records the assessment so the
-reasoning stays auditable, in the same spirit as the
+OCF currently orchestrates with *both* tools: our existing production services run on Apache
+Airflow, as a fleet of micro-services (each service in its own git repository, running in its
+own container), while our on-prem data pipelines run on Dagster. Since Flexpectation
+orchestrates with Dagster, the question naturally arises whether this project could — or
+should — converge on Airflow — especially as OCF has, since around August 2025, been
+discussing standardising on Airflow (a direction under discussion, not yet a settled
+decision). This page records the assessment so the reasoning stays auditable, in the same
+spirit as the
 [rejected designs in Production Deployment](production-deployment.md#considered-but-rejected-designs).
 
 The page answers three questions in turn:
@@ -23,7 +26,17 @@ Airflow claims on this page were verified against Airflow 3.3.0 (released 6 July
 
 ## Why we chose Dagster (August 2025)
 
-The ML R&D side of this project was designed around a specific workflow: mint an
+This project is ML-R&D-heavy by design. Beyond improving demand-forecast skill, the
+[requirements](../background/requirements.md#ml-experimentation-at-scale) span switching-event
+detection, effective-capacity estimation, faulty-meter detection, and DER disaggregation — and
+we hold far more ideas than we can try at once. The infrastructure therefore has to support
+running **on the order of hundreds of ML experiments per month**, make each run — and,
+crucially, each *re-run*, when an inevitable bug fix invalidates earlier results — as
+frictionless as possible, and land every result on a standardised leaderboard. Orchestrator
+ergonomics for experimentation are not a nice-to-have here; they are load-bearing for the
+project's core output.
+
+Concretely, the workflow we designed for this is: mint an
 `{experiment_name}__{fold_id}` partition key per cross-validation cell at runtime, and get
 individually addressable, retryable, observable materialisations per key — with a UI that shows
 at a glance which (experiment, fold) cells exist, succeeded, or failed, across every experiment
@@ -57,7 +70,10 @@ When the system was designed in August 2025, the current Airflow release was 3.0
 So the design-time claim is straightforward: in August 2025, Airflow could not deliver the
 per-cell experiment workflow this project was built around, and its nearest substitute had a
 broken per-fold retry story in the release we would have deployed. Choosing Dagster was not a
-matter of taste.
+matter of taste. Nor was it contrarian within OCF: we already ran Dagster for our on-prem data
+pipelines, and OCF's data-engineering view at the time favoured Dagster of the two
+orchestrators. (The later organisational shift towards possibly standardising on Airflow
+post-dates this design decision.)
 
 ## Could we migrate today? (assessed July 2026)
 
@@ -133,7 +149,10 @@ The honest framing is no longer "Airflow can't do ML R&D" — it demonstrably ca
 model closed the dynamic-partition gap in July 2026. The framing is: **Airflow can run the
 workload; what it lacks is the catalog** — the persistent per-cell status surface and in-place
 experiment extension that Dagster gives us for free — and re-platforming to chase a weeks-old
-partition feature whose observability UI is still on the roadmap would be premature.
+partition feature whose observability UI is still on the roadmap would be premature. At our
+[experiment volume](../background/requirements.md#ml-experimentation-at-scale) — hundreds of
+runs a month, with routine re-runs of old experiments — small per-experiment friction
+compounds into a real tax on the project's core output.
 
 ## What would a port look like?
 
@@ -233,8 +252,11 @@ The assessment cuts both ways — Airflow would bring some genuine improvements:
   The trade is ~1 minute of task provisioning latency per *task* instead of per *run*.
 - **Pluggable retry policies** (AIP-105, Airflow 3.3) map cleanly onto "retry only on
   `NwpRunNotYetAvailable`, fail fast on genuine bugs".
-- **Organisational familiarity and managed hosting.** Airflow is what OCF already runs in
-  production, so a port buys shared operational knowledge, shared tooling, and a hiring pool.
+- **Organisational alignment and managed hosting.** OCF runs Airflow for its existing
+  production services (alongside Dagster for the on-prem data pipelines), and has been
+  discussing standardising on Airflow since around August 2025. If that lands as a platform
+  decision, a port buys alignment with the OCF standard: shared operational knowledge, shared
+  tooling, and a hiring pool.
   AWS offers managed Airflow (MWAA, supporting Airflow 3.2.1 as of May 2026) — though MWAA
   pins Python 3.12, so this project's 3.14-only packages could not be imported by MWAA workers
   directly; the standard escape is thin DAGs of `EcsRunTaskOperator` calls launching our own
@@ -318,7 +340,8 @@ We would happily revisit this page if any of the following happens:
 - **A concrete handover signal** — NGED (or a post-NIA operating agreement) indicating that
   they run Airflow or want MWAA-managed orchestration. This is the strongest trigger, and it
   points at Option B, not Option A.
-- **An OCF platform decision** that all production services must run on the shared Airflow
+- **OCF standardising on Airflow.** The discussion under way since around August 2025 becoming
+  a firm platform decision that all production services must run on the shared Airflow
   infrastructure. Also points at Option B.
 - **AIP-76 partition observability shipping** — a per-partition status surface (which keys
   exist, succeeded, failed, over all time) for runtime-minted partitions. The data model

--- a/docs/background/requirements.md
+++ b/docs/background/requirements.md
@@ -56,6 +56,31 @@ Further down the same continuum:
 * Model and forecast *unmetered* solar PV and wind power on each primary substation by disaggregating net power flow.
 * Disaggregate and forecast other distributed energy resources (DERs): EV chargers, heat pumps, price-sensitive batteries.
 
+## ML experimentation at scale
+
+Nearly every objective above is an open research question — improving NRA forecast skill,
+detecting switching events, estimating effective capacity, flagging faulty meters,
+disaggregating DERs — and we hold far more ideas than we can try at once. That turns
+experimentation throughput into an infrastructure requirement in its own right: we need to run
+**on the order of hundreds of ML experiments per month**, and the workflow must make each one
+as frictionless as possible.
+
+Two properties matter as much as raw throughput:
+
+* **Re-runnability.** We will inevitably find and fix bugs that invalidate earlier results —
+  in feature engineering, in evaluation, in the data itself. When that happens we must be able
+  to re-run old experiments cheaply and confidently (same configuration, same folds), so that
+  results reflect the fixed world rather than a mixture of before and after.
+* **A standardised leaderboard.** Every experiment's metrics land in one comparable place,
+  computed the same way, so "is this idea better?" is a lookup, not an analysis project. See
+  [Metrics & Leaderboard](../roadmap/metrics-and-leaderboard.md).
+
+This requirement shapes the orchestration architecture: it is why the experiment layer is
+built around per-(experiment, fold) partitions that can be run — and re-run — individually
+(see [ML Orchestration Design](../architecture/ml-orchestration.md)), and it was decisive in
+choosing Dagster over Airflow (see
+[Why Dagster, not Airflow?](../architecture/why-dagster-not-airflow.md)).
+
 ## Operating model & handover
 
 NGED confirmed (2026-07-14) that their preference for running Flexpectation business-as-usual

--- a/docs/background/requirements.md
+++ b/docs/background/requirements.md
@@ -65,7 +65,7 @@ experimentation throughput into an infrastructure requirement in its own right: 
 **on the order of hundreds of ML experiments per month**, and the workflow must make each one
 as frictionless as possible.
 
-Two properties matter as much as raw throughput:
+Three properties matter as much as raw throughput:
 
 * **Re-runnability.** We will inevitably find and fix bugs that invalidate earlier results —
   in feature engineering, in evaluation, in the data itself. When that happens we must be able
@@ -74,11 +74,19 @@ Two properties matter as much as raw throughput:
 * **A standardised leaderboard.** Every experiment's metrics land in one comparable place,
   computed the same way, so "is this idea better?" is a lookup, not an analysis project. See
   [Metrics & Leaderboard](../roadmap/metrics-and-leaderboard.md).
+* **A short, safe path from R&D to production.** Conducting experiments is only half the
+  loop: an experiment that wins on the leaderboard must move into the live service as easily
+  and as safely as possible. This is why R&D and production share a single unified codebase —
+  the exact feature-engineering and model code that won the experiment is what runs in
+  production, and promotion is an
+  [audited configuration change](../architecture/production-deployment.md#promote-the-champion-via-a-dagster-asset-not-a-script),
+  not a rewrite or a port between systems.
 
-This requirement shapes the orchestration architecture: it is why the experiment layer is
-built around per-(experiment, fold) partitions that can be run — and re-run — individually
-(see [ML Orchestration Design](../architecture/ml-orchestration.md)), and it was decisive in
-choosing Dagster over Airflow (see
+This requirement shapes the architecture: it is why the experiment layer is built around
+per-(experiment, fold) partitions that can be run — and re-run — individually (see
+[ML Orchestration Design](../architecture/ml-orchestration.md)), why R&D and production live
+in one repository and one execution path rather than separate codebases, and it was decisive
+in choosing Dagster over Airflow (see
 [Why Dagster, not Airflow?](../architecture/why-dagster-not-airflow.md)).
 
 ## Operating model & handover

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -51,7 +51,7 @@ nav:
       - Forecast Delivery: architecture/forecast-delivery.md
       - ML Orchestration Design: architecture/ml-orchestration.md
       - Production Deployment Design: architecture/production-deployment.md
-      - Porting to Airflow: architecture/airflow-portability.md
+      - "Why Dagster, not Airflow?": architecture/why-dagster-not-airflow.md
       - Code Style: architecture/code-style.md
   - ML Experimentation:
       - Overview: ml_experimentation/index.md


### PR DESCRIPTION
## Summary

An adversarial fact-check of the Airflow-portability page (run 2026-07-19, verified against Airflow 3.3.0 and primary sources) found two load-bearing claims out of date and one overstated. Rather than patch in place, this PR restructures and renames the page — now **[Why Dagster, not Airflow?](https://openclimatefix.github.io/nged-substation-forecast/architecture/why-dagster-not-airflow/)** — around the three questions it should answer:

1. **Why we chose Dagster (August 2025)** — a time-stamped design-time snapshot that will not rot: Airflow 3.0.4 had no asset partitioning of any kind (AIP-76 was an unshipped proposal), a live regression ([apache/airflow#54779](https://github.com/apache/airflow/issues/54779)) meant clearing one mapped task instance restarted all its siblings, backfill conf had just come out of one silent-drop bug with a second variant still live, and Airflow could not run Python 3.14. The design-time choice was clear-cut — and not contrarian within OCF, which also runs Dagster for its on-prem pipelines.
2. **Could we migrate today? (July 2026)** — a closer call than at design time, assessed fairly against an Airflow-*native* redesign rather than a mechanical port.
3. **What would a port look like?** — the mechanics, feature mapping, trickiest parts, where Airflow is genuinely better, and the three options (recommendation unchanged: stay on Dagster with the seam documented).

The page now also states the project's experimentation-scale requirement explicitly — on the order of **hundreds of ML experiments per month** across many research threads (forecast skill, switching-event detection, capacity estimation, faulty-meter detection, DER disaggregation), with frictionless re-runs when bug fixes invalidate old results, a standardised leaderboard, and a short, safe path from R&D into production (the unified R&D/prod codebase, with promotion as an audited configuration change). That requirement gets a durable home as a new section in [Requirements](https://openclimatefix.github.io/nged-substation-forecast/background/requirements/#ml-experimentation-at-scale), cross-linked from the orchestrator page.

## Factual corrections

- **Runtime-minted partitions now exist in Airflow.** 3.3.0 (released 2026-07-06) added the `PartitionedAtRuntime` timetable and `outlet_events[asset].add_partitions(...)` ([AIP-76](https://cwiki.apache.org/confluence/pages/viewpage.action?pageId=311626969), [3.3.0 blog](https://airflow.apache.org/blog/airflow-3.3.0/)) — the direct analogue of Dagster's `DynamicPartitionsDefinition`. The page's "no equivalent of minting new partition keys at runtime" claim is replaced by the surviving, narrower gap: there is no partition-status UI (which keys exist / succeeded / failed, all time); AIP-76 lists that observability as future work.
- **The backfill-conf bugs are closed, and the page had swapped their descriptions.** [apache/airflow#59043](https://github.com/apache/airflow/issues/59043) (conf silently not applied to runs with existing logical dates) was fixed in Airflow 3.2.2 (2026-05-29, [PR #64939](https://github.com/apache/airflow/pull/64939)). [apache/airflow#52622](https://github.com/apache/airflow/issues/52622) was a different, earlier bug (conf not reaching backfill runs at all; duplicate of [#51439](https://github.com/apache/airflow/issues/51439), fixed ~3.0.4). MWAA's newest version (3.2.1) predates the 3.2.2 fix, so the caution survives on the managed-hosting path only.
- **"Would lose per-fold observability and retry" was overstated.** Dynamic task mapping gives per-instance state, logs, automatic retry, and single-map-index clear (UI, and REST since late 2025; regression-free since 3.1.4), with `map_index_template` (2.9+) for fold names. The page now locates the real irreducible gaps: no all-time experiment×fold status catalog, no in-place extension of a past experiment (run `conf` is immutable), and asset-event metadata being raw JSON with no rendered tables or history plots.
- **"Airflow assets carry no materialisation metadata" softened** to the accurate form: asset-event `extra` (Airflow 2.10+) is a partial `add_output_metadata` equivalent — stored, queryable, UI-visible, but not rendered.
- **The OCF orchestrator picture corrected**: OCF runs *both* Airflow (production services) and Dagster (on-prem data pipelines); OCF's data-engineering preference at design time favoured Dagster; standardising on Airflow has been under discussion since around August 2025 but is not a settled decision. The "what would change this assessment" trigger now names that decision explicitly.
- **Dagster surface line count** refreshed from ~1,600 to ~1,900 (the five `defs/` files now total 1,870 lines).
- **Revisit triggers sharpened**: the full-port trigger has half-fired (data model shipped, UI pending), so it now names AIP-76 partition observability specifically, plus MWAA reaching ≥3.2.2.

## Verification

- All Airflow/MWAA claims checked against primary sources (Airflow release notes and blogs, official docs, GitHub issues via API, AWS MWAA docs); confirmed claims (deferrable sensors, pools, params trigger forms, ECS per-task granularity, multi-executor GA in 3.0, AIP-105 pluggable retries, MWAA 3.2.1 / Python 3.12) are retained with dates.
- `uv run pymarkdown scan` clean; `uv run mkdocs build --strict` passes; the renamed page's nav entry and inbound links updated; the new requirements anchor verified in the rendered HTML.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
