### PR TITLE
Stop pytest recursing into .claude worktrees during collection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,10 @@ pythonpath = ["tests"]
 filterwarnings = [
     "ignore:codecs.open\\(\\) is deprecated:DeprecationWarning:mlflow.*",
 ]
-norecursedirs = [".venv", "venv", ".git", "__pycache__"]
+# `.claude` holds git worktrees (`.claude/worktrees/*`), each a full checkout carrying its own
+# copy of this `conftest.py`; recursing into them re-registers the `--run-network` option and
+# aborts collection with "option names {'--run-network'} already added".
+norecursedirs = [".venv", "venv", ".git", ".claude", "__pycache__"]
 markers = [
     "integration: tests that exercise real wiring (Dagster + file-based MLflow + temp Delta)",
     "network: hits the real Dynamical.org NWP catalog; skipped by default, `--run-network` to run",


### PR DESCRIPTION
## Problem

A plain `uv run pytest` aborts during collection:

```
ValueError: option names {'--run-network'} already added
ERROR .claude/worktrees/epic-sub-issues-v03-v10-170d21
ERROR .claude/worktrees/session-98c5af
```

Git worktrees created under `.claude/worktrees/` are each a full checkout of the repo, carrying their own copy of the repo-root `conftest.py`. pytest recursed into them and tried to register the `--run-network` option a second time, which aborts collection.

## Fix

Add `.claude` to `norecursedirs` in `pyproject.toml` so pytest never descends into worktree checkouts. Collection then succeeds cleanly (371 tests collected).

This is a durable fix independent of whether any particular worktree exists: worktrees will keep being created under `.claude/`, and none of them should be collected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)