### PR TITLE
Fix Polars 2.0 empty_as_null DeprecationWarning in geo.h3

### DIFF
--- a/packages/geo/src/geo/h3.py
+++ b/packages/geo/src/geo/h3.py
@@ -111,7 +111,7 @@ def compute_h3_grid_weights(
 
     weights_df = (
         df.with_columns(child_h3=plh3.cell_to_children("h3_index", child_h3_res))
-        .explode("child_h3")
+        .explode("child_h3", empty_as_null=False)
         .with_columns(
             nwp_lat=_snap_to_grid(plh3.cell_to_lat("child_h3")),
             nwp_lon=_snap_to_grid(plh3.cell_to_lng("child_h3")),


### PR DESCRIPTION
Fixes #371.

`compute_h3_grid_weights` emitted a `DeprecationWarning` from its `.explode("child_h3")` call: in Polars 2.0 the `empty_as_null` default flips from `True` to `False`.

## Change
One line — pass `empty_as_null=False` explicitly at [`packages/geo/src/geo/h3.py:114`](https://github.com/openclimatefix/nged-substation-forecast/blob/main/packages/geo/src/geo/h3.py).

`plh3.cell_to_children` never returns an empty list (`child_h3_res > h3_res` is enforced, and every H3 cell has children at a finer resolution), so this is behaviourally identical today. `False` is chosen because it (a) matches the Polars 2.0 default, so nothing changes when 2.0 lands, and (b) is the more robust intent: an empty list would drop the row rather than inject a null-poisoned `nwp_lat`/`nwp_lon` that would then fail `H3GridWeights.validate()`.

## Verification
- `uv run pytest packages/geo -W error::DeprecationWarning` — all 9 tests pass (warning is gone; would otherwise error).
- `uv run ruff check packages/geo` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)