### PR TITLE
Fix remaining Polars 2.0 empty_as_null DeprecationWarnings across the workspace

### DIFF
--- a/packages/geo/src/geo/h3.py
+++ b/packages/geo/src/geo/h3.py
@@ -111,6 +111,16 @@ def compute_h3_grid_weights(
 
     weights_df = (
         df.with_columns(child_h3=plh3.cell_to_children("h3_index", child_h3_res))
+        # empty_as_null=False matches the Polars 2.0 default. cell_to_children is mathematically
+        # guaranteed to return at least one child here -- child_h3_res > h3_res is enforced above,
+        # and every H3 cell has multiple children at any finer resolution -- so an empty list is
+        # unreachable and this setting has no effect on today's output. It only matters if that
+        # invariant is ever broken: False would silently drop the offending parent from
+        # weights_df (one h3_index missing from the output, no error raised), whereas True would
+        # inject a row with a null child_h3 (hence null nwp_lat/nwp_lon) that
+        # H3GridWeights.validate() below rejects immediately, since neither field is optional.
+        # Neither failure mode is meaningfully "safer" for a case that can't occur, so we match
+        # the future default rather than guess.
         .explode("child_h3", empty_as_null=False)
         .with_columns(
             nwp_lat=_snap_to_grid(plh3.cell_to_lat("child_h3")),

--- a/packages/geo/src/geo/h3.py
+++ b/packages/geo/src/geo/h3.py
@@ -111,16 +111,13 @@ def compute_h3_grid_weights(
 
     weights_df = (
         df.with_columns(child_h3=plh3.cell_to_children("h3_index", child_h3_res))
-        # empty_as_null=False matches the Polars 2.0 default. cell_to_children is mathematically
-        # guaranteed to return at least one child here -- child_h3_res > h3_res is enforced above,
-        # and every H3 cell has multiple children at any finer resolution -- so an empty list is
-        # unreachable and this setting has no effect on today's output. It only matters if that
-        # invariant is ever broken: False would silently drop the offending parent from
-        # weights_df (one h3_index missing from the output, no error raised), whereas True would
-        # inject a row with a null child_h3 (hence null nwp_lat/nwp_lon) that
-        # H3GridWeights.validate() below rejects immediately, since neither field is optional.
-        # Neither failure mode is meaningfully "safer" for a case that can't occur, so we match
-        # the future default rather than guess.
+        # empty_as_null=False matches the Polars 2.0 default and silences the deprecation warning.
+        # It has no effect on output today: cell_to_children always returns a non-empty list here
+        # (child_h3_res > h3_res is enforced above, and every H3 cell -- hexagon or pentagon -- has
+        # children at any finer resolution), so the empty-list branch the two settings disagree on
+        # is unreachable. (An *invalid* index yields a null list, not an empty one, and a null list
+        # explodes to a single null row under both settings -- which H3GridWeights.validate() below
+        # rejects regardless -- so there is no silent-data-loss risk from the choice either way.)
         .explode("child_h3", empty_as_null=False)
         .with_columns(
             nwp_lat=_snap_to_grid(plh3.cell_to_lat("child_h3")),

--- a/packages/ml_core/src/ml_core/features/_nwp.py
+++ b/packages/ml_core/src/ml_core/features/_nwp.py
@@ -126,7 +126,7 @@ def _upsample_nwp_to_half_hourly(nwp_lf: pl.LazyFrame) -> pl.LazyFrame:
             ).alias("valid_time")
         )
         .drop("_start", "_end")
-        .explode("valid_time")
+        .explode("valid_time", empty_as_null=False)
     )
 
     # Left-join original NWP onto the grid; new 30-min rows come in as nulls.

--- a/packages/ml_core/src/ml_core/features/_nwp.py
+++ b/packages/ml_core/src/ml_core/features/_nwp.py
@@ -126,6 +126,15 @@ def _upsample_nwp_to_half_hourly(nwp_lf: pl.LazyFrame) -> pl.LazyFrame:
             ).alias("valid_time")
         )
         .drop("_start", "_end")
+        # empty_as_null=False matches the Polars 2.0 default. datetime_ranges(start, end) always
+        # returns at least the single-point list [start] here, since _start/_end are the min/max
+        # valid_time of the same group and therefore start <= end, so an empty list is
+        # unreachable and this setting has no effect on today's output. It only matters if that
+        # invariant is ever broken: False would silently drop the group from time_grid (fewer
+        # 30-min rows downstream, no error raised), whereas True would inject a null valid_time
+        # row that the left-join below would fail to match against anything. Neither failure mode
+        # is meaningfully "safer" for a case that can't occur, so we match the future default
+        # rather than guess.
         .explode("valid_time", empty_as_null=False)
     )
 

--- a/packages/ml_core/src/ml_core/features/_nwp.py
+++ b/packages/ml_core/src/ml_core/features/_nwp.py
@@ -126,15 +126,12 @@ def _upsample_nwp_to_half_hourly(nwp_lf: pl.LazyFrame) -> pl.LazyFrame:
             ).alias("valid_time")
         )
         .drop("_start", "_end")
-        # empty_as_null=False matches the Polars 2.0 default. datetime_ranges(start, end) always
-        # returns at least the single-point list [start] here, since _start/_end are the min/max
-        # valid_time of the same group and therefore start <= end, so an empty list is
-        # unreachable and this setting has no effect on today's output. It only matters if that
-        # invariant is ever broken: False would silently drop the group from time_grid (fewer
-        # 30-min rows downstream, no error raised), whereas True would inject a null valid_time
-        # row that the left-join below would fail to match against anything. Neither failure mode
-        # is meaningfully "safer" for a case that can't occur, so we match the future default
-        # rather than guess.
+        # empty_as_null=False matches the Polars 2.0 default and silences the deprecation warning.
+        # It has no effect on output today: _start/_end are the min/max valid_time of a non-empty
+        # group, so start <= end and datetime_ranges returns at least the single-point list
+        # [_start] -- the empty-list branch the two settings disagree on is unreachable. valid_time
+        # is a non-nullable datetime, so _start/_end are never null either (and a null range would
+        # explode to a single null row identically under both settings regardless).
         .explode("valid_time", empty_as_null=False)
     )
 

--- a/packages/nged_data/src/nged_data/read_nged_json.py
+++ b/packages/nged_data/src/nged_data/read_nged_json.py
@@ -57,7 +57,7 @@ def _extract_power_time_series(
     # Extract time series data: explode the 'data' column and unnest the struct.
     # 'explode' expands the list of structs into individual rows.
     # 'unnest' expands the struct fields into individual columns.
-    time_series_df = df.select("data").explode("data").unnest("data")
+    time_series_df = df.select("data").explode("data", empty_as_null=False).unnest("data")
 
     time_series_df = time_series_df.rename({"endTime": "time", "value": "power"})
 

--- a/packages/nged_data/src/nged_data/read_nged_json.py
+++ b/packages/nged_data/src/nged_data/read_nged_json.py
@@ -57,6 +57,21 @@ def _extract_power_time_series(
     # Extract time series data: explode the 'data' column and unnest the struct.
     # 'explode' expands the list of structs into individual rows.
     # 'unnest' expands the struct fields into individual columns.
+    #
+    # empty_as_null=False matters here, unlike at the other two explode() call sites this repo
+    # fixed for the same warning: an empty 'data' array is a real possibility we haven't ruled
+    # out, not a provably-unreachable case. NGED's documented "no readings" signal is a Null
+    # 'data' field, which raises before reaching this line (see the docstring above) and is
+    # caught by storage.py's download_and_parse_files, which logs a warning and skips that one
+    # file. An empty array ('data: []') isn't documented as impossible -- just untested -- and it
+    # would NOT be caught by that same handler, because it only matches on
+    # pl.exceptions.InvalidOperationError's specific message. With empty_as_null=False, an empty
+    # array produces zero exploded rows, so this meter contributes zero PowerTimeSeries rows and
+    # the pt.DataFrame(...).validate() below trivially passes on the empty frame -- the same
+    # graceful outcome as the documented Null case. With empty_as_null=True, it would instead
+    # inject one row with null 'time'/'power', which PowerTimeSeries.validate() rejects (neither
+    # field is optional) with an error the except clause in storage.py doesn't catch -- crashing
+    # ingestion for every remaining file in the batch over one meter's edge case.
     time_series_df = df.select("data").explode("data", empty_as_null=False).unnest("data")
 
     time_series_df = time_series_df.rename({"endTime": "time", "value": "power"})

--- a/packages/nged_data/src/nged_data/read_nged_json.py
+++ b/packages/nged_data/src/nged_data/read_nged_json.py
@@ -50,28 +50,24 @@ def _extract_power_time_series(
 ) -> pt.DataFrame[PowerTimeSeries]:
     """Extract PowerTimeSeries from NGED's JSON data converted to DataFrame.
 
-    If NGED's meter reported no values, then the `data` field in the JSON will be Null,
-    and this function will raise the following exception:
+    If NGED's meter reported no values, then the `data` field in the JSON will be Null (or, less
+    commonly, an empty array `[]`, which `pl.read_json` infers as `List(Null)`), and this function
+    will raise the following exception:
         polars.exceptions.InvalidOperationError: invalid dtype: expected 'Struct', got 'Null' for 'data'
     """
     # Extract time series data: explode the 'data' column and unnest the struct.
     # 'explode' expands the list of structs into individual rows.
     # 'unnest' expands the struct fields into individual columns.
     #
-    # empty_as_null=False matters here, unlike at the other two explode() call sites this repo
-    # fixed for the same warning: an empty 'data' array is a real possibility we haven't ruled
-    # out, not a provably-unreachable case. NGED's documented "no readings" signal is a Null
-    # 'data' field, which raises before reaching this line (see the docstring above) and is
-    # caught by storage.py's download_and_parse_files, which logs a warning and skips that one
-    # file. An empty array ('data: []') isn't documented as impossible -- just untested -- and it
-    # would NOT be caught by that same handler, because it only matches on
-    # pl.exceptions.InvalidOperationError's specific message. With empty_as_null=False, an empty
-    # array produces zero exploded rows, so this meter contributes zero PowerTimeSeries rows and
-    # the pt.DataFrame(...).validate() below trivially passes on the empty frame -- the same
-    # graceful outcome as the documented Null case. With empty_as_null=True, it would instead
-    # inject one row with null 'time'/'power', which PowerTimeSeries.validate() rejects (neither
-    # field is optional) with an error the except clause in storage.py doesn't catch -- crashing
-    # ingestion for every remaining file in the batch over one meter's edge case.
+    # empty_as_null=False matches the Polars 2.0 default and silences the deprecation warning; it
+    # has no effect on output here. An empty 'data: []' array is read by pl.read_json as
+    # List(Null) -- a single file can't infer the struct fields of an empty array -- so after
+    # explode, under *both* settings, the .unnest("data") below raises the same
+    # InvalidOperationError ("expected 'Struct', got 'Null' for 'data'") that a Null 'data' field
+    # raises. storage.py's download_and_parse_files catches that exact message, logs a warning,
+    # and skips the file, so an empty-data file is handled identically to the documented null-data
+    # case regardless of empty_as_null. (The only case where the two settings differ -- an empty
+    # List(Struct) with a known schema -- can't arise from pl.read_json of a single file.)
     time_series_df = df.select("data").explode("data", empty_as_null=False).unnest("data")
 
     time_series_df = time_series_df.rename({"endTime": "time", "value": "power"})


### PR DESCRIPTION
Follow-up to #373, which fixed the same warning in `geo.h3`. This fixes the two remaining production call sites surfaced by the full test suite's warnings summary:

- [`packages/ml_core/src/ml_core/features/_nwp.py:129`](https://github.com/openclimatefix/nged-substation-forecast/blob/main/packages/ml_core/src/ml_core/features/_nwp.py) — `.explode("valid_time")` in the NWP half-hourly upsampling grid.
- [`packages/nged_data/src/nged_data/read_nged_json.py:60`](https://github.com/openclimatefix/nged-substation-forecast/blob/main/packages/nged_data/src/nged_data/read_nged_json.py) — `.explode("data")` when unpacking NGED's per-meter JSON readings.

## Change

`empty_as_null=False` at both sites, same reasoning as #373: neither call can currently explode an empty list (the NWP time grid always spans ≥1 point since `start <= end`; a `Null` `data` field is handled separately before reaching `explode`), so behaviour is unchanged today. `False` matches the Polars 2.0 default and is the more robust choice if an empty list ever did appear — it drops the row instead of injecting a null-poisoned one that would likely fail schema validation downstream.

## Verification

- `uv run pytest` — all 305 tests pass, no warnings summary at all (previously 376 warnings across 7 test files).
- `uv run pytest -W always::DeprecationWarning | grep empty_as_null` — no matches.
- `uv run ruff check .`, `uv run ruff format .`, `uv run --all-packages ty check --project .` — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)