### PR TITLE
Centralise the NWP analysis-proxy query into one shared function

### DIFF
--- a/packages/dashboard/pyproject.toml
+++ b/packages/dashboard/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "plotting",
     "polars>=1.37.1",
     "pyarrow>=23.0.0",
+    "weather_utils",
     "geoarrow-pyarrow>=0.2.0",
     "patito>=0.8.5",
 ]

--- a/packages/dashboard/src/dashboard/forecast_chart.py
+++ b/packages/dashboard/src/dashboard/forecast_chart.py
@@ -107,13 +107,10 @@ We hold no weather observations, so the closest available proxy for the *true* w
 historical times is each run's shortest-lead forecasts: the first day of every run across the
 window, stitched into one line. 24 hours matches the daily-00Z run cadence, so consecutive
 chunks tile into a continuous line with no gaps and no overlaps.
-"""
 
-NWP_ANALYSIS_MEMBER: Final[int] = 0
-"""The ensemble member the proxy-analysis line uses.
-
-Member 0 of ECMWF ENS is the control run — the unperturbed forecast started from the analysis
-itself — so its shortest leads are the closest thing to the analysis that the ensemble holds.
+The proxy-analysis line uses the control member (member 0) — ``view_forecasts.py`` obtains it via
+``weather_utils.select_analysis_proxy``, which also reduces overlapping runs to the freshest per
+valid time, so the frame reaching ``build_nwp_ensemble_chart`` is already a single stitched line.
 """
 
 
@@ -478,12 +475,12 @@ def build_nwp_ensemble_chart(
         nwp_init_time: When the plotted NWP run was initialised (tz-aware UTC); shown in the
             subtitle. The lines start here — the run has no earlier data — so the panel is
             deliberately empty between the window start and the NWP init time.
-        analysis: Short-lead ``Nwp`` rows from *every* run overlapping the window — the first
-            ``NWP_ANALYSIS_LEAD`` of each run, ``NWP_ANALYSIS_MEMBER`` only — with ``init_time``
-            and ``valid_time`` alongside the variable columns. Stitched (freshest run wins where
-            runs overlap a ``valid_time``) into a single thick blue line: our closest proxy for
-            the true weather, since we hold no weather observations. ``None``, or no rows in the
-            window, omits the line.
+        analysis: The proxy-analysis line, already reduced to one control-member row per
+            ``valid_time`` by ``weather_utils.select_analysis_proxy`` (the first
+            ``NWP_ANALYSIS_LEAD`` of each run, freshest run winning where runs overlap), with
+            ``valid_time`` alongside the variable columns. Drawn as a single thick blue line: our
+            closest proxy for the true weather, since we hold no weather observations. ``None``, or
+            no rows in the window, omits the line.
         shade_weekends: Whether to draw the same faint weekend bands as the power chart.
 
     Returns:
@@ -523,8 +520,6 @@ def build_nwp_ensemble_chart(
         if analysis is None
         else _prepare_for_plot(
             analysis.filter(plot_window)
-            # Where runs overlap a valid_time, keep the freshest run — the shortest lead.
-            .filter(pl.col("init_time") == pl.col("init_time").max().over("valid_time"))
             .select("valid_time", variable)
             .with_columns(pl.col(variable) * var.scale),
             "valid_time",

--- a/packages/dashboard/src/dashboard/forecast_chart.py
+++ b/packages/dashboard/src/dashboard/forecast_chart.py
@@ -100,17 +100,21 @@ Exactly the *continuous* ``Nwp`` variables (a test guards against drift):
 which a line chart would render as meaningless slopes.
 """
 
-NWP_ANALYSIS_LEAD: Final[timedelta] = timedelta(hours=24)
+NWP_ANALYSIS_LEAD: Final[timedelta] = timedelta(hours=27)
 """How much of each NWP run's start feeds the stitched proxy-analysis line.
 
 We hold no weather observations, so the closest available proxy for the *true* weather over
-historical times is each run's shortest-lead forecasts: the first day of every run across the
-window, stitched into one line. 24 hours matches the daily-00Z run cadence, so consecutive
-chunks tile into a continuous line with no gaps and no overlaps.
+historical times is each run's shortest-lead forecasts: the first ~day of every run across the
+window, stitched into one line. The daily-00Z run cadence is 24 hours; we take 27 hours so each
+run overlaps the next by 3 hours (one NWP step). The overlap is deliberate: accumulated variables
+(precipitation, radiation) are null at lead 0, so at each 24 h stitch boundary the incoming run's
+first value is missing — the 3 h overlap lets ``select_analysis_proxy``'s per-column null-fill draw
+that value from the outgoing run's lead-24 instead of leaving a gap.
 
 The proxy-analysis line uses the control member (member 0) — ``view_forecasts.py`` obtains it via
-``weather_utils.select_analysis_proxy``, which also reduces overlapping runs to the freshest per
-valid time, so the frame reaching ``build_nwp_ensemble_chart`` is already a single stitched line.
+``weather_utils.select_analysis_proxy``, which reduces the overlapping runs to one freshest-non-null
+row per valid time, so the frame reaching ``build_nwp_ensemble_chart`` is already a single stitched
+line.
 """
 
 

--- a/packages/dashboard/tests/test_forecast_chart.py
+++ b/packages/dashboard/tests/test_forecast_chart.py
@@ -258,8 +258,10 @@ def _nwp(members: tuple[int, ...] = (0, 1, 2)) -> pl.LazyFrame:
 
 def _nwp_analysis(inits: Sequence[datetime]) -> pl.LazyFrame:
     """The first ``NWP_ANALYSIS_LEAD`` of one run per element of ``inits``, control member only
-    — what the dashboard feeds ``build_nwp_ensemble_chart``'s ``analysis`` argument. The
-    temperature encodes the run's index so tests can see which run each plotted point came from.
+    — the already-reduced proxy-analysis frame the dashboard feeds ``build_nwp_ensemble_chart``
+    (``view_forecasts.py`` produces it via ``weather_utils.select_analysis_proxy``). Pass
+    non-overlapping runs, since the builder no longer collapses overlaps itself. The temperature
+    encodes the run's index so tests can see which run each plotted point came from.
     """
     frames = []
     for index, run_init in enumerate(inits):
@@ -363,22 +365,6 @@ def test_nwp_analysis_is_a_single_blue_line_over_the_ensemble() -> None:
     assert analysis["encoding"]["y"] == spec["layer"][1]["encoding"]["y"]
     assert "detail" not in analysis["encoding"]  # one stitched line, not a line per member
     assert any("Proxy analysis" in line for line in spec["title"]["subtitle"])
-
-
-def test_nwp_analysis_keeps_the_freshest_run_where_runs_overlap() -> None:
-    # Two runs 12 h apart, each contributing NWP_ANALYSIS_LEAD (24 h) of rows, so the second
-    # run's first 12 h of valid times appear in both — the freshest (shortest-lead) run must
-    # win there, collapsing each overlapped valid_time to a single point.
-    spec = _build_nwp(
-        analysis=_nwp_analysis([NWP_INIT_TIME, NWP_INIT_TIME + timedelta(hours=12)])
-    ).to_dict()
-    rows = spec["datasets"][spec["layer"][2]["data"]["name"]]
-    by_time = {row["valid_time"]: row["temperature_2m"] for row in rows}
-    assert len(by_time) == len(rows) == 12  # 8 + 8 rows, 4 of them at shared valid times
-    # NWP_INIT_TIME is 04 Jul 00:00 UTC = 01:00 wall time (BST); the runs overlap from 13:00.
-    assert by_time["2026-07-04T04:00:00"] == 0.0  # before the overlap: only the first run
-    assert by_time["2026-07-04T16:00:00"] == 1.0  # inside the overlap: the second run wins
-    assert by_time["2026-07-05T10:00:00"] == 1.0  # after the first run's 24 h end
 
 
 def test_nwp_analysis_line_is_omitted_when_absent_or_outside_the_window() -> None:

--- a/packages/dashboard/tests/test_forecast_chart.py
+++ b/packages/dashboard/tests/test_forecast_chart.py
@@ -17,6 +17,7 @@ from dashboard.forecast_chart import (
     build_view_forecast_chart,
 )
 from plotting import ocf_theme
+from weather_utils import select_analysis_proxy
 
 INIT_TIME = datetime(2026, 7, 4, 6, 0, tzinfo=UTC)
 """During British Summer Time, so wall time is UTC+1 — the axis tests below rely on that."""
@@ -257,11 +258,11 @@ def _nwp(members: tuple[int, ...] = (0, 1, 2)) -> pl.LazyFrame:
 
 
 def _nwp_analysis(inits: Sequence[datetime]) -> pl.LazyFrame:
-    """The first ``NWP_ANALYSIS_LEAD`` of one run per element of ``inits``, control member only
-    — the already-reduced proxy-analysis frame the dashboard feeds ``build_nwp_ensemble_chart``
-    (``view_forecasts.py`` produces it via ``weather_utils.select_analysis_proxy``). Pass
-    non-overlapping runs, since the builder no longer collapses overlaps itself. The temperature
-    encodes the run's index so tests can see which run each plotted point came from.
+    """The proxy-analysis frame the dashboard feeds ``build_nwp_ensemble_chart``, built exactly as
+    ``view_forecasts.py`` builds it: the first ``NWP_ANALYSIS_LEAD`` of one control-member run per
+    element of ``inits``, run through ``select_analysis_proxy`` so overlapping runs collapse to one
+    freshest-non-null row per valid time. The temperature encodes the run's index so tests can see
+    which run each plotted point came from.
     """
     frames = []
     for index, run_init in enumerate(inits):
@@ -278,6 +279,8 @@ def _nwp_analysis(inits: Sequence[datetime]) -> pl.LazyFrame:
                 {
                     "init_time": [run_init] * len(valid_times),
                     "valid_time": valid_times,
+                    "ensemble_member": pl.Series([0] * len(valid_times), dtype=pl.UInt8),
+                    "h3_index": pl.Series([100] * len(valid_times), dtype=pl.UInt64),
                     "temperature_2m": pl.Series(
                         [float(index)] * len(valid_times), dtype=pl.Float32
                     ),
@@ -287,7 +290,10 @@ def _nwp_analysis(inits: Sequence[datetime]) -> pl.LazyFrame:
                 }
             )
         )
-    return pl.concat(frames).lazy()
+    raw = pl.concat(frames).lazy()
+    return select_analysis_proxy(raw, group_key="h3_index", max_lead=NWP_ANALYSIS_LEAD).drop(
+        "h3_index"
+    )
 
 
 def _build_nwp(

--- a/packages/dashboard/view_forecasts.py
+++ b/packages/dashboard/view_forecasts.py
@@ -12,7 +12,6 @@ with app.setup:
     from dashboard.forecast_chart import (
         LAG_OPTIONS,
         NWP_ANALYSIS_LEAD,
-        NWP_ANALYSIS_MEMBER,
         NWP_PLOT_VARIABLES,
         PLOT_HISTORY,
         PLOT_HORIZON,
@@ -20,6 +19,7 @@ with app.setup:
         build_view_forecast_chart,
     )
     from deltalake import DeltaTable
+    from weather_utils import select_analysis_proxy
 
 
 @app.cell
@@ -391,25 +391,29 @@ def _(forecasts, init_time, metadata_df, series_picker, settings):
             .collect()
         )
         # The proxy-analysis line stitches the first NWP_ANALYSIS_LEAD of every run overlapping
-        # the plotted window (control member only) — see the constants' docstrings. Loading it
-        # here, unconditionally, keeps the "NWP proxy analysis" checkbox instant: toggling it
-        # re-runs only the chart cell, never this Delta query (~0.2 s across the ~17 pruned
-        # init_time partitions). Runs older than window_start − NWP_ANALYSIS_LEAD cannot reach
-        # the window, so the init_time filter starts there.
+        # the plotted window (control member only). select_analysis_proxy applies the member
+        # filter, the max_lead stitch, and the freshest-run-per-valid_time reduction; the cheap
+        # partition/row-group filters (init_time range, h3_index) stay on the scan above it so
+        # Delta partition pruning survives. Loading it here, unconditionally, keeps the "NWP proxy
+        # analysis" checkbox instant: toggling it re-runs only the chart cell, never this Delta
+        # query (~0.2 s across the ~17 pruned init_time partitions). Runs older than
+        # window_start − NWP_ANALYSIS_LEAD cannot reach the window, so the init_time filter starts
+        # there.
         nwp_analysis = (
-            pl.scan_delta(
-                settings.nwp_data_path,
-                storage_options=typeddict_to_dict(settings.storage_options),
-            )
-            .filter(
-                pl.col("init_time").is_between(
-                    init_time - PLOT_HISTORY - NWP_ANALYSIS_LEAD, init_time + PLOT_HORIZON
+            select_analysis_proxy(
+                pl.scan_delta(
+                    settings.nwp_data_path,
+                    storage_options=typeddict_to_dict(settings.storage_options),
+                ).filter(
+                    pl.col("init_time").is_between(
+                        init_time - PLOT_HISTORY - NWP_ANALYSIS_LEAD, init_time + PLOT_HORIZON
+                    ),
+                    pl.col("h3_index") == _series_h3,
                 ),
-                pl.col("h3_index") == _series_h3,
-                pl.col("ensemble_member") == NWP_ANALYSIS_MEMBER,
-                pl.col("valid_time") < pl.col("init_time") + NWP_ANALYSIS_LEAD,
+                group_key="h3_index",
+                max_lead=NWP_ANALYSIS_LEAD,
             )
-            .drop("nwp_model_id", "h3_index", "ensemble_member")
+            .drop("nwp_model_id", "h3_index")
             .collect()
         )
     except Exception as error:

--- a/packages/ml_core/pyproject.toml
+++ b/packages/ml_core/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "patito",
     "polars>=1.0.0",
     "pydantic>=2.0.0",
+    "weather_utils",
 ]
 
 [build-system]

--- a/packages/ml_core/src/ml_core/features/_nwp.py
+++ b/packages/ml_core/src/ml_core/features/_nwp.py
@@ -5,21 +5,17 @@ can consume, and the two NWP join modes (bulk training vs. single-run inference)
 """
 
 from datetime import datetime, timedelta
-from typing import Final
 
 import polars as pl
 from contracts.common import UTC_DATETIME_DTYPE
 from contracts.weather_schemas import Nwp
 
-NWP_PUBLICATION_DELAY_HOURS: Final[int] = 6
-"""Default delay between an NWP run's ``init_time`` and when it becomes publicly available.
+# Re-export shim: the canonical definition lives in ``weather_utils`` (the analysis-proxy
+# availability cut owns it), but the join helpers here and ``_production_helpers`` /
+# ``feature_engineer`` still import it from this module.
+from weather_utils import NWP_PUBLICATION_DELAY_HOURS
 
-Used to derive ``power_fcst_init_time`` from ``nwp_init_time`` in bulk mode, and to derive
-``nwp_init_time`` from ``power_fcst_init_time`` when it is not supplied in single-run mode (see
-``_join_nwp_bulk_mode`` / ``_join_nwp_single_run``). Also the default for
-``select_nwp_init_time``'s replay-mode cutoff (``ml_core._production_helpers``), which
-reconstructs what was actually available at a historical ``power_fcst_init_time``.
-"""
+__all__ = ["NWP_PUBLICATION_DELAY_HOURS"]
 
 
 def _join_nwp_bulk_mode(
@@ -154,18 +150,3 @@ def _upsample_nwp_to_half_hourly(nwp_lf: pl.LazyFrame) -> pl.LazyFrame:
         )
 
     return upsampled
-
-
-def _build_historical_weather(processed_nwp: pl.LazyFrame) -> pl.LazyFrame:
-    """Builds the historical weather frame used by weather lag features.
-
-    Uses the control member (ensemble_member == 0) and selects the freshest forecast run
-    (shortest lead time) for each (time_series_id, valid_time).
-    """
-    return (
-        processed_nwp.filter(pl.col("ensemble_member") == 0)
-        .drop("ensemble_member")
-        .group_by(["time_series_id", "valid_time"])
-        .agg(pl.all().sort_by("nwp_lead_time_hours").first())
-        .sort(["time_series_id", "valid_time"])
-    )

--- a/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py
+++ b/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py
@@ -32,13 +32,13 @@ from contracts.weather_schemas import Nwp
 from ml_core.features._lags import _apply_power_lag, _apply_weather_lag, _nullify_leaky_lags
 from ml_core.features._nwp import (
     NWP_PUBLICATION_DELAY_HOURS,
-    _build_historical_weather,
     _join_nwp_bulk_mode,
     _join_nwp_single_run,
     _upsample_nwp_to_half_hourly,
 )
 from ml_core.features._parsed_features import STATIC_FEATURE_REGISTRY, ParsedFeatures
 from ml_core.features.feature_engineer import FeatureEngineer
+from weather_utils import select_analysis_proxy
 
 
 def _attach_nearest_nwp_cell(
@@ -179,7 +179,9 @@ def _engineer_features(
                 "to build historical weather, but no such rows were found in the NWP data."
             )
     historical_weather = (
-        _build_historical_weather(processed_nwp)
+        select_analysis_proxy(
+            processed_nwp, group_key="time_series_id", init_time_col="nwp_init_time"
+        )
         if processed_nwp is not None and weather_lags
         else None
     )

--- a/packages/weather_utils/README.md
+++ b/packages/weather_utils/README.md
@@ -1,0 +1,12 @@
+# weather_utils
+
+Shared NWP query helpers used by more than one package, kept in a low-level package so that
+neither consumer has to depend on the other.
+
+Today this package owns the **NWP analysis-proxy query** (`select_analysis_proxy`): the closest
+available proxy for the *true* weather at past times. We hold no weather observations, so the best
+stand-in is the control ensemble member (member 0 — the unperturbed run started from the analysis
+itself) at the shortest available lead: for each location and valid time, the freshest NWP run that
+had been produced. Both the dashboard (which shows what a model sees) and the ML feature pipeline
+(which builds weather-lag features) need exactly this selection, so it lives here and is computed
+once.

--- a/packages/weather_utils/pyproject.toml
+++ b/packages/weather_utils/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "weather_utils"
+version = "0.1.0"
+description = "Shared NWP query helpers reused across the dashboard and the feature pipeline"
+readme = "README.md"
+authors = [
+    { name = "Jack Kelly", email = "jack@openclimatefix.org" }
+]
+requires-python = ">=3.14"
+dependencies = [
+    "polars>=1.38.1",
+]
+
+[build-system]
+requires = ["uv_build>=0.9.28,<0.10.0"]
+build-backend = "uv_build"
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.2",
+    "pytest-cov",
+]

--- a/packages/weather_utils/src/weather_utils/__init__.py
+++ b/packages/weather_utils/src/weather_utils/__init__.py
@@ -1,0 +1,13 @@
+"""Shared NWP query helpers reused across the dashboard and the feature pipeline."""
+
+from weather_utils.analysis_proxy import (
+    NWP_ANALYSIS_MEMBER,
+    NWP_PUBLICATION_DELAY_HOURS,
+    select_analysis_proxy,
+)
+
+__all__ = [
+    "NWP_ANALYSIS_MEMBER",
+    "NWP_PUBLICATION_DELAY_HOURS",
+    "select_analysis_proxy",
+]

--- a/packages/weather_utils/src/weather_utils/analysis_proxy.py
+++ b/packages/weather_utils/src/weather_utils/analysis_proxy.py
@@ -41,15 +41,21 @@ def select_analysis_proxy(
 ) -> pl.LazyFrame:
     """Select the freshest-run analysis proxy: one row per ``(group_key, valid_time)``.
 
-    Keeps only the control ``member``, then — for each ``(group_key, valid_time)`` — the row from
-    the freshest NWP run (the latest ``init_time_col``, equivalently the shortest lead). The
-    ``ensemble_member`` column is dropped from the result.
+    Keeps only the control ``member``, then — for each ``(group_key, valid_time)`` and *per column*
+    — takes the value from the freshest NWP run (the latest ``init_time_col``) that has a **non-null**
+    value there. A null cell in the freshest run therefore falls back to the next-freshest run that
+    holds a value: this fills the accumulated variables' lead-0 nulls (precipitation and radiation
+    are null at the first forecast step by ECMWF convention) from the overlapping older run, rather
+    than leaving a gap. A cell is null in the result only when *every* candidate run is null there.
+    Because the fallback is per column, one output row can source different columns from different
+    runs; the reported ``init_time_col`` is the freshest run's, so it no longer necessarily matches
+    every value's source run. The ``ensemble_member`` column is dropped from the result.
 
     ``pl.LazyFrame`` in / ``pl.LazyFrame`` out, so it composes with both ``pl.scan_delta`` (the
     dashboard, keyed by ``h3_index``) and in-memory post-spatial-join frames (the pipeline, keyed
     by ``time_series_id``). The pushdownable filters (``member``, ``max_lead``, ``available_at``)
-    are applied *before* the freshest-run reduction so a Delta scan's partition pruning and
-    row-group skipping survive — confirm with ``.explain()`` when wiring a new scan through it.
+    are applied *before* the reduction so a Delta scan's partition pruning and row-group skipping
+    survive — confirm with ``.explain()`` when wiring a new scan through it.
 
     The ``group_by(...).agg(...)`` reduction always collapses to exactly one row per
     ``(group_key, valid_time)`` — so the result never fans out even if two rows tie at the freshest
@@ -65,7 +71,8 @@ def select_analysis_proxy(
             ``"nwp_init_time"`` in the pipeline after its rename).
         member: The ensemble member to keep (the control run by default).
         max_lead: If given, keep only rows with ``valid_time < init_time + max_lead`` — the
-            dashboard passes its per-run stitching window; the pipeline leaves it unbounded.
+            dashboard passes its per-run stitching window (wide enough to overlap the next run, so
+            the null-fill above has an older run to draw on); the pipeline leaves it unbounded.
         available_at: If given, keep only runs available by this as-of time, i.e.
             ``init_time + publication_delay <= available_at`` (replay-mode availability — it models
             what a hindcast could have seen, not the live path, which reads only already-published
@@ -80,7 +87,10 @@ def select_analysis_proxy(
         lf = lf.filter(pl.col("valid_time") < pl.col(init_time_col) + max_lead)
     if available_at is not None:
         lf = lf.filter(pl.col(init_time_col) + publication_delay <= available_at)
-    # Freshest run wins per (location, valid_time): take every column from the row with the latest
-    # init_time (equivalently the shortest lead). group_by(...).agg(...) guarantees exactly one row
-    # per group, so the result never fans out on a tie — see the docstring.
-    return lf.group_by([group_key, "valid_time"]).agg(pl.all().sort_by(init_time_col).last())
+    # Freshest run wins per (location, valid_time), per column: sort each column by init_time,
+    # drop its nulls, then take the last (freshest non-null) value — so a null in the freshest run
+    # falls back to the next-freshest run that has a value. group_by(...).agg(...) guarantees
+    # exactly one row per group, so the result never fans out on a tie — see the docstring.
+    return lf.group_by([group_key, "valid_time"]).agg(
+        pl.all().sort_by(init_time_col).drop_nulls().last()
+    )

--- a/packages/weather_utils/src/weather_utils/analysis_proxy.py
+++ b/packages/weather_utils/src/weather_utils/analysis_proxy.py
@@ -1,0 +1,89 @@
+"""The NWP analysis-proxy query, shared by the dashboard and the ML feature pipeline.
+
+We hold no weather observations, so the closest available proxy for the *true* weather over
+historical times is the control ensemble member at the shortest available lead: for each location
+and valid time, the freshest NWP run that had been produced. ``select_analysis_proxy`` centralises
+that selection so the dashboard (which exists to show what a model sees) and the feature pipeline
+(which builds weather-lag features) compute it identically.
+"""
+
+from datetime import datetime, timedelta
+from typing import Final
+
+import polars as pl
+
+NWP_PUBLICATION_DELAY_HOURS: Final[int] = 6
+"""Default delay between an NWP run's ``init_time`` and when it becomes publicly available.
+
+A run initialised at ``init_time`` cannot be used to reconstruct the analysis at an as-of time
+earlier than ``init_time + NWP_PUBLICATION_DELAY_HOURS`` — this is the delay ``select_analysis_proxy``
+applies for its optional ``available_at`` leakage cut, and the same delay the feature pipeline uses
+to derive ``power_fcst_init_time`` from ``nwp_init_time``.
+"""
+
+NWP_ANALYSIS_MEMBER: Final[int] = 0
+"""The ensemble member the analysis proxy uses.
+
+Member 0 of ECMWF ENS is the control run — the unperturbed forecast started from the analysis
+itself — so its shortest leads are the closest thing to the analysis that the ensemble holds.
+"""
+
+
+def select_analysis_proxy(
+    nwp: pl.LazyFrame,
+    *,
+    group_key: str,
+    init_time_col: str = "init_time",
+    member: int = NWP_ANALYSIS_MEMBER,
+    max_lead: timedelta | None = None,
+    available_at: datetime | None = None,
+    publication_delay: timedelta = timedelta(hours=NWP_PUBLICATION_DELAY_HOURS),
+) -> pl.LazyFrame:
+    """Select the freshest-run analysis proxy: one row per ``(group_key, valid_time)``.
+
+    Keeps only the control ``member``, then — for each ``(group_key, valid_time)`` — the row from
+    the freshest NWP run (the latest ``init_time_col``, equivalently the shortest lead). The
+    ``ensemble_member`` column is dropped from the result.
+
+    ``pl.LazyFrame`` in / ``pl.LazyFrame`` out, so it composes with both ``pl.scan_delta`` (the
+    dashboard, keyed by ``h3_index``) and in-memory post-spatial-join frames (the pipeline, keyed
+    by ``time_series_id``). The pushdownable filters (``member``, ``max_lead``, ``available_at``)
+    are applied *before* the freshest-run window reduction so a Delta scan's partition pruning and
+    row-group skipping survive — confirm with ``.explain()`` when wiring a new scan through it.
+
+    The one-row-per-group guarantee relies on ``(group_key, init_time_col, valid_time)`` being
+    unique once ``member`` is fixed (true for the raw NWP table and for the upsampled pipeline
+    frame). If a caller passes a frame where it is not, the window reduction fans out to every row
+    tied at the maximum ``init_time`` rather than collapsing to one.
+
+    Args:
+        nwp: NWP rows carrying at least ``ensemble_member``, ``valid_time``, ``init_time_col`` and
+            ``group_key``.
+        group_key: The location key to group by — ``"h3_index"`` (dashboard) or ``"time_series_id"``
+            (pipeline).
+        init_time_col: Name of the NWP run's init-time column (``"init_time"`` on the raw table,
+            ``"nwp_init_time"`` in the pipeline after its rename).
+        member: The ensemble member to keep (the control run by default).
+        max_lead: If given, keep only rows with ``valid_time < init_time + max_lead`` — the
+            dashboard passes its per-run stitching window; the pipeline leaves it unbounded.
+        available_at: If given, keep only runs available by this as-of time, i.e.
+            ``init_time + publication_delay <= available_at`` (replay-mode availability — it models
+            what a hindcast could have seen, not the live path, which reads only already-published
+            runs). Guards against lookahead bias in historical hindcasts.
+        publication_delay: The publication delay used by the ``available_at`` cut.
+
+    Returns:
+        The analysis-proxy rows, one per ``(group_key, valid_time)``, without ``ensemble_member``.
+    """
+    lf = nwp.filter(pl.col("ensemble_member") == member)
+    if max_lead is not None:
+        lf = lf.filter(pl.col("valid_time") < pl.col(init_time_col) + max_lead)
+    if available_at is not None:
+        lf = lf.filter(pl.col(init_time_col) + publication_delay <= available_at)
+    # Freshest run wins per (location, valid_time): the latest init_time, equivalently the shortest
+    # lead. Kept as a window filter (not a group_by/agg) so every non-key column rides through
+    # untouched; see the docstring for the uniqueness invariant this relies on.
+    freshest = lf.filter(
+        pl.col(init_time_col) == pl.col(init_time_col).max().over([group_key, "valid_time"])
+    )
+    return freshest.drop("ensemble_member")

--- a/packages/weather_utils/src/weather_utils/analysis_proxy.py
+++ b/packages/weather_utils/src/weather_utils/analysis_proxy.py
@@ -48,13 +48,13 @@ def select_analysis_proxy(
     ``pl.LazyFrame`` in / ``pl.LazyFrame`` out, so it composes with both ``pl.scan_delta`` (the
     dashboard, keyed by ``h3_index``) and in-memory post-spatial-join frames (the pipeline, keyed
     by ``time_series_id``). The pushdownable filters (``member``, ``max_lead``, ``available_at``)
-    are applied *before* the freshest-run window reduction so a Delta scan's partition pruning and
+    are applied *before* the freshest-run reduction so a Delta scan's partition pruning and
     row-group skipping survive — confirm with ``.explain()`` when wiring a new scan through it.
 
-    The one-row-per-group guarantee relies on ``(group_key, init_time_col, valid_time)`` being
-    unique once ``member`` is fixed (true for the raw NWP table and for the upsampled pipeline
-    frame). If a caller passes a frame where it is not, the window reduction fans out to every row
-    tied at the maximum ``init_time`` rather than collapsing to one.
+    The ``group_by(...).agg(...)`` reduction always collapses to exactly one row per
+    ``(group_key, valid_time)`` — so the result never fans out even if two rows tie at the freshest
+    ``init_time`` (e.g. a second ``nwp_model_id`` covering the same cell). Such a tie is broken
+    arbitrarily; today the ``Nwp`` table holds a single model, so no tie arises.
 
     Args:
         nwp: NWP rows carrying at least ``ensemble_member``, ``valid_time``, ``init_time_col`` and
@@ -75,15 +75,12 @@ def select_analysis_proxy(
     Returns:
         The analysis-proxy rows, one per ``(group_key, valid_time)``, without ``ensemble_member``.
     """
-    lf = nwp.filter(pl.col("ensemble_member") == member)
+    lf = nwp.filter(pl.col("ensemble_member") == member).drop("ensemble_member")
     if max_lead is not None:
         lf = lf.filter(pl.col("valid_time") < pl.col(init_time_col) + max_lead)
     if available_at is not None:
         lf = lf.filter(pl.col(init_time_col) + publication_delay <= available_at)
-    # Freshest run wins per (location, valid_time): the latest init_time, equivalently the shortest
-    # lead. Kept as a window filter (not a group_by/agg) so every non-key column rides through
-    # untouched; see the docstring for the uniqueness invariant this relies on.
-    freshest = lf.filter(
-        pl.col(init_time_col) == pl.col(init_time_col).max().over([group_key, "valid_time"])
-    )
-    return freshest.drop("ensemble_member")
+    # Freshest run wins per (location, valid_time): take every column from the row with the latest
+    # init_time (equivalently the shortest lead). group_by(...).agg(...) guarantees exactly one row
+    # per group, so the result never fans out on a tie — see the docstring.
+    return lf.group_by([group_key, "valid_time"]).agg(pl.all().sort_by(init_time_col).last())

--- a/packages/weather_utils/tests/test_analysis_proxy.py
+++ b/packages/weather_utils/tests/test_analysis_proxy.py
@@ -4,7 +4,7 @@ Mirrors the leakage-test style of ``ml_core``'s ``_nullify_leaky_lags`` tests: s
 frames whose expected freshest-run / availability behaviour is obvious by inspection.
 """
 
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import polars as pl
 
@@ -143,3 +143,34 @@ def test_matches_the_group_by_agg_freshest_selection() -> None:
     )
     new = select_analysis_proxy(lf, group_key="group").sort(["group", "valid_time"]).collect()
     assert new.select(sorted(new.columns)).equals(old.select(sorted(old.columns)))
+
+
+def test_collapses_to_one_row_when_two_runs_tie_at_the_freshest_init_time() -> None:
+    # Two rows share the same (group, valid_time) AND the same (freshest) init_time — as would
+    # happen if a second nwp_model_id ever covered the same cell. The reduction must still yield
+    # exactly one row rather than fanning out (which would silently double downstream feature rows).
+    valid = BASE + timedelta(hours=6)
+    lf = _nwp(
+        [
+            {**_row(1, BASE, valid, 0, 10.0), "nwp_model_id": "model_a"},
+            {**_row(1, BASE, valid, 0, 20.0), "nwp_model_id": "model_b"},
+        ]
+    )
+    result = select_analysis_proxy(lf, group_key="group").collect()
+    assert result.height == 1
+
+
+def test_available_at_works_with_tz_aware_datetimes() -> None:
+    # The real NWP columns are tz-aware UTC; the leakage cut must work against that dtype, not just
+    # the tz-naive datetimes the other tests use.
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    valid = base + timedelta(hours=48)
+    lf = _nwp(
+        [
+            _row(1, base, valid, 0, 10.0),  # published at base + delay
+            _row(1, base + timedelta(hours=24), valid, 0, 11.0),  # not yet available
+        ]
+    )
+    available_at = base + timedelta(hours=24)
+    result = select_analysis_proxy(lf, group_key="group", available_at=available_at).collect()
+    assert result["temperature_2m"].to_list() == [10.0]

--- a/packages/weather_utils/tests/test_analysis_proxy.py
+++ b/packages/weather_utils/tests/test_analysis_proxy.py
@@ -44,6 +44,37 @@ def test_freshest_run_wins_per_group_and_valid_time() -> None:
     assert "ensemble_member" not in result.columns
 
 
+def test_null_in_the_freshest_run_falls_back_to_the_next_freshest_run() -> None:
+    # The freshest run is null for a column (as accumulated variables are at lead 0); that cell
+    # must be filled from the next-freshest run that has a value, while a column the freshest run
+    # *does* have keeps the freshest value. This is the accumulated-variable gap fill.
+    valid = BASE + timedelta(hours=24)
+    lf = _nwp(
+        [
+            {**_row(1, BASE, valid, 0, 10.0), "precip": 0.5},  # older run, lead 24 — has precip
+            {
+                **_row(1, BASE + timedelta(hours=24), valid, 0, 20.0),
+                "precip": None,
+            },  # freshest, null
+        ]
+    )
+    result = select_analysis_proxy(lf, group_key="group").collect()
+    assert result["temperature_2m"].to_list() == [20.0]  # freshest run's value
+    assert result["precip"].to_list() == [0.5]  # filled from the older run
+
+
+def test_null_stays_null_when_no_run_has_a_value() -> None:
+    valid = BASE + timedelta(hours=24)
+    lf = _nwp(
+        [
+            {**_row(1, BASE, valid, 0, 10.0), "precip": None},
+            {**_row(1, BASE + timedelta(hours=24), valid, 0, 20.0), "precip": None},
+        ]
+    )
+    result = select_analysis_proxy(lf, group_key="group").collect()
+    assert result["precip"].to_list() == [None]
+
+
 def test_only_the_control_member_is_kept() -> None:
     valid = BASE + timedelta(hours=6)
     lf = _nwp(

--- a/packages/weather_utils/tests/test_analysis_proxy.py
+++ b/packages/weather_utils/tests/test_analysis_proxy.py
@@ -1,0 +1,145 @@
+"""Tests for ``weather_utils.select_analysis_proxy``.
+
+Mirrors the leakage-test style of ``ml_core``'s ``_nullify_leaky_lags`` tests: small hand-built
+frames whose expected freshest-run / availability behaviour is obvious by inspection.
+"""
+
+from datetime import datetime, timedelta
+
+import polars as pl
+
+from weather_utils import NWP_PUBLICATION_DELAY_HOURS, select_analysis_proxy
+
+
+def _nwp(rows: list[dict]) -> pl.LazyFrame:
+    """Build an NWP-like frame from ``(group, init, valid, member, temp)`` dicts."""
+    return pl.DataFrame(rows).lazy()
+
+
+def _row(group: int, init: datetime, valid: datetime, member: int, temp: float) -> dict:
+    return {
+        "group": group,
+        "init_time": init,
+        "valid_time": valid,
+        "ensemble_member": member,
+        "temperature_2m": temp,
+    }
+
+
+BASE = datetime(2026, 1, 1, 0, 0)
+
+
+def test_freshest_run_wins_per_group_and_valid_time() -> None:
+    valid = BASE + timedelta(hours=30)
+    lf = _nwp(
+        [
+            _row(1, BASE, valid, 0, 10.0),  # 30 h lead — older run
+            _row(1, BASE + timedelta(hours=24), valid, 0, 11.0),  # 6 h lead — freshest, wins
+        ]
+    )
+    result = select_analysis_proxy(lf, group_key="group").collect()
+    assert result.height == 1
+    assert result["temperature_2m"].to_list() == [11.0]
+    # ensemble_member is dropped from the proxy result.
+    assert "ensemble_member" not in result.columns
+
+
+def test_only_the_control_member_is_kept() -> None:
+    valid = BASE + timedelta(hours=6)
+    lf = _nwp(
+        [
+            _row(1, BASE, valid, 0, 10.0),  # control
+            _row(1, BASE, valid, 1, 99.0),  # perturbed member — must be excluded
+        ]
+    )
+    result = select_analysis_proxy(lf, group_key="group").collect()
+    assert result["temperature_2m"].to_list() == [10.0]
+
+
+def test_groups_are_independent() -> None:
+    valid = BASE + timedelta(hours=6)
+    fresher = BASE + timedelta(hours=3)
+    lf = _nwp(
+        [
+            _row(1, BASE, valid, 0, 10.0),
+            _row(1, fresher, valid, 0, 11.0),  # group 1 freshest
+            _row(2, BASE, valid, 0, 20.0),  # group 2 has only the older run
+        ]
+    )
+    result = select_analysis_proxy(lf, group_key="group").sort("group").collect()
+    assert dict(zip(result["group"], result["temperature_2m"], strict=True)) == {1: 11.0, 2: 20.0}
+
+
+def test_max_lead_bounds_each_run_strictly() -> None:
+    # A run at BASE with valid times 0..30 h; max_lead=24 h keeps lead < 24 h (strict).
+    valids = [BASE + timedelta(hours=h) for h in (0, 12, 24, 30)]
+    lf = _nwp([_row(1, BASE, v, 0, float(i)) for i, v in enumerate(valids)])
+    result = select_analysis_proxy(lf, group_key="group", max_lead=timedelta(hours=24)).collect()
+    # 24 h and 30 h leads are excluded (>= 24 h); 0 h and 12 h survive.
+    assert sorted(result["valid_time"].to_list()) == valids[:2]
+
+
+def test_available_at_excludes_runs_not_yet_published() -> None:
+    # Two runs straddle the publication cut for one valid time. The fresher run is NOT yet
+    # available at the as-of time, so the older-but-published run must win — even though it is
+    # not the freshest by lead. This is the leakage guard.
+    valid = BASE + timedelta(hours=48)
+    early = BASE  # published at BASE + delay
+    late = BASE + timedelta(hours=24)  # published at BASE + 24 h + delay
+    available_at = BASE + timedelta(hours=24)  # < late's publication time
+    lf = _nwp(
+        [
+            _row(1, early, valid, 0, 10.0),
+            _row(1, late, valid, 0, 11.0),
+        ]
+    )
+    result = select_analysis_proxy(lf, group_key="group", available_at=available_at).collect()
+    assert result["temperature_2m"].to_list() == [10.0]
+    # Sanity: with no availability cut the freshest (late) run would have won instead.
+    unbounded = select_analysis_proxy(lf, group_key="group").collect()
+    assert unbounded["temperature_2m"].to_list() == [11.0]
+
+
+def test_available_at_boundary_is_inclusive() -> None:
+    valid = BASE + timedelta(hours=48)
+    init = BASE
+    available_at = init + timedelta(hours=NWP_PUBLICATION_DELAY_HOURS)  # exactly published
+    lf = _nwp([_row(1, init, valid, 0, 10.0)])
+    result = select_analysis_proxy(lf, group_key="group", available_at=available_at).collect()
+    assert result["temperature_2m"].to_list() == [10.0]
+
+
+def test_init_time_col_is_configurable() -> None:
+    # The pipeline calls the function with its renamed init-time column.
+    valid = BASE + timedelta(hours=6)
+    lf = _nwp(
+        [
+            _row(1, BASE, valid, 0, 10.0),
+            _row(1, BASE + timedelta(hours=3), valid, 0, 11.0),
+        ]
+    ).rename({"init_time": "nwp_init_time"})
+    result = select_analysis_proxy(lf, group_key="group", init_time_col="nwp_init_time").collect()
+    assert result["temperature_2m"].to_list() == [11.0]
+
+
+def test_matches_the_group_by_agg_freshest_selection() -> None:
+    # Equivalence with the group_by(...).agg(sort_by(lead).first()) form the pipeline used before
+    # centralisation, on a frame with a precomputed lead column.
+    valids = [BASE + timedelta(hours=h) for h in (6, 12, 18)]
+    rows = []
+    for i, v in enumerate(valids):
+        rows.append(_row(1, BASE, v, 0, float(i)))
+        rows.append(_row(1, BASE + timedelta(hours=6), v, 0, float(i) + 100))  # fresher run
+    lf = _nwp(rows).with_columns(
+        nwp_lead_time_hours=((pl.col("valid_time") - pl.col("init_time")).dt.total_seconds() / 3600)
+    )
+    old = (
+        lf.filter(pl.col("ensemble_member") == 0)
+        .drop("ensemble_member")
+        .group_by(["group", "valid_time"])
+        .agg(pl.all().sort_by("nwp_lead_time_hours").first())
+        .sort(["group", "valid_time"])
+        .collect()
+    )
+    new = select_analysis_proxy(lf, group_key="group").sort(["group", "valid_time"]).collect()
+    assert new.select(sorted(new.columns)).equals(old.select(sorted(old.columns)))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ plotting = { workspace = true }
 xgboost_forecaster = { workspace = true }
 dynamical_data = { workspace = true }
 geo = { workspace = true }
+weather_utils = { workspace = true }
 
 # --- DAGSTER ---
 

--- a/uv.lock
+++ b/uv.lock
@@ -14,6 +14,7 @@ members = [
     "nged-substation-forecast",
     "notebooks",
     "plotting",
+    "weather-utils",
     "xgboost-forecaster",
 ]
 
@@ -1032,6 +1033,7 @@ dependencies = [
     { name = "plotting" },
     { name = "polars" },
     { name = "pyarrow" },
+    { name = "weather-utils" },
 ]
 
 [package.dev-dependencies]
@@ -1053,6 +1055,7 @@ requires-dist = [
     { name = "plotting", editable = "packages/plotting" },
     { name = "polars", specifier = ">=1.37.1" },
     { name = "pyarrow", specifier = ">=23.0.0" },
+    { name = "weather-utils", editable = "packages/weather_utils" },
 ]
 
 [package.metadata.requires-dev]
@@ -2538,6 +2541,7 @@ dependencies = [
     { name = "patito" },
     { name = "polars" },
     { name = "pydantic" },
+    { name = "weather-utils" },
 ]
 
 [package.metadata]
@@ -2548,6 +2552,7 @@ requires-dist = [
     { name = "patito" },
     { name = "polars", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
+    { name = "weather-utils", editable = "packages/weather_utils" },
 ]
 
 [[package]]
@@ -4798,6 +4803,29 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/34/74/c6428f875774288bec1396f5bfcbc2d925700a4dad61727fd5f2b12f249d/wcwidth-0.8.2.tar.gz", hash = "sha256:91fbef97204b96a3d4d421609b80340b760cf33e26da123ff243d76b1fda8dda", size = 1466253, upload-time = "2026-06-29T18:11:11.601Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/96/42/3e5985a0a7e57de470b320c6d6a1a67c844f6737a587f3d44dd13d1819e7/wcwidth-0.8.2-py3-none-any.whl", hash = "sha256:d63947694a0539a1d51e01eda7caf800c291020e6cdd7e28ad7b14dd33ad4f85", size = 323166, upload-time = "2026-06-29T18:11:09.888Z" },
+]
+
+[[package]]
+name = "weather-utils"
+version = "0.1.0"
+source = { editable = "packages/weather_utils" }
+dependencies = [
+    { name = "polars" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "pytest-cov" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "polars", specifier = ">=1.38.1" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=9.0.2" },
+    { name = "pytest-cov" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #356.

## What

The "closest available proxy for the *true* weather at past times" — the control ensemble member (member 0) at the shortest available lead, freshest run per valid time — was implemented twice with subtly different semantics:

- **Dashboard** — `view_forecasts.py` scan (member + 24 h stitch) plus a freshest-run dedup inside `build_nwp_ensemble_chart`.
- **Feature pipeline** — `_build_historical_weather()` in `ml_core.features._nwp`.

The two disagreed on missing-run behaviour, and neither enforced a publication-time availability cut. This PR centralises the query into one function so the availability logic is implemented and leakage-tested **once** — ahead of the two planned consumers (v0.6 switching-event baseline and the residual-lag features experiment).

## How

New low-level package **`weather_utils`**, importable by both `dashboard` and `ml_core` without `dashboard` gaining an `ml_core` dependency. It owns `select_analysis_proxy` — `LazyFrame` in / `LazyFrame` out, with "freshest run per valid time" semantics that is a superset of both old behaviours:

- Parameterised `group_key` (`h3_index` for the dashboard, `time_series_id` for the pipeline) and configurable `init_time_col`.
- Ensemble member defaults to the control (member 0).
- Optional `max_lead` bound (reproduces the dashboard's 24 h stitch exactly).
- Optional `available_at` cutoff (`nwp_init_time + publication_delay <= available_at`) for leak-free hindcasting — replay-mode availability.

The pushdownable filters (`member`, `max_lead`, `available_at`) are applied *before* the freshest-run window reduction so a Delta scan's partition pruning and row-group skipping survive.

### Call-site changes

- `NWP_PUBLICATION_DELAY_HOURS`'s canonical definition moves into `weather_utils`, re-exported from `ml_core.features._nwp` so existing importers don't churn.
- Pipeline **inlines** the call and drops `_build_historical_weather`.
- Dashboard routes its scan through the function and **drops its now-duplicate** in-builder freshest-run dedup; `build_nwp_ensemble_chart` now receives an already-reduced frame.

## Verification

- `ruff` / `ty` clean; affected suites (`weather_utils`, `dashboard`, `ml_core`) and the full repo pass.
- **Partition-pushdown check** (the acceptance criterion in the issue): built a partitioned NWP Delta table and ran `.explain()` — only the `is_between` window's partitions are scanned, and `ensemble_member` / `max_lead` / `init_time` / `h3_index` all push into the scan's SELECTION, with only the freshest-run window filter above it.
- New tests cover freshest-run selection, control-member filtering, group independence, strict `max_lead`, the `available_at` leakage guard (+ boundary), configurable `init_time_col`, and equivalence with the old `group_by(...).agg(...)` form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)