### PR TITLE
Defer Settings() construction to first use via get_settings()

### DIFF
--- a/packages/contracts/src/contracts/settings.py
+++ b/packages/contracts/src/contracts/settings.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from pathlib import Path
 from typing import Final, Self
 
@@ -304,3 +305,21 @@ class Settings(BaseSettings):
         """Validate that the S3 bucket URL is a valid URL."""
         url_adapter.validate_python(v)
         return v
+
+
+@lru_cache
+def get_settings() -> Settings:
+    """Return the shared, lazily-constructed ``Settings`` singleton.
+
+    Prefer this over constructing ``Settings()`` at module import time. ``Settings`` has required
+    fields (the ``nged_s3_bucket_*`` credentials) with no defaults, so instantiation reads ``.env``
+    and raises ``ValidationError`` when those are absent. Deferring construction to first *use*
+    keeps library modules (e.g. the ``contracts`` schemas) importable without live credentials —
+    so type-checkers, doc builders, and tests that only touch in-memory frames don't need a
+    populated ``.env`` — while still failing fast the moment settings are actually needed.
+
+    Cached with ``lru_cache`` so every caller shares one instance (matching the previous
+    module-level singletons). Call ``get_settings.cache_clear()`` in a test that needs to
+    re-read the environment after changing it.
+    """
+    return Settings()

--- a/packages/contracts/src/contracts/weather_schemas.py
+++ b/packages/contracts/src/contracts/weather_schemas.py
@@ -8,13 +8,10 @@ import patito as pt
 import polars as pl
 
 from contracts._uri import ObjectStoreOptions
-from contracts.settings import Settings
+from contracts.settings import get_settings
 from contracts.typing_utils import typeddict_to_dict
 
 from .common import UTC_DATETIME_DTYPE
-
-SETTINGS = Settings()
-
 
 WeatherFeature = Literal[
     "temperature_2m",
@@ -62,8 +59,15 @@ class NwpMetaData(pt.Model):
     is_ensemble: bool = pt.Field(description="Whether this NWP model produces ensemble forecasts.")
 
     @classmethod
-    def load(cls, csv_path: str | Path = SETTINGS.nwp_metadata_csv_path) -> pt.DataFrame[Self]:
-        """Load NWP metadata from a static CSV file."""
+    def load(cls, csv_path: str | Path | None = None) -> pt.DataFrame[Self]:
+        """Load NWP metadata from a static CSV file.
+
+        Args:
+            csv_path: Path to the metadata CSV; defaults to ``get_settings().nwp_metadata_csv_path``
+                (resolved lazily so importing this module needs no ``.env``).
+        """
+        if csv_path is None:
+            csv_path = get_settings().nwp_metadata_csv_path
         df = pl.read_csv(csv_path)
         # Patito's .cast() will handle the conversion to the Enum type defined in the model
         return pt.DataFrame(df).set_model(cls).cast().validate()
@@ -326,8 +330,8 @@ class Nwp(pt.Model):
     @classmethod
     def scan_delta(
         cls,
-        path: str | Path = SETTINGS.nwp_data_path,
-        storage_options: ObjectStoreOptions = SETTINGS.storage_options,
+        path: str | Path | None = None,
+        storage_options: ObjectStoreOptions | None = None,
     ) -> pt.LazyFrame[Self]:
         """Lazily scan the NWP Delta table, typed and cast to this contract's dtypes.
 
@@ -335,11 +339,18 @@ class Nwp(pt.Model):
         so no rescale step is needed.
 
         Args:
-            path: Path or URI of the ``nwp`` Delta table.
+            path: Path or URI of the ``nwp`` Delta table; defaults to
+                ``get_settings().nwp_data_path`` (resolved lazily so importing this module needs
+                no ``.env``).
             storage_options: delta-rs object-store options (credentials/endpoint) for a remote
-                ``path``; defaults to the ``SETTINGS`` singleton's options (empty for a local
-                ``path``). Read-only — never mutated here (shared mutable default).
+                ``path``; defaults to ``get_settings().storage_options`` (empty for a local
+                ``path``).
         """
+        settings = get_settings()
+        if path is None:
+            path = settings.nwp_data_path
+        if storage_options is None:
+            storage_options = settings.storage_options
         return (
             pt.LazyFrame.from_existing(
                 pl.scan_delta(path, storage_options=typeddict_to_dict(storage_options))

--- a/packages/contracts/tests/conftest.py
+++ b/packages/contracts/tests/conftest.py
@@ -1,0 +1,21 @@
+"""Shared fixtures for the ``contracts`` tests."""
+
+from collections.abc import Iterator
+
+import pytest
+from contracts.settings import get_settings
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings_cache() -> Iterator[None]:
+    """Give every test a fresh ``get_settings()`` cache.
+
+    ``get_settings`` is a process-global ``lru_cache``, so without this the first test to call it
+    (e.g. a defaulted ``NwpMetaData.load()`` or ``Nwp.scan_delta()``) would freeze the ``Settings``
+    instance for the rest of the session — a later test that changes the environment and expects a
+    rebuilt ``Settings`` would silently read the stale one. Clearing before and after keeps each
+    test independent of execution order.
+    """
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()

--- a/packages/contracts/tests/test_settings.py
+++ b/packages/contracts/tests/test_settings.py
@@ -1,7 +1,9 @@
+import subprocess
+import sys
 from typing import cast
 
 import pytest
-from contracts.settings import DataQualitySettings, Settings
+from contracts.settings import DataQualitySettings, Settings, get_settings
 from pydantic import ValidationError
 
 
@@ -163,3 +165,38 @@ def test_storage_options_populated_from_dev_credentials():
         "aws_secret_access_key": "minio123",
         "aws_region": "us-east-1",
     }
+
+
+def test_get_settings_is_cached(monkeypatch: pytest.MonkeyPatch):
+    """get_settings returns a single shared instance; cache_clear forces a rebuild."""
+    monkeypatch.setenv("NGED_S3_BUCKET_URL", "https://example.com")
+    monkeypatch.setenv("NGED_S3_BUCKET_ACCESS_KEY", "key")
+    monkeypatch.setenv("NGED_S3_BUCKET_SECRET", "secret")
+    get_settings.cache_clear()
+    try:
+        assert get_settings() is get_settings()
+        first = get_settings()
+        get_settings.cache_clear()
+        assert get_settings() is not first
+    finally:
+        # Don't leak this module's hermetic instance into other test modules' cache.
+        get_settings.cache_clear()
+
+
+def test_importing_contracts_constructs_no_settings():
+    """Importing the schema modules must not construct Settings (no import-time .env read).
+
+    Settings has required credential fields with no defaults, so any import-time construction would
+    make the whole contracts package unimportable without a populated .env — breaking type-checkers,
+    doc builders, and credential-free unit tests. Run in a fresh interpreter because this process
+    has already imported (and used) these modules. See contracts.settings.get_settings.
+    """
+    probe = (
+        "import contracts.settings, contracts.weather_schemas\n"
+        "size = contracts.settings.get_settings.cache_info().currsize\n"
+        "assert size == 0, f'Settings constructed at import time (cache size {size})'\n"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", probe], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0, result.stderr

--- a/packages/contracts/tests/test_settings.py
+++ b/packages/contracts/tests/test_settings.py
@@ -190,11 +190,22 @@ def test_importing_contracts_constructs_no_settings():
     make the whole contracts package unimportable without a populated .env — breaking type-checkers,
     doc builders, and credential-free unit tests. Run in a fresh interpreter because this process
     has already imported (and used) these modules. See contracts.settings.get_settings.
+
+    The guard patches ``Settings.__init__`` to raise, so it catches *any* import-time construction —
+    a direct module-level ``Settings()`` as well as one routed through ``get_settings()`` — not just
+    a populated cache. ``contracts/__init__.py`` imports nothing, so the patch lands before any
+    schema module loads.
     """
     probe = (
-        "import contracts.settings, contracts.weather_schemas\n"
-        "size = contracts.settings.get_settings.cache_info().currsize\n"
-        "assert size == 0, f'Settings constructed at import time (cache size {size})'\n"
+        "import contracts.settings as s\n"
+        "def _boom(*args, **kwargs):\n"
+        "    raise AssertionError('Settings() constructed at import time')\n"
+        "s.Settings.__init__ = _boom\n"
+        "import contracts.weather_schemas\n"
+        "import contracts.geo_schemas\n"
+        "import contracts.power_schemas\n"
+        "import contracts.ml_schemas\n"
+        "assert s.get_settings.cache_info().currsize == 0\n"
     )
     result = subprocess.run(
         [sys.executable, "-c", probe], capture_output=True, text=True, check=False

--- a/packages/dynamical_data/src/dynamical_data/ecmwf_ens/convert_to_polars.py
+++ b/packages/dynamical_data/src/dynamical_data/ecmwf_ens/convert_to_polars.py
@@ -7,10 +7,7 @@ import polars.selectors as cs
 import xarray as xr
 from contracts.common import UTC_DATETIME_DTYPE
 from contracts.geo_schemas import H3GridWeights
-from contracts.settings import Settings
 from contracts.weather_schemas import NWP_MODEL_ID_DTYPE, Nwp, NwpModelId
-
-_SETTINGS = Settings()
 
 
 def convert_nwp_xarray_dataset_to_polars_dataframe(

--- a/packages/dynamical_data/src/dynamical_data/ecmwf_ens/download.py
+++ b/packages/dynamical_data/src/dynamical_data/ecmwf_ens/download.py
@@ -8,9 +8,6 @@ import patito as pt
 import polars as pl
 import xarray as xr
 from contracts.geo_schemas import H3GridWeights
-from contracts.settings import Settings
-
-_SETTINGS = Settings()
 
 
 class NwpRunNotYetAvailable(Exception):


### PR DESCRIPTION
## Problem

`contracts.weather_schemas` ran `SETTINGS = Settings()` at **import time**. `Settings` has three required credential fields with no defaults:

```python
nged_s3_bucket_url: str = Field(...)
nged_s3_bucket_access_key: str = Field(...)
nged_s3_bucket_secret: str = Field(...)
```

so instantiation reads `.env` and raises `ValidationError` when those are absent. That made a **pure schema module require live S3 credentials just to import** — breaking type-checkers, doc builders, and unit tests that only touch in-memory frames, and forcing `.env` to be symlinked into every worktree.

Two other module-level `Settings()` calls (in `dynamical_data`) were **dead** — assigned to `_SETTINGS` and never referenced, i.e. a pure import-time side effect.

## Change

Introduce a cached `get_settings()` accessor and convert the **library** import-time sites to it:

- **`weather_schemas`** — drop the module-level `SETTINGS` singleton and resolve the three method defaults (`NwpMetaData.load`, `Nwp.scan_delta`) lazily via a `None` sentinel. Default args are evaluated at `def`/import time, so a lazy singleton *alone* wouldn't have fixed those — the sentinel is what defers the read.
- **`dynamical_data`** (`convert_to_polars`, `download`) — delete the dead `_SETTINGS = Settings()` assignments and their now-unused imports.

Misconfiguration still fails fast — just at first *use* of settings rather than at import of a schema. The Dagster entrypoint (`definitions.py`) is left untouched: eager construction + fail-fast at app load is correct there.

## API ripple

`Nwp.scan_delta` and `NwpMetaData.load` default params change from a concrete path to `None` (resolved internally). Behaviour when called with no args is identical; both are called that way today.

## Tests

- A subprocess regression guard proving the schema modules construct **no** `Settings` at import (`get_settings.cache_info().currsize == 0` in a fresh interpreter).
- A `get_settings` caching test.
- Full suite: **307 passed**. `ruff`, `ty` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)