### PR TITLE
Plan tail & exceedance metrics; name threshold exceedance as a core requirement

### DIFF
--- a/docs/background/requirements.md
+++ b/docs/background/requirements.md
@@ -49,6 +49,23 @@ formal report to NGED, so a change of shape there (such as replacing the discret
 `substation_switching` table with continuous signals) is something to agree with NGED, not to
 decide unilaterally.
 
+### The worst case matters most: forecasting threshold exceedance
+
+NGED's need for these forecasts is driven by **flexibility procurement**: deciding, days
+ahead, whether to pay flexible customers to reduce their demand when a substation risks
+running beyond its capability. So the question users ask of a forecast is rarely "what is the
+most likely load?" and usually "**how likely is load to cross this limit?**" — NGED's
+[incumbent forecasting tool](nged-incumbent-forecast.md#the-operators-view) literally plots
+demand as headroom below a constraint line. The project's value therefore concentrates in the
+**upper tail** of each forecast distribution: a model that is excellent on typical half-hours
+but unreliable in the handful of near-limit hours has failed at the job. This is why the
+delivery quantiles are deliberately tail-heavy, and why evaluation includes
+[tail & exceedance metrics](../roadmap/metrics-and-leaderboard.md#tail-exceedance-metrics-scoring-the-question-nged-actually-asks)
+alongside average-error metrics. (One honest complication: a substation's real limit is not a
+single number — it varies with ambient temperature and with how long an overload lasts — so
+the evaluation metrics use documented static proxies; see
+[the threshold-choice discussion](../techniques/evaluation-metrics.md#choosing-the-thresholds-static-per-series-quantile-derived).)
+
 ## Stretch Goals
 
 Further down the same continuum:

--- a/docs/roadmap/metrics-and-leaderboard.md
+++ b/docs/roadmap/metrics-and-leaderboard.md
@@ -459,6 +459,19 @@ and nothing is logged to the leaderboard MLflow runs.
 > per-fold and mean-across-folds aggregates logged to MLflow — see
 > [Running an ML experiment end-to-end](../ml_experimentation/dagster-workflow.md#step-8-materialise-metrics).
 
+**Every metric above is also broken out by named population-filter slices**, which appear as
+extra leaderboard columns. Most are legitimate ranking columns, because the filter is fixed by
+information known *before* the outcome: the
+[horizon slice](#time-slices-for-performance-evaluation) a forecast falls in, the
+[Tricky days](#tricky-days-a-calendar-deterministic-metric-filter) calendar, and logged
+[switching events](#measuring-performance-during-switching-events). Two are **diagnostic only
+and must never drive ranking**, because they select hours by what actually happened and so
+reward a model that simply over-forecasts (the
+[forecaster's-dilemma trap](../techniques/evaluation-metrics.md#the-trap-scoring-only-the-hours-when-the-worst-case-actually-happened)):
+the **peak-events slice** (the top 5% highest *observed* demand) and NGED's hand-picked **hard
+examples**. Both are described under
+[Tail & exceedance metrics](#tail-exceedance-metrics-scoring-the-question-nged-actually-asks).
+
 ### Which ensemble collapse defines the deterministic point forecast? 🚧
 
 **Decided: metric-matched collapse, uniform across every model.** Implemented as part of the

--- a/docs/roadmap/metrics-and-leaderboard.md
+++ b/docs/roadmap/metrics-and-leaderboard.md
@@ -13,7 +13,7 @@ How OCF measures the skill of its forecasts and compares forecasting approaches.
 > [#6](https://github.com/openclimatefix/nged-substation-forecast/issues/6):
 > baseline forecasters [#147](https://github.com/openclimatefix/nged-substation-forecast/issues/147) ·
 > probabilistic evaluation [#225](https://github.com/openclimatefix/nged-substation-forecast/issues/225) ·
-> peak-events filter [#254](https://github.com/openclimatefix/nged-substation-forecast/issues/254) ·
+> tail & exceedance metrics [#254](https://github.com/openclimatefix/nged-substation-forecast/issues/254) ·
 > tricky-days filter [#255](https://github.com/openclimatefix/nged-substation-forecast/issues/255) ·
 > fold hygiene [#226](https://github.com/openclimatefix/nged-substation-forecast/issues/226).
 
@@ -447,6 +447,9 @@ and nothing is logged to the leaderboard MLflow runs.
 | [Interval width](../techniques/evaluation-metrics.md#interval-width) | Quantile | ✅ | Mean band width (MW) — the sharpness companion that stops PICP being gamed by over-widening. |
 | [CRPS (Continuous Ranked Probability Score)](../techniques/evaluation-metrics.md#crps-continuous-ranked-probability-score) | Ensemble | ✅ | Probabilistic equivalent of MAE; rewards both accuracy and sharpness. Fair (finite-ensemble-unbiased) form — the one metric comparable across ensemble sizes. |
 | [Spread-Skill Ratio](../techniques/evaluation-metrics.md#spread-skill-ratio) | Ensemble | ✅ | Fortin-corrected RMS ensemble spread ÷ RMSE of the ensemble mean. 1.0 = well-calibrated; < 1 under-dispersed (overconfident); > 1 over-dispersed (underconfident). |
+| [Threshold-weighted CRPS (twCRPS)](../techniques/evaluation-metrics.md#threshold-weighted-crps-twcrps) | Ensemble | 🚧 | CRPS confined to behaviour above a per-series threshold — the ranking-grade metric for skill near the network limit. See [Tail & exceedance metrics](#tail-exceedance-metrics-scoring-the-question-nged-actually-asks). |
+| [Exceedance rate of upper quantiles](../techniques/evaluation-metrics.md#exceedance-rate-of-the-upper-delivery-quantiles) | Quantile | 🚧 | "When we said p95, was it exceeded ~5% of the time?" — one-sided calibration check for the delivered tail quantiles. |
+| [Brier score for threshold exceedance](../techniques/evaluation-metrics.md#brier-score-for-threshold-exceedance) | Ensemble | 🚧 | Grades the ensemble's "chance load exceeds the threshold" probability — the score for the yes/no warning NGED acts on. |
 
 > The `Metrics` schema (`contracts.ml_schemas.Metrics`) stores results as
 > `(time_series_id, power_fcst_model_name, fold_id, horizon_slice, metric_name, metric_param,
@@ -586,23 +589,109 @@ time (the two-pass training scheme) must be the **causal** estimate available at
 backtests gain lookahead — see
 [Capacity estimation](capacity-estimation.md#causal-vs-smoothed-capacity-a-lookahead-trap-in-the-two-pass-scheme).
 
-### Peak events — the metric filter that matters most for flexibility
+### Tail & exceedance metrics — scoring the question NGED actually asks 🚧
 
 Issue: [#254](https://github.com/openclimatefix/nged-substation-forecast/issues/254)
 
-Because NGED's goal is **flexibility procurement** (entirely about peak management and congestion),
-overall RMSE only tells half the story. We add a **"Peak Events"** filter:
+NGED's goal is **flexibility procurement**: paying flexible customers to reduce demand when a
+substation risks running beyond its capability. The question they ask of a forecast is therefore
+"**will load cross the limit?**" — their operator tool plots demand as headroom below a
+constraint line (see [NGED's incumbent
+forecast](../background/nged-incumbent-forecast.md#the-operators-view)), and the
+[requirements](../background/requirements.md#the-worst-case-matters-most-forecasting-threshold-exceedance)
+name threshold exceedance as the core concept. The existing metrics lean toward the tails (the
+mean pinball loss is deliberately tail-weighted; PICP covers the p1–p99 band) but they measure
+upper-quantile skill *at every hour equally* — including hours when nothing is anywhere near a
+limit. This section adds the metrics that measure skill *near the limit* itself.
 
-- **Peak RMSE / Peak Pinball Loss**: score models *only* on the top 5% highest-demand half-hours
-  (or hours where solar generation unexpectedly drops during peak demand).
-- **Hand-picked "hard examples"**: if NGED supplies a list of historically tricky times, we compute
-  performance on those alone.
+One design rule governs the whole section: **never rank models on a sample selected by what
+actually happened.** Scoring models only on the top-N% highest *observed* half-hours rewards
+models that simply bias every forecast upward — the "forecaster's dilemma", explained in
+plain language in the [evaluation-metrics
+reference](../techniques/evaluation-metrics.md#the-trap-scoring-only-the-hours-when-the-worst-case-actually-happened).
+Ranking-grade tail emphasis instead comes from proper scores re-weighted toward the tail and
+computed over **all** hours. Concretely, three metrics — definitions, equations, and intuitive
+explanations in the [evaluation-metrics
+reference](../techniques/evaluation-metrics.md#tail-and-exceedance-metrics):
+
+- **Threshold-weighted CRPS
+  ([twCRPS](../techniques/evaluation-metrics.md#threshold-weighted-crps-twcrps))** — CRPS
+  confined to behaviour above a per-series threshold; the headline *ranking* metric for tail
+  skill. Implementation is nearly free: replace members and observation by `max(value,
+  threshold)` and reuse the existing fair-CRPS aggregation unchanged, inheriting its
+  comparability across ensemble sizes.
+
+- **[Exceedance rate of the upper delivery
+  quantiles](../techniques/evaluation-metrics.md#exceedance-rate-of-the-upper-delivery-quantiles)**
+  (p80–p99) — "when we said p95, was it exceeded ~5% of the time?"; the plain-language
+  *calibration* check for the tail quantiles NGED reads, one-sided where PICP's bands are
+  symmetric.
+
+- **[Brier score for threshold
+  exceedance](../techniques/evaluation-metrics.md#brier-score-for-threshold-exceedance)** —
+  grades the ensemble's "chance that load exceeds the threshold" the way one would grade a
+  "70% chance of rain" forecast; the most *decision-legible* number, scoring exactly the
+  warning NGED acts on.
+
+All three fit the existing `Metrics` schema — `metric_param` carries the threshold or quantile
+label — so there is no schema change.
+
+**Thresholds: static, per-series, quantile-derived.** A substation's true limit is not a
+single number (ratings vary with ambient temperature; transformers tolerate short overloads,
+so exceedance *duration* matters; switching changes what a feeder carries — NGED's own limit
+line is a time-varying "Flex Profile"). We deliberately do not model any of that for scoring.
+Each series gets two static thresholds — the P90 and P98 of its full observation history, in
+the series type's constraint-side direction (high load for demand; reverse power flow for
+generation) — chosen because they guarantee every series a scoreable event rate, mean the same
+thing across series, and stay stable across CV folds. Physical firm/flex ratings, where NGED
+supplies them, feed ad-hoc case studies and dashboard overlays instead: a rating that is never
+breached in the validation window yields zero events, and a warning system cannot be graded on
+events that never happen. The full rationale, and the explicit "this is a proxy" caveat, live
+in [the threshold-choice
+section](../techniques/evaluation-metrics.md#choosing-the-thresholds-static-per-series-quantile-derived)
+of the reference.
+
+**Diagnostic slices — never ranking columns.** Two observed-outcome views stay available for
+*understanding* a model's errors, clearly labelled as ineligible for ranking (the design rule
+above): a **peak-events slice** (the top 5% highest-observed-demand half-hours, via the same
+population-filter mechanism as the Tricky-days filter) and **hand-picked "hard examples"** —
+historically difficult periods NGED supplies, scored as case studies.
+
+These metrics also serve the [probabilistic-calibration
+work](#delivering-the-probabilistic-metrics): an underdispersed ensemble pushes its exceedance
+probabilities to 0 or 1 too early, so the Brier score and exceedance rates are the sharpest
+before/after instruments for Phases C and D.
+
+#### Implementation details — tail & exceedance metrics (deleted when this ships)
+
+- **Thresholds:** compute per-series `hist_p90` / `hist_p98` scalars from the full observation
+  history alongside (or within) the `effective_capacity` asset — same full-history stability
+  rationale, same join shape (`time_series_id`-only). Constraint-side direction resolved per
+  `time_series_type`; confirm the mapping with NGED for ambiguous types (BESS charges *and*
+  discharges).
+- **twCRPS:** transform members and observation with `pl.max_horizontal(col, threshold)` and
+  reuse the existing fair-CRPS expression (sorted-member identity, Float64 accumulation)
+  verbatim, once per threshold rung.
+- **Exceedance rates:** compare `y` against the already-computed empirical quantile columns
+  for p80, p90, p95, p98, p99 — one boolean mean per level.
+- **Brier score:** exceedance probability = member fraction above the threshold; outcome
+  indicator from `y`; squared difference, averaged.
+- **MLflow allowlist:** extend `_MLFLOW_LOGGED_PARAMETRIC` with a small headline subset (e.g.
+  `twcrps@hist_p98`, exceedance rate at p95, `brier@hist_p98`); decide the exact set at
+  implementation time and keep it small — everything is in Delta regardless.
+- **Peak-events diagnostic slice:** one more named population filter on the shared mechanism
+  (with the Tricky-days filter), flagged in the leaderboard UI as diagnostic-only.
+- **Verification:** hand-computed toy-ensemble values for all three metrics; cross-check
+  twCRPS against the `scoringrules` reference implementation; Monte-Carlo the finite-ensemble
+  one-sided exceedance references (mirroring the PICP reference-table verification); on a
+  smoke fold, confirm `nged_incumbent`'s P95 operating point scores well on the p95 exceedance
+  rate while paying for its conservatism on Brier/twCRPS sharpness.
 
 ### Tricky days — a calendar-deterministic metric filter 🚧
 
 Issue: [#255](https://github.com/openclimatefix/nged-substation-forecast/issues/255)
 
-Alongside Peak Events, we add a **"Tricky days"** filter: score models separately on the handful of
+Alongside the tail & exceedance metrics, we add a **"Tricky days"** filter: score models separately on the handful of
 calendar dates whose demand shape departs sharply from the usual weekly rhythm. We scope it
 deliberately to the **calendar-deterministic** set — fixed and moveable public holidays (Christmas,
 Easter, and the rest of the GB bank holidays) plus the two annual daylight-saving transitions —
@@ -613,8 +702,12 @@ that are hard for *data-dependent* reasons stay in their own already-planned fil
 different failure modes into one bucket would make the number impossible to act on ("bad on tricky
 days" — is that Christmas, or a switching event?).
 
-Mechanically it is another population filter (the same mechanism the planned Peak Events filter
-uses): a boolean flag per timestep, derived from `valid_time` alone. Because it is purely
+Mechanically it is another population filter (the same mechanism the peak-events diagnostic
+slice uses): a boolean flag per timestep, derived from `valid_time` alone. Unlike that
+observed-peak slice, this one *is* a legitimate ranking column: the flag depends only on the
+calendar, which every forecaster knew in advance, so it does not fall into the
+[forecaster's-dilemma
+trap](../techniques/evaluation-metrics.md#the-trap-scoring-only-the-hours-when-the-worst-case-actually-happened). Because it is purely
 calendar-driven it **shares its calendar module with `nged_incumbent_holiday_aligned`** — the same
 GB bank-holiday calendar (the pure-Python `holidays` package) plus the two DST dates feed both the
 holiday-aligned baseline and this metric filter. And the two reinforce each other: `nged_incumbent`
@@ -644,9 +737,9 @@ explicit day-of-week-aware modelling of the run-up until there is evidence it mo
 - A small calendar module (shared with baseline 2, `nged_incumbent_holiday_aligned`) answers, for
   any `valid_time`, whether it falls inside a tricky-days window. Back it with the `holidays` GB
   calendar plus the two annual DST dates; expose the per-event window widths as config.
-- Represent the tricky-days slice the same way the Peak Events filter is represented — one more
-  named population filter, resolved by the same mechanism, **not** a new schema axis — so the
-  leaderboard gains a **Tricky days** column with no `Metrics` schema change.
+- Represent the tricky-days slice the same way the peak-events diagnostic slice is represented —
+  one more named population filter, resolved by the same mechanism, **not** a new schema axis —
+  so the leaderboard gains a **Tricky days** column with no `Metrics` schema change.
 - Verification: unit-test the flag on known dates (a Christmas week, an Easter, both DST
   switchovers, and a plain week that must be *excluded*); on a smoke-test fold, confirm
   `nged_incumbent` scores worse on the tricky-days slice than overall.
@@ -688,7 +781,11 @@ ensembles are systematically overconfident, worst at short horizons where member
 diverged. Flexibility procurement is a tails problem (P90+ peaks), so this hits the use case
 directly. Phases A and B below (both shipped) built the measurement machinery — every metric in
 the [evaluation-metrics reference](../techniques/evaluation-metrics.md), per horizon slice; the
-remaining phases act on what those numbers show.
+remaining phases act on what those numbers show. The planned
+[tail & exceedance metrics](#tail-exceedance-metrics-scoring-the-question-nged-actually-asks)
+will sharpen the picture further: an underdispersed ensemble pushes its exceedance
+probabilities to 0 or 1 too early, so the Brier score and the quantile exceedance rates are
+the clearest before/after instruments for Phases C and D.
 
 The theory behind this diagnosis — the three-term uncertainty decomposition, why a
 deterministic model driven by an NWP ensemble captures only the weather term, and what the

--- a/docs/techniques/evaluation-metrics.md
+++ b/docs/techniques/evaluation-metrics.md
@@ -325,15 +325,19 @@ raised on all the other hours were thrown away before grading. Formally, restric
 proper (un-gameable) score to cases *selected by the observed outcome* makes it improper: a
 model can climb that ranking by simply biasing every forecast upward, adding no skill at all.
 
-The fix is a distinction between two kinds of hour-selection:
+The fix turns on *what* the hour-selection is based on:
 
-- **Selecting hours on information known *ex ante*** — Latin for "before the event", meaning
-  information available before the outcome was known — is safe. Scoring separately on
-  bank-holiday dates, on logged switching events, or per lead-time slice conditions only on
-  things a forecaster also knew in advance, so honest forecasts still win.
+- **Selecting hours by the load we are forecasting** — e.g. "the top 5% highest *observed*
+  demand half-hours" — is the unsafe case, for the reason above: because the selection is made
+  on the very quantity being scored, it rewards the forecaster who always predicts extremes.
 
-- **Selecting hours by what actually happened** — e.g. "the top 5% highest *observed* demand
-  half-hours" — is not safe for ranking models, for the reason above.
+- **Selecting hours by anything *other than* that observed load is safe** — the calendar
+  (bank-holiday dates), the lead time, or whether a switching event was logged. None of these
+  is the quantity we forecast, so restricting the score to them keeps it proper and honest
+  forecasts still win. A handy rule of thumb: if the selection could have been made *ex ante*
+  (Latin for "before the event") it is certainly safe — and a slice like logged switching
+  events is safe on the same grounds even when the event itself was an unforeseen fault,
+  because the test is "not the observed load", not "foreseeable".
 
 The consequence for this project: the calendar-based and switching-event metric slices are
 legitimate ranking columns, while any slice defined by observed peaks is a *diagnostic view

--- a/docs/techniques/evaluation-metrics.md
+++ b/docs/techniques/evaluation-metrics.md
@@ -1,10 +1,11 @@
 # Evaluation metrics
 
-> **Status: durable metric reference.** This page defines every metric computed by
+> **Status: durable metric reference.** This page defines the metrics computed by
 > `compute_metrics` (`packages/ml_core/src/ml_core/metrics.py`): a plain-language summary of
 > each, the equation, how to interpret the number, and — where the definition involved a real
-> choice — why we chose what we chose. The theory of *why* our ensembles need probabilistic
-> evaluation at all is the companion explainer
+> choice — why we chose what we chose. Sections marked 🚧 define metrics that are designed but
+> not yet computed; each links to its delivery plan. The theory of *why* our ensembles need
+> probabilistic evaluation at all is the companion explainer
 > [Probabilistic forecasting from NWP ensembles](probabilistic-forecasting.md); the plan that
 > delivered these metrics (and the calibration work that builds on them) is
 > [Metrics & leaderboard](../roadmap/metrics-and-leaderboard.md#delivering-the-probabilistic-metrics).
@@ -288,6 +289,179 @@ $$
 
 It is computed for the same six bands as PICP.
 
+## Tail and exceedance metrics 🚧
+
+> **Status: designed, not yet computed.** The metrics in this section are planned; the delivery
+> plan is [Metrics & leaderboard → Tail & exceedance
+> metrics](../roadmap/metrics-and-leaderboard.md#tail-exceedance-metrics-scoring-the-question-nged-actually-asks).
+> The principles (which selections of hours are safe to score on, and why) are durable and apply
+> today.
+
+### Why the tails need their own metrics
+
+NGED's need for these forecasts is [threshold exceedance](../background/requirements.md#the-worst-case-matters-most-forecasting-threshold-exceedance):
+"will load cross this substation's limit?". Their own operator tool plots demand as headroom
+below a constraint line — the y-axis is literally "MW Exceedance of Constraint" (see
+[NGED's incumbent forecast](../background/nged-incumbent-forecast.md#the-operators-view)). So
+the most valuable forecast skill lives in a specific *region of power values*: the region near
+each substation's limit.
+
+The metrics above already lean toward the tails — the
+[mean pinball loss](#mean-pinball-loss) is deliberately tail-weighted, and PICP covers the
+p1–p99 band — but they measure something subtly different: how well the model estimates the
+*upper quantiles of every half-hour's distribution*, including quiet summer nights when even
+the 95th percentile sits far below any limit. Getting the p95 right *everywhere* is not the
+same skill as getting the forecast right *near the limit*. The metrics in this section target
+the second skill directly.
+
+### The trap: scoring only the hours when the worst case actually happened
+
+The natural instinct — "NGED cares about peaks, so score the model only on the peak
+half-hours" — is a well-known statistical trap called the **forecaster's dilemma** (Lerch et
+al. 2017). The intuition: if you grade forecasters only on the occasions when something extreme
+actually happened, you systematically reward the forecaster who *always* predicts extremes.
+Their alarmist forecasts happen to look right on the hours you kept, and the false alarms they
+raised on all the other hours were thrown away before grading. Formally, restricting even a
+proper (un-gameable) score to cases *selected by the observed outcome* makes it improper: a
+model can climb that ranking by simply biasing every forecast upward, adding no skill at all.
+
+The fix is a distinction between two kinds of hour-selection:
+
+- **Selecting hours on information known *ex ante*** — Latin for "before the event", meaning
+  information available before the outcome was known — is safe. Scoring separately on
+  bank-holiday dates, on logged switching events, or per lead-time slice conditions only on
+  things a forecaster also knew in advance, so honest forecasts still win.
+
+- **Selecting hours by what actually happened** — e.g. "the top 5% highest *observed* demand
+  half-hours" — is not safe for ranking models, for the reason above.
+
+The consequence for this project: the calendar-based and switching-event metric slices are
+legitimate ranking columns, while any slice defined by observed peaks is a *diagnostic view
+only* — useful for asking "where did this model's error come from?", never for deciding which
+model is better. To *rank* models on tail skill, we instead re-weight a proper score across
+**all** hours, which is exactly what the next metric does.
+
+### Threshold-weighted CRPS (twCRPS)
+
+**MW; smaller is better.** The threshold-weighted Continuous Ranked Probability Score is
+[CRPS](#crps-continuous-ranked-probability-score) with its attention confined to the region
+above a threshold. Plain-language version: ordinary CRPS asks "how far was the forecast
+distribution from what happened?" and cares equally about errors at every power level; twCRPS
+asks the same question but only about behaviour *above the threshold* — how much probability
+the forecast placed above the line, and how far above. Distinctions entirely below the
+threshold contribute nothing. Because every half-hour is still scored (hours far below the
+threshold simply contribute ≈ 0 naturally, rather than being deleted from the sample), twCRPS
+stays a proper score — it avoids the forecaster's dilemma while still concentrating on the
+region NGED cares about. It is the ranking-grade tail metric: two models can tie on CRPS while
+twCRPS reveals which one actually knows more about the near-limit hours.
+
+Computation is a one-line extension of the existing machinery: for the threshold $r$, replace
+every member and the observation by $v(z) = \max(z, r)$ and compute the
+[fair CRPS](#crps-continuous-ranked-probability-score) of the transformed values (this
+equivalence is standard — Gneiting & Ranjan 2011):
+
+$$
+\mathrm{twCRPS}_t(r) = \mathrm{CRPS}_t\!\left( \max(x_{t,1}, r), \dots, \max(x_{t,m}, r);\;
+\max(y_t, r) \right)
+$$
+
+Because it reuses the fair form, twCRPS inherits CRPS's one crucial comparability property:
+it is unbiased across ensemble sizes, so the 13-member `nged_incumbent` and the 51-member ML
+models can be compared on it directly. It is computed per threshold in the
+[per-series threshold ladder](#choosing-the-thresholds-static-per-series-quantile-derived),
+with `metric_param` carrying the threshold label.
+
+### Exceedance rate of the upper delivery quantiles
+
+**Dimensionless; aim for the calibrated reference.** The plainest calibration question NGED
+can ask of the product: *"when the forecast says p95, how often does reality end up above
+it?"* For an honest p95, the answer should be close to 5%. This metric reports, for each upper
+delivery quantile (p80, p90, p95, p98, p99), the observed fraction of half-hours in which the
+outcome exceeded the forecast quantile:
+
+$$
+\mathrm{ER}_\tau = \frac{1}{T} \sum_t \mathbf{1}\!\left[ y_t > \hat{q}_t(\tau) \right]
+$$
+
+It is the one-sided companion to [PICP](#picp-prediction-interval-coverage-probability):
+PICP checks symmetric bands (p10–p90, etc.), but NGED's operating point is one-sided — an
+operator reads the p95 as "the level demand should stay under, 19 times out of 20" — so its
+honesty deserves its own directly-readable number. It is *not* a ranking metric (a model can
+hit perfect exceedance rates with absurdly wide quantiles; pinball loss and twCRPS punish
+that); it is the trust check for the delivered tail quantiles.
+
+As with PICP, empirical quantiles from a finite ensemble sit slightly inside the true ones, so
+even a perfectly calibrated ensemble exceeds its p95 slightly *more* than 5% of the time. The
+exact calibrated reference per quantile and ensemble size will be derived and verified by
+Monte Carlo at implementation time, mirroring [PICP's reference table](#picp-prediction-interval-coverage-probability).
+
+### Brier score for threshold exceedance
+
+**Dimensionless (0 to 1); smaller is better.** The ensemble can answer "what is the chance
+load exceeds threshold $r$?" — the fraction of members above $r$. The Brier score grades those
+probability statements the way you would grade a weather presenter's "70% chance of rain": it
+is the mean squared difference between the stated probability and what actually happened
+(1 if load exceeded the threshold, 0 if not):
+
+$$
+\mathrm{BS}(r) = \frac{1}{T} \sum_t \left( p_t(r) - \mathbf{1}\!\left[ y_t > r \right] \right)^2,
+\qquad
+p_t(r) = \frac{1}{m} \sum_i \mathbf{1}\!\left[ x_{t,i} > r \right]
+$$
+
+A forecaster minimises it by stating their honest probability — hedging toward 50% and
+alarmism both cost — so it is a proper score. Mathematically it is not independent of twCRPS
+(CRPS is the Brier score integrated over all possible thresholds, so twCRPS above $r$
+aggregates the Brier scores above $r$); we compute it anyway because it is the most
+*decision-legible* number in this section — it grades exactly the yes/no warning NGED acts on.
+
+One caveat to carry into reading it: a 51-member ensemble can only express 52 distinct
+probabilities, and an underdispersed ensemble slams its exceedance probabilities to 0 or 1 too
+early. That is not a flaw in the metric — it is precisely the failure mode this metric exists
+to expose, and the before/after instrument for the
+[calibration work](../roadmap/metrics-and-leaderboard.md#delivering-the-probabilistic-metrics).
+The per-probability breakdown (a *reliability diagram*) is a curve rather than a scalar, so it
+lives in ad-hoc analyses — see
+[What is deliberately not here](#what-is-deliberately-not-here).
+
+### Choosing the thresholds: static, per-series, quantile-derived
+
+The metrics above need a threshold $r$ per series, and here honesty matters: **a substation's
+true limit is not a single number.** Thermal ratings vary with ambient temperature and season;
+transformers tolerate being overloaded for short periods, so the *duration* of an exceedance
+matters (cyclic ratings); and switching changes what a feeder carries. NGED's own operator
+tool draws the limit as a time-varying "Flex Profile", not a constant. We do not attempt to
+model any of that for scoring. Instead we pick **static, per-series thresholds chosen for
+their scoring properties**, and state plainly that they are a proxy — these metrics measure
+"skill near a fixed line standing where the limit typically lives", not operational breach
+prediction:
+
+- **The threshold ladder: the P90 and P98 of each series' full observation history** (of
+  power in the constraint-side direction — see below). Labels `hist_p90` / `hist_p98` in
+  `metric_param`, deliberately distinct from forecast-quantile labels like `p95`: one names a
+  fixed power level derived from history, the other a level of the forecast distribution. The
+  two rungs give a "busy periods" and a "genuinely extreme" read without exploding the key
+  count.
+
+- **Why historical quantiles rather than the physical ratings:** ratings are not available
+  for every series; a rating that is never breached in a 12-month validation window yields
+  *zero events* — and a warning system cannot be graded on events that never happen; and
+  per-series ratings sit at wildly different points of each series' distribution, breaking
+  cross-series comparability. Full-history quantile thresholds guarantee every series a
+  scoreable event rate (~10% and ~2% by construction), are identical in meaning across
+  series, and are stable across CV folds for the same reason the
+  [effective-capacity denominator](../roadmap/metrics-and-leaderboard.md#normalising-nmae-by-effective_capacity)
+  is computed over the full history.
+
+- **NGED-supplied firm/flex ratings** for the trial area remain valuable — for ad-hoc case
+  studies and dashboard overlays, where a zero-event outcome is informative rather than
+  fatal. They do not enter the leaderboard.
+
+- **Constraint direction.** For demand substations the dangerous tail is high load; for
+  generation-dominated feeders the binding constraint can be reverse power flow — the most
+  *negative* tail. The threshold metrics therefore apply to power measured in each series
+  type's constraint-side direction, rather than assuming "high is bad" universally.
+
 ## Where the numbers live: Delta vs MLflow
 
 The `forecast_metrics` Delta table always holds the complete detail: all thirteen pinball
@@ -315,3 +489,22 @@ not in MLflow is still one Polars filter away in Delta.
   approach) rather than stored per experiment.
 - **Histogram of errors** — same reason; planned as a visual check on the
   [roadmap](../roadmap/metrics-and-leaderboard.md#evaluation-metrics).
+
+- **Reliability diagrams** — the per-probability breakdown of the
+  [Brier score](#brier-score-for-threshold-exceedance): "of the hours where the forecast said
+  a 70% chance of exceedance, how many actually exceeded?", plotted across probability bins. A
+  curve, not a scalar; computed ad hoc when the Brier numbers need explaining.
+
+- **Hit-rate / false-alarm trigger analyses** — turning the ensemble's exceedance probability
+  into a yes/no warning requires choosing a trigger ("warn when the probability tops X%"), and
+  the informative object is the *scan* across triggers (a ROC curve — Receiver Operating
+  Characteristic — and, for rare events, base-rate-robust summaries such as the Symmetric
+  Extremal Dependence Index, SEDI). Curves again, and trigger choice is an operational
+  decision to make with NGED; ad-hoc analyses, not leaderboard columns.
+
+- **Cost-loss economic value curves** — the fully decision-theoretic summary of exceedance
+  skill: for each ratio of "cost of acting on a warning" to "loss if an unwarned exceedance
+  occurs", how much of a perfect forecast's value does this model capture? This is the natural
+  bridge to the 🔬 v2 stretch goal of estimating **cost savings (£)** per leaderboard row
+  ([Grouping the results](../roadmap/metrics-and-leaderboard.md#grouping-the-results)); until
+  then it is an ad-hoc analysis.


### PR DESCRIPTION
## Why

NGED's users care most about the worst case: *will a substation's load cross a limit?* Their incumbent tool plots demand as headroom below a constraint line. The existing metric suite measures upper-*quantile* skill well (tail-heavy mean pinball, tail PICP bands, the P95 operating-point rows) but not skill *near the limit itself* — and the previously-planned Peak Events filter (score only the top-5% highest-observed-demand half-hours) falls into the **forecaster's dilemma**: restricting even a proper score to cases selected by the observed outcome makes it improper and rewards models that simply bias every forecast upward.

## What

- **[Evaluation metrics reference](https://openclimatefix.github.io/nged-substation-forecast/techniques/evaluation-metrics/)** — new 🚧 "Tail and exceedance metrics" section, written intuition-first for non-experts:
  - the safe-vs-unsafe hour-selection principle (conditioning on ex-ante information vs on observed outcomes);
  - **threshold-weighted CRPS (twCRPS)** — the ranking-grade tail metric, implemented via the `max(z, r)` chaining identity so the existing fair-CRPS machinery is reused verbatim and cross-ensemble-size comparability is inherited;
  - **exceedance rate of the upper delivery quantiles** — "when we said p95, was it exceeded ~5% of the time?";
  - **Brier score for threshold exceedance** — grades the yes/no warning NGED acts on;
  - the threshold convention: static per-series `hist_p90`/`hist_p98` full-history quantiles (guaranteed event rates, cross-series comparability, fold stability), with the honest caveat that real limits vary with ambient temperature and overload duration (cyclic ratings) — static thresholds are a documented scoring proxy, not breach prediction; constraint-side direction per series type.
  - "What is deliberately not here" gains reliability diagrams, ROC/SEDI trigger scans, and cost-loss economic-value curves (curves, not scalars; the last bridges to the 🔬 £-savings stretch goal).
- **[Metrics & leaderboard roadmap](https://openclimatefix.github.io/nged-substation-forecast/roadmap/metrics-and-leaderboard/)** — the Peak Events section becomes "Tail & exceedance metrics" (#254): the three metrics above as ranking columns (no `Metrics` schema change — `metric_param` carries the labels), observed-peak and hand-picked hard-example slices retained as **diagnostic-only**, an implementation-details subsection, and three new 🚧 rows in the metrics table. Tricky-days is noted as a legitimate ranking slice (calendar-conditioned).
- **[Requirements](https://openclimatefix.github.io/nged-substation-forecast/background/requirements/)** — new "The worst case matters most: forecasting threshold exceedance" subsection naming the core concept at requirements level.

## Verification

- `pymarkdown scan` clean; `mkdocs build --strict` clean.
- Every new anchor checked against the generated HTML (slug collapse of `&`/`—`/emoji verified).
- Rendered HTML inspected for the Python-Markdown list-interruption gotcha — all bullet lists render as real `<li>` items, no literal-hyphen leaks.

Issue #254 has been retitled to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)