### PR TITLE
Stamp git SHA and Delta table versions on MLflow runs (#227)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,6 +202,19 @@ Each `BaseForecaster` also carries a `feature_engineer: ClassVar[FeatureEngineer
 
 - `snake_case` for variables/functions, `PascalCase` for classes, `UPPER_SNAKE_CASE` for constants.
 - All function signatures must have complete type hints including return types.
+- **Prefer self-documenting type hints over bare containers — a signature is documentation.**
+  Jack strongly prefers expressive signatures and is happy to spend a few extra lines of code to
+  get them, as long as complexity stays low. Whenever you would write `dict[str, str]` (or a bare
+  `str` for a value from a fixed set, or a tuple of positional values), stop and ask whether a more
+  self-documenting type is practical. Reach for: a `Type`-suffixed `Literal` alias for a closed set
+  of string values (`StageType = Literal["register", "train", "predict", "metrics"]`); a named
+  alias for a recurring shape (`MlflowTags = dict[str, str]`) so the intent is stated once and
+  reused; a `TypedDict` for a structured mapping with known keys (e.g. `ObjectStoreOptions`) —
+  taking the `TypedDict` in the signature and widening to a plain dict at the call boundary.
+  Constraining `dict` *keys* to a `Literal` alias (`dict[TableNameType, str]`) is worthwhile for a
+  closed vocabulary and works with bidirectional inference when callers pass dict literals.
+  `packages/ml_core/src/ml_core/_repro.py` is the worked example. Don't force it where no honest
+  stricter type exists — a genuinely heterogeneous or open-ended dict stays `dict[str, str]`.
 - All consts must be marked with the maximally "constant" type.
   e.g. `CONST_SEQ: Final[tuple[str, ...]] = ("a", "b")` or `FOO: Final[str] = "bar"`
 - Never relax an existing test to make it pass.

--- a/docs/ml_experimentation/dagster-workflow.md
+++ b/docs/ml_experimentation/dagster-workflow.md
@@ -261,6 +261,26 @@ FastAPI server.
 Full MLflow (which bundles the web server) is in the `dev` dependency group, so `uv sync` installs
 it; production runs use `mlflow-skinny` (the client, without the server).
 
+## Reproducibility: reconstructing a run from its stamped provenance
+
+Every run carries the code and data provenance needed to answer "exactly which code and which data
+produced this?". Each asset stamps **stage-prefixed** MLflow tags on the run it writes:
+
+- `register_git_sha` / `register_git_dirty` on the **parent run** — the code that registered the
+  experiment. (`git_dirty` is `true` when the working tree had uncommitted changes.)
+- `train_*`, `predict_*`, `metrics_*` on the **fold run** — one snapshot per stage, because
+  `trained_cv_model`, `cv_power_forecasts` and `metrics` all write to the same fold run and may run
+  days apart on different code. Each carries that stage's `git_sha` / `git_dirty` plus a
+  `{stage}_delta_version__{table}` tag holding the [Delta Lake](https://delta.io/) version of every
+  table it read (e.g. `train_delta_version__power_time_series`, `train_delta_version__nwp_data`).
+  The git SHA is stamped explicitly rather than via MLflow's auto-detection, which needs gitpython
+  and a repo working directory — neither present in a production container (there the SHA degrades
+  to `unknown`, never failing the run).
+
+To reconstruct the training-time state of a fold: `git checkout {train_git_sha}`, then read each
+table at its logged version with Delta time travel —
+`pl.scan_delta(power_time_series_path, version=<train_delta_version__power_time_series>)`.
+
 ---
 
 ## Why `trained_cv_model` reads config from MLflow, not from YAML

--- a/docs/roadmap/engineering-health.md
+++ b/docs/roadmap/engineering-health.md
@@ -5,7 +5,6 @@
 > roughly one-PR piece of work; sections are deleted as they ship. Mostly the v0.2 epic
 > [#138](https://github.com/openclimatefix/nged-substation-forecast/issues/138):
 > CI [#9](https://github.com/openclimatefix/nged-substation-forecast/issues/9) ·
-> reproducibility stamping [#227](https://github.com/openclimatefix/nged-substation-forecast/issues/227) ·
 > NWP ingestion checks [#161](https://github.com/openclimatefix/nged-substation-forecast/issues/161) ·
 > Hydra removal [#228](https://github.com/openclimatefix/nged-substation-forecast/issues/228) ·
 > rigor tests [#229](https://github.com/openclimatefix/nged-substation-forecast/issues/229).
@@ -86,56 +85,6 @@ status check in the GitHub repo settings (manual step, note it in the PR descrip
 **Verification.** (1) `uv run pytest` from the repo root passes locally after step 1. (2) Open
 the PR; the CI workflow runs and passes. (3) Push a deliberately broken commit to the PR
 branch (e.g. an unused import) and confirm the workflow fails, then revert.
-
-## Reproducibility: stamp git SHA and Delta table versions on MLflow runs
-
-Issue: [#227](https://github.com/openclimatefix/nged-substation-forecast/issues/227)
-
-Experiments log config, class targets, hyperparams, and window bounds to MLflow — but no git
-commit and no data versions (verified: nothing in `defs/jobs.py` or `ml_core/_mlflow_runs.py`).
-A run ID today cannot answer "exactly which code and which data produced this model?". Delta
-Lake's time travel makes data versioning nearly free — logging the table version at read time
-buys full data reproducibility for one integer per table. (MLflow *can* auto-set
-`mlflow.source.git.commit`, but only when gitpython is installed and CWD is in the repo —
-neither holds in a production container, so stamp explicitly.)
-
-### Implementation details — stamping (deleted when it ships)
-
-**1. Git identity helper.** New module `packages/ml_core/src/ml_core/_repro.py`:
-
-- `get_git_info() -> dict[str, str]` returning `{"git_sha": ..., "git_dirty": "true"/"false"}`
-  via `subprocess` (`git rev-parse HEAD`, `git status --porcelain`). Return
-  `{"git_sha": "unknown", ...}` instead of raising when not in a git repo (containers) —
-  callers must never fail because of provenance.
-- `get_delta_versions(paths: dict[str, Path]) -> dict[str, str]` returning
-  `{f"delta_version__{name}": str(DeltaTable(path).version())}` per table (`deltalake` is
-  already a dependency). Missing table → `"absent"`, again never raising.
-
-**2. Stamp at registration.** In `register_experiment`
-(`src/nged_substation_forecast/defs/jobs.py:108`), alongside the existing experiment tags
-(`config`, `forecaster_target`, …): set `git_sha` / `git_dirty` tags on the **parent run** in
-the existing `with mlflow.start_run(run_id=parent_run_id)` block (`jobs.py:134-141`).
-
-**3. Stamp at training and prediction time.** Registration SHA ≠ training SHA (folds can be
-trained days later on different code), so the fold-level stamp is the load-bearing one:
-
-- In the `trained_cv_model` asset (`defs/cv_assets.py`), where training params are already
-  logged to the fold run: add `git_sha`/`git_dirty` tags plus
-  `get_delta_versions({"power_time_series": ..., "nwp_data": ..., "eligible_time_series": ...})`
-  using the paths from `Settings`. Log versions as tags (they're provenance, not metrics).
-- In `cv_power_forecasts`, same stamps (prediction may run on yet another SHA/data state) —
-  the forecast-metadata logging block is the natural place.
-
-**4. Surface in docs.** One short paragraph in
-`docs/ml_experimentation/dagster-workflow.md`: what is stamped, where, and how to reconstruct
-a run (`git checkout {sha}` + `pl.scan_delta(..., version=N)`).
-
-**Verification.** (1) Unit tests for `_repro.py`: git info in a temp repo; `unknown` outside
-one; Delta version of a freshly written temp table is `0` and increments on append. (2) Extend
-`tests/test_register_experiment_job.py` to assert the parent run carries `git_sha`. (3) Run
-the smoke-test fold end-to-end and confirm the fold run shows git + Delta-version tags in the
-MLflow UI. (4) Round-trip check: `pl.scan_delta(power_time_series_path, version=<logged>)`
-returns the training-time state after a subsequent append.
 
 ## NWP ingestion: completeness checks and Dagster metrics
 

--- a/packages/ml_core/src/ml_core/_repro.py
+++ b/packages/ml_core/src/ml_core/_repro.py
@@ -1,0 +1,124 @@
+"""Reproducibility provenance: the git SHA and Delta-table versions behind an MLflow run.
+
+Answers "exactly which code and which data produced this?" for any MLflow run. The git SHA pins
+the code — stamped **explicitly** because MLflow's ``mlflow.source.git.commit`` auto-detection
+needs gitpython installed *and* the working directory inside the repo, neither of which holds in a
+production container. Each Delta table's ``version()`` pins the data: Delta Lake time travel makes
+data versioning one integer per table, so a run can later be replayed with
+``pl.scan_delta(path, version=N)`` after ``git checkout {sha}``.
+
+Every function here is deliberately **non-raising**: provenance is metadata, and a missing ``.git``
+directory (containers) or an absent Delta table must never fail the surrounding training or
+forecasting run. Such failures degrade to the sentinels ``"unknown"`` / ``"absent"``.
+
+``provenance_tags`` **stage-prefixes** its keys (``register_``, ``train_``, ``predict_``,
+``metrics_``) because a single MLflow fold run is written by three separate assets —
+``trained_cv_model``, ``cv_power_forecasts`` and ``metrics`` — each potentially on a different code
+revision and data state. Un-prefixed keys would clobber one another; the prefix preserves all
+three provenance snapshots side by side.
+"""
+
+import logging
+import subprocess
+from pathlib import Path
+from typing import Final
+
+from deltalake import DeltaTable
+
+logger = logging.getLogger(__name__)
+
+UNKNOWN: Final[str] = "unknown"
+"""Sentinel git SHA / dirty flag returned when no git repository is reachable (e.g. a container)."""
+
+ABSENT: Final[str] = "absent"
+"""Sentinel Delta version returned when a table does not exist or cannot be read."""
+
+_GIT_CWD: Final[Path] = Path(__file__).resolve().parent
+"""Directory the git commands run from — inside the repo for an editable/workspace install, so the
+SHA is captured independently of the process's working directory; outside any repo for a wheel
+install in a container, where the commands fail and ``get_git_info`` returns ``UNKNOWN``."""
+
+
+def get_git_info(cwd: Path | None = None) -> dict[str, str]:
+    """Return ``{"git_sha", "git_dirty"}`` for the current checkout, never raising.
+
+    ``git_dirty`` is ``"true"`` when the working tree has uncommitted changes, ``"false"`` when
+    clean. Outside a git repository (no ``.git``, or no ``git`` binary) both values are ``UNKNOWN``.
+
+    Args:
+        cwd: Directory the ``git`` commands run from. Defaults to this module's directory
+            (``_GIT_CWD``) — inside the repo for an editable/workspace install, so the SHA is
+            captured regardless of the process's working directory. Overridable for testing.
+    """
+    run_from = cwd if cwd is not None else _GIT_CWD
+    try:
+        sha = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=run_from,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        porcelain = subprocess.run(
+            ["git", "status", "--porcelain"],
+            cwd=run_from,
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout
+    except subprocess.CalledProcessError, FileNotFoundError, OSError:
+        return {"git_sha": UNKNOWN, "git_dirty": UNKNOWN}
+    return {"git_sha": sha, "git_dirty": "true" if porcelain.strip() else "false"}
+
+
+def get_delta_versions(
+    paths: dict[str, str], storage_options: dict[str, str] | None = None
+) -> dict[str, str]:
+    """Return ``{f"delta_version__{name}": str(version)}`` for each named Delta table, never raising.
+
+    Args:
+        paths: ``{logical_name: table_uri}``. The URI may be local or a remote object-store URI.
+        storage_options: delta-rs storage options for a remote URI; ``None``/empty for local.
+
+    Returns:
+        One entry per input path. A table that does not exist (or cannot be read) maps to
+        ``ABSENT`` rather than raising, so provenance capture never fails the calling run.
+    """
+    versions: dict[str, str] = {}
+    for name, path in paths.items():
+        key = f"delta_version__{name}"
+        try:
+            if not DeltaTable.is_deltatable(path, storage_options=storage_options or {}):
+                versions[key] = ABSENT
+                continue
+            versions[key] = str(DeltaTable(path, storage_options=storage_options).version())
+        except Exception:  # noqa: BLE001 — provenance must never fail the surrounding run.
+            logger.warning("Could not read Delta version for %r at %s", name, path, exc_info=True)
+            versions[key] = ABSENT
+    return versions
+
+
+def provenance_tags(
+    stage: str,
+    delta_paths: dict[str, str] | None = None,
+    storage_options: dict[str, str] | None = None,
+) -> dict[str, str]:
+    """Build stage-prefixed MLflow tags stamping the code (git) and data (Delta versions) provenance.
+
+    Args:
+        stage: Prefix identifying the writing asset (``"register"``, ``"train"``, ``"predict"``,
+            ``"metrics"``). Keeps the tags of assets that share one MLflow run from clobbering.
+        delta_paths: ``{logical_name: table_uri}`` for the Delta tables this stage reads; omit for
+            a stage that reads no data (registration).
+        storage_options: delta-rs storage options for remote table URIs; ``None``/empty for local.
+
+    Returns:
+        e.g. for ``stage="train"``: ``{"train_git_sha", "train_git_dirty",
+        "train_delta_version__power_time_series", ...}``.
+    """
+    git = get_git_info()
+    tags = {f"{stage}_git_sha": git["git_sha"], f"{stage}_git_dirty": git["git_dirty"]}
+    if delta_paths:
+        for key, version in get_delta_versions(delta_paths, storage_options).items():
+            tags[f"{stage}_{key}"] = version
+    return tags

--- a/packages/ml_core/src/ml_core/_repro.py
+++ b/packages/ml_core/src/ml_core/_repro.py
@@ -36,14 +36,27 @@ ABSENT: Final[str] = "absent"
 _GIT_CWD: Final[Path] = Path(__file__).resolve().parent
 """Directory the git commands run from — inside the repo for an editable/workspace install, so the
 SHA is captured independently of the process's working directory; outside any repo for a wheel
-install in a container, where the commands fail and ``get_git_info`` returns ``UNKNOWN``."""
+install in a container, where the commands fail and ``get_git_info`` returns ``UNKNOWN``.
+
+Caveat: ``git rev-parse`` walks *upward* for a ``.git`` directory, so if an install location that
+is not this project nonetheless sits inside some *other* git repo (e.g. a Docker build context that
+copied the project's ``.git``, or a rogue ``.git`` above ``site-packages``), the returned SHA is
+that repo's HEAD, not this project's. In this workspace-install project that does not arise, but a
+confidently-wrong SHA is worse than ``UNKNOWN``; treat the SHA as trustworthy only for
+editable/workspace installs."""
+
+_GIT_TIMEOUT_S: Final[float] = 5.0
+"""Hard cap on each git subprocess so a stalled ``.git`` (NFS, a stale lock) can never hang the
+surrounding Dagster asset — provenance is best-effort metadata, not a blocking dependency."""
 
 
 def get_git_info(cwd: Path | None = None) -> dict[str, str]:
     """Return ``{"git_sha", "git_dirty"}`` for the current checkout, never raising.
 
     ``git_dirty`` is ``"true"`` when the working tree has uncommitted changes, ``"false"`` when
-    clean. Outside a git repository (no ``.git``, or no ``git`` binary) both values are ``UNKNOWN``.
+    clean. When the SHA cannot be read (no ``.git``, no ``git`` binary, a timeout) both values are
+    ``UNKNOWN``; when the SHA is read but the dirty check fails, the SHA is kept and only
+    ``git_dirty`` degrades to ``UNKNOWN`` — a good SHA is never discarded.
 
     Args:
         cwd: Directory the ``git`` commands run from. Defaults to this module's directory
@@ -51,23 +64,26 @@ def get_git_info(cwd: Path | None = None) -> dict[str, str]:
             captured regardless of the process's working directory. Overridable for testing.
     """
     run_from = cwd if cwd is not None else _GIT_CWD
-    try:
-        sha = subprocess.run(
-            ["git", "rev-parse", "HEAD"],
+
+    def _git(*args: str) -> str:
+        return subprocess.run(
+            ["git", *args],
             cwd=run_from,
             capture_output=True,
             text=True,
+            errors="replace",  # non-UTF-8 bytes (e.g. an odd filename) must not raise on decode.
             check=True,
-        ).stdout.strip()
-        porcelain = subprocess.run(
-            ["git", "status", "--porcelain"],
-            cwd=run_from,
-            capture_output=True,
-            text=True,
-            check=True,
+            timeout=_GIT_TIMEOUT_S,
         ).stdout
-    except subprocess.CalledProcessError, FileNotFoundError, OSError:
+
+    try:
+        sha = _git("rev-parse", "HEAD").strip()
+    except Exception:  # noqa: BLE001 — provenance must never fail the surrounding run.
         return {"git_sha": UNKNOWN, "git_dirty": UNKNOWN}
+    try:
+        porcelain = _git("status", "--porcelain")
+    except Exception:  # noqa: BLE001 — keep the SHA we already have; only dirtiness is unknown.
+        return {"git_sha": sha, "git_dirty": UNKNOWN}
     return {"git_sha": sha, "git_dirty": "true" if porcelain.strip() else "false"}
 
 
@@ -88,10 +104,11 @@ def get_delta_versions(
     for name, path in paths.items():
         key = f"delta_version__{name}"
         try:
-            if not DeltaTable.is_deltatable(path, storage_options=storage_options or {}):
+            options = storage_options or {}
+            if not DeltaTable.is_deltatable(path, storage_options=options):
                 versions[key] = ABSENT
                 continue
-            versions[key] = str(DeltaTable(path, storage_options=storage_options).version())
+            versions[key] = str(DeltaTable(path, storage_options=options).version())
         except Exception:  # noqa: BLE001 — provenance must never fail the surrounding run.
             logger.warning("Could not read Delta version for %r at %s", name, path, exc_info=True)
             versions[key] = ABSENT

--- a/packages/ml_core/src/ml_core/_repro.py
+++ b/packages/ml_core/src/ml_core/_repro.py
@@ -21,11 +21,30 @@ three provenance snapshots side by side.
 import logging
 import subprocess
 from pathlib import Path
-from typing import Final
+from typing import Final, Literal
 
+from contracts._uri import ObjectStoreOptions
+from contracts.typing_utils import typeddict_to_dict
 from deltalake import DeltaTable
 
 logger = logging.getLogger(__name__)
+
+MlflowTags = dict[str, str]
+"""A ``{tag_key: tag_value}`` mapping ready to hand to ``mlflow.set_tags``."""
+
+StageType = Literal["register", "train", "predict", "metrics"]
+"""The assets that stamp provenance; each value becomes a tag-key prefix (see ``provenance_tags``).
+Add a new member when a new asset starts stamping."""
+
+TableNameType = Literal[
+    "power_time_series",
+    "nwp_data",
+    "eligible_time_series",
+    "power_forecasts",
+    "effective_capacity",
+]
+"""Logical names of the Delta tables whose versions get stamped — the keys of a ``delta_paths``
+mapping. Add a new member when a stage starts reading (and stamping) another table."""
 
 UNKNOWN: Final[str] = "unknown"
 """Sentinel git SHA / dirty flag returned when no git repository is reachable (e.g. a container)."""
@@ -50,7 +69,7 @@ _GIT_TIMEOUT_S: Final[float] = 5.0
 surrounding Dagster asset — provenance is best-effort metadata, not a blocking dependency."""
 
 
-def get_git_info(cwd: Path | None = None) -> dict[str, str]:
+def get_git_info(cwd: Path | None = None) -> MlflowTags:
     """Return ``{"git_sha", "git_dirty"}`` for the current checkout, never raising.
 
     ``git_dirty`` is ``"true"`` when the working tree has uncommitted changes, ``"false"`` when
@@ -88,23 +107,24 @@ def get_git_info(cwd: Path | None = None) -> dict[str, str]:
 
 
 def get_delta_versions(
-    paths: dict[str, str], storage_options: dict[str, str] | None = None
-) -> dict[str, str]:
+    paths: dict[TableNameType, str], storage_options: ObjectStoreOptions | None = None
+) -> MlflowTags:
     """Return ``{f"delta_version__{name}": str(version)}`` for each named Delta table, never raising.
 
     Args:
         paths: ``{logical_name: table_uri}``. The URI may be local or a remote object-store URI.
-        storage_options: delta-rs storage options for a remote URI; ``None``/empty for local.
+        storage_options: object-store options for a remote URI; ``None``/empty for local. Widened
+            to the plain dict delta-rs expects at the call boundary.
 
     Returns:
         One entry per input path. A table that does not exist (or cannot be read) maps to
         ``ABSENT`` rather than raising, so provenance capture never fails the calling run.
     """
-    versions: dict[str, str] = {}
+    options = typeddict_to_dict(storage_options) or {}
+    versions: MlflowTags = {}
     for name, path in paths.items():
         key = f"delta_version__{name}"
         try:
-            options = storage_options or {}
             if not DeltaTable.is_deltatable(path, storage_options=options):
                 versions[key] = ABSENT
                 continue
@@ -116,25 +136,25 @@ def get_delta_versions(
 
 
 def provenance_tags(
-    stage: str,
-    delta_paths: dict[str, str] | None = None,
-    storage_options: dict[str, str] | None = None,
-) -> dict[str, str]:
+    stage: StageType,
+    delta_paths: dict[TableNameType, str] | None = None,
+    storage_options: ObjectStoreOptions | None = None,
+) -> MlflowTags:
     """Build stage-prefixed MLflow tags stamping the code (git) and data (Delta versions) provenance.
 
     Args:
-        stage: Prefix identifying the writing asset (``"register"``, ``"train"``, ``"predict"``,
-            ``"metrics"``). Keeps the tags of assets that share one MLflow run from clobbering.
+        stage: Prefix identifying the writing asset. Keeps the tags of assets that share one MLflow
+            run from clobbering.
         delta_paths: ``{logical_name: table_uri}`` for the Delta tables this stage reads; omit for
             a stage that reads no data (registration).
-        storage_options: delta-rs storage options for remote table URIs; ``None``/empty for local.
+        storage_options: object-store options for remote table URIs; ``None``/empty for local.
 
     Returns:
         e.g. for ``stage="train"``: ``{"train_git_sha", "train_git_dirty",
         "train_delta_version__power_time_series", ...}``.
     """
     git = get_git_info()
-    tags = {f"{stage}_git_sha": git["git_sha"], f"{stage}_git_dirty": git["git_dirty"]}
+    tags: MlflowTags = {f"{stage}_git_sha": git["git_sha"], f"{stage}_git_dirty": git["git_dirty"]}
     if delta_paths:
         for key, version in get_delta_versions(delta_paths, storage_options).items():
             tags[f"{stage}_{key}"] = version

--- a/packages/ml_core/tests/test_repro.py
+++ b/packages/ml_core/tests/test_repro.py
@@ -1,0 +1,84 @@
+"""Unit tests for the reproducibility provenance helpers (`ml_core._repro`).
+
+These exercise real ``git`` subprocesses in throwaway repos and real Delta tables in ``tmp_path``
+— no MLflow and no network — so they run in the default (non-integration) suite.
+"""
+
+import subprocess
+from pathlib import Path
+
+import polars as pl
+from deltalake import write_deltalake
+from ml_core._repro import (
+    ABSENT,
+    UNKNOWN,
+    get_delta_versions,
+    get_git_info,
+    provenance_tags,
+)
+
+
+def _init_repo(path: Path) -> None:
+    """Create a git repo at ``path`` with one committed file and a usable identity."""
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=path, check=True)
+    (path / "tracked.txt").write_text("hello\n")
+    subprocess.run(["git", "add", "."], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=path, check=True)
+
+
+def test_git_info_clean_repo(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    info = get_git_info(cwd=tmp_path)
+    assert len(info["git_sha"]) == 40
+    assert all(c in "0123456789abcdef" for c in info["git_sha"])
+    assert info["git_dirty"] == "false"
+
+
+def test_git_info_dirty_repo(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    (tmp_path / "tracked.txt").write_text("changed\n")  # modify a tracked file
+    assert get_git_info(cwd=tmp_path)["git_dirty"] == "true"
+
+
+def test_git_info_outside_repo_is_unknown_never_raises(tmp_path: Path) -> None:
+    # tmp_path has no .git — the git commands fail and both values degrade to the sentinel.
+    info = get_git_info(cwd=tmp_path)
+    assert info == {"git_sha": UNKNOWN, "git_dirty": UNKNOWN}
+
+
+def test_delta_version_zero_then_increments_on_append(tmp_path: Path) -> None:
+    table_path = str(tmp_path / "tbl")
+    frame = pl.DataFrame({"a": [1, 2, 3]}).to_arrow()
+    write_deltalake(table_path, frame)
+    assert get_delta_versions({"tbl": table_path}) == {"delta_version__tbl": "0"}
+
+    write_deltalake(table_path, frame, mode="append")
+    assert get_delta_versions({"tbl": table_path}) == {"delta_version__tbl": "1"}
+
+
+def test_delta_version_missing_table_is_absent(tmp_path: Path) -> None:
+    versions = get_delta_versions({"nope": str(tmp_path / "does_not_exist")})
+    assert versions == {"delta_version__nope": ABSENT}
+
+
+def test_provenance_tags_are_stage_prefixed(tmp_path: Path) -> None:
+    _init_repo(tmp_path)
+    table_path = str(tmp_path / "tbl")
+    write_deltalake(table_path, pl.DataFrame({"a": [1]}).to_arrow())
+
+    # get_git_info here uses the real repo of the test run (default cwd); we only assert the keys
+    # and the Delta-version value, which are deterministic.
+    tags = provenance_tags("train", {"power": table_path})
+    assert set(tags) == {
+        "train_git_sha",
+        "train_git_dirty",
+        "train_delta_version__power",
+    }
+    assert tags["train_delta_version__power"] == "0"
+
+
+def test_provenance_tags_without_delta_paths_is_git_only() -> None:
+    tags = provenance_tags("register")
+    assert set(tags) == {"register_git_sha", "register_git_dirty"}

--- a/packages/ml_core/tests/test_repro.py
+++ b/packages/ml_core/tests/test_repro.py
@@ -48,6 +48,13 @@ def test_git_info_outside_repo_is_unknown_never_raises(tmp_path: Path) -> None:
     assert info == {"git_sha": UNKNOWN, "git_dirty": UNKNOWN}
 
 
+def test_git_info_never_raises_on_bad_cwd(tmp_path: Path) -> None:
+    # A nonexistent working directory makes subprocess raise FileNotFoundError *for the cwd* — a
+    # different path from the out-of-repo case — which the broad guard must still swallow.
+    info = get_git_info(cwd=tmp_path / "does_not_exist")
+    assert info == {"git_sha": UNKNOWN, "git_dirty": UNKNOWN}
+
+
 def test_delta_version_zero_then_increments_on_append(tmp_path: Path) -> None:
     table_path = str(tmp_path / "tbl")
     frame = pl.DataFrame({"a": [1, 2, 3]}).to_arrow()

--- a/packages/ml_core/tests/test_repro.py
+++ b/packages/ml_core/tests/test_repro.py
@@ -59,15 +59,19 @@ def test_delta_version_zero_then_increments_on_append(tmp_path: Path) -> None:
     table_path = str(tmp_path / "tbl")
     frame = pl.DataFrame({"a": [1, 2, 3]}).to_arrow()
     write_deltalake(table_path, frame)
-    assert get_delta_versions({"tbl": table_path}) == {"delta_version__tbl": "0"}
+    assert get_delta_versions({"power_time_series": table_path}) == {
+        "delta_version__power_time_series": "0"
+    }
 
     write_deltalake(table_path, frame, mode="append")
-    assert get_delta_versions({"tbl": table_path}) == {"delta_version__tbl": "1"}
+    assert get_delta_versions({"power_time_series": table_path}) == {
+        "delta_version__power_time_series": "1"
+    }
 
 
 def test_delta_version_missing_table_is_absent(tmp_path: Path) -> None:
-    versions = get_delta_versions({"nope": str(tmp_path / "does_not_exist")})
-    assert versions == {"delta_version__nope": ABSENT}
+    versions = get_delta_versions({"nwp_data": str(tmp_path / "does_not_exist")})
+    assert versions == {"delta_version__nwp_data": ABSENT}
 
 
 def test_provenance_tags_are_stage_prefixed(tmp_path: Path) -> None:
@@ -77,13 +81,13 @@ def test_provenance_tags_are_stage_prefixed(tmp_path: Path) -> None:
 
     # get_git_info here uses the real repo of the test run (default cwd); we only assert the keys
     # and the Delta-version value, which are deterministic.
-    tags = provenance_tags("train", {"power": table_path})
+    tags = provenance_tags("train", {"power_time_series": table_path})
     assert set(tags) == {
         "train_git_sha",
         "train_git_dirty",
-        "train_delta_version__power",
+        "train_delta_version__power_time_series",
     }
-    assert tags["train_delta_version__power"] == "0"
+    assert tags["train_delta_version__power_time_series"] == "0"
 
 
 def test_provenance_tags_without_delta_paths_is_git_only() -> None:

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -55,6 +55,7 @@ from ml_core._mlflow_runs import (
     get_or_create_parent_run,
     load_experiment_forecaster,
 )
+from ml_core._repro import provenance_tags
 from nged_data.storage import time_series_coverage
 
 # The CV folds are the shared leaderboard evaluation protocol, read from conf/cv/default.yaml
@@ -425,6 +426,21 @@ def trained_cv_model(context: AssetExecutionContext) -> None:
     }
     with mlflow.start_run(run_id=fold_run_id):
         mlflow.log_params(training_params)
+        # Provenance: the code + data versions that produced this fold's model — the load-bearing
+        # stamp, since a fold can be trained days after registration on a different SHA. Tags (not
+        # params) because provenance overwrites cleanly on re-materialise; these are the three
+        # Delta tables the training path reads above.
+        mlflow.set_tags(
+            provenance_tags(
+                "train",
+                {
+                    "power_time_series": settings.power_time_series_data_path,
+                    "nwp_data": settings.nwp_data_path,
+                    "eligible_time_series": settings.eligible_time_series_data_path,
+                },
+                storage_options=typeddict_to_dict(settings.storage_options),
+            )
+        )
 
     context.add_output_metadata(
         {
@@ -545,6 +561,20 @@ def cv_power_forecasts(context: AssetExecutionContext) -> None:
         # raise "Changing param values is not allowed" — the covered window is mutable metadata.
         mlflow.set_tag("val_start", val_start.isoformat())
         mlflow.set_tag("val_end", val_end.isoformat())
+        # Provenance: prediction may run on yet another SHA / data state than training. Stamps the
+        # two Delta tables the forecasting path reads (via _load_engineering_inputs) — not
+        # eligible_time_series, which prediction does not read (the trained series come from the
+        # loaded model).
+        mlflow.set_tags(
+            provenance_tags(
+                "predict",
+                {
+                    "power_time_series": settings.power_time_series_data_path,
+                    "nwp_data": settings.nwp_data_path,
+                },
+                storage_options=typeddict_to_dict(settings.storage_options),
+            )
+        )
         mlflow.log_metrics(
             {
                 "n_forecast_rows": float(n_rows),
@@ -788,6 +818,7 @@ def _score_forecast_group(
     metrics_path: str,
     now: datetime,
     storage_options: ObjectStoreOptions | None = None,
+    provenance: dict[str, str] | None = None,
 ) -> tuple[int, dict[str, float] | None]:
     """Score one ``(experiment_name, fold_id)`` group, write ``Metrics`` to Delta, and
     optionally log to MLflow.
@@ -822,6 +853,9 @@ def _score_forecast_group(
             one asset materialisation share the same timestamp).
         storage_options: Object-store options for a remote ``metrics_path``; ``None``/empty
             for local.
+        provenance: Stage-prefixed provenance tags (git SHA + scored Delta-table versions) to
+            stamp on the fold's MLflow run in ``"leaderboard"`` scope; built once by the caller
+            so every group shares one snapshot. ``None`` skips the stamp.
 
     Returns:
         A ``(n_rows_written, fold_metric_dict)`` tuple where:
@@ -876,6 +910,8 @@ def _score_forecast_group(
     if evaluation_scope == "leaderboard":
         fold_metric_dict = build_mlflow_aggregate_metrics(per_series_metrics)
         with mlflow.start_run(run_id=mlflow_run_id):
+            if provenance is not None:
+                mlflow.set_tags(provenance)
             mlflow.log_metrics(fold_metric_dict)
         return enriched.height, fold_metric_dict
 
@@ -960,6 +996,18 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
 
     if_local_path_then_make_parent_dir(settings.forecast_metrics_data_path)
     now = datetime.now(timezone.utc)
+    # Provenance for every fold + parent run this materialisation touches: the code SHA and the
+    # versions of the three Delta tables scoring reads (forecasts, actuals, capacity). Built once
+    # — all groups are scored in this one process, so they share a single code + data snapshot.
+    metrics_provenance = provenance_tags(
+        "metrics",
+        {
+            "power_forecasts": settings.power_forecasts_data_path,
+            "power_time_series": settings.power_time_series_data_path,
+            "effective_capacity": settings.effective_capacity_data_path,
+        },
+        storage_options=typeddict_to_dict(storage_options),
+    )
     total_rows = 0
     # Accumulates per-fold metric values for parent-run aggregation (leaderboard scope only).
     # Structure: {experiment_name: {mlflow_metric_key: [value_per_fold, ...]}}
@@ -979,6 +1027,7 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
             settings.forecast_metrics_data_path,
             now,
             storage_options,
+            provenance=metrics_provenance,
         )
         total_rows += n_rows
         if fold_metric_dict is not None:
@@ -992,6 +1041,7 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
             parent_run_id = get_or_create_parent_run(experiment_id)
             parent_metric_dict = {k: sum(v) / len(v) for k, v in fold_metrics.items()}
             with mlflow.start_run(run_id=parent_run_id):
+                mlflow.set_tags(metrics_provenance)
                 mlflow.log_metrics(parent_metric_dict)
 
     context.add_output_metadata(

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -55,7 +55,7 @@ from ml_core._mlflow_runs import (
     get_or_create_parent_run,
     load_experiment_forecaster,
 )
-from ml_core._repro import provenance_tags
+from ml_core._repro import MlflowTags, provenance_tags
 from nged_data.storage import time_series_coverage
 
 # The CV folds are the shared leaderboard evaluation protocol, read from conf/cv/default.yaml
@@ -438,7 +438,7 @@ def trained_cv_model(context: AssetExecutionContext) -> None:
                     "nwp_data": settings.nwp_data_path,
                     "eligible_time_series": settings.eligible_time_series_data_path,
                 },
-                storage_options=typeddict_to_dict(settings.storage_options),
+                storage_options=settings.storage_options,
             )
         )
 
@@ -572,7 +572,7 @@ def cv_power_forecasts(context: AssetExecutionContext) -> None:
                     "power_time_series": settings.power_time_series_data_path,
                     "nwp_data": settings.nwp_data_path,
                 },
-                storage_options=typeddict_to_dict(settings.storage_options),
+                storage_options=settings.storage_options,
             )
         )
         mlflow.log_metrics(
@@ -818,7 +818,7 @@ def _score_forecast_group(
     metrics_path: str,
     now: datetime,
     storage_options: ObjectStoreOptions | None = None,
-    provenance: dict[str, str] | None = None,
+    provenance: MlflowTags | None = None,
 ) -> tuple[int, dict[str, float] | None]:
     """Score one ``(experiment_name, fold_id)`` group, write ``Metrics`` to Delta, and
     optionally log to MLflow.
@@ -1006,7 +1006,7 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
             "power_time_series": settings.power_time_series_data_path,
             "effective_capacity": settings.effective_capacity_data_path,
         },
-        storage_options=typeddict_to_dict(storage_options),
+        storage_options=storage_options,
     )
     total_rows = 0
     # Accumulates per-fold metric values for parent-run aggregation (leaderboard scope only).

--- a/src/nged_substation_forecast/defs/jobs.py
+++ b/src/nged_substation_forecast/defs/jobs.py
@@ -15,6 +15,7 @@ from contracts.settings import PROJECT_ROOT, Settings
 from dagster import Config, OpExecutionContext, job, op
 from ml_core._cv_helpers import CV_PARTITION_KEY_SEPARATOR, flatten_config
 from ml_core._mlflow_runs import get_or_create_experiment, get_or_create_parent_run
+from ml_core._repro import provenance_tags
 from ml_core.base_forecaster import BaseForecaster, BaseForecasterConfig
 from mlflow.tracking import MlflowClient
 from omegaconf import OmegaConf
@@ -137,6 +138,9 @@ def register_experiment(context: OpExecutionContext, config: RegisterExperimentC
             {
                 "model_family": forecaster_cls.MODEL_NAME,
                 "weather_source": forecaster_config.weather_source,
+                # Provenance: which code registered this experiment. Registration reads no data
+                # tables, so no Delta versions here — those are stamped at train/predict/metrics.
+                **provenance_tags("register"),
             }
         )
 

--- a/tests/test_register_experiment_job.py
+++ b/tests/test_register_experiment_job.py
@@ -71,6 +71,10 @@ def test_smoke_test_registers_experiment_and_dev_fold(mlflow_env: None) -> None:
     parent = _parent_run(experiment.experiment_id)
     assert parent.data.tags["model_family"] == "xgboost"
     assert parent.data.tags["weather_source"] == "ecmwf_control"
+    # Provenance: registration stamps the git SHA on the parent run (the tests run inside the
+    # repo, so it resolves to a real 40-char SHA, not the out-of-repo "unknown" sentinel).
+    assert len(parent.data.tags["register_git_sha"]) == 40
+    assert parent.data.tags["register_git_dirty"] in ("true", "false")
     # Resolved config is logged as flattened params (e.g. an XGBoost hyperparameter).
     assert "n_estimators" in parent.data.params
 


### PR DESCRIPTION
Closes #227.

## What

A run ID could not answer "exactly which code and which data produced this model?" — experiments logged config and hyperparams but no git commit and no data versions. This stamps both onto every MLflow run.

New helper `packages/ml_core/src/ml_core/_repro.py`:

- **`get_git_info()`** — `{git_sha, git_dirty}` via `subprocess` (`git rev-parse HEAD`, `git status --porcelain`). Degrades to `"unknown"` outside a git repo (production containers) rather than raising. Stamped explicitly because MLflow's `mlflow.source.git.commit` auto-detection needs gitpython **and** a repo working directory, neither of which holds in a container.
- **`get_delta_versions()`** — each Delta table's `version()` (time travel makes data versioning one integer per table). Missing/unreadable table → `"absent"`, never raising.
- **`provenance_tags(stage, ...)`** — assembles stage-prefixed git + Delta-version tags.

## Where it's stamped

| Asset | Run | Tag prefix | Delta versions stamped |
|---|---|---|---|
| `register_experiment` | parent | `register_` | — (reads no data) |
| `trained_cv_model` | fold | `train_` | power_time_series, nwp_data, eligible_time_series |
| `cv_power_forecasts` | fold | `predict_` | power_time_series, nwp_data |
| `metrics` | fold + parent | `metrics_` | power_forecasts, power_time_series, effective_capacity |

## Two decisions worth a look

1. **Stage-prefixed tag keys.** `trained_cv_model`, `cv_power_forecasts` and `metrics` all write to the *same* fold run, and each may run days apart on a different SHA. A bare `git_sha` tag would clobber — the run would show only whichever asset ran last. Prefixing (`train_git_sha`, `predict_git_sha`, `metrics_git_sha`) keeps all three snapshots. The load-bearing one is `train_*` — it pins the code+data that produced the model.

2. **`storage_options` threaded through** (deviation from the roadmap stub). The `Settings` table paths are `str` and may be remote S3 URIs, so `get_delta_versions` takes `storage_options` and passes it into `DeltaTable(...)`; without this every remote table would report `absent`.

Each stage stamps only the tables it actually reads (e.g. prediction does **not** read `eligible_time_series` — the trained series come from the loaded model — so it isn't stamped there).

## Reconstructing a run

`git checkout {train_git_sha}`, then `pl.scan_delta(power_time_series_path, version=<train_delta_version__power_time_series>)`. Documented in `docs/ml_experimentation/dagster-workflow.md`.

## Tests

- `packages/ml_core/tests/test_repro.py` — git info in a temp repo (clean/dirty), `unknown` outside a repo, Delta version `0` → `1` on append, missing table → `absent`, stage-prefix shape.
- `tests/test_register_experiment_job.py` — extended to assert the parent run carries `register_git_sha` (40-char SHA in-repo).
- Full `uv run pytest` green from the repo root (369 passed, 1 skipped); ruff/format/ty/pymarkdown clean.

## Ship-time triage (done here)

Deleted the "Reproducibility" section from `docs/roadmap/engineering-health.md` and its entry in the page's status banner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)