### PR TITLE
Install the dashboard package so its tests run under `uv run pytest`

### DIFF
--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -16,7 +16,21 @@ row counts wrapping past 2³² rows.
 - **Discovery is automatic.** The only pytest configuration is the root
   `[tool.pytest.ini_options]` block; there is no `testpaths` setting, so pytest collects both the
   top-level `tests/` directory and every `packages/*/tests/` directory. A brand-new
-  `packages/<pkg>/tests/` directory is picked up with no configuration change.
+  `packages/<pkg>/tests/` directory is picked up with no configuration change — provided the
+  package is installed in the root environment, which is automatic only when something already
+  depends on it. A **leaf** package that nothing depends on (for example `dashboard`, a marimo app)
+  is *not* in the default environment, so `uv run pytest` cannot import its tests; add it to the
+  root `[dependency-groups] dev` list (and give it a `[tool.uv.sources]` workspace entry) so a plain
+  `uv sync` installs it.
+- **Run the whole suite with plain `uv run pytest`, never `--all-packages`.** `uv run pytest`
+  executes against the root environment, which holds exactly the packages reachable from the root's
+  dependencies and dev group — i.e. every package that has tests, by the rule above. `--all-packages`
+  additionally installs workspace members that have no tests (`notebooks`) and each member's own
+  dev-groups, so it is heavier for no benefit here. It is the right tool for the pre-commit `ty` hook
+  (`uv run --all-packages ty check`) for a different reason: `ty` type-checks the *source* of every
+  workspace member, including leaf packages that are never installed as a dependency of anything, and
+  that source must be present for the check. Type-checking needs the source; running tests needs the
+  package installed — so the two commands legitimately differ.
 - **`--import-mode=importlib` is set deliberately** so that identically-named test modules in
   different packages (for example, two `test_storage.py` files) do not collide during collection.
   Because of this, test directories do not need `__init__.py` files.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,9 @@ dev = [
     "pymarkdownlnt>=0.9.13",
     "mlflow>=3.14.0",
     "moto[server]>=5.0.0",
+    # dashboard is a leaf marimo app that nothing depends on at runtime, so it is a dev
+    # dependency purely so `uv sync` installs it and `uv run pytest` can collect its tests.
+    "dashboard",
 ]
 
 [project.urls]
@@ -79,6 +82,7 @@ xgboost_forecaster = { workspace = true }
 dynamical_data = { workspace = true }
 geo = { workspace = true }
 weather_utils = { workspace = true }
+dashboard = { workspace = true }
 
 # --- DAGSTER ---
 

--- a/uv.lock
+++ b/uv.lock
@@ -2820,6 +2820,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "dagster-dg-cli" },
+    { name = "dashboard" },
     { name = "mkdocs-include-markdown-plugin" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings", extra = ["python"] },
@@ -2862,6 +2863,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "dagster-dg-cli" },
+    { name = "dashboard", editable = "packages/dashboard" },
     { name = "mkdocs-include-markdown-plugin", specifier = ">=7.2.2" },
     { name = "mkdocs-material", specifier = ">=9.7.6" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=1.0.3" },


### PR DESCRIPTION
## Problem

`uv run pytest` failed during collection with:

```
ERROR packages/dashboard/tests/test_forecast_chart.py
E   ModuleNotFoundError: No module named 'dashboard'
```

`dashboard` is a workspace member, but it was the only test-bearing package missing from `[tool.uv.sources]`, and nothing depends on it at runtime (it's a leaf marimo app). So a plain `uv sync` pruned it from the environment — yet the root pytest config still collects `packages/dashboard/tests/`. The tests were collected but the package wasn't importable.

## Fix

- Declare `dashboard = { workspace = true }` in `[tool.uv.sources]`.
- Add `"dashboard"` to the root `dev` dependency group.

This mirrors how every other test-bearing workspace package is already wired in, so a plain `uv sync` installs it and the documented `uv run pytest` collects its tests.

## Verification

After a clean `uv sync`, `uv run pytest`: **370 passed, 1 skipped**.

> Note: separately, running the suite in a fresh git worktree also needs `.env` symlinked in (the required `nged_s3_bucket_*` settings), otherwise `test_nwp_metadata_load` and `test_successive_appends_create_separate_partitions` fail with a pydantic `Settings` validation error. That's an environment/worktree-setup step, not a code change, so it isn't part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)