### PR TITLE
Send telemetry to OCF's Sentry.io: error reporting + missed-check-in alarm (#63)

### DIFF
--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -461,6 +461,8 @@ production-resilience mechanism.
   `EcsRunLauncher`) and its implementation workstreams.
 - [Setting up the live service on AWS](../live_service/aws.md) — the step-by-step runbook:
   promotion, image build/push, and the full AWS bring-up including the control-plane box.
+- [Setting up Sentry telemetry](../live_service/sentry.md) — the how-to for the error reporting
+  and missed-check-in alarm designed above: get a DSN, test from a laptop, enable in production.
 - [Configuration reference](../live_service/setup.md) — where data tables and local
   artifacts live, and how to point `Settings` at S3.
 - [ML Orchestration Design](ml-orchestration.md) — why production inference doesn't reuse the

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -39,11 +39,10 @@ The design accepts two trade-offs:
   [uptime requirements are lenient by design](../background/requirements.md#uptime-lenient-by-design):
   previously published forecasts stay readable from S3 and extend 14 days ahead, so a missed
   slot degrades forecast freshness rather than cutting NGED off. Mitigation: the
-  [missed-check-in alarm](../roadmap/live-service.md#alert-on-absence-the-missed-check-in-alarm)
-  — each successful 6-hourly run checks in with an external monitoring service (Sentry cron
-  monitoring is the planned mechanism), and an alert fires when an expected check-in fails to
-  arrive. The alarm is the only component that lives outside the box, and the stack does not
-  depend on it to function.
+  [missed-check-in alarm](#send-telemetry-to-sentry-and-alarm-on-absence) — each successful
+  6-hourly run checks in with Sentry (external to the whole deployment), and an alert fires when
+  an expected check-in fails to arrive. The alarm is the only component that lives outside the
+  box, and the stack does not depend on it to function.
 
 - **No run-level auto-retry after a hard crash.** Accepted; covered by the existing
   replay/backfill mode for missed slots plus the missed-check-in alarm.
@@ -82,13 +81,48 @@ NGED recovers (the pipeline back-fills the gap automatically), so it must not bl
 assets.
 
 This in-Dagster check is complementary to — not a replacement for — the
-[missed-check-in alarm](../roadmap/live-service.md#alert-on-absence-the-missed-check-in-alarm).
-The alarm fires on total silence from *outside* the deployment, because a dead daemon cannot
-report itself; this check reports per-series staleness from *inside* Dagster while the daemon
-is alive. The freshness evaluation is a pure function, and it is the hand-off point for
-[Sentry telemetry (#63)](https://github.com/openclimatefix/nged-substation-forecast/issues/63):
-when that lands, the same result object also feeds Sentry, and later the forecast-warnings
-delivery table.
+[missed-check-in alarm](#send-telemetry-to-sentry-and-alarm-on-absence). The alarm fires on total
+silence from *outside* the deployment, because a dead daemon cannot report itself; this check
+reports per-series staleness from *inside* Dagster while the daemon is alive. The freshness
+evaluation is a pure function, which makes it the natural hand-off point for routing per-series
+staleness to Sentry as well — reusing the same `PowerFreshnessResult` rather than recomputing it,
+an immediate follow-up to the initial Sentry telemetry work, and later the source for the
+forecast-warnings delivery table.
+
+## Send telemetry to Sentry, and alarm on absence
+
+Two independent Sentry mechanisms live in `nged_substation_forecast._sentry`, and both are active
+in every Dagster process (daemon, webserver, and each Fargate run worker) only when a `SENTRY_DSN`
+is configured — so laptops and CI stay silent by default.
+
+- **Error telemetry.** `init_sentry` initialises the SDK once per process at import of the Dagster
+  definitions module, and a Dagster `@failure_hook` (`sentry_capture_failure`, attached to the
+  scheduled asset jobs) reports a failed step's exception — traceback intact — from inside the run
+  worker. The explicit hook is used rather than relying on Sentry's logging integration alone
+  because Dagster logs a step failure without `exc_info`, so a purely log-based capture would yield
+  a message-only event with no stack trace.
+
+- **The missed-check-in alarm** — the *primary* production alert. After each successful *live*
+  `live_forecasts` run, the asset sends one success check-in (a heartbeat) to a Sentry cron
+  monitor; Sentry raises the alarm when no heartbeat lands within the margin (the 6-hourly schedule
+  plus ~2 h grace), regardless of cause. Evaluation must live outside the deployment because a dead
+  daemon cannot report itself — the reasoning for why this, not a Dagster sensor, is the mechanism
+  is in [Alert on absence](../roadmap/live-service.md#alert-on-absence-the-missed-check-in-alarm).
+  Only *success* heartbeats are ever sent (never an `error` check-in), so the alarm keys purely off
+  absence: an in-band run error is the failure hook's job, and a manual `replay` backfill — which
+  reprocesses the past rather than proving the service is live now — deliberately does not check in.
+
+### Separating laptop telemetry from production
+
+Sentry's `environment` tag (from `Settings.sentry_environment`) keeps the two apart. The always-on
+box sets `environment=production`; each developer overrides the `local` default with
+`<name>-laptop` (e.g. `jacks-laptop`, `alexs-laptop`), so error events filter cleanly by origin.
+The missed-check-in alert rule is scoped to `environment:production`, so an intermittently-run
+laptop never pages. When a developer wants to exercise the heartbeat path locally, they set
+`SENTRY_MONITOR_FORECASTS=true` and point it at a *throwaway* monitor slug (`live-forecasts-test`),
+never the production `live-forecasts` monitor — otherwise the shared production monitor would be
+left expecting a 6-hourly check-in that the laptop won't keep sending, and would flag it as missed.
+The [AWS runbook](../live_service/aws.md) lists the exact environment variables set on the box.
 
 ## Separate "is this run usable?" from "is it perfect?"
 

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -100,7 +100,10 @@ is configured — so laptops and CI stay silent by default.
   scheduled asset jobs) reports a failed step's exception — traceback intact — from inside the run
   worker. The explicit hook is used rather than relying on Sentry's logging integration alone
   because Dagster logs a step failure without `exc_info`, so a purely log-based capture would yield
-  a message-only event with no stack trace.
+  a message-only event with no stack trace. The hook is attached to the three *scheduled* asset
+  jobs, so it covers the whole unattended production workload; failures in a manual UI
+  materialisation, a replay backfill, or an experiment job are watched by the operator at the
+  Dagster UI, not routed to Sentry.
 
 - **The missed-check-in alarm** — the *primary* production alert. After each successful *live*
   `live_forecasts` run, the asset sends one success check-in (a heartbeat) to a Sentry cron

--- a/docs/live_service/aws.md
+++ b/docs/live_service/aws.md
@@ -27,8 +27,9 @@ bake the model in at build time, an always-on control plane rather than EventBri
 > [access-phasing plan](../roadmap/live-service.md#access-phasing), and infrastructure-as-code
 > ([#326](https://github.com/openclimatefix/nged-substation-forecast/issues/326)) is scheduled
 > to start at Stage 2, when team access adds enough moving parts to justify it.
-> Alerting (per-task failure emails, the missed-check-in alarm) is also still to come — see
-> [the roadmap](../roadmap/live-service.md#alert-on-absence-the-missed-check-in-alarm).
+> Sentry error telemetry and the missed-check-in alarm are wired (set the `SENTRY_*` vars in
+> [Step 14](#step-14-configure-dagster-on-the-box)); only per-task failure emails (SNS) are still
+> to come — see [the roadmap](../roadmap/live-service.md#alert-on-absence-the-missed-check-in-alarm).
 
 ## Step 1 — Create the S3 buckets
 
@@ -934,7 +935,17 @@ NGED_S3_BUCKET_URL=<same value as the Parameter Store entry>
 NGED_S3_BUCKET_ACCESS_KEY=<same value as the Parameter Store entry>
 NGED_S3_BUCKET_SECRET=<same value as the Parameter Store entry>
 DAGSTER_PG_PASSWORD=<same value as /nged-forecast/dagster-pg-password from Step 8>
+SENTRY_DSN=<OCF Sentry project DSN>
+SENTRY_ENVIRONMENT=production
+SENTRY_MONITOR_FORECASTS=true
 ```
+
+The three `SENTRY_*` lines turn on error telemetry and the missed-check-in alarm (see
+[Send telemetry to Sentry](../architecture/production-deployment.md#send-telemetry-to-sentry-and-alarm-on-absence)).
+`SENTRY_ENVIRONMENT=production` is what the alarm's alert rule is scoped to; a developer testing
+from a laptop instead sets `SENTRY_ENVIRONMENT=<name>-laptop` and leaves `SENTRY_MONITOR_FORECASTS`
+unset (so a laptop never registers a stale check-in on the production monitor). An empty/absent
+`SENTRY_DSN` disables Sentry entirely, so this is safe to omit while bringing the box up.
 
 (The Fargate containers get these injected from Parameter Store; the box's containers read this
 file instead — Stage-1 simplicity, one hand-managed box.)
@@ -1244,10 +1255,13 @@ If a slot gets missed (box down, failed run), backfill it from the same UI —
 - **Security patches**: Ubuntu Server installs security updates automatically via
   `unattended-upgrades`; confirm it's active with `systemctl status unattended-upgrades`.
 
-The remaining operational safety nets — per-task failure alerts (email via SNS, the Simple
-Notification Service) and the missed-check-in alarm that catches a silently-dead daemon — are
-still to come; see
-[the roadmap](../roadmap/live-service.md#alert-on-absence-the-missed-check-in-alarm).
+The missed-check-in alarm that catches a silently-dead daemon is wired via Sentry cron monitoring
+(the `SENTRY_*` vars in [Step 14](#step-14-configure-dagster-on-the-box)); the one console step it
+needs is to **scope its alert rule to `environment:production`** in Sentry, so a developer testing
+from a laptop never trips it. The one remaining operational safety net is per-task failure alerts
+(email via SNS, the Simple Notification Service) — still to come; see
+[the roadmap](../roadmap/live-service.md#alert-on-absence-the-missed-check-in-alarm) and
+[Send telemetry to Sentry](../architecture/production-deployment.md#send-telemetry-to-sentry-and-alarm-on-absence).
 
 ## Redeploying a new champion model
 

--- a/docs/live_service/index.md
+++ b/docs/live_service/index.md
@@ -9,9 +9,10 @@ already built — once each piece ships. Design rationale (the *why*) lives in
 counterpart.
 [The roadmap's Live Service page](../roadmap/live-service.md) sends readers here as its sections
 land (so far: the `live_forecasts` and `promoted_model` assets, local 6-hourly automation, the
-container build/verify runbook, and the AWS bring-up runbook; still to come: production
-monitoring, alerting). Once the whole v0.1 epic ships, the roadmap page is deleted and this
-section is the sole home for how the live service works.
+container build/verify runbook, the AWS bring-up runbook, and Sentry telemetry with the
+missed-check-in alarm; still to come: production monitoring, and per-task failure-email alerting).
+Once the whole v0.1 epic ships, the roadmap page is deleted and this section is the sole home for
+how the live service works.
 
 This is distinct from [ML Experimentation](../ml_experimentation/index.md): that area covers
 training and backtesting candidate models against historical data; this area covers picking one
@@ -44,5 +45,7 @@ driving is identical in both environments, so it lives on one shared page:
 - [Operating the live service](operations.md) — driving a running stack day to day: promote a
   champion model, let the 6-hourly `live_forecasts` schedule run (or materialise a slot by
   hand), inspect a forecast, and backfill a missed slot in replay mode.
+- [Setting up Sentry telemetry](sentry.md) — point error reporting and the missed-check-in alarm
+  at a Sentry project: get a DSN, test it from your laptop, and turn it on in production.
 - [Configuration reference](setup.md) — what the storage roots, the derive-from-root
   convention, and the credential settings mean, and which combination each environment uses.

--- a/docs/live_service/sentry.md
+++ b/docs/live_service/sentry.md
@@ -94,6 +94,30 @@ Then check the Sentry UI:
 Once you are satisfied, delete the throwaway `live-forecasts-test` monitor in Sentry (and
 optionally resolve the test issue). Neither affects the production wiring.
 
+## What gets sent when you run Dagster locally
+
+With a `SENTRY_DSN` configured, `init_sentry` runs at import of the Dagster definitions module, so
+every local Dagster process (the webserver and each run worker) has Sentry active and tags
+everything with your `SENTRY_ENVIRONMENT`. But the telemetry is deliberately narrow — running
+Dagster on your laptop does **not** forward everything to Sentry:
+
+- **Failures of the three scheduled jobs are sent.** `power_time_series_and_metadata_job`,
+  `ecmwf_ens_job`, and `live_forecasts_job` each attach the `sentry_capture_failure` hook, so a
+  failed step in any of them forwards the live exception — traceback intact — to Sentry Issues,
+  tagged with your environment. This fires whether the run was launched by its schedule or started
+  by hand as that named job.
+- **Ad-hoc asset materialisations are *not* sent.** Clicking "Materialize" on an asset in the
+  Dagster UI runs it outside those jobs, so no failure hook is attached and a failure there never
+  reaches Sentry — it is yours to watch at the UI. To exercise the real hook end to end, launch
+  `live_forecasts_job` by name rather than materialising the `live_forecasts` asset directly.
+- **No heartbeats are sent.** The live check-in is gated on `SENTRY_MONITOR_FORECASTS`, which you
+  have left unset (see the warning above), so your laptop sends no cron check-ins and cannot touch
+  the production `live-forecasts` monitor.
+
+This is the same scope that runs in production; the [design page](../architecture/production-deployment.md#send-telemetry-to-sentry-and-alarm-on-absence)
+explains why the failure hook covers only the scheduled jobs and why only success heartbeats are
+ever sent.
+
 ## Turn it on in production
 
 On the always-on control-plane box, the three `SENTRY_*` variables go in the box's `.env` — see

--- a/docs/live_service/sentry.md
+++ b/docs/live_service/sentry.md
@@ -1,0 +1,126 @@
+# Setting up Sentry telemetry
+
+How to point this project's error telemetry and missed-check-in alarm at a Sentry.io project —
+first testing it from your laptop, then turning it on in production. This is the operational
+recipe; the design rationale (why the alarm lives outside the deployment, why an explicit failure
+hook rather than log capture) is on the
+[Send telemetry to Sentry](../architecture/production-deployment.md#send-telemetry-to-sentry-and-alarm-on-absence)
+design page.
+
+Everything here is **opt-in**: with no `SENTRY_DSN` configured, every Sentry code path is a no-op,
+so a laptop or CI run sends nothing until you deliberately set it up.
+
+## Get a project DSN from Sentry
+
+A **DSN** (Data Source Name) is the only credential you need. It is a project *ingest* key —
+write-only, so it lets code send events but cannot read your Sentry data — which makes it far less
+sensitive than a password.
+
+1. Sign in to OCF's organisation at [sentry.io](https://sentry.io).
+2. You send events to a **project**. Reuse the existing project for this service if there is one;
+   otherwise create one with **Projects → Create Project**, platform **Python**, named e.g.
+   `nged-substation-forecast`.
+3. Open the DSN at **Settings → Projects → _your project_ → Client Keys (DSN)** (a newly created
+   project also shows it on its setup screen).
+4. Copy the **DSN** string. It looks like
+   `https://<hash>@o<org-id>.ingest.<region>.sentry.io/<project-id>`.
+
+## Configure your laptop
+
+Add two lines to the repo-root `.env` (the same git-ignored file that holds the NGED source
+credentials — see the [Configuration reference](setup.md#the-env-file-and-nged-source-credentials)):
+
+```dotenv
+SENTRY_DSN=<paste your DSN here>
+SENTRY_ENVIRONMENT=jacks-laptop
+```
+
+`SENTRY_ENVIRONMENT` is the tag that separates your telemetry from everyone else's in the Sentry
+UI. Use `<your-name>-laptop` (e.g. `jacks-laptop`, `alexs-laptop`) so error events filter cleanly
+by origin, and so the production missed-check-in alert — scoped to `environment:production` — never
+fires for your machine.
+
+Do **not** set `SENTRY_MONITOR_FORECASTS` on a laptop. It gates the live heartbeat, and an
+intermittently-run laptop must never register a check-in on the production monitor: the monitor
+would then expect a 6-hourly heartbeat your laptop won't keep sending, and would flag it as missed.
+The verification below sends its heartbeat to a throwaway monitor slug instead.
+
+## Verify it works from your laptop
+
+Save this script and run it with `uv run python <file>`. It exercises the two real code paths — the
+failure hook and the heartbeat — and flushes so the events reach Sentry before the process exits:
+
+```python
+import sentry_sdk
+from contracts.settings import Settings
+from dagster import job, op
+
+from nged_substation_forecast._sentry import (
+    init_sentry,
+    send_forecast_checkin,
+    sentry_capture_failure,
+)
+
+TEST_MONITOR_SLUG = "live-forecasts-test"  # a throwaway slug — never the production monitor
+
+
+@op
+def _intended_failure() -> None:
+    raise ValueError("laptop Sentry acceptance test — this failure is intentional")
+
+
+@job(hooks={sentry_capture_failure})  # the same hook the production jobs attach
+def _sentry_smoke_job() -> None:
+    _intended_failure()
+
+
+settings = Settings()
+if not settings.sentry_dsn:
+    raise SystemExit("No SENTRY_DSN in .env — nothing to test.")
+
+init_sentry(settings)
+_sentry_smoke_job.execute_in_process(raise_on_error=False)  # fires the failure hook
+send_forecast_checkin(Settings(sentry_monitor_forecasts=True), monitor_slug=TEST_MONITOR_SLUG)
+sentry_sdk.flush(timeout=10)
+```
+
+Then check the Sentry UI:
+
+- **Issues**, filtered to `environment:<your-name>-laptop` — a `ValueError: laptop Sentry
+  acceptance test…` with a full stack trace. A traceback (not a message-only event) is the point:
+  it confirms the failure hook forwards the live exception rather than relying on log capture.
+- **Crons → `live-forecasts-test`** — one OK check-in.
+
+Once you are satisfied, delete the throwaway `live-forecasts-test` monitor in Sentry (and
+optionally resolve the test issue). Neither affects the production wiring.
+
+## Turn it on in production
+
+On the always-on control-plane box, the three `SENTRY_*` variables go in the box's `.env` — see
+[Setting up the live service on AWS, Step 14](aws.md#step-14-configure-dagster-on-the-box):
+
+```dotenv
+SENTRY_DSN=<the OCF Sentry project DSN>
+SENTRY_ENVIRONMENT=production
+SENTRY_MONITOR_FORECASTS=true
+```
+
+`SENTRY_MONITOR_FORECASTS=true` makes each successful live `live_forecasts` run check in to the
+production `live-forecasts` monitor. Two one-time console steps complete the setup:
+
+1. The monitor is created automatically on the first check-in (the code sends its schedule and
+   margin with every heartbeat), so no manual monitor creation is needed.
+2. **Scope the missed-check-in alert rule to `environment:production`** in Sentry, so a developer
+   testing from a laptop can never trip the production alarm.
+
+One handover note: the Sentry account is OCF's today, so at handover the alert routing (and
+possibly the account itself) moves to NGED — see
+[Handover to NGED](../roadmap/handover.md#2-alert-on-absence-not-just-failure).
+
+## See also
+
+- [Send telemetry to Sentry, and alarm on absence](../architecture/production-deployment.md#send-telemetry-to-sentry-and-alarm-on-absence)
+  — the design rationale.
+- [Setting up the live service on AWS](aws.md) — where the production `SENTRY_*` variables sit in
+  the full bring-up.
+- [Configuration reference](setup.md) — how `.env` and environment variables feed `Settings`.

--- a/docs/live_service/setup.md
+++ b/docs/live_service/setup.md
@@ -114,6 +114,11 @@ NGED_S3_BUCKET_SECRET=<secret>
 `.env` is git-ignored — never commit real credentials. Everything else on this page is optional and
 layers on top of these three.
 
+The optional `SENTRY_*` settings (`SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `SENTRY_MONITOR_FORECASTS`,
+`SENTRY_TRACES_SAMPLE_RATE`) enable error telemetry and the missed-check-in alarm; an empty
+`SENTRY_DSN` (the default) disables Sentry entirely. Their setup — laptop testing and production —
+has its own page: [Setting up Sentry telemetry](sentry.md).
+
 ### Credentials for our own S3 data (`DATA_STORE_*`)
 
 The four `DATA_STORE_*` fields (`ACCESS_KEY_ID`, `SECRET_ACCESS_KEY`, `REGION`, `ENDPOINT_URL`)

--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -15,8 +15,7 @@
 > ([#328](https://github.com/openclimatefix/nged-substation-forecast/issues/328),
 > [#329](https://github.com/openclimatefix/nged-substation-forecast/issues/329)),
 > infra-as-code ([#326](https://github.com/openclimatefix/nged-substation-forecast/issues/326)),
-> the [missed-check-in alarm](#alert-on-absence-the-missed-check-in-alarm), and the
-> MLflow-server / dev-dashboard future work
+> and the MLflow-server / dev-dashboard future work
 > ([#235](https://github.com/openclimatefix/nged-substation-forecast/issues/235),
 > [#236](https://github.com/openclimatefix/nged-substation-forecast/issues/236)) — plus the
 > durable record of the costed [AWS-architecture decision](#aws-architecture) behind the
@@ -63,11 +62,11 @@ plan (phases 0–6.7 complete, PRs #182–#214); its final cleanup phase lives i
 - The NGED-delivery schema/contract
   ([#96](https://github.com/openclimatefix/nged-substation-forecast/issues/96)) — v0.1 is
   "forecast running", not "delivery contract live".
-- Telemetry to Sentry.io
-  ([#63](https://github.com/openclimatefix/nged-substation-forecast/issues/63)) — including
-  Sentry cron monitoring as the
-  [missed-check-in alarm](#alert-on-absence-the-missed-check-in-alarm); basic per-task failure
-  alerting covers v0.1 first.
+- Basic **per-task failure email alerting** (a failed run → SNS → email). Sentry error telemetry
+  and the [missed-check-in alarm](#alert-on-absence-the-missed-check-in-alarm) have shipped
+  ([#63](https://github.com/openclimatefix/nged-substation-forecast/issues/63) — see
+  [Send telemetry to Sentry](../architecture/production-deployment.md#send-telemetry-to-sentry-and-alarm-on-absence));
+  the remaining piece is the thin SNS→email notification edge for individual run failures.
 - An **MLflow tracking server** (issue [#235](https://github.com/openclimatefix/nged-substation-forecast/issues/235)) and a separate **development dashboard** ([#236](https://github.com/openclimatefix/nged-substation-forecast/issues/236)), both hosted on the
   always-on control-plane box once it exists — see the [note below](#aws-architecture).
 - [Production monitoring](#production-monitoring): score live forecasts over trailing 24h/7d
@@ -477,6 +476,14 @@ below already reserves that slot).
 
 ### Alert on absence: the missed-check-in alarm
 
+> **Status: ✅ Shipped** ([#63](https://github.com/openclimatefix/nged-substation-forecast/issues/63)).
+> The heartbeat, the failure hook, and the laptop/production environment split are built and
+> documented as-built in
+> [Send telemetry to Sentry](../architecture/production-deployment.md#send-telemetry-to-sentry-and-alarm-on-absence).
+> This section keeps the *why* — the design rationale for alerting on absence from outside the
+> deployment. The remaining monitoring work on this page is the separate per-task failure email
+> edge (SNS → email).
+
 Per-task failure alerts ([Deployment workstream 3](#deployment-workstream-3-aws-infrastructure))
 only fire when something runs and fails. Whole classes of failure are silent: a hung daemon, a
 full disk, an expired credential, a schedule that stopped firing. The **primary** production
@@ -618,7 +625,7 @@ order issues were opened.
 | [#206 Deploy to AWS!](https://github.com/openclimatefix/nged-substation-forecast/issues/206) | This page (the options above supersede its cost analysis) — done; deployed and running |
 | [#286 Create docs for setting up compute infra on AWS](https://github.com/openclimatefix/nged-substation-forecast/issues/286) | [Deployment workstream 3](#deployment-workstream-3-aws-infrastructure) — done; the option-agnostic pieces and the control-plane box are all in the [AWS runbook](../live_service/aws.md). Infra-as-code ([#326](https://github.com/openclimatefix/nged-substation-forecast/issues/326)) is a separate 🚧 follow-up |
 | [#197 Make fold-run param logging re-run-safe](https://github.com/openclimatefix/nged-substation-forecast/issues/197) | Bug fix folded into the v0.1 epic (MLflow param immutability on re-runs) |
-| [#63 Send telemetry to OCF's Sentry.io](https://github.com/openclimatefix/nged-substation-forecast/issues/63) | Observability — Sentry cron monitoring provides the planned [missed-check-in alarm](#alert-on-absence-the-missed-check-in-alarm), plus error telemetry |
+| [#63 Send telemetry to OCF's Sentry.io](https://github.com/openclimatefix/nged-substation-forecast/issues/63) | Observability — done; Sentry error telemetry + the [missed-check-in alarm](#alert-on-absence-the-missed-check-in-alarm), as-built in [Send telemetry to Sentry](../architecture/production-deployment.md#send-telemetry-to-sentry-and-alarm-on-absence). Per-task failure email alerting is a separate 🚧 follow-up |
 | [#246 Scale `power_fcst` to [−1, +1] using the static P99 effective capacity](https://github.com/openclimatefix/nged-substation-forecast/issues/246) | Not detailed on this page — decided 2026-07-03 (see the issue for the full worklist); an open follow-up, not required for v0.1 |
 | [#96 Write power forecasts in schema agreed with NGED](https://github.com/openclimatefix/nged-substation-forecast/issues/96) | Deferred to the v1.0 epic ([#133](https://github.com/openclimatefix/nged-substation-forecast/issues/133)) — v0.1 is "forecast running", not "delivery contract live" |
 | [#161 More Dagster-UI metrics + validation for NWP ingestion](https://github.com/openclimatefix/nged-substation-forecast/issues/161) | Deferred to the v0.2 epic ([#138](https://github.com/openclimatefix/nged-substation-forecast/issues/138)) — mostly [NWP ingestion completeness checks](engineering-health.md#nwp-ingestion-completeness-checks-and-dagster-metrics) |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
       - Setting up the live service on AWS: live_service/aws.md
       - Connecting to the AWS control plane: live_service/connecting.md
       - Operating the live service: live_service/operations.md
+      - Setting up Sentry telemetry: live_service/sentry.md
       - Configuration reference: live_service/setup.md
   - Roadmap:
       - Overview: roadmap/index.md

--- a/packages/contracts/src/contracts/settings.py
+++ b/packages/contracts/src/contracts/settings.py
@@ -250,6 +250,42 @@ class Settings(BaseSettings):
         ),
     )
 
+    # --- Sentry observability (all optional; an empty DSN disables Sentry entirely) ---
+
+    sentry_dsn: str = Field(
+        default="",
+        description=(
+            "Sentry.io project DSN. Empty (the default) disables Sentry entirely — every Sentry"
+            " code path becomes a no-op — so laptops and CI need no Sentry config. Set it in the"
+            " .env file to enable error telemetry. Passed explicitly to sentry_sdk.init as the"
+            " single source of truth (the SDK would otherwise also auto-read the SENTRY_DSN env"
+            " var)."
+        ),
+    )
+    sentry_environment: str = Field(
+        default="local",
+        description=(
+            "Sentry environment tag, the dimension that separates deployments in Sentry's UI,"
+            " alerts, and cron monitors. The always-on production box sets 'production'; each"
+            " developer overrides the 'local' fallback with '<name>-laptop' (e.g. 'jacks-laptop')"
+            " so laptop telemetry is cleanly filterable and the production-scoped missed-check-in"
+            " alert never fires for a laptop."
+        ),
+    )
+    sentry_traces_sample_rate: float = Field(
+        default=0.0,
+        description="Fraction of transactions sampled for Sentry performance tracing (off by default).",
+    )
+    sentry_monitor_forecasts: bool = Field(
+        default=False,
+        description=(
+            "Emit the live_forecasts success heartbeat to Sentry's cron monitor (the"
+            " missed-check-in alarm). True only on the always-on production deployment; left"
+            " False on laptops so an intermittently-run laptop never registers a monitor"
+            " environment that Sentry would then mark as missed."
+        ),
+    )
+
     @model_validator(mode="after")
     def _derive_unset_paths(self) -> Self:
         """Fill any unset ("") path from its root, so callers always see a concrete path.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ dependencies = [
     "polars>=1.0.0",
     "pyarrow",
     "requests>=2.31.0",
+    "sentry-sdk>=2.66,<3",
     "xgboost_forecaster",
 ]
 

--- a/src/nged_substation_forecast/_sentry.py
+++ b/src/nged_substation_forecast/_sentry.py
@@ -1,0 +1,104 @@
+"""Sentry.io telemetry: error reporting and the missed-check-in alarm.
+
+Two independent mechanisms, both no-ops unless ``Settings.sentry_dsn`` is set, so laptops and CI
+need no Sentry configuration:
+
+- **Error telemetry** — :func:`init_sentry` initialises the SDK once per process, and the
+  :data:`sentry_capture_failure` Dagster failure hook reports the real exception (with traceback)
+  from inside the run worker. The hook is used rather than relying on Sentry's ``LoggingIntegration``
+  alone because Dagster logs a step failure without ``exc_info``, so the log-based path would yield a
+  message-only event with no stack trace.
+- **The missed-check-in alarm** — :func:`send_forecast_checkin` sends a *success-only* heartbeat to
+  a Sentry cron monitor after each live ``live_forecasts`` run. Sentry fires the alarm on the
+  *absence* of a heartbeat past the margin (a dead daemon cannot report itself); in-band run errors
+  are handled by the failure hook above, never by this heartbeat.
+
+The ``environment`` tag (``Settings.sentry_environment``) separates deployments: ``production`` on
+the always-on box, ``<name>-laptop`` on each developer's machine. The alarm's alert rule is scoped
+to ``environment:production`` so intermittently-run laptops never page. See
+[Production Deployment](https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/).
+"""
+
+from typing import TYPE_CHECKING, Final
+
+import sentry_sdk
+from contracts.settings import Settings
+from dagster import HookContext, failure_hook
+from sentry_sdk.crons import capture_checkin
+from sentry_sdk.crons.consts import MonitorStatus
+
+if TYPE_CHECKING:
+    from sentry_sdk._types import MonitorConfig
+
+LIVE_FORECAST_MONITOR_SLUG: Final[str] = "live-forecasts"
+"""Slug of the Sentry cron monitor fed by ``live_forecasts``' success heartbeat.
+
+Laptop testing must use a *different*, throwaway slug (e.g. ``"live-forecasts-test"``) so an
+intermittently-run laptop never registers a stale environment on the production monitor."""
+
+LIVE_FORECAST_MONITOR_CONFIG: "Final[MonitorConfig]" = {
+    "schedule": {"type": "crontab", "value": "0 0,6,12,18 * * *"},
+    "timezone": "UTC",
+    "checkin_margin": 120,
+    "max_runtime": 60,
+}
+"""Declarative config upserted with each heartbeat: the 6-hourly live schedule, 120-minute grace
+before a slot counts as missed (≈ one missed 6-hourly slot plus margin), and a 60-minute max
+runtime. Only *success* heartbeats are ever sent, so the alarm keys off missed check-ins alone."""
+
+
+def init_sentry(settings: Settings) -> None:
+    """Initialise the Sentry SDK for this process, or do nothing if Sentry is disabled.
+
+    A no-op when ``settings.sentry_dsn`` is empty (the default), so nothing is sent from laptops
+    or CI unless a DSN is explicitly configured. Called once per process at import of the Dagster
+    definitions module, so it runs in the daemon, the webserver, and every run worker.
+
+    Args:
+        settings: The project settings carrying the Sentry DSN, environment, and sample rate.
+    """
+    if not settings.sentry_dsn:
+        return
+    sentry_sdk.init(
+        dsn=settings.sentry_dsn,
+        environment=settings.sentry_environment,
+        traces_sample_rate=settings.sentry_traces_sample_rate,
+        send_default_pii=False,
+    )
+
+
+@failure_hook
+def sentry_capture_failure(context: HookContext) -> None:
+    """Report a failed op/asset step to Sentry with its real exception and traceback.
+
+    Runs in the run worker after a step raises, so ``context.op_exception`` is the live exception
+    (traceback intact) rather than Dagster's serialized error info. A no-op when Sentry is
+    uninitialised (empty DSN), because ``capture_exception`` needs an active Sentry client.
+    """
+    exception = context.op_exception
+    if exception is not None:
+        sentry_sdk.capture_exception(exception)
+
+
+def send_forecast_checkin(
+    settings: Settings, monitor_slug: str = LIVE_FORECAST_MONITOR_SLUG
+) -> None:
+    """Send a success heartbeat to the Sentry cron monitor, or do nothing if disabled.
+
+    A no-op unless ``settings.sentry_monitor_forecasts`` is set (True only on the always-on
+    production box), so a laptop never registers a monitor environment that Sentry would then mark
+    as missed. Sends a single ``OK`` check-in — never ``in_progress`` or ``error`` — so the alarm
+    fires purely on the *absence* of a heartbeat.
+
+    Args:
+        settings: The project settings carrying ``sentry_monitor_forecasts`` and the environment.
+        monitor_slug: The Sentry monitor to check in to. Defaults to the production
+            ``live-forecasts`` monitor; laptop tests should pass a throwaway slug.
+    """
+    if not settings.sentry_monitor_forecasts:
+        return
+    capture_checkin(
+        monitor_slug=monitor_slug,
+        status=MonitorStatus.OK,
+        monitor_config=LIVE_FORECAST_MONITOR_CONFIG,
+    )

--- a/src/nged_substation_forecast/_sentry.py
+++ b/src/nged_substation_forecast/_sentry.py
@@ -1,17 +1,21 @@
 """Sentry.io telemetry: error reporting and the missed-check-in alarm.
 
-Two independent mechanisms, both no-ops unless ``Settings.sentry_dsn`` is set, so laptops and CI
-need no Sentry configuration:
+Two independent mechanisms, both no-ops when Sentry is unconfigured, so laptops and CI need no
+Sentry configuration:
 
-- **Error telemetry** — :func:`init_sentry` initialises the SDK once per process, and the
-  :data:`sentry_capture_failure` Dagster failure hook reports the real exception (with traceback)
-  from inside the run worker. The hook is used rather than relying on Sentry's ``LoggingIntegration``
-  alone because Dagster logs a step failure without ``exc_info``, so the log-based path would yield a
-  message-only event with no stack trace.
+- **Error telemetry** — :func:`init_sentry` initialises the SDK once per process (a no-op unless
+  ``Settings.sentry_dsn`` is set), and the :data:`sentry_capture_failure` Dagster failure hook
+  reports the real exception (with traceback) from inside the run worker. The hook is used rather
+  than relying on Sentry's ``LoggingIntegration`` alone because Dagster logs a step failure without
+  ``exc_info``, so the log-based path would yield a message-only event with no stack trace. The hook
+  is attached to the *scheduled* asset jobs only, so it covers the unattended production workload;
+  manual/backfill/experiment runs are watched by the operator at the Dagster UI, not Sentry.
 - **The missed-check-in alarm** — :func:`send_forecast_checkin` sends a *success-only* heartbeat to
-  a Sentry cron monitor after each live ``live_forecasts`` run. Sentry fires the alarm on the
-  *absence* of a heartbeat past the margin (a dead daemon cannot report itself); in-band run errors
-  are handled by the failure hook above, never by this heartbeat.
+  a Sentry cron monitor after each live ``live_forecasts`` run. It is gated on
+  ``Settings.sentry_monitor_forecasts`` (not the DSN), so a laptop with a DSN set for error testing
+  never heartbeats the production monitor. Sentry fires the alarm on the *absence* of a heartbeat
+  past the margin (a dead daemon cannot report itself); in-band run errors are handled by the
+  failure hook above, never by this heartbeat.
 
 The ``environment`` tag (``Settings.sentry_environment``) separates deployments: ``production`` on
 the always-on box, ``<name>-laptop`` on each developer's machine. The alarm's alert rule is scoped
@@ -40,11 +44,13 @@ LIVE_FORECAST_MONITOR_CONFIG: "Final[MonitorConfig]" = {
     "schedule": {"type": "crontab", "value": "0 0,6,12,18 * * *"},
     "timezone": "UTC",
     "checkin_margin": 120,
-    "max_runtime": 60,
 }
-"""Declarative config upserted with each heartbeat: the 6-hourly live schedule, 120-minute grace
-before a slot counts as missed (≈ one missed 6-hourly slot plus margin), and a 60-minute max
-runtime. Only *success* heartbeats are ever sent, so the alarm keys off missed check-ins alone."""
+"""Declarative config upserted with each heartbeat: the 6-hourly live schedule plus 120 minutes of
+grace after each expected check-in before that slot counts as missed — so the alarm effectively
+fires ~8 hours after the last success (one 6-hourly slot plus the 2-hour margin). Only *success*
+check-ins are ever sent, so the alarm keys off missed check-ins alone; ``max_runtime`` is
+deliberately omitted because it needs an ``in_progress`` check-in to time against, which the
+success-only heartbeat never sends."""
 
 
 def init_sentry(settings: Settings) -> None:
@@ -74,6 +80,9 @@ def sentry_capture_failure(context: HookContext) -> None:
     Runs in the run worker after a step raises, so ``context.op_exception`` is the live exception
     (traceback intact) rather than Dagster's serialized error info. A no-op when Sentry is
     uninitialised (empty DSN), because ``capture_exception`` needs an active Sentry client.
+
+    Args:
+        context: The Dagster hook context for the failed step, carrying ``op_exception``.
     """
     exception = context.op_exception
     if exception is not None:

--- a/src/nged_substation_forecast/_sentry.py
+++ b/src/nged_substation_forecast/_sentry.py
@@ -41,6 +41,11 @@ Laptop testing must use a *different*, throwaway slug (e.g. ``"live-forecasts-te
 intermittently-run laptop never registers a stale environment on the production monitor."""
 
 LIVE_FORECAST_MONITOR_CONFIG: "Final[MonitorConfig]" = {
+    # DUPLICATED SCHEDULE: this crontab must match live_forecast_partitions.cron_schedule in
+    # defs/production_assets.py — it is the cadence Sentry expects a heartbeat on, so it has to
+    # track the cadence the live_forecasts asset actually runs on. The value is copied rather than
+    # imported because defs/production_assets.py imports this module (for send_forecast_checkin), so
+    # importing back would be a circular import. If you change the live schedule there, change it here.
     "schedule": {"type": "crontab", "value": "0 0,6,12,18 * * *"},
     "timezone": "UTC",
     "checkin_margin": 120,
@@ -50,7 +55,10 @@ grace after each expected check-in before that slot counts as missed — so the 
 fires ~8 hours after the last success (one 6-hourly slot plus the 2-hour margin). Only *success*
 check-ins are ever sent, so the alarm keys off missed check-ins alone; ``max_runtime`` is
 deliberately omitted because it needs an ``in_progress`` check-in to time against, which the
-success-only heartbeat never sends."""
+success-only heartbeat never sends.
+
+The ``schedule`` crontab is a hand-kept copy of ``live_forecast_partitions.cron_schedule`` in
+``defs/production_assets.py`` — see the inline comment above for why it is copied, not imported."""
 
 
 def init_sentry(settings: Settings) -> None:

--- a/src/nged_substation_forecast/definitions.py
+++ b/src/nged_substation_forecast/definitions.py
@@ -1,8 +1,9 @@
 """Dagster definitions entry point."""
 
+from contracts.settings import get_settings
 from dagster import Definitions, load_assets_from_modules
-from contracts.settings import Settings
 
+from nged_substation_forecast._sentry import init_sentry
 from nged_substation_forecast.defs import (
     assets,
     checks,
@@ -14,7 +15,10 @@ from nged_substation_forecast.defs import (
 
 all_assets = load_assets_from_modules([assets, cv_assets, production_assets])
 
-settings = Settings()
+# Initialise Sentry once per process. This module is imported by every Dagster process — the
+# daemon, the webserver, and each run worker — so error telemetry and the live_forecasts
+# heartbeat are active wherever code runs. A no-op unless a Sentry DSN is configured.
+init_sentry(get_settings())
 
 defs = Definitions(
     assets=all_assets,

--- a/src/nged_substation_forecast/defs/checks.py
+++ b/src/nged_substation_forecast/defs/checks.py
@@ -12,11 +12,11 @@ timestamp — the job succeeds hourly even when NGED publishes nothing, so only 
 would miss exactly the failure this check exists to catch.
 
 ``evaluate_power_freshness`` is a pure function so it is unit-testable without Dagster or Delta,
-and it is the hand-off point for the future Sentry missed-check-in alarm
-([#63](https://github.com/openclimatefix/nged-substation-forecast/issues/63)): that alarm, when
-it lands, consumes the same ``PowerFreshnessResult``. The two stay complementary — the Sentry
-alarm fires on total silence from outside the deployment, this check reports per-series
-staleness from inside Dagster.
+and it is the hand-off point for routing per-series staleness to Sentry: a follow-up will feed the
+same ``PowerFreshnessResult`` to Sentry rather than recomputing it. The two mechanisms stay
+complementary — the [Sentry missed-check-in alarm](https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/#send-telemetry-to-sentry-and-alarm-on-absence)
+fires on total silence from outside the deployment, while this check reports per-series staleness
+from inside Dagster.
 """
 
 from dataclasses import dataclass

--- a/src/nged_substation_forecast/defs/production_assets.py
+++ b/src/nged_substation_forecast/defs/production_assets.py
@@ -39,6 +39,7 @@ from ml_core._production_helpers import (
     select_nwp_init_time,
 )
 
+from nged_substation_forecast._sentry import send_forecast_checkin
 from nged_substation_forecast.defs.cv_assets import _load_engineering_inputs
 
 LIVE_FORECAST_HORIZON: Final[timedelta] = timedelta(days=14)
@@ -292,6 +293,12 @@ def live_forecasts(context: AssetExecutionContext, config: LiveForecastsConfig) 
         replace_predicate_extra=f"power_fcst_init_time = '{power_fcst_init_time.isoformat()}'",
         storage_options=settings.storage_options,
     )
+
+    # Heartbeat to Sentry's missed-check-in alarm — only after a genuinely successful live write,
+    # and never on a replay backfill (which reprocesses the past, not "the live service is alive
+    # now"). A no-op unless sentry_monitor_forecasts is set. See nged_substation_forecast._sentry.
+    if config.availability_mode == "live":
+        send_forecast_checkin(settings)
 
     context.add_output_metadata(
         {

--- a/src/nged_substation_forecast/defs/production_assets.py
+++ b/src/nged_substation_forecast/defs/production_assets.py
@@ -55,6 +55,11 @@ Must cover the longest power lag feature any production model uses (currently up
 """
 
 live_forecast_partitions = TimeWindowPartitionsDefinition(
+    # DUPLICATED SCHEDULE: this crontab is the canonical live cadence, but it is also copied into
+    # LIVE_FORECAST_MONITOR_CONFIG in _sentry.py so the Sentry missed-check-in monitor expects a
+    # heartbeat on the same 6-hourly cadence. That module can't import this one back (it would be a
+    # circular import — this module imports send_forecast_checkin from it). If you change this
+    # crontab, change the copy in _sentry.py too.
     cron_schedule="0 0,6,12,18 * * *",
     start="2026-06-28-00:00",
     fmt="%Y-%m-%d-%H:%M",

--- a/src/nged_substation_forecast/defs/schedules.py
+++ b/src/nged_substation_forecast/defs/schedules.py
@@ -10,6 +10,7 @@ from dagster import (
     schedule,
 )
 
+from nged_substation_forecast._sentry import sentry_capture_failure
 from nged_substation_forecast.defs.assets import ecmwf_ens_partitions
 from nged_substation_forecast.defs.production_assets import live_forecast_partitions
 
@@ -17,6 +18,7 @@ from nged_substation_forecast.defs.production_assets import live_forecast_partit
 power_time_series_and_metadata_job = define_asset_job(
     name="power_time_series_and_metadata_job",
     selection=AssetSelection.assets("power_time_series_and_metadata"),
+    hooks={sentry_capture_failure},
 )
 
 power_time_series_and_metadata_schedule = ScheduleDefinition(
@@ -38,6 +40,7 @@ ecmwf_ens_job = define_asset_job(
     "ecmwf_ens_job",
     selection=AssetSelection.assets("ecmwf_ens"),
     partitions_def=ecmwf_ens_partitions,
+    hooks={sentry_capture_failure},
 )
 
 
@@ -60,6 +63,7 @@ live_forecasts_job = define_asset_job(
     "live_forecasts_job",
     selection=AssetSelection.assets("live_forecasts"),
     partitions_def=live_forecast_partitions,
+    hooks={sentry_capture_failure},
 )
 
 live_forecasts_schedule = build_schedule_from_partitioned_job(live_forecasts_job)

--- a/tests/test_live_forecasts.py
+++ b/tests/test_live_forecasts.py
@@ -225,3 +225,33 @@ def test_accumulation_across_partitions(env: dict[str, str]) -> None:
         _EARLIER_TICK_POWER_FCST_INIT_TIME,
         _POWER_FCST_INIT_TIME,
     }
+
+
+def _capture_checkins(monkeypatch: pytest.MonkeyPatch) -> list[dict]:
+    """Enable the monitor flag and capture every Sentry check-in the asset would emit."""
+    monkeypatch.setenv("SENTRY_MONITOR_FORECASTS", "true")
+    calls: list[dict] = []
+    monkeypatch.setattr(
+        "nged_substation_forecast._sentry.capture_checkin", lambda **kw: calls.append(kw)
+    )
+    return calls
+
+
+def test_live_run_sends_sentry_heartbeat(
+    env: dict[str, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A successful live run emits exactly one OK heartbeat to the live-forecasts monitor."""
+    calls = _capture_checkins(monkeypatch)
+    assert _materialize(DagsterInstance.ephemeral(), "live").success
+    assert len(calls) == 1
+    assert calls[0]["monitor_slug"] == "live-forecasts"
+    assert calls[0]["status"] == "ok"
+
+
+def test_replay_run_sends_no_sentry_heartbeat(
+    env: dict[str, str], monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A replay backfill reprocesses the past, so it must not check in to the live monitor."""
+    calls = _capture_checkins(monkeypatch)
+    assert _materialize(DagsterInstance.ephemeral(), "replay").success
+    assert calls == []

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -104,3 +104,16 @@ def test_failure_hook_is_attached_to_the_scheduled_jobs() -> None:
         hooks = job.hooks
         assert hooks is not None
         assert _sentry.sentry_capture_failure in hooks, job.name
+
+
+def test_monitor_config_schedule_matches_live_partitions() -> None:
+    """Drift guard: the Sentry monitor's crontab is a hand-kept copy of the live_forecasts
+    partition schedule (the two can't share an import — it would be circular; see the comment on
+    ``LIVE_FORECAST_MONITOR_CONFIG``). If someone changes one crontab and not the other, the alarm
+    would expect heartbeats on a different cadence than the asset runs; this catches that."""
+    from nged_substation_forecast.defs.production_assets import live_forecast_partitions
+
+    assert (
+        _sentry.LIVE_FORECAST_MONITOR_CONFIG["schedule"]["value"]
+        == live_forecast_partitions.cron_schedule
+    )

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -88,3 +88,19 @@ def test_failure_hook_noop_without_exception(monkeypatch: pytest.MonkeyPatch) ->
     assert hook_fn is not None
     hook_fn(build_hook_context(op_exception=None))
     assert captured == []
+
+
+def test_failure_hook_is_attached_to_the_scheduled_jobs() -> None:
+    """Regression guard: the failure hook stays wired onto every scheduled asset job, so dropping
+    ``hooks={sentry_capture_failure}`` from a ``define_asset_job`` call is caught here."""
+    from nged_substation_forecast.defs import schedules
+
+    scheduled_jobs = (
+        schedules.power_time_series_and_metadata_job,
+        schedules.ecmwf_ens_job,
+        schedules.live_forecasts_job,
+    )
+    for job in scheduled_jobs:
+        hooks = job.hooks
+        assert hooks is not None
+        assert _sentry.sentry_capture_failure in hooks, job.name

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -1,0 +1,90 @@
+"""Unit tests for the Sentry telemetry helpers (``nged_substation_forecast._sentry``).
+
+Every Sentry side effect is monkeypatched, so these tests never touch the network and assert the
+two invariants that matter: everything is a no-op unless explicitly enabled, and when enabled the
+right Sentry call is made with the right arguments.
+"""
+
+from typing import Any
+
+import pytest
+from contracts.settings import Settings
+from dagster import build_hook_context
+
+from nged_substation_forecast import _sentry
+
+
+def _settings(**overrides: Any) -> Settings:
+    """Build a ``Settings`` with Sentry fields overridden (nged creds come from the conftest)."""
+    return Settings(**overrides)
+
+
+def test_init_sentry_is_noop_without_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No DSN (the default) ⇒ ``sentry_sdk.init`` is never called."""
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(_sentry.sentry_sdk, "init", lambda **kw: calls.append(kw))
+    _sentry.init_sentry(_settings(sentry_dsn=""))
+    assert calls == []
+
+
+def test_init_sentry_passes_environment_when_dsn_set(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A DSN ⇒ ``sentry_sdk.init`` is called with the configured environment and PII disabled."""
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(_sentry.sentry_sdk, "init", lambda **kw: calls.append(kw))
+    _sentry.init_sentry(
+        _settings(sentry_dsn="https://k@o1.ingest.sentry.io/1", sentry_environment="jacks-laptop")
+    )
+    assert len(calls) == 1
+    assert calls[0]["dsn"] == "https://k@o1.ingest.sentry.io/1"
+    assert calls[0]["environment"] == "jacks-laptop"
+    assert calls[0]["send_default_pii"] is False
+
+
+def test_send_forecast_checkin_is_noop_when_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``sentry_monitor_forecasts`` False (the default) ⇒ no check-in is sent."""
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(_sentry, "capture_checkin", lambda **kw: calls.append(kw))
+    _sentry.send_forecast_checkin(_settings(sentry_monitor_forecasts=False))
+    assert calls == []
+
+
+def test_send_forecast_checkin_sends_ok_when_flag_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Flag on ⇒ a single ``OK`` check-in to the live-forecasts monitor, carrying the config."""
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(_sentry, "capture_checkin", lambda **kw: calls.append(kw))
+    _sentry.send_forecast_checkin(_settings(sentry_monitor_forecasts=True))
+    assert len(calls) == 1
+    assert calls[0]["monitor_slug"] == _sentry.LIVE_FORECAST_MONITOR_SLUG
+    assert calls[0]["status"] == "ok"
+    assert calls[0]["monitor_config"] == _sentry.LIVE_FORECAST_MONITOR_CONFIG
+
+
+def test_send_forecast_checkin_uses_given_slug(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A throwaway slug (laptop testing) is honoured instead of the production monitor."""
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(_sentry, "capture_checkin", lambda **kw: calls.append(kw))
+    _sentry.send_forecast_checkin(
+        _settings(sentry_monitor_forecasts=True), monitor_slug="live-forecasts-test"
+    )
+    assert calls[0]["monitor_slug"] == "live-forecasts-test"
+
+
+def test_failure_hook_captures_the_real_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The failure hook forwards ``context.op_exception`` to ``capture_exception``."""
+    captured: list[BaseException] = []
+    monkeypatch.setattr(_sentry.sentry_sdk, "capture_exception", lambda exc: captured.append(exc))
+    hook_fn = _sentry.sentry_capture_failure.decorated_fn
+    assert hook_fn is not None
+    boom = ValueError("boom")
+    hook_fn(build_hook_context(op_exception=boom))
+    assert captured == [boom]
+
+
+def test_failure_hook_noop_without_exception(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No exception on the context ⇒ nothing is captured."""
+    captured: list[BaseException] = []
+    monkeypatch.setattr(_sentry.sentry_sdk, "capture_exception", lambda exc: captured.append(exc))
+    hook_fn = _sentry.sentry_capture_failure.decorated_fn
+    assert hook_fn is not None
+    hook_fn(build_hook_context(op_exception=None))
+    assert captured == []

--- a/uv.lock
+++ b/uv.lock
@@ -2814,6 +2814,7 @@ dependencies = [
     { name = "polars" },
     { name = "pyarrow" },
     { name = "requests" },
+    { name = "sentry-sdk" },
     { name = "xgboost-forecaster" },
 ]
 
@@ -2857,6 +2858,7 @@ requires-dist = [
     { name = "polars", specifier = ">=1.0.0" },
     { name = "pyarrow" },
     { name = "requests", specifier = ">=2.31.0" },
+    { name = "sentry-sdk", specifier = ">=2.66,<3" },
     { name = "xgboost-forecaster", editable = "packages/xgboost_forecaster" },
 ]
 
@@ -4257,6 +4259,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/86/5185061a1fcc41d18c5dc2463969b3a3964b31d9ac67b2fb05d4c7ff7670/scipy-1.18.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9aac6192fac56bf2ca534389d24623f07b39ff83317d58287285e7fbd622ff76", size = 37472480, upload-time = "2026-06-19T15:01:35.136Z" },
     { url = "https://files.pythonhosted.org/packages/31/8e/f04c68e39919a010d34f2ee1367fd705b0a25a02f609d755f0bfbc0a15fc/scipy-1.18.0-cp314-cp314t-win_amd64.whl", hash = "sha256:e40baea28ae7f5475c779741e2d90b1247c78531207b49c7030e698ff81cee3f", size = 37365390, upload-time = "2026-06-19T15:01:38.091Z" },
     { url = "https://files.pythonhosted.org/packages/d5/19/969dc072906c84dd0a3b05dcf57ea750936087d7873549e408b35cfc3f97/scipy-1.18.0-cp314-cp314t-win_arm64.whl", hash = "sha256:368e0a705903c466aa5f08eefb39e6b1b6b2d659e7352a31fd9e2438365be0f8", size = 25279661, upload-time = "2026-06-19T15:01:40.817Z" },
+]
+
+[[package]]
+name = "sentry-sdk"
+version = "2.66.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/48/ff/670abe04c5072719b5060ed93851d0d69525d60f8f2c5810f8becd58f9c1/sentry_sdk-2.66.0.tar.gz", hash = "sha256:9727d35aa83c56cd53294676fe65b96296a334c9ce107fa2142bd70f47acb265", size = 935745, upload-time = "2026-07-16T12:42:04.663Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/bb/49b10783f29067da2eec179320617e94faf63196609de47aeab3c26c3325/sentry_sdk-2.66.0-py3-none-any.whl", hash = "sha256:096136c214c602be2b323524d30755dc5b30ec5a218a206207f33b12c05c6f11", size = 504769, upload-time = "2026-07-16T12:42:02.919Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #63.

Wires the deployment into OCF's Sentry.io with two independent mechanisms, both **no-ops unless `SENTRY_DSN` is set**, so laptops and CI stay silent by default.

## What's here

**Error telemetry.** `init_sentry()` runs once per process at import of the Dagster definitions module (so it's active in the daemon, webserver, and every Fargate run worker). A Dagster `@failure_hook` (`sentry_capture_failure`, attached to the scheduled asset jobs) reports a failed step's real exception — traceback intact — from inside the run worker.

> **Why an explicit hook rather than Sentry's `LoggingIntegration` alone?** An adversarial review of the plan traced the installed Dagster: a step failure *is* logged at ERROR, but **without `exc_info`**, so a log-integration-only capture would produce a message-only event with no stack trace, and under `EcsRunLauncher` the exception never reaches `sys.excepthook`. The hook captures the live exception instead.

**Missed-check-in alarm** (the primary production alert). After each successful **live** `live_forecasts` run, the asset sends a single **success-only** heartbeat to a Sentry cron monitor. Sentry raises the alarm on the *absence* of a heartbeat past the margin (6-hourly schedule + ~2 h grace) — a dead daemon can't report itself. No `error` check-ins are sent, so in-band run errors (handled by the failure hook) and manual `replay` backfills (which reprocess the past) never trip the alarm.

## Laptop vs AWS separation

Sentry's `environment` tag is the split dimension:

- Box: `SENTRY_ENVIRONMENT=production`, `SENTRY_MONITOR_FORECASTS=true`.
- Developers: `SENTRY_ENVIRONMENT=<name>-laptop` (e.g. `jacks-laptop`, `alexs-laptop`), monitor flag left off.

The missed-check-in **alert rule is scoped to `environment:production`**, so an intermittently-run laptop never pages. To exercise the heartbeat path locally, a developer sets the flag and points at a **throwaway monitor slug** (`live-forecasts-test`) — never the production monitor, which would otherwise be left expecting a check-in a laptop won't keep sending. Documented in [Production Deployment → Send telemetry to Sentry](https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/#send-telemetry-to-sentry-and-alarm-on-absence).

## Also in this PR

- Sentry fields added to `contracts.Settings` (`sentry_dsn`, `sentry_environment`, `sentry_traces_sample_rate`, `sentry_monitor_forecasts`).
- Removed a dead module-level `Settings()` in `definitions.py`; init now goes through `get_settings()`.
- Docs ship-time triage: as-built section + laptop/AWS split in `production-deployment.md`; roadmap status + table updated; `checks.py` freshness→Sentry docstring retargeted to the durable doc; AWS runbook gains the `SENTRY_*` vars and the alert-rule-scoping step.

## Follow-up (separate PR, immediately after merge)
Route `power_data_is_fresh`'s already-computed `PowerFreshnessResult` to Sentry (reusing the seam, no second computation) — the NGED feed is the most likely production failure.

## Verification
- `ruff`, `ty`, `pymarkdown`, `mkdocs build --strict` all clean.
- New `tests/test_sentry.py` (7) — no-op-without-DSN, environment passthrough, heartbeat gating, failure-hook capture.
- Extended `tests/test_live_forecasts.py` — heartbeat sent on live, **not** on replay.
- **Not yet done: the empirical laptop end-to-end run** against a real Sentry project — to confirm a forced asset failure produces a traceback-bearing event under `environment:<name>-laptop`, and a heartbeat lands under a throwaway slug. This is the real acceptance test for the failure-hook path and is best run by a human with the DSN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)