### PR TITLE
Tolerate scattered ECMWF ENS nulls; fail only structural gaps

### DIFF
--- a/docs/architecture/ecmwf-ens-known-issues.md
+++ b/docs/architecture/ecmwf-ens-known-issues.md
@@ -1,0 +1,64 @@
+# Known ECMWF ENS data-quality issues
+
+We ingest ECMWF IFS ENS from [Dynamical.org](https://dynamical.org). Its data carries a few
+known, recurring quality quirks. This page records what they are, how we tell them apart, and the
+policy the `ecmwf_ens` ingest applies to each. The policy is implemented in
+[`contracts.weather_schemas`](../api/contracts/index.md): `Nwp.validate` is the fatal ingest gate,
+and `assess_nwp_quality` is the non-fatal reporter behind the `nwp_has_no_unexpected_nulls` asset
+check.
+
+## The guiding principle
+
+We fail a run's ingest only when its data is *structurally* broken, and we tolerate *localised*
+corruption that a model can absorb — surfacing it as a warning rather than throwing away an
+otherwise-good run. The variable that is affected turns out to be a clean signal for which case we
+are in, so the fatal gate needs no magic thresholds.
+
+## Scattered per-pixel nulls in the de-accumulated variables (tolerated)
+
+The three de-accumulated variables — `precipitation_surface`,
+`downward_short_wave_radiation_flux_surface`, and `downward_long_wave_radiation_flux_surface` —
+sometimes carry scattered, per-pixel nulls beyond the first forecast step. Dynamical de-accumulates
+these from ECMWF's cumulative source fields to instantaneous rates, and the root cause is corrupt
+source accumulation: some `(ensemble_member, forecast_step)` fields report physically-impossible
+*negative* accumulation, which the de-accumulation step correctly leaves as null rather than
+silently clamping corrupt data to zero. This is documented and WONTFIX upstream in
+[dynamical-org/reformatters#722](https://github.com/dynamical-org/reformatters/issues/722); a
+looser clamp threshold would only convert visibly-null corrupt data into invisibly-zeroed corrupt
+data.
+
+We tolerate these at ingest for two reasons. First, all three variables are already legitimately
+null at lead-0 (the de-accumulation has no previous step to difference against), so every model
+must handle their nulls regardless. Second, the corruption is genuinely scattered — empirically a
+few percent of a slice at most, never a whole slice — so the run remains overwhelmingly usable.
+
+`Nwp.validate` therefore permits scattered nulls in these variables, and the
+`nwp_has_no_unexpected_nulls` asset check reports them (WARN, non-blocking) with the affected
+`(variable, ensemble_member, valid_time)` slices, so the quirk stays visible without failing the
+run.
+
+## Whole-slice and instantaneous nulls (fatal)
+
+Two null patterns *do* fail ingest, because both mean the data is structurally missing rather than
+locally corrupt:
+
+- **A null in any instantaneous variable** (temperature, dew point, winds, pressures,
+  geopotential height). These are never legitimately null, so any null is an anomalous structural
+  gap. They stay non-nullable in the `Nwp` contract, so base validation rejects them. This is the
+  pattern behind the 2026-07-14 run, where a whole forecast step went missing for 50 of 51
+  ensemble members across every variable — reported upstream as
+  [dynamical-org/reformatters#765](https://github.com/dynamical-org/reformatters/issues/765).
+
+- **A whole-slice null in a de-accumulated variable** — an entire `(ensemble_member, valid_time)`
+  slice null across the grid beyond lead-0. Unlike the scattered case above, a wholesale-missing
+  field is a structural outage, so `Nwp._check_no_whole_null_deaccumulated_slices` fails it.
+
+A run that fails ingest writes nothing (validation runs before the Delta append), so there are no
+partial partitions to clean up; the partition simply stays unmaterialised until the upstream data
+is fixed or the partition is re-run.
+
+## `categorical_precipitation_type_surface` before 2024-11-13 (historical)
+
+This variable is all-null for init times on and before 2024-11-12 and populated from the
+2024-11-13 00Z run onwards. `Nwp.validate` enforces that split as a hard invariant — it is a fixed
+historical fact about the dataset, not a quality quirk, so a violation is always fatal.

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -90,6 +90,25 @@ is alive. The freshness evaluation is a pure function, and it is the hand-off po
 when that lands, the same result object also feeds Sentry, and later the forecast-warnings
 delivery table.
 
+## Separate "is this run usable?" from "is it perfect?"
+
+Data ingest poses two different questions, and we answer them with two different mechanisms so
+that neither compromises the other. **"Is this run usable?"** is a fatal gate: the contract
+`validate` inside the ingest asset rejects data that is structurally broken, so a bad run fails
+loudly and writes nothing rather than poisoning the table. **"Is it perfect?"** is a separate,
+non-fatal Dagster asset check: it records known-but-tolerable imperfections as a warning without
+blocking the materialisation or anything downstream. Collapsing the two — failing on every
+imperfection — throws away otherwise-good data; ignoring the distinction the other way lets
+genuinely broken data land silently.
+
+The `ecmwf_ens` asset is the worked example. Its `nwp_has_no_unexpected_nulls` check surfaces the
+scattered per-pixel nulls that ECMWF ENS is known to carry (a WARN), while `Nwp.validate` still
+hard-fails a wholesale structural gap. The reasoning behind exactly where that fatal/tolerated line
+sits is documented in
+[Known ECMWF ENS data-quality issues](ecmwf-ens-known-issues.md). The `power_data_is_fresh` check
+above is the same shape of tool pointed at a different question — staleness rather than
+completeness — and is likewise a warning, never a failure.
+
 ## Bake the model into the image at build time
 
 Production forecasts run as ephemeral Fargate tasks, dispatched by the always-on Dagster

--- a/docs/architecture/why-dagster-not-airflow.md
+++ b/docs/architecture/why-dagster-not-airflow.md
@@ -198,6 +198,7 @@ around the Dagster UI and would need rewriting.
 | Per-fold retry and observability | CV layer | Dynamic task mapping (per-instance state, logs, clear; `map_index_template`) | Good on ≥3.1.4 |
 | Per-partition backfills with run config | `live_forecasts` replay | Backfills take `--dag-run-conf`; conf-dropped bug fixed in 3.2.2 | Good on ≥3.2.2; MWAA (3.2.1) still affected |
 | `add_output_metadata` tables, asset catalog, lineage | every asset | Asset-event `extra` JSON (2.10+) in the events list | Partial — raw JSON, no rendered tables or history plots |
+| Asset checks — non-blocking WARN, attached to an asset, dedicated Checks view (`power_data_is_fresh`, `nwp_has_no_unexpected_nulls`) | power ingest, `ecmwf_ens` | Data-quality as ordinary tasks (`common.sql` check operators; Great Expectations / Soda / dbt-test); no first-class check primitive or Checks UI, blocking by default (as of 3.3.0) | Partial — the capability exists as tasks; the non-blocking severity and check-status surface do not |
 | `EcsRunLauncher` (laptop = subprocess, cloud = Fargate, switched by `dagster.yaml`) | control plane | ECS executor (Amazon provider, Fargate launch type) | Exists; per-*task* rather than per-run granularity |
 | Sensors / run-status coordination (planned, [#324](https://github.com/openclimatefix/nged-substation-forecast/issues/324)) | ingest → forecast ordering | Asset-triggered DAGs, event-driven scheduling | Parity, arguably cleaner in Airflow |
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
       - ML Orchestration Design: architecture/ml-orchestration.md
       - Production Deployment Design: architecture/production-deployment.md
       - "Why Dagster, not Airflow?": architecture/why-dagster-not-airflow.md
+      - Known ECMWF ENS Data-Quality Issues: architecture/ecmwf-ens-known-issues.md
       - Code Style: architecture/code-style.md
       - Testing: architecture/testing.md
   - ML Experimentation:

--- a/packages/contracts/src/contracts/weather_schemas.py
+++ b/packages/contracts/src/contracts/weather_schemas.py
@@ -1,4 +1,5 @@
 from collections.abc import Sequence
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from enum import StrEnum, auto
 from pathlib import Path
@@ -80,6 +81,11 @@ class Nwp(pt.Model):
     Stored on disk as plain Float32, rounded to a significand-bit budget by
     `delta_store.nwp.write_nwp` — see `docs/architecture/overview.md` for the physical format
     and measured numbers.
+
+    `validate` is the fatal ingest gate; `assess_nwp_quality` reports the tolerated scattered nulls
+    (the known upstream ECMWF ENS corruption) as a non-fatal check. Which null patterns are fatal
+    versus tolerated, and why, is documented at
+    <https://openclimatefix.github.io/nged-substation-forecast/architecture/ecmwf-ens-known-issues/>.
     """
 
     nwp_model_id: str = pt.Field(
@@ -222,6 +228,21 @@ class Nwp(pt.Model):
         {"categorical_precipitation_type_surface"}
     )
 
+    deaccumulated_var_names: ClassVar[frozenset[str]] = frozenset(
+        {
+            "precipitation_surface",
+            "downward_short_wave_radiation_flux_surface",
+            "downward_long_wave_radiation_flux_surface",
+        }
+    )
+    """The variables Dynamical.org de-accumulates from ECMWF's cumulative source fields to rates.
+
+    They share a de-accumulation step whose known upstream corruption leaves *scattered* per-pixel
+    nulls beyond lead-0 (and all three are legitimately null at lead-0). Those scattered nulls are
+    tolerated at ingest and reported by :func:`assess_nwp_quality`; only a whole-slice gap is fatal.
+    See <https://openclimatefix.github.io/nged-substation-forecast/architecture/ecmwf-ens-known-issues/>.
+    """
+
     # Columns that aren't NWP variables:
     _non_var_column_names: ClassVar[frozenset[str]] = frozenset(
         {"nwp_model_id", "init_time", "valid_time", "ensemble_member", "h3_index"}
@@ -255,29 +276,34 @@ class Nwp(pt.Model):
             drop_superfluous_columns=drop_superfluous_columns,
         )
 
-        cls._check_nulls_from_second_forecast_step_onwards(validated_df)
+        cls._check_no_whole_null_deaccumulated_slices(validated_df)
         cls._check_unique(validated_df)
         cls._check_variables_that_were_introduced_after_start_of_dataset(validated_df)
         return validated_df
 
     @classmethod
-    def _check_nulls_from_second_forecast_step_onwards(cls, dataframe: pt.DataFrame[Self]) -> None:
-        cols_to_check = [
-            "precipitation_surface",
-            "downward_short_wave_radiation_flux_surface",
-            "downward_long_wave_radiation_flux_surface",
-        ]
+    def _check_no_whole_null_deaccumulated_slices(cls, dataframe: pt.DataFrame[Self]) -> None:
+        """Reject a *structural* gap: any de-accumulated variable whose (ensemble_member,
+        valid_time) slice beyond lead-0 is *entirely* null across the grid.
 
-        second_step_onwards = dataframe.filter(pl.col("valid_time") > pl.col("init_time"))
-
-        for col in cols_to_check:
-            has_nulls = second_step_onwards[col].is_null().any()
-            if has_nulls:
-                raise ValueError(
-                    f"Column '{col}' contains has null values from the second forecast "
-                    "step onwards. These variables are only allowed to be null for the first "
-                    "forecast step (lead time 0)."
-                )
+        Scattered per-pixel nulls in the de-accumulated variables are *tolerated* — they are the
+        known upstream ECMWF ENS corruption (empirically reaching a few percent of a slice), and
+        every model already handles null precipitation/radiation because both are legitimately null
+        at lead-0. A *whole-slice* null is different: it means the field is wholesale missing (a
+        structural outage), which should fail ingest. :func:`assess_nwp_quality` reports the
+        tolerated scatter as a non-fatal check. See
+        <https://openclimatefix.github.io/nged-substation-forecast/architecture/ecmwf-ens-known-issues/>.
+        """
+        whole_null = _deaccumulated_null_breakdown(dataframe).filter(
+            pl.col("n_null") == pl.col("n_total")
+        )
+        if whole_null.height:
+            offenders = whole_null.select("variable", "ensemble_member", "valid_time").rows()
+            raise ValueError(
+                "Whole-slice null in a de-accumulated NWP variable beyond lead-0 — a wholesale "
+                "missing field, not tolerable scattered corruption. Offending "
+                f"(variable, ensemble_member, valid_time): {offenders[:10]}"
+            )
 
     @classmethod
     def _check_unique(cls, dataframe: pt.DataFrame[Self]) -> None:
@@ -358,3 +384,73 @@ class Nwp(pt.Model):
             .set_model(cls)
             .cast()
         )
+
+
+def _deaccumulated_null_breakdown(dataframe: pl.DataFrame) -> pl.DataFrame:
+    """Per (variable, ensemble_member, valid_time) beyond lead-0: null- and total-cell counts.
+
+    Returns only slices that have at least one null. Shared by the fatal whole-slice check and the
+    non-fatal :func:`assess_nwp_quality`, so both agree on what a "null" is. Operates on a single
+    NWP run (~1M rows), far below Polars' 2**32 row-count ceiling, so the counts are exact.
+    """
+    deaccumulated = sorted(Nwp.deaccumulated_var_names)
+    beyond_lead0 = dataframe.filter(pl.col("valid_time") > pl.col("init_time"))
+    return (
+        beyond_lead0.unpivot(
+            on=deaccumulated,
+            index=["ensemble_member", "valid_time"],
+            variable_name="variable",
+            value_name="value",
+        )
+        .group_by("variable", "ensemble_member", "valid_time")
+        .agg(n_null=pl.col("value").is_null().sum(), n_total=pl.len())
+        .filter(pl.col("n_null") > 0)
+    )
+
+
+@dataclass(frozen=True)
+class NwpQualityReport:
+    """Non-fatal data-quality summary for one NWP run.
+
+    Carries the *tolerated* scattered nulls in the de-accumulated variables beyond lead-0 — the
+    known upstream ECMWF ENS corruption. A structural whole-slice gap is rejected by
+    :meth:`Nwp.validate` before this runs, so a validated frame only ever has scatter here.
+    """
+
+    init_time: datetime | None
+    scattered: pl.DataFrame
+    """One row per affected (variable, ensemble_member, valid_time) slice, with ``n_null`` and
+    ``n_total`` cell counts. Empty when the run is clean."""
+
+    @property
+    def n_null_cells(self) -> int:
+        """Total scattered null cells across all affected slices."""
+        return int(self.scattered["n_null"].sum()) if self.scattered.height else 0
+
+    @property
+    def is_healthy(self) -> bool:
+        """True when the run has no unexpected nulls."""
+        return self.scattered.height == 0
+
+    @property
+    def affected_variables(self) -> tuple[str, ...]:
+        """The de-accumulated variables carrying scattered nulls, sorted."""
+        if not self.scattered.height:
+            return ()
+        return tuple(sorted(self.scattered["variable"].unique().to_list()))
+
+
+def assess_nwp_quality(dataframe: pt.DataFrame[Nwp]) -> NwpQualityReport:
+    """Summarise the tolerated-but-noteworthy nulls in a *validated* NWP run.
+
+    Reports the scattered per-pixel nulls in the de-accumulated variables (precipitation/radiation)
+    beyond lead-0 — the known upstream ECMWF ENS corruption that :meth:`Nwp.validate` deliberately
+    tolerates. Pure and Dagster-free (unit-testable in isolation); the ``ecmwf_ens`` asset wraps the
+    result into a WARN ``AssetCheckResult``. See
+    <https://openclimatefix.github.io/nged-substation-forecast/architecture/ecmwf-ens-known-issues/>.
+    """
+    scattered = _deaccumulated_null_breakdown(dataframe).filter(
+        pl.col("n_null") < pl.col("n_total")
+    )
+    init_time = dataframe["init_time"][0] if dataframe.height else None
+    return NwpQualityReport(init_time=init_time, scattered=scattered)

--- a/packages/contracts/src/contracts/weather_schemas.py
+++ b/packages/contracts/src/contracts/weather_schemas.py
@@ -267,7 +267,8 @@ class Nwp(pt.Model):
         allow_superfluous_columns: bool = False,
         drop_superfluous_columns: bool = False,
     ) -> pt.DataFrame[Self]:  # ty:ignore[invalid-method-override]
-        """Validate the given dataframe, ensuring no nulls from second step onwards and uniqueness."""
+        """Validate the frame: rejecting whole-slice nulls in de-accumulated variables (scattered
+        nulls are tolerated), enforcing uniqueness, and the ptype-introduction invariant."""
         validated_df = super().validate(
             dataframe=dataframe,
             columns=columns,
@@ -293,6 +294,10 @@ class Nwp(pt.Model):
         structural outage), which should fail ingest. :func:`assess_nwp_quality` reports the
         tolerated scatter as a non-fatal check. See
         <https://openclimatefix.github.io/nged-substation-forecast/architecture/ecmwf-ens-known-issues/>.
+
+        This relies on a slice having many grid cells (the production GB grid has ~1671), so that
+        scatter (a few null cells) is cleanly distinct from a whole-slice gap (all cells null). On a
+        degenerate one-cell slice the two are indistinguishable, but that does not arise in practice.
         """
         whole_null = _deaccumulated_null_breakdown(dataframe).filter(
             pl.col("n_null") == pl.col("n_total")
@@ -301,8 +306,8 @@ class Nwp(pt.Model):
             offenders = whole_null.select("variable", "ensemble_member", "valid_time").rows()
             raise ValueError(
                 "Whole-slice null in a de-accumulated NWP variable beyond lead-0 — a wholesale "
-                "missing field, not tolerable scattered corruption. Offending "
-                f"(variable, ensemble_member, valid_time): {offenders[:10]}"
+                f"missing field, not tolerable scattered corruption. {whole_null.height} offending "
+                f"(variable, ensemble_member, valid_time) slice(s), first 10: {offenders[:10]}"
             )
 
     @classmethod
@@ -387,22 +392,24 @@ class Nwp(pt.Model):
 
 
 def _deaccumulated_null_breakdown(dataframe: pl.DataFrame) -> pl.DataFrame:
-    """Per (variable, ensemble_member, valid_time) beyond lead-0: null- and total-cell counts.
+    """Per (variable, init_time, ensemble_member, valid_time) beyond lead-0: null-/total-cell counts.
 
     Returns only slices that have at least one null. Shared by the fatal whole-slice check and the
-    non-fatal :func:`assess_nwp_quality`, so both agree on what a "null" is. Operates on a single
-    NWP run (~1M rows), far below Polars' 2**32 row-count ceiling, so the counts are exact.
+    non-fatal :func:`assess_nwp_quality`, so both agree on what a "null" is. ``init_time`` is in the
+    group key so the counts stay correct even on a multi-run frame (each grid cell is one row, so
+    ``n_total`` is the slice's cell count). Operates on a single NWP run in practice (~1M rows), far
+    below Polars' 2**32 row-count ceiling, so the counts are exact.
     """
     deaccumulated = sorted(Nwp.deaccumulated_var_names)
     beyond_lead0 = dataframe.filter(pl.col("valid_time") > pl.col("init_time"))
     return (
         beyond_lead0.unpivot(
             on=deaccumulated,
-            index=["ensemble_member", "valid_time"],
+            index=["init_time", "ensemble_member", "valid_time"],
             variable_name="variable",
             value_name="value",
         )
-        .group_by("variable", "ensemble_member", "valid_time")
+        .group_by("variable", "init_time", "ensemble_member", "valid_time")
         .agg(n_null=pl.col("value").is_null().sum(), n_total=pl.len())
         .filter(pl.col("n_null") > 0)
     )
@@ -417,15 +424,19 @@ class NwpQualityReport:
     :meth:`Nwp.validate` before this runs, so a validated frame only ever has scatter here.
     """
 
-    init_time: datetime | None
     scattered: pl.DataFrame
-    """One row per affected (variable, ensemble_member, valid_time) slice, with ``n_null`` and
-    ``n_total`` cell counts. Empty when the run is clean."""
+    """One row per affected (variable, init_time, ensemble_member, valid_time) slice, with
+    ``n_null`` and ``n_total`` cell counts. Empty when the run is clean."""
 
     @property
     def n_null_cells(self) -> int:
         """Total scattered null cells across all affected slices."""
         return int(self.scattered["n_null"].sum()) if self.scattered.height else 0
+
+    @property
+    def n_affected_slices(self) -> int:
+        """Number of (variable, member, valid_time) slices carrying at least one scattered null."""
+        return self.scattered.height
 
     @property
     def is_healthy(self) -> bool:
@@ -452,5 +463,4 @@ def assess_nwp_quality(dataframe: pt.DataFrame[Nwp]) -> NwpQualityReport:
     scattered = _deaccumulated_null_breakdown(dataframe).filter(
         pl.col("n_null") < pl.col("n_total")
     )
-    init_time = dataframe["init_time"][0] if dataframe.height else None
-    return NwpQualityReport(init_time=init_time, scattered=scattered)
+    return NwpQualityReport(scattered=scattered)

--- a/packages/contracts/tests/test_weather_schemas_validation.py
+++ b/packages/contracts/tests/test_weather_schemas_validation.py
@@ -1,12 +1,138 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
-import pytest
-import polars as pl
 import patito as pt
-from contracts.weather_schemas import Nwp
+import polars as pl
+import pytest
+from contracts.weather_schemas import Nwp, assess_nwp_quality
+
+# A run initialised after 2024-11-12, when categorical_precipitation_type_surface became non-null.
+_INIT_TIME = datetime(2024, 12, 1, tzinfo=timezone.utc)
+_BEYOND_LEAD0 = _INIT_TIME + timedelta(hours=3)
 
 
-def test_categorical_precipitation_type_surface_validation():
+def _nwp_slice(
+    *,
+    valid_time: datetime = _BEYOND_LEAD0,
+    h3_indices: tuple[int, ...] = (100, 101, 102),
+    member: int = 0,
+    overrides: dict[str, list[object]] | None = None,
+) -> pl.DataFrame:
+    """A valid single-(member, valid_time) NWP slice spanning several h3 cells.
+
+    Every column is physically valid by default; pass ``overrides={"column": [...]}`` to replace one
+    with a per-cell list (e.g. inject nulls) so a test can build scattered vs whole-slice gaps.
+    """
+    n = len(h3_indices)
+    columns: dict[str, object] = {
+        "nwp_model_id": ["ECMWF_ENS_0_25_degree"] * n,
+        "init_time": [_INIT_TIME] * n,
+        "valid_time": [valid_time] * n,
+        "ensemble_member": [member] * n,
+        "h3_index": list(h3_indices),
+        "categorical_precipitation_type_surface": [1] * n,
+        "temperature_2m": [10.0] * n,
+        "dew_point_temperature_2m": [5.0] * n,
+        "wind_speed_10m": [5.0] * n,
+        "wind_direction_10m": [180.0] * n,
+        "wind_speed_100m": [5.0] * n,
+        "wind_direction_100m": [180.0] * n,
+        "pressure_surface": [1000.0] * n,
+        "pressure_reduced_to_mean_sea_level": [1000.0] * n,
+        "geopotential_height_500hpa": [5000.0] * n,
+        "downward_long_wave_radiation_flux_surface": [100.0] * n,
+        "downward_short_wave_radiation_flux_surface": [100.0] * n,
+        "precipitation_surface": [0.001] * n,
+    }
+    if overrides:
+        columns.update(overrides)
+    return pl.DataFrame(columns)
+
+
+def _validate(df: pl.DataFrame) -> pt.DataFrame[Nwp]:
+    return Nwp.validate(pt.DataFrame(df).set_model(Nwp).cast())
+
+
+def test_valid_slice_passes_and_is_healthy() -> None:
+    validated = _validate(_nwp_slice())
+    report = assess_nwp_quality(validated)
+    assert report.is_healthy
+    assert report.n_null_cells == 0
+    assert report.affected_variables == ()
+
+
+@pytest.mark.parametrize(
+    "instantaneous_var",
+    [
+        "temperature_2m",
+        "pressure_surface",
+        "wind_speed_10m",
+        "geopotential_height_500hpa",
+    ],
+)
+def test_instantaneous_null_beyond_lead0_is_fatal(instantaneous_var: str) -> None:
+    """A structural gap that nulls an instantaneous variable (the 2026-07-14 class) must fail
+    ingest — those fields are non-nullable, so base Patito validation rejects it."""
+    df = _nwp_slice(overrides={instantaneous_var: [10.0, None, 10.0]})
+    with pytest.raises(pt.exceptions.DataFrameValidationError):
+        _validate(df)
+
+
+@pytest.mark.parametrize(
+    "deaccumulated_var",
+    [
+        "precipitation_surface",
+        "downward_short_wave_radiation_flux_surface",
+        "downward_long_wave_radiation_flux_surface",
+    ],
+)
+def test_scattered_deaccumulated_null_beyond_lead0_is_tolerated(deaccumulated_var: str) -> None:
+    """Scattered per-pixel nulls in a de-accumulated variable (the 2026-07-12 / #722 class) are
+    tolerated at ingest and surfaced by the quality assessor, not failed."""
+    valid_value = 0.001 if deaccumulated_var == "precipitation_surface" else 100.0
+    df = _nwp_slice(
+        overrides={deaccumulated_var: [valid_value, None, valid_value]}
+    )  # 1 of 3 cells null
+
+    validated = _validate(df)  # does not raise
+
+    report = assess_nwp_quality(validated)
+    assert not report.is_healthy
+    assert report.n_null_cells == 1
+    assert report.affected_variables == (deaccumulated_var,)
+
+
+@pytest.mark.parametrize(
+    "deaccumulated_var",
+    [
+        "precipitation_surface",
+        "downward_short_wave_radiation_flux_surface",
+        "downward_long_wave_radiation_flux_surface",
+    ],
+)
+def test_whole_slice_deaccumulated_null_beyond_lead0_is_fatal(deaccumulated_var: str) -> None:
+    """A whole (member, valid_time) slice that is entirely null for a de-accumulated variable is a
+    wholesale missing field, not tolerable scatter — it must fail ingest."""
+    df = _nwp_slice(overrides={deaccumulated_var: [None, None, None]})  # all 3 cells null
+    with pytest.raises(ValueError, match="Whole-slice null"):
+        _validate(df)
+
+
+def test_lead0_deaccumulated_nulls_are_allowed() -> None:
+    """De-accumulated variables are legitimately null at lead-0 (valid_time == init_time); that is
+    not flagged as fatal nor as a quality issue."""
+    df = _nwp_slice(
+        valid_time=_INIT_TIME,  # lead-0
+        overrides={
+            "precipitation_surface": [None, None, None],
+            "downward_short_wave_radiation_flux_surface": [None, None, None],
+            "downward_long_wave_radiation_flux_surface": [None, None, None],
+        },
+    )
+    validated = _validate(df)
+    assert assess_nwp_quality(validated).is_healthy
+
+
+def test_categorical_precipitation_type_surface_validation() -> None:
     # Test case 1: Valid data (all null before 2024-11-12, not null after)
     df_valid = pl.DataFrame(
         {

--- a/packages/contracts/tests/test_weather_schemas_validation.py
+++ b/packages/contracts/tests/test_weather_schemas_validation.py
@@ -98,6 +98,7 @@ def test_scattered_deaccumulated_null_beyond_lead0_is_tolerated(deaccumulated_va
     report = assess_nwp_quality(validated)
     assert not report.is_healthy
     assert report.n_null_cells == 1
+    assert report.n_affected_slices == 1
     assert report.affected_variables == (deaccumulated_var,)
 
 

--- a/src/nged_substation_forecast/defs/assets.py
+++ b/src/nged_substation_forecast/defs/assets.py
@@ -276,14 +276,28 @@ def _nwp_quality_check_result(report: NwpQualityReport) -> AssetCheckResult:
         description=description,
         metadata={
             "n_scattered_null_cells": report.n_null_cells,
+            "n_affected_slices": report.n_affected_slices,
             "affected_variables": list(report.affected_variables),
             "affected_slices": _nwp_null_slices_metadata(report.scattered),
         },
     )
 
 
+_NWP_NULL_SLICES_TABLE_LIMIT: Final[int] = 100
+"""Cap on rows rendered in the affected-slices metadata table.
+
+A broadly-corrupt upstream run could touch thousands of (variable, member, valid_time) slices;
+the exact totals live in the scalar metadata, so the table only needs the worst offenders to be
+useful — bounding it keeps the Dagster event log from bloating on a bad day."""
+
+
 def _nwp_null_slices_metadata(scattered: pl.DataFrame) -> TableMetadataValue:
-    """Render the affected (variable, member, valid_time) slices as a Dagster metadata table."""
+    """Render the worst affected (variable, member, valid_time) slices as a Dagster metadata table.
+
+    Capped at ``_NWP_NULL_SLICES_TABLE_LIMIT`` rows (most-null first); the full counts are in the
+    scalar metadata alongside.
+    """
+    top = scattered.sort("n_null", descending=True).head(_NWP_NULL_SLICES_TABLE_LIMIT)
     records = [
         TableRecord(
             {
@@ -294,7 +308,7 @@ def _nwp_null_slices_metadata(scattered: pl.DataFrame) -> TableMetadataValue:
                 "n_total_cells": row["n_total"],
             }
         )
-        for row in scattered.iter_rows(named=True)
+        for row in top.iter_rows(named=True)
     ]
     return MetadataValue.table(records, schema=_NWP_NULL_SLICES_SCHEMA)
 

--- a/src/nged_substation_forecast/defs/assets.py
+++ b/src/nged_substation_forecast/defs/assets.py
@@ -10,13 +10,20 @@ from contracts.geo_schemas import H3GridWeights
 from contracts.power_schemas import PowerTimeSeries
 from contracts.settings import Settings
 from contracts.typing_utils import typeddict_to_dict
+from contracts.weather_schemas import NwpQualityReport, assess_nwp_quality
 from dagster import (
+    AssetCheckResult,
+    AssetCheckSeverity,
+    AssetCheckSpec,
     AssetExecutionContext,
     DailyPartitionsDefinition,
+    MaterializeResult,
     MetadataValue,
     RetryRequested,
+    TableColumn,
     TableMetadataValue,
     TableRecord,
+    TableSchema,
     asset,
 )
 from delta_store.nwp import write_nwp
@@ -165,17 +172,38 @@ _ECMWF_ENS_MAX_RETRIES: Final[int] = 8
 _ECMWF_ENS_RETRY_DELAY_SECONDS: Final[int] = 1800
 """How long to wait between retries of a not-yet-published ECMWF run."""
 
+_NWP_QUALITY_CHECK_NAME: Final[str] = "nwp_has_no_unexpected_nulls"
+"""Name of the per-run NWP data-quality check emitted by ``ecmwf_ens`` (see ``assess_nwp_quality``).
+
+Computed in-asset from the frame already in memory rather than as a standalone ``@asset_check``
+scanning the Delta table: the quality of a run is a property of the specific ingest we are holding,
+so there is nothing to re-scan (and re-scanning the whole ~5.9B-row NWP table would hit Polars'
+2**32 row-count ceiling). This differs from ``power_data_is_fresh``, whose freshness genuinely
+drifts over time and so must re-read the table on a schedule."""
+
+_NWP_NULL_SLICES_SCHEMA: Final[TableSchema] = TableSchema(
+    columns=[
+        TableColumn("variable", "string"),
+        TableColumn("ensemble_member", "int"),
+        TableColumn("valid_time", "string"),
+        TableColumn("n_null_cells", "int"),
+        TableColumn("n_total_cells", "int"),
+    ]
+)
+"""Fixed schema for the affected-slices metadata table (so an empty table still renders)."""
+
 
 @asset(
     partitions_def=ecmwf_ens_partitions,
     deps=["h3_grid_weights"],
+    check_specs=[AssetCheckSpec(name=_NWP_QUALITY_CHECK_NAME, asset="ecmwf_ens")],
     # The `pool="ECMWF"` works in conjunction with the Dagster instance configuration
     # (e.g., in `dagster.yaml`) to limit the number of times this asset can be run
     # concurrently. This is crucial because downloading ECMWF data is memory-intensive.
     # See: https://docs.dagster.io/guides/operate/managing-concurrency/concurrency-pools
     pool="ECMWF",
 )
-def ecmwf_ens(context: AssetExecutionContext) -> None:
+def ecmwf_ens(context: AssetExecutionContext) -> MaterializeResult:
     """
     Downloads and processes ECMWF ensemble NWP data for a specific day.
 
@@ -215,13 +243,60 @@ def ecmwf_ens(context: AssetExecutionContext) -> None:
     write_nwp(nwp, nwp_data_path, storage_options)
     context.log.info(f"Saved NWP data to Delta table at {nwp_data_path}.")
 
-    context.add_output_metadata(
-        {
+    # Non-fatal data-quality check: surface the tolerated scattered nulls (known upstream ECMWF ENS
+    # corruption) that Nwp.validate deliberately let through. A structural gap would have failed the
+    # validate above, so this only ever WARNs about scatter.
+    quality = assess_nwp_quality(nwp)
+    return MaterializeResult(
+        metadata={
             "n_rows": len(nwp),
             "path": nwp_data_path,
             "init_time": str(nwp_init_time),
-        }
+        },
+        check_results=[_nwp_quality_check_result(quality)],
     )
+
+
+def _nwp_quality_check_result(report: NwpQualityReport) -> AssetCheckResult:
+    """Wrap an :class:`NwpQualityReport` into a WARN-severity Dagster check result."""
+    if report.is_healthy:
+        description = "No unexpected nulls in the de-accumulated NWP variables."
+    else:
+        variables = ", ".join(report.affected_variables)
+        description = (
+            f"{report.n_null_cells} scattered null cell(s) beyond lead-0 in {variables} — known "
+            "upstream ECMWF ENS corruption, tolerated. See "
+            "https://openclimatefix.github.io/nged-substation-forecast/architecture/ecmwf-ens-known-issues/."
+        )
+    return AssetCheckResult(
+        check_name=_NWP_QUALITY_CHECK_NAME,
+        # WARN, never fail: the scatter is expected upstream corruption we deliberately ingest.
+        passed=report.is_healthy,
+        severity=AssetCheckSeverity.WARN,
+        description=description,
+        metadata={
+            "n_scattered_null_cells": report.n_null_cells,
+            "affected_variables": list(report.affected_variables),
+            "affected_slices": _nwp_null_slices_metadata(report.scattered),
+        },
+    )
+
+
+def _nwp_null_slices_metadata(scattered: pl.DataFrame) -> TableMetadataValue:
+    """Render the affected (variable, member, valid_time) slices as a Dagster metadata table."""
+    records = [
+        TableRecord(
+            {
+                "variable": row["variable"],
+                "ensemble_member": row["ensemble_member"],
+                "valid_time": str(row["valid_time"]),
+                "n_null_cells": row["n_null"],
+                "n_total_cells": row["n_total"],
+            }
+        )
+        for row in scattered.iter_rows(named=True)
+    ]
+    return MetadataValue.table(records, schema=_NWP_NULL_SLICES_SCHEMA)
 
 
 ##############################################################################

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -238,6 +238,44 @@ def test_ecmwf_ens_materialises_and_appends_nwp(env: Path, monkeypatch: pytest.M
     # ...and the converted frame is actually persisted via write_nwp (all 4 rows round-trip).
     written = pl.read_delta(Settings().nwp_data_path)
     assert written.height == 4
+    # The clean run emits a passing data-quality check.
+    (evaluation,) = result.get_asset_check_evaluations()
+    assert evaluation.check_name == "nwp_has_no_unexpected_nulls"
+    assert evaluation.passed
+
+
+def test_ecmwf_ens_warns_on_scattered_nulls_but_still_materialises(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Scattered per-pixel nulls in a de-accumulated variable (the known upstream ECMWF ENS
+    corruption) are tolerated: the run still materialises, and the data-quality check WARNs."""
+    from contracts.settings import Settings
+
+    _write_h3_grid_weights(Settings().h3_grid_weights_path)
+    init_time = datetime(2024, 12, 1, tzinfo=timezone.utc)
+
+    # One (member, valid_time) slice across three h3 cells, one cell's precipitation nulled.
+    scattered = _make_nwp(init_time, n=3).with_columns(
+        init_time=pl.lit(init_time),
+        valid_time=pl.lit(init_time + timedelta(hours=3)),
+        ensemble_member=pl.lit(0, dtype=pl.UInt8),
+        precipitation_surface=pl.Series([0.001, None, 0.001], dtype=pl.Float32),
+    )
+    monkeypatch.setattr(assets, "open_ecmwf_ens_run", lambda *, nwp_init_time, h3_grid: object())
+    monkeypatch.setattr(assets, "download_ecmwf_ens_data", lambda ds: object())
+    monkeypatch.setattr(
+        assets, "convert_nwp_xarray_dataset_to_polars_dataframe", lambda ds, h3_grid: scattered
+    )
+
+    result = materialize(
+        [ecmwf_ens], partition_key="2024-12-01", instance=DagsterInstance.ephemeral()
+    )
+    assert result.success  # tolerated — the run is NOT failed
+    assert pl.read_delta(Settings().nwp_data_path).height == 3  # data was persisted
+    (evaluation,) = result.get_asset_check_evaluations()
+    assert evaluation.check_name == "nwp_has_no_unexpected_nulls"
+    assert not evaluation.passed  # WARN: the scatter is surfaced
+    assert evaluation.metadata["n_scattered_null_cells"].value == 1
 
 
 def test_ecmwf_ens_retries_when_run_not_yet_available(
@@ -295,9 +333,10 @@ def test_definitions_resolve(env: Path) -> None:
     }
     assert "h3_grid_weights" in ecmwf_parents
 
-    # The power-data freshness check is registered against its asset.
+    # The power-data freshness check and the NWP data-quality check are both registered.
     check_keys = {key.name for key in asset_graph.asset_check_keys}
     assert "power_data_is_fresh" in check_keys
+    assert "nwp_has_no_unexpected_nulls" in check_keys
 
     # A job whose AssetSelection names a missing asset resolves to an empty/wrong key set.
     for job_name, expected_asset in [


### PR DESCRIPTION
## Problem

The `ecmwf_ens` asset discarded an entire NWP run whenever `Nwp.validate` found *any* null in a de-accumulated variable beyond lead-0. Two distinct upstream defects tripped this and left partitions unmaterialised:

- **2026-07-12** (and ten historical inits: 2024-09-05, 2024-10-16, 2024-10-31, 2025-02-22, 2025-06-04, 2025-12-15, 2026-01-02, 2026-02-20, 2026-03-31, 2026-04-13): scattered per-pixel nulls in the de-accumulated variables. This is the **known, WONTFIX** upstream corruption of ECMWF's cumulative source fields (negative accumulation → correctly left null by Dynamical), [dynamical-org/reformatters#722](https://github.com/dynamical-org/reformatters/issues/722). Empirically it hits `precipitation_surface` **and** the radiation fluxes (same members, same 123h step).
- **2026-07-14**: a whole forecast step missing for 50 of 51 ensemble members across *every* variable — a structural gap, reported upstream as [dynamical-org/reformatters#765](https://github.com/dynamical-org/reformatters/issues/765).

The ML pipeline already tolerates null weather (`AllFeatures` fields are all `float | None`), so failing the whole run was the wrong response to the scattered case.

## Approach

Separate **"is this run usable?"** (the fatal ingest gate) from **"is it perfect?"** (a non-fatal quality check). The affected variable is itself the signal, so no magic threshold is needed:

- **Instantaneous** variables are never legitimately null → any null is a structural gap → stays **fatal** (base Patito). This keeps 2026-07-14 failing (also caught by the ptype rule).
- **De-accumulated** variables are already null at lead-0 by design → scattered nulls beyond it are the known #722 corruption → **tolerated**; only a **whole-slice** null (an entire `(member, valid_time)` slice, i.e. a wholesale missing field) is fatal. Observed scatter reaches ~7% of a slice; whole-slice is 100%, so the boundary is threshold-free.

## Changes

- `Nwp.validate`: drop the blanket "no nulls from the second step onwards" check; add `_check_no_whole_null_deaccumulated_slices` (whole-slice only). Nullability of the contract is unchanged.
- `assess_nwp_quality` / `NwpQualityReport`: pure, Dagster-free reporter for the tolerated scatter.
- `ecmwf_ens` asset: emit `assess_nwp_quality` as the non-blocking **WARN** asset check `nwp_has_no_unexpected_nulls`, computed in-asset from the frame already in hand (no re-scan of the ~5.9B-row NWP table, sidestepping the Polars 2³² row-count ceiling).
- New docs page `docs/architecture/ecmwf-ens-known-issues.md` + pointer from the `Nwp` docstring.

## Verification

- Fatal/tolerated boundary **empirically checked against real 2026-07-12 and 2026-04-13 data** (scatter present in precip + solar radiation, never whole-slice).
- New tests: instantaneous-null → fatal; scattered de-accumulated null → tolerated + reported; whole-slice → fatal; lead-0 nulls allowed; asset emits the check (pass + WARN cases); check registers in definitions.
- Full suite green (351 passed, 1 network-skipped), `ruff`, `ty`, `pymarkdown`, `mkdocs --strict` all clean.

## Follow-up (not in this PR)

- **Backfill** 2026-07-12 and the ten historical inits (re-run; `write_nwp` is append-only, and failed validations wrote nothing).
- 2026-07-14 stays red until #765 is resolved upstream; there is no separate alert that an init is missing from the table (Dagster's failed-run alerting covers it). A future NWP-completeness check could close that gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)