### PR TITLE
Route NGED power-data staleness to Sentry as a warning

### DIFF
--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -124,10 +124,13 @@ is configured — so laptops and CI stay silent by default.
   (`["nged-power-data-stale", <environment>]`) — Sentry's `environment` is a filter facet, not a
   grouping key, so without the environment in the fingerprint every deployment would share one
   issue; with it, each deployment gets its own ongoing issue, and the hourly re-reports of a
-  continuing stall collapse into that one issue rather than a fresh issue each hour. The per-series
-  detail is attached as event context, capped so a whole-feed stall at V2 scale can't attach
-  thousands of rows (the true late count is always carried by the `n_late` tag). Sending is
-  best-effort: `report_power_freshness` never raises, so a Sentry hiccup can't fail the
+  continuing stall collapse into that one issue rather than a fresh issue each hour. The message
+  body lists the late series and how late each is (`series 12: 48.5h late (last seen …)`, or `never
+  reported`), and the full per-series detail is attached as structured event context. Both are
+  capped — the message to a short leading slice with an `…and N more` line, the context to a larger
+  slice — so a whole-feed stall at V2 scale can't attach thousands of rows; the true late count is
+  always carried by the `n_late` tag, so a capped list never makes a large stall look small. Sending
+  is best-effort: `report_power_freshness` never raises, so a Sentry hiccup can't fail the
   `blocking=False` check (which, inside the hooked hourly job, would otherwise trip the failure hook
   and fail the run).
 

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -84,10 +84,11 @@ This in-Dagster check is complementary to — not a replacement for — the
 [missed-check-in alarm](#send-telemetry-to-sentry-and-alarm-on-absence). The alarm fires on total
 silence from *outside* the deployment, because a dead daemon cannot report itself; this check
 reports per-series staleness from *inside* Dagster while the daemon is alive, and forwards that
-same staleness to Sentry as a warning (see [the freshness-warning bullet](#send-telemetry-to-sentry-and-alarm-on-absence)
-below). The freshness evaluation is a pure function, so the Sentry warning reuses the same
-`PowerFreshnessResult` the check already computed rather than recomputing it; the same result will
-later also feed the forecast-warnings delivery table.
+same staleness to Sentry as a warning (see the freshness-warning bullet under
+[Send telemetry to Sentry](#send-telemetry-to-sentry-and-alarm-on-absence)). The freshness
+evaluation is a pure function, so the Sentry warning reuses the same `PowerFreshnessResult` the
+check already computed rather than recomputing it; the same result will later also feed the
+forecast-warnings delivery table.
 
 ## Send telemetry to Sentry, and alarm on absence
 

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -83,15 +83,15 @@ assets.
 This in-Dagster check is complementary to — not a replacement for — the
 [missed-check-in alarm](#send-telemetry-to-sentry-and-alarm-on-absence). The alarm fires on total
 silence from *outside* the deployment, because a dead daemon cannot report itself; this check
-reports per-series staleness from *inside* Dagster while the daemon is alive. The freshness
-evaluation is a pure function, which makes it the natural hand-off point for routing per-series
-staleness to Sentry as well — reusing the same `PowerFreshnessResult` rather than recomputing it,
-an immediate follow-up to the initial Sentry telemetry work, and later the source for the
-forecast-warnings delivery table.
+reports per-series staleness from *inside* Dagster while the daemon is alive, and forwards that
+same staleness to Sentry as a warning (see [the freshness-warning bullet](#send-telemetry-to-sentry-and-alarm-on-absence)
+below). The freshness evaluation is a pure function, so the Sentry warning reuses the same
+`PowerFreshnessResult` the check already computed rather than recomputing it; the same result will
+later also feed the forecast-warnings delivery table.
 
 ## Send telemetry to Sentry, and alarm on absence
 
-Two independent Sentry mechanisms live in `nged_substation_forecast._sentry`, and both are active
+Three independent Sentry mechanisms live in `nged_substation_forecast._sentry`, all active
 in every Dagster process (daemon, webserver, and each Fargate run worker) only when a `SENTRY_DSN`
 is configured — so laptops and CI stay silent by default.
 
@@ -114,6 +114,29 @@ is configured — so laptops and CI stay silent by default.
   Only *success* heartbeats are ever sent (never an `error` check-in), so the alarm keys purely off
   absence: an in-band run error is the failure hook's job, and a manual `replay` backfill — which
   reprocesses the past rather than proving the service is live now — deliberately does not check in.
+
+- **Freshness warnings.** When the `power_data_is_fresh` asset check finds late series,
+  `report_power_freshness` forwards that per-series staleness to Sentry as a `warning`-level event,
+  reusing the `PowerFreshnessResult` the check already computed. It is gated on the DSN (like error
+  telemetry, not the heartbeat flag), so it fires from wherever a configured environment runs the
+  hourly check, separated by the `environment` tag. The event is fingerprinted **per environment**
+  (`["nged-power-data-stale", <environment>]`) — Sentry's `environment` is a filter facet, not a
+  grouping key, so without the environment in the fingerprint every deployment would share one
+  issue; with it, each deployment gets its own ongoing issue, and the hourly re-reports of a
+  continuing stall collapse into that one issue rather than a fresh issue each hour. The per-series
+  detail is attached as event context, capped so a whole-feed stall at V2 scale can't attach
+  thousands of rows (the true late count is always carried by the `n_late` tag). Sending is
+  best-effort: `report_power_freshness` never raises, so a Sentry hiccup can't fail the
+  `blocking=False` check (which, inside the hooked hourly job, would otherwise trip the failure hook
+  and fail the run).
+
+  Freshness is a *two-way* state (stale ↔ recovered) modelled with a *one-way* primitive: a warning
+  event has no "resolved" counterpart. So **recovery is signalled by the events stopping** — the
+  issue's "last seen" timestamp stops advancing — and the operator resolves the issue by hand. The
+  production alert rule should fire on *regressions* (and the project's Sentry auto-resolve window
+  kept short) so that a fresh stall after a recovery re-pages rather than silently appending to a
+  stale-but-unresolved issue. This is a deliberate trade: the missed-check-in alarm above is the
+  primary two-directional signal; this warning is the richer per-series breadcrumb layered on top.
 
 ### Separating laptop telemetry from production
 

--- a/docs/live_service/sentry.md
+++ b/docs/live_service/sentry.md
@@ -113,9 +113,10 @@ Then check the Sentry UI:
 - **Issues**, filtered to `environment:<your-name>-laptop` — two events: a `ValueError: laptop
   Sentry acceptance test…` with a full stack trace (a traceback, not a message-only event, is the
   point — it confirms the failure hook forwards the live exception rather than relying on log
-  capture), and a `NGED power data stale: 1/1 time series late…` warning carrying the per-series
-  context. Both are fingerprinted with your `<your-name>-laptop` environment, so they form their
-  own issues, separate from production's.
+  capture), and a `NGED power data stale: 1/1 time series late…` warning whose message lists the
+  late series and how late each is (here, `series 999: 9999.0h late …`) with the full per-series
+  detail also in the event context. Both events are fingerprinted with your `<your-name>-laptop`
+  environment, so they form their own issues, separate from production's.
 - **Crons → `live-forecasts-test`** — one OK check-in.
 
 Once you are satisfied, delete the throwaway `live-forecasts-test` monitor in Sentry (and

--- a/docs/live_service/sentry.md
+++ b/docs/live_service/sentry.md
@@ -113,10 +113,17 @@ Dagster on your laptop does **not** forward everything to Sentry:
 - **No heartbeats are sent.** The live check-in is gated on `SENTRY_MONITOR_FORECASTS`, which you
   have left unset (see the warning above), so your laptop sends no cron check-ins and cannot touch
   the production `live-forecasts` monitor.
+- **Freshness warnings *are* sent — if your local power data is stale.** Whenever the
+  `power_data_is_fresh` asset check runs (alongside every `power_time_series_and_metadata`
+  materialisation) and finds any series past the staleness threshold, it forwards a `warning`-level
+  event to Sentry. This is gated on the DSN, not the heartbeat flag, so a laptop with a stale local
+  Delta table *will* emit one. It can't pollute production's issue, though: the event is
+  fingerprinted per environment, so your `<name>-laptop` staleness forms its own Sentry issue,
+  separate from production's. Resolve or ignore it as you like.
 
-This is the same scope that runs in production; the [design page](../architecture/production-deployment.md#send-telemetry-to-sentry-and-alarm-on-absence)
-explains why the failure hook covers only the scheduled jobs and why only success heartbeats are
-ever sent.
+The failure hook and heartbeat scope is the same in production; the [design page](../architecture/production-deployment.md#send-telemetry-to-sentry-and-alarm-on-absence)
+explains why the failure hook covers only the scheduled jobs, why only success heartbeats are ever
+sent, and how the freshness warning models recovery.
 
 ## Turn it on in production
 
@@ -130,12 +137,20 @@ SENTRY_MONITOR_FORECASTS=true
 ```
 
 `SENTRY_MONITOR_FORECASTS=true` makes each successful live `live_forecasts` run check in to the
-production `live-forecasts` monitor. Two one-time console steps complete the setup:
+production `live-forecasts` monitor. Three one-time console steps complete the setup:
 
 1. The monitor is created automatically on the first check-in (the code sends its schedule and
    margin with every heartbeat), so no manual monitor creation is needed.
 2. **Scope the missed-check-in alert rule to `environment:production`** in Sentry, so a developer
    testing from a laptop can never trip the production alarm.
+3. **Add an alert rule for the freshness warning, also scoped to `environment:production`, and set
+   it to fire on *regressions*.** The freshness warning is a one-way event: when NGED's feed
+   recovers, the code simply stops sending, so the Sentry issue's "last seen" timestamp stops
+   advancing but the issue stays open until someone resolves it. Resolve it once you've confirmed
+   recovery. Firing on regressions (plus a short project-level auto-resolve window) means a *new*
+   stall after a recovery re-pages instead of silently appending to the old, unresolved issue. This
+   warning is a richer per-series breadcrumb layered on top of the missed-check-in alarm, which
+   remains the primary two-directional signal.
 
 One handover note: the Sentry account is OCF's today, so at handover the alert routing (and
 possibly the account itself) moves to NGED — see

--- a/docs/live_service/sentry.md
+++ b/docs/live_service/sentry.md
@@ -47,19 +47,25 @@ The verification below sends its heartbeat to a throwaway monitor slug instead.
 
 ## Verify it works from your laptop
 
-Save this script and run it with `uv run python <file>`. It exercises the two real code paths — the
-failure hook and the heartbeat — and flushes so the events reach Sentry before the process exits:
+Save this script and run it with `uv run python <file>`. It exercises the three real code paths —
+the failure hook, the heartbeat, and the freshness warning — and flushes so the events reach Sentry
+before the process exits:
 
 ```python
+from datetime import datetime, timezone
+
+import polars as pl
 import sentry_sdk
 from contracts.settings import Settings
 from dagster import job, op
 
 from nged_substation_forecast._sentry import (
     init_sentry,
+    report_power_freshness,
     send_forecast_checkin,
     sentry_capture_failure,
 )
+from nged_substation_forecast.defs.checks import PowerFreshnessResult
 
 TEST_MONITOR_SLUG = "live-forecasts-test"  # a throwaway slug — never the production monitor
 
@@ -74,6 +80,23 @@ def _sentry_smoke_job() -> None:
     _intended_failure()
 
 
+# A synthetic "one series is late" result, so report_power_freshness has something to send.
+_stale_result = PowerFreshnessResult(
+    n_series_total=1,
+    n_stale=1,
+    n_never=0,
+    threshold_hours=24.0,
+    late=pl.DataFrame(
+        {
+            "time_series_id": pl.Series([999], dtype=pl.Int32),
+            "last_seen": pl.Series([datetime(2000, 1, 1, tzinfo=timezone.utc)]),
+            "hours_late": pl.Series([9999.0], dtype=pl.Float64),
+            "status": pl.Series(["stale"]),
+        }
+    ),
+)
+
+
 settings = Settings()
 if not settings.sentry_dsn:
     raise SystemExit("No SENTRY_DSN in .env — nothing to test.")
@@ -81,18 +104,22 @@ if not settings.sentry_dsn:
 init_sentry(settings)
 _sentry_smoke_job.execute_in_process(raise_on_error=False)  # fires the failure hook
 send_forecast_checkin(Settings(sentry_monitor_forecasts=True), monitor_slug=TEST_MONITOR_SLUG)
+report_power_freshness(settings, _stale_result)  # fires the freshness warning
 sentry_sdk.flush(timeout=10)
 ```
 
 Then check the Sentry UI:
 
-- **Issues**, filtered to `environment:<your-name>-laptop` — a `ValueError: laptop Sentry
-  acceptance test…` with a full stack trace. A traceback (not a message-only event) is the point:
-  it confirms the failure hook forwards the live exception rather than relying on log capture.
+- **Issues**, filtered to `environment:<your-name>-laptop` — two events: a `ValueError: laptop
+  Sentry acceptance test…` with a full stack trace (a traceback, not a message-only event, is the
+  point — it confirms the failure hook forwards the live exception rather than relying on log
+  capture), and a `NGED power data stale: 1/1 time series late…` warning carrying the per-series
+  context. Both are fingerprinted with your `<your-name>-laptop` environment, so they form their
+  own issues, separate from production's.
 - **Crons → `live-forecasts-test`** — one OK check-in.
 
 Once you are satisfied, delete the throwaway `live-forecasts-test` monitor in Sentry (and
-optionally resolve the test issue). Neither affects the production wiring.
+optionally resolve the two test issues). Neither affects the production wiring.
 
 ## What gets sent when you run Dagster locally
 

--- a/src/nged_substation_forecast/_sentry.py
+++ b/src/nged_substation_forecast/_sentry.py
@@ -1,6 +1,6 @@
-"""Sentry.io telemetry: error reporting and the missed-check-in alarm.
+"""Sentry.io telemetry: error reporting, the missed-check-in alarm, and freshness warnings.
 
-Two independent mechanisms, both no-ops when Sentry is unconfigured, so laptops and CI need no
+Three independent mechanisms, all no-ops when Sentry is unconfigured, so laptops and CI need no
 Sentry configuration:
 
 - **Error telemetry** — :func:`init_sentry` initialises the SDK once per process (a no-op unless
@@ -16,6 +16,12 @@ Sentry configuration:
   never heartbeats the production monitor. Sentry fires the alarm on the *absence* of a heartbeat
   past the margin (a dead daemon cannot report itself); in-band run errors are handled by the
   failure hook above, never by this heartbeat.
+- **Freshness warnings** — :func:`report_power_freshness` forwards the ``power_data_is_fresh`` asset
+  check's per-series staleness to Sentry as a *warning*-level event when any series is late. Gated
+  on the DSN like error telemetry (not the heartbeat flag), and fingerprinted per environment so
+  each deployment gets its own ongoing issue. Because a warning event models only one direction of
+  a two-way state (stale vs recovered), recovery is signalled by the events *stopping* and is
+  resolved by the operator — see the design page's freshness section.
 
 The ``environment`` tag (``Settings.sentry_environment``) separates deployments: ``production`` on
 the always-on box, ``<name>-laptop`` on each developer's machine. The alarm's alert rule is scoped
@@ -23,6 +29,7 @@ to ``environment:production`` so intermittently-run laptops never page. See
 [Production Deployment](https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/).
 """
 
+import logging
 from typing import TYPE_CHECKING, Final
 
 import sentry_sdk
@@ -33,6 +40,14 @@ from sentry_sdk.crons.consts import MonitorStatus
 
 if TYPE_CHECKING:
     from sentry_sdk._types import MonitorConfig
+
+    # Type-only import: importing this at runtime would be circular (defs/checks.py imports
+    # report_power_freshness from this module). Annotate as a string below. Deferring the pure
+    # freshness core into its own module — so this could be a real import — is left until a second
+    # consumer (the forecast-warnings delivery table) actually lands.
+    from nged_substation_forecast.defs.checks import PowerFreshnessResult
+
+logger = logging.getLogger(__name__)
 
 LIVE_FORECAST_MONITOR_SLUG: Final[str] = "live-forecasts"
 """Slug of the Sentry cron monitor fed by ``live_forecasts``' success heartbeat.
@@ -119,3 +134,89 @@ def send_forecast_checkin(
         status=MonitorStatus.OK,
         monitor_config=LIVE_FORECAST_MONITOR_CONFIG,
     )
+
+
+POWER_DATA_STALE_FINGERPRINT: Final[str] = "nged-power-data-stale"
+"""Stable fingerprint root for the power-data staleness warning.
+
+Combined with ``Settings.sentry_environment`` (see :func:`report_power_freshness`) so every
+deployment gets its *own* ongoing Sentry issue — Sentry's ``environment`` is a filter facet, not a
+grouping dimension, so without the environment in the fingerprint every deployment (production and
+each ``<name>-laptop``) would share one issue. A stable fingerprint also collapses the hourly
+re-reports of an ongoing stall into that single issue rather than a fresh issue each hour."""
+
+MAX_LATE_SERIES_IN_CONTEXT: Final[int] = 50
+"""Cap on the number of late series listed in the Sentry event context.
+
+Keeps the payload small at V2 scale (~2,500 series) where a whole-feed stall would otherwise attach
+thousands of rows. The *true* late count is always carried by the ``n_late`` tag and context field,
+so a capped list never makes a large stall look like a small one."""
+
+
+def report_power_freshness(settings: Settings, result: "PowerFreshnessResult") -> None:
+    """Forward per-series power-data staleness to Sentry as a warning, or do nothing if healthy.
+
+    A no-op when Sentry is unconfigured (empty ``settings.sentry_dsn``) or when no series is late
+    (``result.is_healthy``), so a healthy feed and an un-configured environment both stay silent.
+    Sends a single ``warning``-level event fingerprinted per environment; the hourly re-reports of
+    an ongoing stall collapse into one issue, and recovery is signalled by the events stopping (a
+    warning event has no "resolved" counterpart — the operator resolves the issue). Never raises:
+    telemetry must not fail the ``blocking=False`` freshness check, which — inside the hooked
+    ``power_time_series_and_metadata_job`` — would otherwise trip the failure hook and fail the run.
+
+    Args:
+        settings: The project settings carrying the Sentry DSN and environment.
+        result: The freshness evaluation to report, reused verbatim from the asset check (never
+            recomputed).
+    """
+    if not settings.sentry_dsn or result.is_healthy:
+        return
+    try:
+        _capture_power_freshness_warning(settings, result)
+    except Exception:
+        # Catch-all is deliberate: telemetry is best-effort and must never fail the check. Log at
+        # ERROR with the traceback (not a silent swallow) so a genuine bug — e.g. in the payload
+        # build over result.late — is still visible.
+        logger.exception("Failed to report power-data freshness to Sentry")
+
+
+def _capture_power_freshness_warning(settings: Settings, result: "PowerFreshnessResult") -> None:
+    """Build and send the freshness warning event on an isolated Sentry scope.
+
+    Split from :func:`report_power_freshness` so the latter's ``try``/``except`` wraps the whole
+    payload build (iterating ``result.late``), not only the network send — a bug in the payload is
+    the likelier raiser than ``capture_message`` itself.
+    """
+    late_preview = result.late.head(MAX_LATE_SERIES_IN_CONTEXT)
+    late_series = [
+        {
+            "time_series_id": row["time_series_id"],
+            "last_seen": "never" if row["last_seen"] is None else str(row["last_seen"]),
+            "hours_late": None if row["hours_late"] is None else round(row["hours_late"], 1),
+            "status": row["status"],
+        }
+        for row in late_preview.iter_rows(named=True)
+    ]
+    with sentry_sdk.new_scope() as scope:
+        scope.fingerprint = [POWER_DATA_STALE_FINGERPRINT, settings.sentry_environment]
+        scope.set_tag("n_late", result.n_late)
+        scope.set_tag("n_stale", result.n_stale)
+        scope.set_tag("n_never_reported", result.n_never)
+        scope.set_context(
+            "power_freshness",
+            {
+                "n_late": result.n_late,
+                "n_stale": result.n_stale,
+                "n_never_reported": result.n_never,
+                "n_series_total": result.n_series_total,
+                "threshold_hours": result.threshold_hours,
+                "late_series_shown": len(late_series),
+                "late_series": late_series,
+            },
+        )
+        sentry_sdk.capture_message(
+            f"NGED power data stale: {result.n_late}/{result.n_series_total} time series late "
+            f"({result.n_stale} stale >{result.threshold_hours:.0f}h, "
+            f"{result.n_never} never reported)",
+            level="warning",
+        )

--- a/src/nged_substation_forecast/_sentry.py
+++ b/src/nged_substation_forecast/_sentry.py
@@ -30,7 +30,7 @@ to ``environment:production`` so intermittently-run laptops never page. See
 """
 
 import logging
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Final, TypedDict
 
 import sentry_sdk
 from contracts.settings import Settings
@@ -146,11 +146,28 @@ each ``<name>-laptop``) would share one issue. A stable fingerprint also collaps
 re-reports of an ongoing stall into that single issue rather than a fresh issue each hour."""
 
 MAX_LATE_SERIES_IN_CONTEXT: Final[int] = 50
-"""Cap on the number of late series listed in the Sentry event context.
+"""Cap on the number of late series listed in the Sentry event *context* (the structured payload).
 
 Keeps the payload small at V2 scale (~2,500 series) where a whole-feed stall would otherwise attach
 thousands of rows. The *true* late count is always carried by the ``n_late`` tag and context field,
 so a capped list never makes a large stall look like a small one."""
+
+MAX_LATE_SERIES_IN_MESSAGE: Final[int] = 20
+"""Cap on the number of late series spelled out in the human-readable *message* body.
+
+Smaller than the context cap: the message is the at-a-glance view (Sentry uses its first line as the
+issue title), so it lists only the leading late series and how late each is, with an ``…and N more``
+line pointing at the fuller context when it overflows."""
+
+
+class _LateSeriesEntry(TypedDict):
+    """One late series in the freshness event: its id, when last seen (``"never"`` if it never
+    reported), how many hours late it is (``None`` if never reported), and its status."""
+
+    time_series_id: int
+    last_seen: str
+    hours_late: float | None
+    status: str
 
 
 def report_power_freshness(settings: Settings, result: "PowerFreshnessResult") -> None:
@@ -188,7 +205,7 @@ def _capture_power_freshness_warning(settings: Settings, result: "PowerFreshness
     the likelier raiser than ``capture_message`` itself.
     """
     late_preview = result.late.head(MAX_LATE_SERIES_IN_CONTEXT)
-    late_series = [
+    late_series: list[_LateSeriesEntry] = [
         {
             "time_series_id": row["time_series_id"],
             "last_seen": "never" if row["last_seen"] is None else str(row["last_seen"]),
@@ -214,9 +231,36 @@ def _capture_power_freshness_warning(settings: Settings, result: "PowerFreshness
                 "late_series": late_series,
             },
         )
-        sentry_sdk.capture_message(
-            f"NGED power data stale: {result.n_late}/{result.n_series_total} time series late "
-            f"({result.n_stale} stale >{result.threshold_hours:.0f}h, "
-            f"{result.n_never} never reported)",
-            level="warning",
-        )
+        sentry_sdk.capture_message(_freshness_message(result, late_series), level="warning")
+
+
+def _freshness_message(result: "PowerFreshnessResult", late_series: list[_LateSeriesEntry]) -> str:
+    """Compose the warning message: a one-line summary (Sentry's issue title) followed by the
+    leading late series and how late each is.
+
+    The per-series lines are capped at :data:`MAX_LATE_SERIES_IN_MESSAGE`; if more series are late,
+    a trailing ``…and N more`` line reports the remainder (with the fuller list in the event's
+    ``power_freshness`` context). ``late_series`` is already ordered never-reported first, then
+    most-stale first, so the message leads with the worst offenders."""
+    summary = (
+        f"NGED power data stale: {result.n_late}/{result.n_series_total} time series late "
+        f"({result.n_stale} stale >{result.threshold_hours:.0f}h, {result.n_never} never reported)"
+    )
+    shown = late_series[:MAX_LATE_SERIES_IN_MESSAGE]
+    lines = [summary, *(_late_series_line(entry) for entry in shown)]
+    remaining = result.n_late - len(shown)
+    if remaining > 0:
+        lines.append(f"  …and {remaining} more (context lists up to {MAX_LATE_SERIES_IN_CONTEXT})")
+    return "\n".join(lines)
+
+
+def _late_series_line(entry: _LateSeriesEntry) -> str:
+    """One human-readable line for a late series: how many hours late it is, or that it never
+    reported (a null ``hours_late`` marks a never-reported series)."""
+    hours_late = entry["hours_late"]
+    if hours_late is None:
+        return f"  • series {entry['time_series_id']}: never reported"
+    return (
+        f"  • series {entry['time_series_id']}: {hours_late:.1f}h late "
+        f"(last seen {entry['last_seen']})"
+    )

--- a/src/nged_substation_forecast/defs/checks.py
+++ b/src/nged_substation_forecast/defs/checks.py
@@ -12,11 +12,12 @@ timestamp — the job succeeds hourly even when NGED publishes nothing, so only 
 would miss exactly the failure this check exists to catch.
 
 ``evaluate_power_freshness`` is a pure function so it is unit-testable without Dagster or Delta,
-and it is the hand-off point for routing per-series staleness to Sentry: a follow-up will feed the
-same ``PowerFreshnessResult`` to Sentry rather than recomputing it. The two mechanisms stay
-complementary — the [Sentry missed-check-in alarm](https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/#send-telemetry-to-sentry-and-alarm-on-absence)
-fires on total silence from outside the deployment, while this check reports per-series staleness
-from inside Dagster.
+and it is the hand-off point for routing per-series staleness to Sentry: the same
+``PowerFreshnessResult`` is fed to ``report_power_freshness`` (in ``nged_substation_forecast._sentry``)
+rather than recomputed. The two mechanisms stay complementary — the
+[Sentry missed-check-in alarm](https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/#send-telemetry-to-sentry-and-alarm-on-absence)
+fires on total silence from outside the deployment, while this check (and its Sentry warning) report
+per-series staleness from inside Dagster while the daemon is alive.
 """
 
 from dataclasses import dataclass
@@ -38,6 +39,7 @@ from dagster import (
 )
 from nged_data.storage import time_series_coverage
 
+from nged_substation_forecast._sentry import report_power_freshness
 from nged_substation_forecast.defs.assets import power_time_series_and_metadata
 
 _LATE_TABLE_SCHEMA: Final[TableSchema] = TableSchema(
@@ -97,7 +99,7 @@ def evaluate_power_freshness(
     """Classify each time series as fresh, stale, or never-reported.
 
     Pure and deterministic — no Dagster, Delta, or clock access — so it is unit-testable
-    directly and reusable by the future Sentry alarm.
+    directly and reused (not recomputed) by ``report_power_freshness`` for the Sentry warning.
 
     Args:
         coverage: One row per ``time_series_id`` that has data, carrying its most recent
@@ -251,4 +253,7 @@ def power_data_is_fresh() -> AssetCheckResult:
         now=datetime.now(timezone.utc),
         threshold=_POWER_DATA_STALENESS_THRESHOLD,
     )
+    # Forward per-series staleness to Sentry (a no-op unless a DSN is set and some series is late).
+    # Best-effort: report_power_freshness never raises, so a telemetry hiccup can't fail this check.
+    report_power_freshness(settings, result)
     return _to_asset_check_result(result)

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -217,38 +217,55 @@ def test_power_data_is_fresh_no_data_yet_warns(env: Path) -> None:
     assert result.metadata["n_series_total"].value == 0
 
 
-def test_power_data_is_fresh_hands_result_to_sentry(
+def test_power_data_is_fresh_hands_evaluated_result_to_sentry(
     env: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """The check hands its computed ``PowerFreshnessResult`` to ``report_power_freshness`` — reused,
-    not recomputed. The reporter self-gates on health (tested in ``test_sentry.py``), so the check
-    calls it unconditionally; here we assert the object it receives matches what the check evaluated
-    and returned."""
+    """The check forwards the *exact* ``PowerFreshnessResult`` it evaluated to
+    ``report_power_freshness`` — reused, not recomputed. We patch ``evaluate_power_freshness`` to
+    return a sentinel and assert *object identity* on the reporter's argument: asserting counts
+    alone would not prove reuse, since the pure function is deterministic and a recompute would
+    yield equal counts and pass a weaker test. The reporter self-gates on health (tested in
+    ``test_sentry.py``), so the check calls it unconditionally."""
     from contracts.settings import Settings
 
+    sentinel = PowerFreshnessResult(
+        n_series_total=8,
+        n_stale=7,
+        n_never=0,
+        threshold_hours=24.0,
+        late=pl.DataFrame(
+            {
+                "time_series_id": pl.Series(range(7), dtype=pl.Int32),
+                "last_seen": pl.Series([datetime(2020, 1, 1, tzinfo=timezone.utc)] * 7).cast(
+                    UTC_DATETIME_DTYPE
+                ),
+                "hours_late": pl.Series([9999.0] * 7, dtype=pl.Float64),
+                "status": pl.Series(["stale"] * 7),
+            }
+        ),
+    )
+    monkeypatch.setattr(checks, "evaluate_power_freshness", lambda **_: sentinel)
     captured: list[PowerFreshnessResult] = []
     monkeypatch.setattr(
         checks, "report_power_freshness", lambda settings, result: captured.append(result)
     )
 
+    # The check still reads coverage + roster before calling the (patched) evaluator, so a minimal
+    # Delta table and roster must exist for those reads to succeed.
     now = datetime.now(timezone.utc)
     settings = Settings()
     pl.DataFrame(
         {
-            "time_series_id": pl.Series([1, 2], dtype=pl.Int32),
-            "time": pl.Series([now - timedelta(hours=1), now - timedelta(hours=48)]).cast(
-                UTC_DATETIME_DTYPE
-            ),
-            "power": pl.Series([1.0, 2.0], dtype=pl.Float32),
+            "time_series_id": pl.Series([1], dtype=pl.Int32),
+            "time": pl.Series([now - timedelta(hours=1)]).cast(UTC_DATETIME_DTYPE),
+            "power": pl.Series([1.0], dtype=pl.Float32),
         }
     ).write_delta(settings.power_time_series_data_path)
-    _write_metadata_roster(settings.metadata_path, ids=[1, 2, 99])
+    _write_metadata_roster(settings.metadata_path, ids=[1])
 
-    result = checks.power_data_is_fresh()
-    assert isinstance(result, AssetCheckResult)
+    check_result = checks.power_data_is_fresh()
+    assert isinstance(check_result, AssetCheckResult)
     assert len(captured) == 1
-    reported = captured[0]
-    assert isinstance(reported, PowerFreshnessResult)
-    # The reported object carries the same counts the check turned into its returned metadata.
-    assert reported.n_stale == 1 and reported.n_never == 1
-    assert reported.n_late == result.metadata["n_late"].value == 2
+    assert captured[0] is sentinel  # the exact evaluated object, not a recomputation
+    # ...and that same object drove the returned check result (n_late == n_stale + n_never == 7).
+    assert check_result.metadata["n_late"].value == 7

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -215,3 +215,40 @@ def test_power_data_is_fresh_no_data_yet_warns(env: Path) -> None:
     assert result.passed is False
     assert result.severity == AssetCheckSeverity.WARN
     assert result.metadata["n_series_total"].value == 0
+
+
+def test_power_data_is_fresh_hands_result_to_sentry(
+    env: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The check hands its computed ``PowerFreshnessResult`` to ``report_power_freshness`` — reused,
+    not recomputed. The reporter self-gates on health (tested in ``test_sentry.py``), so the check
+    calls it unconditionally; here we assert the object it receives matches what the check evaluated
+    and returned."""
+    from contracts.settings import Settings
+
+    captured: list[PowerFreshnessResult] = []
+    monkeypatch.setattr(
+        checks, "report_power_freshness", lambda settings, result: captured.append(result)
+    )
+
+    now = datetime.now(timezone.utc)
+    settings = Settings()
+    pl.DataFrame(
+        {
+            "time_series_id": pl.Series([1, 2], dtype=pl.Int32),
+            "time": pl.Series([now - timedelta(hours=1), now - timedelta(hours=48)]).cast(
+                UTC_DATETIME_DTYPE
+            ),
+            "power": pl.Series([1.0, 2.0], dtype=pl.Float32),
+        }
+    ).write_delta(settings.power_time_series_data_path)
+    _write_metadata_roster(settings.metadata_path, ids=[1, 2, 99])
+
+    result = checks.power_data_is_fresh()
+    assert isinstance(result, AssetCheckResult)
+    assert len(captured) == 1
+    reported = captured[0]
+    assert isinstance(reported, PowerFreshnessResult)
+    # The reported object carries the same counts the check turned into its returned metadata.
+    assert reported.n_stale == 1 and reported.n_never == 1
+    assert reported.n_late == result.metadata["n_late"].value == 2

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -203,6 +203,8 @@ def test_report_power_freshness_sends_warning_with_fingerprint_and_context(
     # Environment IS in the fingerprint: Sentry's environment is a filter facet, not a grouping
     # dimension, so this is what gives each deployment its own issue.
     assert call["fingerprint"] == [_sentry.POWER_DATA_STALE_FINGERPRINT, "jacks-laptop"]
+    # These are the python ints on the pre-serialization scope; Sentry str()s tag values on the
+    # wire, so in the UI they filter as e.g. `n_late:3`.
     assert call["tags"] == {"n_late": 3, "n_stale": 2, "n_never_reported": 1}
     ctx = call["contexts"]["power_freshness"]
     assert ctx["n_late"] == 3

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -211,7 +211,13 @@ def test_report_power_freshness_sends_warning_with_fingerprint_and_context(
     assert ctx["n_series_total"] == 32
     assert ctx["late_series_shown"] == 3
     assert len(ctx["late_series"]) == 3
-    assert "3/32" in call["message"]
+    # The message spells out the summary AND each late series with how late it is.
+    message = call["message"]
+    assert "3/32" in message
+    assert "series 0: 30.0h late" in message
+    assert "last seen 2026-07-01" in message
+    assert "series 2: never reported" in message
+    assert "…and" not in message  # all 3 fit under the message cap, so no overflow line
 
 
 def test_report_power_freshness_caps_context_but_keeps_true_total(
@@ -230,6 +236,23 @@ def test_report_power_freshness_caps_context_but_keeps_true_total(
     assert ctx["late_series_shown"] == _sentry.MAX_LATE_SERIES_IN_CONTEXT
     assert ctx["n_late"] == n_stale  # true total preserved
     assert call["tags"]["n_late"] == n_stale
+
+
+def test_report_power_freshness_caps_series_listed_in_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """More late series than the message cap ⇒ the message spells out only the leading
+    ``MAX_LATE_SERIES_IN_MESSAGE`` and reports the rest as an ``…and N more`` line."""
+    calls = _capture_message_recorder(monkeypatch)
+    n_stale = _sentry.MAX_LATE_SERIES_IN_MESSAGE + 5
+    _sentry.report_power_freshness(
+        _settings(sentry_dsn=_DSN), _freshness_result(n_stale=n_stale, n_total=n_stale)
+    )
+    (call,) = calls
+    message = call["message"]
+    series_lines = [line for line in message.splitlines() if "• series" in line]
+    assert len(series_lines) == _sentry.MAX_LATE_SERIES_IN_MESSAGE
+    assert "…and 5 more" in message
 
 
 def test_report_power_freshness_swallows_and_logs_on_send_error(

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -5,18 +5,73 @@ two invariants that matter: everything is a no-op unless explicitly enabled, and
 right Sentry call is made with the right arguments.
 """
 
+import logging
+from datetime import datetime, timezone
 from typing import Any
 
+import polars as pl
 import pytest
+from contracts.common import UTC_DATETIME_DTYPE
 from contracts.settings import Settings
 from dagster import build_hook_context
 
 from nged_substation_forecast import _sentry
+from nged_substation_forecast.defs.checks import PowerFreshnessResult
+
+_DSN = "https://k@o1.ingest.sentry.io/1"
 
 
 def _settings(**overrides: Any) -> Settings:
     """Build a ``Settings`` with Sentry fields overridden (nged creds come from the conftest)."""
     return Settings(**overrides)
+
+
+def _freshness_result(
+    *, n_stale: int, n_never: int = 0, n_total: int = 100
+) -> PowerFreshnessResult:
+    """Build a ``PowerFreshnessResult`` with ``n_stale`` stale + ``n_never`` never-reported rows.
+
+    The ``late`` frame mirrors what ``evaluate_power_freshness`` produces (stale rows carry a
+    ``last_seen``/``hours_late``; never rows carry nulls), so the reporter's row-iteration is
+    exercised realistically."""
+    n_late = n_stale + n_never
+    late = pl.DataFrame(
+        {
+            "time_series_id": pl.Series(range(n_late), dtype=pl.Int32),
+            "last_seen": pl.Series(
+                [datetime(2026, 7, 1, tzinfo=timezone.utc)] * n_stale + [None] * n_never
+            ).cast(UTC_DATETIME_DTYPE),
+            "hours_late": pl.Series([30.0] * n_stale + [None] * n_never, dtype=pl.Float64),
+            "status": pl.Series(["stale"] * n_stale + ["never"] * n_never),
+        }
+    )
+    return PowerFreshnessResult(
+        n_series_total=n_total, n_stale=n_stale, n_never=n_never, threshold_hours=24.0, late=late
+    )
+
+
+def _capture_message_recorder(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Patch ``capture_message`` to snapshot the *current scope* at call time.
+
+    ``report_power_freshness`` sends inside ``with sentry_sdk.new_scope()``, so the current scope
+    when ``capture_message`` fires is the forked scope carrying the fingerprint/tags/context we want
+    to assert on (verified: ``get_current_scope()`` is that same object inside the block)."""
+    calls: list[dict[str, Any]] = []
+
+    def fake(message: str, level: str | None = None, **_: Any) -> None:
+        scope = _sentry.sentry_sdk.get_current_scope()
+        calls.append(
+            {
+                "message": message,
+                "level": level,
+                "fingerprint": scope._fingerprint,
+                "tags": dict(scope._tags),
+                "contexts": dict(scope._contexts),
+            }
+        )
+
+    monkeypatch.setattr(_sentry.sentry_sdk, "capture_message", fake)
+    return calls
 
 
 def test_init_sentry_is_noop_without_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -117,3 +172,87 @@ def test_monitor_config_schedule_matches_live_partitions() -> None:
         _sentry.LIVE_FORECAST_MONITOR_CONFIG["schedule"]["value"]
         == live_forecast_partitions.cron_schedule
     )
+
+
+def test_report_power_freshness_noop_without_dsn(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No DSN (the default) ⇒ no warning is sent even when series are late."""
+    calls = _capture_message_recorder(monkeypatch)
+    _sentry.report_power_freshness(_settings(sentry_dsn=""), _freshness_result(n_stale=3))
+    assert calls == []
+
+
+def test_report_power_freshness_noop_when_healthy(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A DSN but no late series ⇒ nothing sent (the reporter self-gates on health)."""
+    calls = _capture_message_recorder(monkeypatch)
+    _sentry.report_power_freshness(_settings(sentry_dsn=_DSN), _freshness_result(n_stale=0))
+    assert calls == []
+
+
+def test_report_power_freshness_sends_warning_with_fingerprint_and_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """DSN + late series ⇒ one warning, fingerprinted per environment, with counts as tags/context."""
+    calls = _capture_message_recorder(monkeypatch)
+    _sentry.report_power_freshness(
+        _settings(sentry_dsn=_DSN, sentry_environment="jacks-laptop"),
+        _freshness_result(n_stale=2, n_never=1, n_total=32),
+    )
+    assert len(calls) == 1
+    (call,) = calls
+    assert call["level"] == "warning"
+    # Environment IS in the fingerprint: Sentry's environment is a filter facet, not a grouping
+    # dimension, so this is what gives each deployment its own issue.
+    assert call["fingerprint"] == [_sentry.POWER_DATA_STALE_FINGERPRINT, "jacks-laptop"]
+    assert call["tags"] == {"n_late": 3, "n_stale": 2, "n_never_reported": 1}
+    ctx = call["contexts"]["power_freshness"]
+    assert ctx["n_late"] == 3
+    assert ctx["n_series_total"] == 32
+    assert ctx["late_series_shown"] == 3
+    assert len(ctx["late_series"]) == 3
+    assert "3/32" in call["message"]
+
+
+def test_report_power_freshness_caps_context_but_keeps_true_total(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A whole-feed stall (more late series than the cap) ⇒ the listed rows are capped, but the
+    true late count still surfaces via the tag and count field, so a big stall never looks small."""
+    calls = _capture_message_recorder(monkeypatch)
+    n_stale = _sentry.MAX_LATE_SERIES_IN_CONTEXT + 10
+    _sentry.report_power_freshness(
+        _settings(sentry_dsn=_DSN), _freshness_result(n_stale=n_stale, n_total=n_stale)
+    )
+    (call,) = calls
+    ctx = call["contexts"]["power_freshness"]
+    assert len(ctx["late_series"]) == _sentry.MAX_LATE_SERIES_IN_CONTEXT  # list capped
+    assert ctx["late_series_shown"] == _sentry.MAX_LATE_SERIES_IN_CONTEXT
+    assert ctx["n_late"] == n_stale  # true total preserved
+    assert call["tags"]["n_late"] == n_stale
+
+
+def test_report_power_freshness_swallows_and_logs_on_send_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A Sentry send error must not propagate (it would fail the data-health check and trip the
+    failure hook), but it must be logged at ERROR with a traceback rather than silently swallowed."""
+
+    def boom(*_: Any, **__: Any) -> None:
+        raise RuntimeError("sentry down")
+
+    monkeypatch.setattr(_sentry.sentry_sdk, "capture_message", boom)
+    with caplog.at_level(logging.ERROR, logger="nged_substation_forecast._sentry"):
+        _sentry.report_power_freshness(_settings(sentry_dsn=_DSN), _freshness_result(n_stale=1))
+    assert any(
+        "freshness" in r.message.lower() and r.levelno == logging.ERROR for r in caplog.records
+    )
+    assert any(r.exc_info is not None for r in caplog.records)  # traceback attached
+
+
+def test_report_power_freshness_does_not_leak_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The fingerprint/context live on an isolated ``new_scope()`` — after the call the current
+    scope carries neither, so a later unrelated ``capture_exception`` can't inherit them."""
+    _capture_message_recorder(monkeypatch)
+    _sentry.report_power_freshness(_settings(sentry_dsn=_DSN), _freshness_result(n_stale=1))
+    scope = _sentry.sentry_sdk.get_current_scope()
+    assert scope._fingerprint is None
+    assert scope._contexts.get("power_freshness") is None


### PR DESCRIPTION
Follow-up to #63 (the Sentry telemetry work). Adds a third Sentry mechanism alongside error telemetry and the missed-check-in alarm: **freshness warnings**.

## What
The `power_data_is_fresh` asset check already computes a per-series `PowerFreshnessResult` every hour. This PR forwards it to Sentry via `report_power_freshness` (in `_sentry.py`) when any series is late, so a stalled NGED feed surfaces in OCF's Sentry — not only in Dagster's Checks UI. The check reuses the same result verbatim (no recomputation).

## Design decisions
- **Sentry primitive:** one `warning`-level `capture_message`, not an exception or a check-in.
- **Gating:** on the DSN (like error telemetry), not the heartbeat flag; separated by the `environment` tag.
- **Grouping:** fingerprinted **per environment** — `["nged-power-data-stale", <environment>]`. Sentry's `environment` is a filter facet, not a grouping key, so the environment must be *in* the fingerprint for each deployment to get its own ongoing issue (and for the hourly re-reports of a continuing stall to collapse into it rather than spawn a fresh issue each hour).
- **Payload cap:** per-series detail is context, capped at `MAX_LATE_SERIES_IN_CONTEXT` so a whole-feed stall at V2 scale (~2,500 series) can't attach thousands of rows; the true late count is always carried by the `n_late` tag.
- **Best-effort:** `report_power_freshness` never raises — a Sentry hiccup must not fail the `blocking=False` check and trip the failure hook. Errors log at ERROR with a traceback rather than silently swallowing.
- **Recovery:** freshness is a two-way state (stale ↔ recovered) modelled with a one-way primitive, so recovery is signalled by the events *stopping* and the operator resolves the issue; the production alert rule fires on regressions. Documented on the design page and the Sentry how-to.

## Structure
The runtime import stays one-directional (`checks.py` → `_sentry.py`); `_sentry.py` imports `PowerFreshnessResult` only under `TYPE_CHECKING` to avoid the cycle (the same trick already used for `MonitorConfig`). Extracting the pure freshness core into its own module is **deferred** until the forecast-warnings delivery table gives it a second consumer.

## Tests
- `test_sentry.py`: no-op without DSN; no-op when healthy; warning sent with per-environment fingerprint + tags + context; context cap keeps the true total; send-error is swallowed and logged at ERROR with a traceback; scope isolation (no fingerprint/context leak after the call).
- `test_checks.py`: the check hands its computed result to the reporter (reused, not recomputed).

Full suite: 388 passed, 1 skipped (network-gated). `ruff`, `ty`, `pymarkdown`, `mkdocs --strict` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)