### PR TITLE
Weather/calendar-only XGBoost baseline (no lags) + export for switching detection (#179)

### DIFF
--- a/packages/notebooks/view_baseline_export.py
+++ b/packages/notebooks/view_baseline_export.py
@@ -33,7 +33,11 @@ with app.setup:
     SETTINGS = Settings()
     # Per-series descriptive metadata (name, type, unit) keyed by time_series_id, loaded once.
     SERIES_META: dict[int, dict[str, str]] = {
-        row["time_series_id"]: row
+        row["time_series_id"]: {
+            "time_series_name": row["time_series_name"],
+            "time_series_type": row["time_series_type"],
+            "units": row["units"],
+        }
         for row in pl.read_parquet(
             SETTINGS.metadata_path,
             storage_options=typeddict_to_dict(SETTINGS.storage_options),

--- a/packages/notebooks/view_baseline_export.py
+++ b/packages/notebooks/view_baseline_export.py
@@ -1,0 +1,216 @@
+"""Inspect the three baseline-export parquets produced by ``scripts/export_forecasts_for_alex.py``.
+
+For a chosen time series it overlays observed power against the forecast (ensemble mean, p50, and
+the p10-p90 band), plots the observed-minus-expected residual (the raw material for switching-event
+detection), and draws the raw ensemble members over a selected window. All three exported parquets
+(``*_full_ensemble``, ``*_ensemble_mean``, ``*_quantiles``) are used.
+
+    uv run marimo edit packages/notebooks/view_baseline_export.py
+"""
+
+import marimo
+
+__generated_with = "0.23.6"
+app = marimo.App(width="full")
+
+with app.setup:
+    from pathlib import Path
+
+    import altair as alt
+    import marimo as mo
+    import polars as pl
+    from contracts.settings import PROJECT_ROOT
+
+    DEFAULT_EXPORT_DIR = PROJECT_ROOT / "data" / "exports"
+
+    def available_stems(export_dir: Path) -> list[str]:
+        """Return the export stems (``{experiment}__{fold}``) found in ``export_dir``.
+
+        A stem is present when its ``*_ensemble_mean.parquet`` file exists.
+
+        Args:
+            export_dir: Directory holding the exported parquet files.
+
+        Returns:
+            Sorted list of stems, empty if the directory has no exports.
+        """
+        if not export_dir.is_dir():
+            return []
+        return sorted(
+            p.name.removesuffix("_ensemble_mean.parquet")
+            for p in export_dir.glob("*_ensemble_mean.parquet")
+        )
+
+    def load_frame(export_dir: Path, stem: str, kind: str) -> pl.DataFrame:
+        """Read one exported parquet (``kind`` in {full_ensemble, ensemble_mean, quantiles})."""
+        return pl.read_parquet(export_dir / f"{stem}_{kind}.parquet")
+
+
+@app.cell
+def _():
+    mo.md(
+        """
+        # Baseline export viewer
+
+        Weather/calendar-only XGBoost baseline (no power lags) — issue #179. Pick an export and a
+        time series to compare the forecast against observed power and inspect the residual.
+        """
+    )
+    return
+
+
+@app.cell
+def _():
+    export_dir_ui = mo.ui.text(
+        value=str(DEFAULT_EXPORT_DIR),
+        label="Export directory",
+        full_width=True,
+    )
+    export_dir_ui
+    return (export_dir_ui,)
+
+
+@app.cell
+def _(export_dir_ui):
+    export_dir = Path(export_dir_ui.value).expanduser()
+    stems = available_stems(export_dir)
+    stem_ui = mo.ui.dropdown(
+        options=stems,
+        value=stems[0] if stems else None,
+        label="Export (experiment__fold)",
+    )
+    mo.stop(
+        not stems,
+        mo.md(f"No `*_ensemble_mean.parquet` files found in `{export_dir}`."),
+    )
+    stem_ui
+    return export_dir, stem_ui
+
+
+@app.cell
+def _(export_dir, stem_ui):
+    mean_df = load_frame(export_dir, stem_ui.value, "ensemble_mean")
+    quantiles_df = load_frame(export_dir, stem_ui.value, "quantiles")
+
+    series_ids = mean_df["time_series_id"].unique().sort().to_list()
+    series_ui = mo.ui.dropdown(
+        options=[str(s) for s in series_ids],
+        value=str(series_ids[0]),
+        label="Time series id",
+    )
+    series_ui
+    return mean_df, quantiles_df, series_ui
+
+
+@app.cell
+def _(mean_df, quantiles_df, series_ui):
+    series_id = int(series_ui.value)
+    mean_one = mean_df.filter(pl.col("time_series_id") == series_id).sort("valid_time")
+    quant_one = quantiles_df.filter(pl.col("time_series_id") == series_id).sort("valid_time")
+
+    band = (
+        alt.Chart(quant_one)
+        .mark_area(opacity=0.25, color="#4c78a8")
+        .encode(
+            x=alt.X("valid_time:T", title="valid time"),
+            y=alt.Y("power_fcst_p10:Q", title="power (MW / MVA)"),
+            y2="power_fcst_p90:Q",
+        )
+    )
+    p50_line = (
+        alt.Chart(quant_one)
+        .mark_line(strokeWidth=1, color="#4c78a8")
+        .encode(x="valid_time:T", y="power_fcst_p50:Q")
+    )
+    mean_line = (
+        alt.Chart(mean_one)
+        .mark_line(strokeWidth=1, strokeDash=[4, 2], color="#f58518")
+        .encode(x="valid_time:T", y="power_fcst_mean:Q")
+    )
+    observed_line = (
+        alt.Chart(mean_one)
+        .mark_line(strokeWidth=1.2, color="#333333")
+        .encode(x="valid_time:T", y=alt.Y("observed_power:Q"))
+    )
+    forecast_chart = mo.ui.altair_chart(
+        (band + p50_line + mean_line + observed_line).properties(
+            height=320,
+            width="container",
+            title="Observed (black) vs p10–p90 band, p50, ensemble mean (dashed)",
+        )
+    )
+    forecast_chart
+    return mean_one, series_id
+
+
+@app.cell
+def _(mean_one):
+    residual_df = mean_one.with_columns(
+        residual=pl.col("observed_power") - pl.col("power_fcst_mean")
+    )
+    residual_chart = mo.ui.altair_chart(
+        alt.Chart(residual_df)
+        .mark_line(strokeWidth=1, color="#54a24b")
+        .encode(
+            x=alt.X("valid_time:T", title="valid time"),
+            y=alt.Y("residual:Q", title="observed − ensemble mean (MW / MVA)"),
+        )
+        .properties(
+            height=200,
+            width="container",
+            title="Residual — a sustained level shift here is the switching-event signature",
+        )
+    )
+    residual_chart
+    return
+
+
+@app.cell
+def _(export_dir, stem_ui):
+    window_ui = mo.ui.range_slider(
+        start=1,
+        stop=28,
+        value=[1, 14],
+        step=1,
+        label="Ensemble spaghetti: window (days from series start)",
+    )
+    full_lf = pl.scan_parquet(export_dir / f"{stem_ui.value}_full_ensemble.parquet")
+    window_ui
+    return full_lf, window_ui
+
+
+@app.cell
+def _(full_lf, series_id, window_ui):
+    one = full_lf.filter(pl.col("time_series_id") == series_id)
+    start = one.select(pl.col("valid_time").min()).collect().item()
+    lo = start + pl.duration(days=window_ui.value[0] - 1)
+    hi = start + pl.duration(days=window_ui.value[1])
+    ens_one = (
+        one.filter(pl.col("valid_time") >= lo, pl.col("valid_time") < hi)
+        .select("valid_time", "ensemble_member", "power_fcst", "observed_power")
+        .collect()
+    )
+    members = (
+        alt.Chart(ens_one)
+        .mark_line(strokeWidth=0.5, opacity=0.3, color="#4c78a8")
+        .encode(
+            x=alt.X("valid_time:T", title="valid time"),
+            y=alt.Y("power_fcst:Q", title="power (MW / MVA)"),
+            detail="ensemble_member:N",
+        )
+    )
+    observed = (
+        alt.Chart(ens_one.unique("valid_time"))
+        .mark_line(strokeWidth=1.2, color="#333333")
+        .encode(x="valid_time:T", y="observed_power:Q")
+    )
+    mo.ui.altair_chart(
+        (members + observed).properties(
+            height=300, width="container", title="All ensemble members (blue) vs observed (black)"
+        )
+    )
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/packages/notebooks/view_baseline_export.py
+++ b/packages/notebooks/view_baseline_export.py
@@ -3,14 +3,16 @@
 For a chosen time series it overlays observed power against the forecast (ensemble mean, p50, and
 the p10-p90 band), plots the observed-minus-expected residual (the raw material for switching-event
 detection), and draws the raw ensemble members over a selected window. All three exported parquets
-(``*_full_ensemble``, ``*_ensemble_mean``, ``*_quantiles``) are used.
+(``*_full_ensemble``, ``*_ensemble_mean``, ``*_quantiles``) are used. Every chart is pan/zoom
+interactive; titles carry the series id, type, and name; the y-axis is labelled in the series' own
+unit (MW or MVA).
 
     uv run marimo edit packages/notebooks/view_baseline_export.py
 """
 
 import marimo
 
-__generated_with = "0.23.6"
+__generated_with = "0.23.14"
 app = marimo.App(width="full")
 
 with app.setup:
@@ -19,9 +21,26 @@ with app.setup:
     import altair as alt
     import marimo as mo
     import polars as pl
-    from contracts.settings import PROJECT_ROOT
+    from contracts.settings import PROJECT_ROOT, Settings
+    from contracts.typing_utils import typeddict_to_dict
 
     DEFAULT_EXPORT_DIR = PROJECT_ROOT / "data" / "exports"
+
+    # A single series spans ~17k half-hourly rows; mo.ui.altair_chart serves them as a virtual file
+    # rather than inlining, so lift altair's default 5000-row guard (mirrors the dashboard).
+    alt.data_transformers.disable_max_rows()
+
+    SETTINGS = Settings()
+    # Per-series descriptive metadata (name, type, unit) keyed by time_series_id, loaded once.
+    SERIES_META: dict[int, dict[str, str]] = {
+        row["time_series_id"]: row
+        for row in pl.read_parquet(
+            SETTINGS.metadata_path,
+            storage_options=typeddict_to_dict(SETTINGS.storage_options),
+        )
+        .select("time_series_id", "time_series_name", "time_series_type", "units")
+        .iter_rows(named=True)
+    }
 
     def available_stems(export_dir: Path) -> list[str]:
         """Return the export stems (``{experiment}__{fold}``) found in ``export_dir``.
@@ -45,17 +64,38 @@ with app.setup:
         """Read one exported parquet (``kind`` in {full_ensemble, ensemble_mean, quantiles})."""
         return pl.read_parquet(export_dir / f"{stem}_{kind}.parquet")
 
+    def series_descr(series_id: int) -> tuple[str, str]:
+        """Return ``(title_prefix, unit)`` for a series from its metadata.
+
+        Args:
+            series_id: The ``time_series_id`` to describe.
+
+        Returns:
+            A ``(title_prefix, unit)`` tuple — e.g. ``("id 7 · pv · Foo Primary", "MW")``.
+            Falls back to ``("id {series_id}", "MW/MVA")`` when the series is absent from metadata.
+        """
+        meta = SERIES_META.get(series_id)
+        if meta is None:
+            return f"id {series_id}", "MW/MVA"
+        return (
+            f"id {series_id} · {meta['time_series_type']} · {meta['time_series_name']}",
+            meta["units"],
+        )
+
+    def date_x() -> alt.X:
+        """An x-axis channel over ``valid_time`` whose tick labels always show the date."""
+        return alt.X("valid_time:T", axis=alt.Axis(title="date", format="%d %b %Y"))
+
 
 @app.cell
 def _():
-    mo.md(
-        """
-        # Baseline export viewer
+    mo.md("""
+    # Baseline export viewer
 
-        Weather/calendar-only XGBoost baseline (no power lags) — issue #179. Pick an export and a
-        time series to compare the forecast against observed power and inspect the residual.
-        """
-    )
+    Weather/calendar-only XGBoost baseline (no power lags) — issue #179. Pick an export and a
+    time series to compare the forecast against observed power and inspect the residual. Drag to
+    pan and scroll to zoom on any chart.
+    """)
     return
 
 
@@ -105,46 +145,56 @@ def _(export_dir, stem_ui):
 @app.cell
 def _(mean_df, quantiles_df, series_ui):
     series_id = int(series_ui.value)
+    title_prefix, unit = series_descr(series_id)
+    y_title = f"power ({unit})"
     mean_one = mean_df.filter(pl.col("time_series_id") == series_id).sort("valid_time")
     quant_one = quantiles_df.filter(pl.col("time_series_id") == series_id).sort("valid_time")
 
     band = (
         alt.Chart(quant_one)
         .mark_area(opacity=0.25, color="#4c78a8")
-        .encode(
-            x=alt.X("valid_time:T", title="valid time"),
-            y=alt.Y("power_fcst_p10:Q", title="power (MW / MVA)"),
-            y2="power_fcst_p90:Q",
-        )
+        .encode(x=date_x(), y=alt.Y("power_fcst_p10:Q", title=y_title), y2="power_fcst_p90:Q")
     )
     p50_line = (
         alt.Chart(quant_one)
         .mark_line(strokeWidth=1, color="#4c78a8")
-        .encode(x="valid_time:T", y="power_fcst_p50:Q")
+        .encode(x=date_x(), y="power_fcst_p50:Q")
     )
     mean_line = (
         alt.Chart(mean_one)
         .mark_line(strokeWidth=1, strokeDash=[4, 2], color="#f58518")
-        .encode(x="valid_time:T", y="power_fcst_mean:Q")
+        .encode(x=date_x(), y="power_fcst_mean:Q")
     )
     observed_line = (
         alt.Chart(mean_one)
         .mark_line(strokeWidth=1.2, color="#333333")
-        .encode(x="valid_time:T", y=alt.Y("observed_power:Q"))
-    )
-    forecast_chart = mo.ui.altair_chart(
-        (band + p50_line + mean_line + observed_line).properties(
-            height=320,
-            width="container",
-            title="Observed (black) vs p10–p90 band, p50, ensemble mean (dashed)",
+        .encode(
+            x=date_x(),
+            y=alt.Y("observed_power:Q", title=y_title),
+            tooltip=[
+                alt.Tooltip("valid_time:T", format="%Y-%m-%d %H:%M", title="valid time"),
+                alt.Tooltip("observed_power:Q", format=".2f", title="observed"),
+                alt.Tooltip("power_fcst_mean:Q", format=".2f", title="ens mean"),
+            ],
         )
     )
+    forecast_chart = mo.ui.altair_chart(
+        (band + p50_line + mean_line + observed_line)
+        .properties(
+            height=320,
+            width="container",
+            title=f"{title_prefix} — observed (black) vs p10–p90 band, p50, ensemble mean (dashed)",
+        )
+        .interactive(),
+        chart_selection=False,
+        legend_selection=False,
+    )
     forecast_chart
-    return mean_one, series_id
+    return mean_one, series_id, title_prefix, unit
 
 
 @app.cell
-def _(mean_one):
+def _(mean_one, title_prefix, unit):
     residual_df = mean_one.with_columns(
         residual=pl.col("observed_power") - pl.col("power_fcst_mean")
     )
@@ -152,14 +202,21 @@ def _(mean_one):
         alt.Chart(residual_df)
         .mark_line(strokeWidth=1, color="#54a24b")
         .encode(
-            x=alt.X("valid_time:T", title="valid time"),
-            y=alt.Y("residual:Q", title="observed − ensemble mean (MW / MVA)"),
+            x=date_x(),
+            y=alt.Y("residual:Q", title=f"observed − ensemble mean ({unit})"),
+            tooltip=[
+                alt.Tooltip("valid_time:T", format="%Y-%m-%d %H:%M", title="valid time"),
+                alt.Tooltip("residual:Q", format=".2f", title="residual"),
+            ],
         )
         .properties(
             height=200,
             width="container",
-            title="Residual — a sustained level shift here is the switching-event signature",
+            title=f"{title_prefix} — residual (a sustained level shift is the switching signature)",
         )
+        .interactive(),
+        chart_selection=False,
+        legend_selection=False,
     )
     residual_chart
     return
@@ -180,7 +237,7 @@ def _(export_dir, stem_ui):
 
 
 @app.cell
-def _(full_lf, series_id, window_ui):
+def _(full_lf, series_id, title_prefix, unit, window_ui):
     one = full_lf.filter(pl.col("time_series_id") == series_id)
     start = one.select(pl.col("valid_time").min()).collect().item()
     lo = start + pl.duration(days=window_ui.value[0] - 1)
@@ -194,20 +251,26 @@ def _(full_lf, series_id, window_ui):
         alt.Chart(ens_one)
         .mark_line(strokeWidth=0.5, opacity=0.3, color="#4c78a8")
         .encode(
-            x=alt.X("valid_time:T", title="valid time"),
-            y=alt.Y("power_fcst:Q", title="power (MW / MVA)"),
+            x=date_x(),
+            y=alt.Y("power_fcst:Q", title=f"power ({unit})"),
             detail="ensemble_member:N",
         )
     )
     observed = (
         alt.Chart(ens_one.unique("valid_time"))
         .mark_line(strokeWidth=1.2, color="#333333")
-        .encode(x="valid_time:T", y="observed_power:Q")
+        .encode(x=date_x(), y="observed_power:Q")
     )
     mo.ui.altair_chart(
-        (members + observed).properties(
-            height=300, width="container", title="All ensemble members (blue) vs observed (black)"
+        (members + observed)
+        .properties(
+            height=300,
+            width="container",
+            title=f"{title_prefix} — all ensemble members (blue) vs observed (black)",
         )
+        .interactive(),
+        chart_selection=False,
+        legend_selection=False,
     )
     return
 

--- a/scripts/export_forecasts_for_alex.py
+++ b/scripts/export_forecasts_for_alex.py
@@ -1,0 +1,204 @@
+"""Export a CV experiment's forecasts to three parquet files for offline analysis.
+
+Written for issue #179: hand the weather/calendar-only baseline forecasts (the switching-event
+"shared baseline") to a colleague for switching-event detection work. The forecasts are read from
+the internal ``power_forecasts`` Delta table and written as three self-contained parquet files,
+all in physical MW/MVA units (``power_fcst`` is already stored in MW/MVA on disk — see
+``PowerForecast.power_fcst``; the per-series unit lives in ``TimeSeriesMetadata.units``).
+
+For each ``(time_series_id, valid_time)`` we keep only the **freshest** forecast run — the one
+whose ``power_fcst_init_time`` is largest (i.e. the most recent run that still precedes the target
+time). ``PowerForecast`` guarantees ``valid_time > power_fcst_init_time``, so this is an
+analysis-proxy view: the shortest-lead hindcast of expected power, which is the natural baseline
+for an observed-minus-expected residual.
+
+Three files are written:
+
+- ``*_full_ensemble.parquet`` — every ECMWF ensemble member (~51) of the freshest run.
+- ``*_ensemble_mean.parquet`` — the ensemble mean of ``power_fcst`` per timestep.
+- ``*_quantiles.parquet``     — the p10 / p50 / p90 of ``power_fcst`` across members per timestep.
+
+Every file also carries ``observed_power`` (the metered value at that ``valid_time``, same MW/MVA
+units), left-joined from the ``power_time_series`` table so residuals can be computed directly.
+
+Run from a checkout where ``.env`` resolves (in a worktree, ``.env`` must be symlinked):
+
+    uv run python scripts/export_forecasts_for_alex.py \
+        --experiment-name xgboost_no_power_lags \
+        --fold-id mid_2025_to_mid_2026
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+import polars as pl
+from contracts.settings import PROJECT_ROOT, Settings
+from contracts.typing_utils import typeddict_to_dict
+
+# Columns carried through to the full-ensemble file (internal-only partition columns
+# experiment_name / fold_id / ml_flow_experiment_id are intentionally dropped).
+_FORECAST_COLUMNS: tuple[str, ...] = (
+    "time_series_id",
+    "valid_time",
+    "power_fcst_init_time",
+    "nwp_init_time",
+    "ensemble_member",
+    "power_fcst",
+)
+
+
+def _freshest_forecasts(
+    power_forecasts_path: str,
+    experiment_name: str,
+    fold_id: str,
+    storage_options: dict[str, str] | None,
+) -> pl.LazyFrame:
+    """Scan ``power_forecasts`` for one experiment/fold, keeping only the freshest run per timestep.
+
+    ``experiment_name`` / ``fold_id`` are ``String`` partition columns, so both filters push down
+    into the Delta scan (partition pruning). For each ``(time_series_id, valid_time)`` the run with
+    the largest ``power_fcst_init_time`` is selected via a semi-join on the per-timestep max init
+    time — this keeps *all* ensemble members of that run (the whole ensemble shares one init time).
+
+    Args:
+        power_forecasts_path: URI of the ``power_forecasts`` Delta table.
+        experiment_name: Experiment whose forecasts to export.
+        fold_id: CV fold whose forecasts to export.
+        storage_options: Object-store options for ``pl.scan_delta``.
+
+    Returns:
+        A lazy frame of the freshest-run forecast rows, columns ``_FORECAST_COLUMNS``.
+    """
+    scan = pl.scan_delta(power_forecasts_path, storage_options=storage_options).filter(
+        pl.col("experiment_name") == experiment_name,
+        pl.col("fold_id") == fold_id,
+    )
+    freshest_init = scan.group_by("time_series_id", "valid_time").agg(
+        power_fcst_init_time=pl.col("power_fcst_init_time").max()
+    )
+    return scan.join(
+        freshest_init,
+        on=["time_series_id", "valid_time", "power_fcst_init_time"],
+        how="semi",
+    ).select(_FORECAST_COLUMNS)
+
+
+def _observed_power(
+    power_time_series_path: str, storage_options: dict[str, str] | None
+) -> pl.LazyFrame:
+    """Scan observed metered power, deduplicated on the join key.
+
+    The dedupe on ``(time_series_id, time)`` mirrors the metrics pipeline: a duplicated observation
+    would double every ensemble member through the left-join. ``power`` is renamed to
+    ``observed_power`` and is in the same MW/MVA units as the forecast.
+
+    Args:
+        power_time_series_path: URI of the ``power_time_series`` Delta table.
+        storage_options: Object-store options for ``pl.scan_delta``.
+
+    Returns:
+        A lazy frame with columns ``time_series_id``, ``time``, ``observed_power``.
+    """
+    return (
+        pl.scan_delta(power_time_series_path, storage_options=storage_options)
+        .select("time_series_id", "time", "power")
+        .unique(subset=["time_series_id", "time"], keep="any")
+        .rename({"power": "observed_power"})
+    )
+
+
+def _with_observed(forecasts: pl.LazyFrame, observed: pl.LazyFrame) -> pl.LazyFrame:
+    """Left-join ``observed_power`` onto forecasts on ``valid_time == time``.
+
+    Both operands are plain (non-Patito) lazy frames, so Polars' cross-model join check does not
+    fire. The observed ``time`` column is dropped after the join (it duplicates ``valid_time``).
+
+    Args:
+        forecasts: Forecast rows with a ``valid_time`` column.
+        observed: Deduplicated observed power with ``time`` / ``observed_power`` columns.
+
+    Returns:
+        ``forecasts`` with an ``observed_power`` column added.
+    """
+    return forecasts.join(
+        observed,
+        left_on=["time_series_id", "valid_time"],
+        right_on=["time_series_id", "time"],
+        how="left",
+    )
+
+
+def export_forecasts(experiment_name: str, fold_id: str, output_dir: Path) -> dict[str, Path]:
+    """Write the three parquet files for one experiment/fold and return their paths.
+
+    Args:
+        experiment_name: Experiment whose forecasts to export.
+        fold_id: CV fold whose forecasts to export.
+        output_dir: Directory to write the parquet files into (created if absent).
+
+    Returns:
+        A mapping of ``{"full_ensemble", "ensemble_mean", "quantiles"} -> written path``.
+    """
+    settings = Settings()
+    storage_options = typeddict_to_dict(settings.storage_options)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    stem = f"{experiment_name}__{fold_id}"
+
+    freshest = _freshest_forecasts(
+        settings.power_forecasts_data_path, experiment_name, fold_id, storage_options
+    )
+    observed = _observed_power(settings.power_time_series_data_path, storage_options)
+    full = _with_observed(freshest, observed)
+
+    per_timestep = ["time_series_id", "valid_time"]
+    ensemble_mean = full.group_by(per_timestep).agg(
+        power_fcst_init_time=pl.col("power_fcst_init_time").first(),
+        power_fcst_mean=pl.col("power_fcst").mean(),
+        observed_power=pl.col("observed_power").first(),
+    )
+    quantiles = full.group_by(per_timestep).agg(
+        power_fcst_init_time=pl.col("power_fcst_init_time").first(),
+        power_fcst_p10=pl.col("power_fcst").quantile(0.1),
+        power_fcst_p50=pl.col("power_fcst").quantile(0.5),
+        power_fcst_p90=pl.col("power_fcst").quantile(0.9),
+        observed_power=pl.col("observed_power").first(),
+    )
+
+    paths = {
+        "full_ensemble": output_dir / f"{stem}_full_ensemble.parquet",
+        "ensemble_mean": output_dir / f"{stem}_ensemble_mean.parquet",
+        "quantiles": output_dir / f"{stem}_quantiles.parquet",
+    }
+    # Stream the (large) full-ensemble frame straight to disk; the aggregates are small.
+    full.sink_parquet(paths["full_ensemble"])
+    ensemble_mean.sort(per_timestep).collect(engine="streaming").write_parquet(
+        paths["ensemble_mean"]
+    )
+    quantiles.sort(per_timestep).collect(engine="streaming").write_parquet(paths["quantiles"])
+    return paths
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--experiment-name", default="xgboost_no_power_lags")
+    parser.add_argument("--fold-id", default="mid_2025_to_mid_2026")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=PROJECT_ROOT / "data" / "exports",
+        help="Directory for the parquet files (default: <PROJECT_ROOT>/data/exports, gitignored).",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    paths = export_forecasts(args.experiment_name, args.fold_id, args.output_dir)
+    for kind, path in paths.items():
+        print(f"{kind:>14}: {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/export_forecasts_for_alex.py
+++ b/scripts/export_forecasts_for_alex.py
@@ -75,6 +75,10 @@ def _freshest_forecasts(
         pl.col("experiment_name") == experiment_name,
         pl.col("fold_id") == fold_id,
     )
+    # NOTE (revisit if this export is ever re-run at larger scale): `scan` is consumed twice —
+    # once for this per-timestep max init time, once for the semi-join below — so the partition
+    # (~369M rows for #179) is read twice. Fine as a one-off; a single-pass "max init_time over
+    # (time_series_id, valid_time)" window filter would avoid the second scan.
     freshest_init = scan.group_by("time_series_id", "valid_time").agg(
         power_fcst_init_time=pl.col("power_fcst_init_time").max()
     )
@@ -158,6 +162,10 @@ def export_forecasts(experiment_name: str, fold_id: str, output_dir: Path) -> di
         power_fcst_mean=pl.col("power_fcst").mean(),
         observed_power=pl.col("observed_power").first(),
     )
+    # NOTE (revisit if this export is ever re-run for serious use): Polars' default quantile
+    # interpolation is "nearest", so these band edges are actual member values across the ~51
+    # members, not linearly-interpolated p10/p50/p90. Acceptable for this under-dispersed baseline
+    # (the band is already caveated), but pass interpolation="linear" for true quantile estimates.
     quantiles = full.group_by(per_timestep).agg(
         power_fcst_init_time=pl.col("power_fcst_init_time").first(),
         power_fcst_p10=pl.col("power_fcst").quantile(0.1),

--- a/scripts/run_baseline_experiment.py
+++ b/scripts/run_baseline_experiment.py
@@ -1,0 +1,163 @@
+"""Reproduce the issue #179 weather/calendar-only baseline experiment end-to-end, headless.
+
+This is the "shared baseline" for switching-event detection: the production XGBoost forecaster
+configured with **no power-lag features** (weather + calendar covariates only), so its residual
+(observed - expected) isolates switching events rather than absorbing them through a lagged-power
+side door. See the roadmap:
+<https://openclimatefix.github.io/nged-substation-forecast/roadmap/switching-events/#the-baseline-shared-foundation>
+
+The whole pipeline runs in one process sharing a single ``DagsterInstance``. That is required, not
+incidental: ``register_experiment`` adds the dynamic partition key
+``xgboost_no_power_lags__mid_2025_to_mid_2026`` to the instance, and the subsequent
+``materialize(..., partition_key=...)`` calls validate that key against the *same* instance's
+dynamic-partition store. Splitting the steps across processes with separate ephemeral instances
+would fail with "partition key not found". This mirrors the canonical pattern in
+``tests/test_metrics.py``.
+
+Only ``selected_features`` (and an honest ``training_strategy`` tag) are overridden; every other
+hyperparameter is inherited from ``conf/model/xgboost.yaml``. The 20 features below are exactly the
+base config's list minus the four ``power_lag_*h`` entries.
+
+Run from the repo root, or a worktree where ``.env`` (and ``data``) are symlinked:
+
+    uv run python scripts/run_baseline_experiment.py
+"""
+
+from __future__ import annotations
+
+import mlflow
+from contracts.settings import Settings
+from dagster import DagsterInstance, RunConfig, materialize
+from mlflow.tracking import MlflowClient
+from nged_substation_forecast.defs.cv_assets import (
+    MetricsConfig,
+    PopulationFilter,
+    cv_power_forecasts,
+    effective_capacity,
+    metrics,
+    trained_cv_model,
+)
+from nged_substation_forecast.defs.jobs import (
+    RegisterExperimentConfig,
+    register_experiment_job,
+)
+
+EXPERIMENT_NAME = "xgboost_no_power_lags"
+FOLD_ID = "mid_2025_to_mid_2026"
+PARTITION_KEY = f"{EXPERIMENT_NAME}__{FOLD_ID}"
+
+# The base conf/model/xgboost.yaml selected_features, minus the four power_lag_*h entries.
+SELECTED_FEATURES: list[str] = [
+    "local_time_of_day_sin",
+    "local_time_of_day_cos",
+    "local_time_of_year_sin",
+    "local_time_of_year_cos",
+    "local_day_of_week_sin",
+    "local_day_of_week_cos",
+    "local_day_of_week",
+    "local_utc_offset",
+    "temperature_2m",
+    "dew_point_temperature_2m",
+    "wind_speed_10m",
+    "wind_direction_10m",
+    "wind_speed_100m",
+    "wind_direction_100m",
+    "pressure_surface",
+    "pressure_reduced_to_mean_sea_level",
+    "geopotential_height_500hpa",
+    "downward_short_wave_radiation_flux_surface",
+    "categorical_precipitation_type_surface",
+    "windchill",
+]
+
+
+def _register(instance: DagsterInstance) -> None:
+    """Create the MLflow experiment + parent run and register the fold's dynamic partition."""
+    result = register_experiment_job.execute_in_process(
+        run_config=RunConfig(
+            ops={
+                "register_experiment": RegisterExperimentConfig(
+                    experiment_name=EXPERIMENT_NAME,
+                    base_model_config="conf/model/xgboost.yaml",
+                    config_overrides={
+                        "selected_features": SELECTED_FEATURES,
+                        # The base tag "horizon_as_feature" is inaccurate here (no lead-time
+                        # feature, no lags); label this experiment for what it is.
+                        "training_strategy": "weather_calendar_only",
+                    },
+                    run_mode="full_cv",
+                    description=(
+                        "Weather/calendar-only baseline (no power lags) — the switching-event"
+                        " detection shared baseline (#179)."
+                    ),
+                )
+            }
+        ),
+        instance=instance,
+    )
+    assert result.success, "register_experiment_job failed"
+
+
+def _report_metrics() -> None:
+    """Print the leaderboard aggregate metrics logged to the experiment's parent (cv_summary) run."""
+    client = MlflowClient()
+    experiment = client.get_experiment_by_name(EXPERIMENT_NAME)
+    if experiment is None:
+        print("No MLflow experiment found; skipping metric report.")
+        return
+    parent_runs = client.search_runs(
+        [experiment.experiment_id],
+        filter_string="tags.cv_role = 'parent'",
+    )
+    if not parent_runs:
+        print("No parent run found; skipping metric report.")
+        return
+    metrics_dict = parent_runs[0].data.metrics
+    print(f"\n=== Leaderboard metrics for {EXPERIMENT_NAME} (mean across folds) ===")
+    for key in sorted(metrics_dict):
+        print(f"  {key:<40} {metrics_dict[key]:.4f}")
+
+
+def main() -> None:
+    settings = Settings()
+    mlflow.set_tracking_uri(settings.mlflow_tracking_uri)
+    instance = DagsterInstance.ephemeral()
+
+    print(f"[1/5] Registering experiment {EXPERIMENT_NAME} ({len(SELECTED_FEATURES)} features)...")
+    _register(instance)
+
+    print(f"[2/5] Training fold {FOLD_ID}...")
+    assert materialize(
+        [trained_cv_model], partition_key=PARTITION_KEY, instance=instance
+    ).success, "trained_cv_model failed"
+
+    print("[3/5] Generating ensemble forecasts (this is the long step)...")
+    assert materialize(
+        [cv_power_forecasts], partition_key=PARTITION_KEY, instance=instance
+    ).success, "cv_power_forecasts failed"
+
+    print("[4/5] Materialising effective_capacity (NMAE denominator)...")
+    assert materialize([effective_capacity], instance=instance).success, "effective_capacity failed"
+
+    print("[5/5] Computing leaderboard metrics...")
+    assert materialize(
+        [metrics],
+        run_config=RunConfig(
+            ops={
+                "metrics": MetricsConfig(
+                    population_filter=PopulationFilter(
+                        experiment_name=EXPERIMENT_NAME, fold_id=FOLD_ID
+                    ),
+                    evaluation_scope="leaderboard",
+                )
+            }
+        ),
+        instance=instance,
+    ).success, "metrics failed"
+
+    _report_metrics()
+    print("\nDone. Now run: uv run python scripts/export_forecasts_for_alex.py")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #179.

## What & why

Alex needs an early version of the switching-event [**shared baseline**](https://openclimatefix.github.io/nged-substation-forecast/roadmap/switching-events/#the-baseline-shared-foundation): the production XGBoost forecaster configured with **no power-lag features** (weather + calendar covariates only). With the lags removed, the model's residual (observed − expected) isolates switching events instead of absorbing them through a lagged-power side door. As the issue notes, this is deliberately *not* a good forecaster yet — the XGBoost improvements that would make it one aren't scheduled until v0.5 — it is the residual-generating baseline the detection work builds on.

This is a **config-only experiment plus two small helper scripts and a viewer** — no library code changes.

## Changes

- **`scripts/run_baseline_experiment.py`** — headless end-to-end runner: registers the experiment (`xgboost_no_power_lags`, the base `conf/model/xgboost.yaml` minus the four `power_lag_*h` features → 20 features), then trains, forecasts, materialises `effective_capacity`, and computes leaderboard metrics for the single leaderboard fold `mid_2025_to_mid_2026`. All steps share one `DagsterInstance` so the dynamic partition registered by the job is visible to the subsequent `materialize()` calls (this is required, not incidental).
- **`scripts/export_forecasts_for_alex.py`** — exports the fold's forecasts as three parquet files, all already in physical **MW/MVA** units (`power_fcst` is stored in MW/MVA on disk; the per-series unit is in `TimeSeriesMetadata.units`):
  - `*_full_ensemble.parquet` — all 51 ECMWF ensemble members
  - `*_ensemble_mean.parquet` — the ensemble mean per timestep
  - `*_quantiles.parquet` — p10 / p50 / p90 per timestep

  For each `(time_series_id, valid_time)` only the **freshest** run (largest `power_fcst_init_time`) is kept — the shortest-lead hindcast, the natural expected-power baseline. Observed power is left-joined (deduplicated on the join key first, to avoid doubling ensemble rows) so residuals can be computed directly.
- **`packages/notebooks/view_baseline_export.py`** — marimo viewer for the three parquets: observed vs the p10–p90 band / p50 / ensemble mean, the residual (where a sustained level shift is the switching signature), and the raw ensemble members over a selectable window.

## Decisions

- **`training_strategy="weather_calendar_only"`** — set honestly for this experiment rather than inheriting the base config's inaccurate `"horizon_as_feature"` tag.
- **`evaluation_scope="leaderboard"`** for metrics — comparable to the lagged `xgboost_cv_0001` run.
- Exports carry **no `units` column** by request (Alex already maps `time_series_id` → unit).

## Results

End-to-end run completed on the leaderboard fold `mid_2025_to_mid_2026` (train 2024-04-01→2025-06-30, validate 2025-07-01→2026-06-30), **28 eligible series**, all 51 ensemble members.

**Deterministic skill (leaderboard aggregate, MW/MVA):**

| metric | all | disagg. demand | pv | wind | bess | biofuel | raw_flow |
|---|---|---|---|---|---|---|---|
| NMAE | 0.134 | 0.119 | 0.093 | 0.199 | 0.084 | 0.017 | 0.228 |
| RMSE | 9.91 | 1.00 | 1.64 | 2.92 | 0.30 | 1.02 | 61.4 |
| CRPS | 6.99 | 0.71 | 0.84 | 1.95 | 0.16 | 0.50 | 43.8 |

(MAE\_\_all 7.50, MBE\_\_all −0.44. `raw_flow`'s large absolute errors reflect its large magnitude; NMAE normalises for that.)

**Calibration caveat (expected, worth flagging):** the ensemble is badly **under-dispersed** — spread-skill ratio 0.12 and PICP of the nominal-80% p10–p90 band only **0.12**. With no power lags and only weather/calendar features, the 51-member NWP spread massively understates true uncertainty. This is a known limitation of the current model (a proper quantile objective is future work), and it doesn't affect the baseline's purpose — the ensemble-mean / p50 residual is what the detection work consumes.

**Deliverables written** (`data/exports/`, gitignored): full ensemble 25.0M rows / 60 MB, ensemble-mean and quantiles 490 k rows each / 4–6 MB. Observed power joined on ~96.5% of rows; quantiles monotonic; exactly one freshest init per `(series, valid_time)`.

## Verification

- Both scripts + the notebook pass `ruff` and `ty`; the docstring-markdown pre-commit hook passes.
- The export was additionally smoke-tested against an existing experiment before the real run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
