### PR TITLE
Order docs nav sub-sections predictably

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -41,18 +41,18 @@ nav:
   - Techniques:
       - Overview: techniques/index.md
       - Convex Optimisation: techniques/convex-optimisation.md
-      - Probabilistic Forecasting: techniques/probabilistic-forecasting.md
-      - Evaluation Metrics: techniques/evaluation-metrics.md
       - Differentiable Physics: techniques/differentiable-physics.md
-      - Encoders: techniques/encoders.md
       - Disaggregation Evaluation: techniques/disaggregation-evaluation.md
+      - Encoders: techniques/encoders.md
+      - Evaluation Metrics: techniques/evaluation-metrics.md
+      - Probabilistic Forecasting: techniques/probabilistic-forecasting.md
   - Architecture:
       - Overview: architecture/overview.md
       - Forecast Delivery: architecture/forecast-delivery.md
+      - Known ECMWF ENS Data-Quality Issues: architecture/ecmwf-ens-known-issues.md
       - ML Orchestration Design: architecture/ml-orchestration.md
       - Production Deployment Design: architecture/production-deployment.md
       - "Why Dagster, not Airflow?": architecture/why-dagster-not-airflow.md
-      - Known ECMWF ENS Data-Quality Issues: architecture/ecmwf-ens-known-issues.md
       - Code Style: architecture/code-style.md
       - Testing: architecture/testing.md
   - ML Experimentation:
@@ -70,17 +70,17 @@ nav:
       - Configuration reference: live_service/setup.md
   - Roadmap:
       - Overview: roadmap/index.md
-      - Live Service: roadmap/live-service.md
-      - Handover to NGED: roadmap/handover.md
-      - Delivery Tables: roadmap/delivery-tables.md
-      - Forecast Building Blocks: roadmap/forecast-building-blocks.md
-      - Metrics & Leaderboard: roadmap/metrics-and-leaderboard.md
-      - Data Sources: roadmap/data-sources.md
       - Capacity Estimation: roadmap/capacity-estimation.md
+      - Data Sources: roadmap/data-sources.md
+      - Delivery Tables: roadmap/delivery-tables.md
+      - Engineering Health: roadmap/engineering-health.md
+      - Forecast Building Blocks: roadmap/forecast-building-blocks.md
+      - Handover to NGED: roadmap/handover.md
+      - Live Service: roadmap/live-service.md
+      - Metrics & Leaderboard: roadmap/metrics-and-leaderboard.md
       - Net-Demand Disaggregation: roadmap/disaggregation.md
       - Switching Events: roadmap/switching-events.md
       - XGBoost Improvements: roadmap/xgboost-improvements.md
-      - Engineering Health: roadmap/engineering-health.md
   - API Reference:
       - Overview: api/index.md
       - Contracts: api/contracts/index.md


### PR DESCRIPTION
Applies a consistent ordering rule to the nav sub-sections that were arbitrary: **Overview first, then alphabetical.** Follows up on a review of every nav sub-section's ordering.

## Changed

- **Techniques** — was arbitrary; now Overview + alphabetical.
- **Roadmap** — was arbitrary (neither alphabetical, nor the milestone arc, nor the `index.md` design-doc order); now Overview + alphabetical. The milestone arc still lives, in execution order, in the "Milestones" section of `roadmap/index.md` — the nav sidebar just needs to be predictable, and several roadmap pages (Delivery Tables, Forecast Building Blocks, Data Sources) are cross-cutting references not tied to a single milestone, so a clean milestone ordering isn't maintainable in the nav.
- **Architecture** — alphabetical *within two groups*: the design/rationale pages first, then Code Style and Testing (contributor conventions) as a pair at the end.

## Deliberately left untouched

Sections already in a meaningful order:

- **ML Experimentation** — step order (configure → run → CV folds → evaluate new sources).
- **Live Service** — lifecycle order (overview → run locally → set up on AWS → connect → operate → config reference).
- **API Reference** — already Overview + alphabetical.
- **Background & Challenges** — reads as a narrative from general context to specific challenges (network → requirements → incumbent forecast → data quality → switching events).

## Verification

`uv run mkdocs build --strict` passes with no nav warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)