### PR TITLE
Add .env.example and a single "Getting started" laptop walkthrough

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,70 @@
+# Environment configuration for the NGED Flexpectation project.
+#
+# Copy this file to `.env` (git-ignored) and fill in the real values:
+#
+#     cp .env.example .env
+#
+# `.env` is read by `Settings` (packages/contracts/src/contracts/settings.py). Every field maps to
+# an upper-case env var, and an actual environment variable wins over the `.env` line. Only the
+# three NGED source-bucket credentials below are required; everything else has a working default
+# and is left commented out here — uncomment and set a line only to override its default.
+#
+# Full explanation of every setting (the three storage roots, the derive-from-root convention, and
+# which values each environment needs):
+# https://openclimatefix.github.io/nged-substation-forecast/live_service/setup/
+#
+# The dashboard has its own S3-mode overrides in `packages/dashboard/.env.s3` — see
+# `packages/dashboard/.env.s3.example`. That file layers on top of this one only when the
+# dashboard's "Data source" toggle is set to "s3"; the rest of the app never reads it.
+
+# --- Required: NGED source-bucket credentials --------------------------------------------------
+#
+# These authenticate reads of NGED's telemetry bucket (a different AWS account and bucket from our
+# own managed data tables). Required in every environment — without them `Settings()` raises a
+# validation error. Never commit the real values.
+
+NGED_S3_BUCKET_URL=<nged source bucket url>
+NGED_S3_BUCKET_ACCESS_KEY=<key>
+NGED_S3_BUCKET_SECRET=<secret>
+
+# --- Optional: storage roots -------------------------------------------------------------------
+#
+# All three default to `<repo>/data`, so out of the box every table and artifact is a plain file on
+# disk under one directory. Point the two data-table roots at `s3://…` URIs to move the tables to
+# S3; LOCAL_ARTIFACTS_PATH is always local. See the config reference for the three-roots model.
+
+# DATA_PATH_INTERNAL=s3://your-internal-bucket/data
+# DATA_PATH_DELIVERY=s3://your-delivery-bucket/data
+# LOCAL_ARTIFACTS_PATH=/absolute/path/to/local/artifacts
+
+# --- Optional: credentials for our own S3 data tables (DATA_STORE_*) ---------------------------
+#
+# Needed only when a data-table root above is a remote `s3://` URI. Leave all unset on AWS (the
+# attached IAM role's credentials and region are auto-discovered). On a laptop reaching real S3,
+# set key + secret + region (not the endpoint). For a local MinIO/S3-compatible rehearsal, set all
+# four — DATA_STORE_ENDPOINT_URL is only for non-AWS endpoints, and setting it also allows plain
+# HTTP.
+
+# DATA_STORE_ENDPOINT_URL=
+# DATA_STORE_ACCESS_KEY_ID=your-access-key-id
+# DATA_STORE_SECRET_ACCESS_KEY=your-secret-access-key
+# DATA_STORE_REGION=eu-west-1
+
+# --- Optional: MLflow tracking -----------------------------------------------------------------
+#
+# Defaults to a local SQLite file (`mlflow.db` in the repo root). Point at a remote MLflow server
+# for shared experiment tracking.
+
+# MLFLOW_TRACKING_URI=sqlite:///mlflow.db
+
+# --- Optional: Sentry error telemetry ----------------------------------------------------------
+#
+# An empty SENTRY_DSN (the default) disables Sentry entirely — every Sentry code path becomes a
+# no-op, so laptops and CI need no Sentry config. Set the DSN to enable error telemetry; on a
+# laptop also override SENTRY_ENVIRONMENT (e.g. "jacks-laptop"). Full setup:
+# https://openclimatefix.github.io/nged-substation-forecast/live_service/sentry/
+
+# SENTRY_DSN=
+# SENTRY_ENVIRONMENT=local
+# SENTRY_TRACES_SAMPLE_RATE=0.0
+# SENTRY_MONITOR_FORECASTS=false

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ marimo/_lsp/
 __marimo__/
 
 #######################
-# Environment variables & secrets
+# Environment variables & secrets. The committed .env.example documents the keys; copy it to .env.
 .env
 .env.backup
 # Dashboard S3-mode overrides (issue #297); the committed .env.s3.example documents the keys.

--- a/README.md
+++ b/README.md
@@ -20,47 +20,17 @@ This repo is a `uv` [workspace](https://docs.astral.sh/uv/concepts/projects/work
 
 ### Setup
 
+The full first-run walkthrough — including creating your `.env`, giving Dagster a persistent
+home, and downloading data to train your first model — is the
+[Getting started guide](https://openclimatefix.github.io/nged-substation-forecast/getting-started/).
+The essentials:
+
 1. Ensure [`uv`](https://docs.astral.sh/uv/) is installed following their [official documentation](https://docs.astral.sh/uv/getting-started/installation/).
 2. **Install dependencies**: `uv sync`
 3. **Install pre-commit hooks**: `uv run pre-commit install`
-
-To run Dagster:
-
-1. `uv run dg dev`
-2. Open `http://localhost:3000` in your browser to see the project.
-
-Optional: To allow Dagster to remember its state after you shut it down:
-
-1. `mkdir ~/dagster_home/`
-2. Put the following into `~/dagster_home/dagster.yaml`:
-
-    ```yaml
-    storage:
-      sqlite:
-        base_dir: "dagster_history"
-
-    concurrency:
-      pools:
-        default_limit: 1  # Used to limit concurrency of ecmwf_ens asset.
-
-    run_monitoring:
-      # Without this, a crashed/killed run can leak its concurrency-pool slot (e.g. the pool
-      # above) forever, since nothing else frees a slot held by a run that never reached a
-      # normal finally-block exit. This lets the daemon self-heal: any run finished (in any
-      # terminal status) for longer than the threshold has its slots freed automatically.
-      enabled: true
-      free_slots_after_run_end_seconds: 300
-
-    python_logs:
-      managed_python_loggers:
-        - nged_data
-      python_log_level: DEBUG
-    ```
-
-3. Add `export DAGSTER_HOME=<dagster_home_path>` to your `.bashrc` file, and restart your terminal.
-
-Note: `dagster.yaml` is only read at process startup, so restart `dg dev` (and the daemon) after
-editing it for changes to take effect.
+4. **Create your `.env`**: `cp .env.example .env`, then fill in the three required
+   `NGED_S3_BUCKET_*` credentials (the only values you must set).
+5. **Run Dagster**: `uv run dg dev`, then open `http://localhost:3000` in your browser.
 
 ### Linting & Formatting
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,8 +1,9 @@
 # Getting started on your laptop
 
 This is the single walkthrough for going from a fresh clone to a running Dagster instance that
-downloads real data and trains a model — entirely on your laptop, no AWS involved. Follow it
-top to bottom the first time; later pages go deeper on each part and are linked as you reach them.
+downloads real data and trains a model — entirely on your laptop, with no AWS account of your own
+to set up. Follow it top to bottom the first time; later pages go deeper on each part and are
+linked as you reach them.
 
 ## Prerequisites
 
@@ -14,11 +15,11 @@ top to bottom the first time; later pages go deeper on each part and are linked 
   where NGED publishes its telemetry. Ask another team member if you do not have them. Nothing in
   this project works without them, because the raw power data lives there.
 
-## Step 1 — Install the project
-
-From your clone of the repository:
+## Step 1 — Clone and install the project
 
 ```bash
+git clone https://github.com/openclimatefix/nged-substation-forecast.git
+cd nged-substation-forecast
 uv sync                    # create the virtualenv and install all workspace packages
 uv run pre-commit install  # install the git hooks (lint, format, markdown, type-check on commit)
 ```
@@ -108,18 +109,27 @@ Leave it running and open <http://localhost:3000>. Everything from here is drive
 ## Step 5 — Download data and train a model
 
 In the Dagster UI, materialise the data assets in order — this is what pulls the real data onto
-your laptop:
+your laptop. The quickest first run is the **`smoke_test`** fold (a ~1-month train / ~1-month
+validation window for a fast end-to-end check), so the concrete values below target it:
 
-1. **`power_time_series_and_metadata`** — pulls NGED telemetry from S3 into a local Delta table.
-2. **`h3_grid_weights`** — computes the spatial weights the NWP download needs (one-off).
-3. **`ecmwf_ens`** — downloads ECMWF ensemble weather; materialise the daily partitions across
-   your training window.
-4. **`eligible_time_series`** — determines which series have enough coverage for a fold.
+1. **`power_time_series_and_metadata`** — pulls NGED telemetry from S3 into a local Delta table
+   (unpartitioned).
+2. **`h3_grid_weights`** — computes the spatial weights the NWP download needs (unpartitioned,
+   one-off).
+3. **`ecmwf_ens`** — downloads ECMWF ensemble weather, one daily partition at a time. Materialise
+   the partitions covering the fold's train **and** validation window; for `smoke_test` that is
+   `2025-01-01` through `2025-02-28`. Do not "Materialise all" on a first run — the full archive
+   back to `2024-04-01` is billions of rows.
+4. **`eligible_time_series`** — determines which series have enough coverage for a fold. This asset
+   is **fold-partitioned**, so materialise the **`smoke_test`** partition (not
+   `mid_2025_to_mid_2026`) to match the run below — otherwise training finds an empty population and
+   raises.
 
 Then register an experiment and train a model. The full recipe — the run config for each job, what
 `smoke_test` versus `full_cv` does, and how the trained model is tracked in MLflow — is
-[Running an ML experiment end-to-end](ml_experimentation/dagster-workflow.md). Start there with a
-`smoke_test` run to check the whole pipeline is wired up before committing to a long training run.
+[Running an ML experiment end-to-end](ml_experimentation/dagster-workflow.md). Register the
+experiment with `run_mode="smoke_test"` to check the whole pipeline is wired up before committing to
+a long `full_cv` training run.
 
 ## Where to go next
 
@@ -132,5 +142,5 @@ Then register an experiment and train a model. The full recipe — the run confi
   forecast schedule running continuously, and an optional MinIO rehearsal of the S3 code paths.
 - The [dashboard README](https://github.com/openclimatefix/nged-substation-forecast/tree/main/packages/dashboard#readme)
   — Marimo apps for inspecting forecasts, and the `.env.s3` toggle for viewing production data.
-- [MLflow experiment tracking](https://openclimatefix.github.io/nged-substation-forecast/ml_experimentation/dagster-workflow/#viewing-results-in-the-mlflow-ui)
-  — viewing your training runs (`uv run mlflow ui --gunicorn-opts "--workers 1"`).
+- [Viewing results in the MLflow UI](ml_experimentation/dagster-workflow.md#viewing-results-in-the-mlflow-ui)
+  — inspecting your training runs (`uv run mlflow ui --gunicorn-opts "--workers 1"`).

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,136 @@
+# Getting started on your laptop
+
+This is the single walkthrough for going from a fresh clone to a running Dagster instance that
+downloads real data and trains a model — entirely on your laptop, no AWS involved. Follow it
+top to bottom the first time; later pages go deeper on each part and are linked as you reach them.
+
+## Prerequisites
+
+- **Python 3.14+** and [`uv`](https://docs.astral.sh/uv/) — install `uv` following its
+  [official instructions](https://docs.astral.sh/uv/getting-started/installation/). `uv` manages
+  the Python version and the virtual environment for you, so you do not need to install Python
+  separately.
+- **Credentials for NGED's telemetry bucket** — the URL, access key, and secret for the S3 bucket
+  where NGED publishes its telemetry. Ask another team member if you do not have them. Nothing in
+  this project works without them, because the raw power data lives there.
+
+## Step 1 — Install the project
+
+From your clone of the repository:
+
+```bash
+uv sync                    # create the virtualenv and install all workspace packages
+uv run pre-commit install  # install the git hooks (lint, format, markdown, type-check on commit)
+```
+
+`uv sync` reads the workspace's lockfile and installs every package under `packages/` plus the
+root Dagster application in one step.
+
+## Step 2 — Create your `.env`
+
+Configuration is read from a `.env` file in the repository root (and from environment variables,
+which win over `.env`). Copy the committed template and fill in the three required NGED credentials:
+
+```bash
+cp .env.example .env
+```
+
+Then edit `.env` and set the three `NGED_S3_BUCKET_*` values from the prerequisites:
+
+```dotenv
+NGED_S3_BUCKET_URL=<nged source bucket url>
+NGED_S3_BUCKET_ACCESS_KEY=<key>
+NGED_S3_BUCKET_SECRET=<secret>
+```
+
+Those three are the only values you must set. Every other setting has a working default, so with
+nothing else in `.env` all data and artifacts live under `<repo>/data` as plain files on disk. The
+[Configuration reference](live_service/setup.md) explains the full menu — the three storage roots,
+the derive-from-root convention, and the credentials you would add to move the data tables to S3.
+
+`.env` is git-ignored; never commit real credentials.
+
+> **Using a git worktree?** `Settings` reads `.env` from the repository root, so a worktree needs
+> its own. Symlink the main checkout's file rather than copying secrets around:
+> `ln -s ../<main-checkout>/.env .env`.
+
+## Step 3 — Give Dagster a persistent home
+
+Dagster works without any of this, but by default it forgets its run history and schedule state
+when you stop it. Point it at a persistent directory so that state survives a restart — this also
+matters later, because the live 6-hourly schedule only keeps time while the daemon runs
+continuously.
+
+1. Create the directory and a `dagster.yaml` inside it:
+
+    ```bash
+    mkdir -p ~/dagster_home
+    ```
+
+2. Put the following into `~/dagster_home/dagster.yaml`:
+
+    ```yaml
+    storage:
+      sqlite:
+        base_dir: "dagster_history"
+
+    concurrency:
+      pools:
+        default_limit: 1  # Used to limit concurrency of the ecmwf_ens asset.
+
+    run_monitoring:
+      # Without this, a crashed/killed run can leak its concurrency-pool slot (e.g. the pool
+      # above) forever, since nothing else frees a slot held by a run that never reached a
+      # normal finally-block exit. This lets the daemon self-heal: any run finished (in any
+      # terminal status) for longer than the threshold has its slots freed automatically.
+      enabled: true
+      free_slots_after_run_end_seconds: 300
+
+    python_logs:
+      managed_python_loggers:
+        - nged_data
+      python_log_level: DEBUG
+    ```
+
+3. Tell Dagster where it is by adding `export DAGSTER_HOME=~/dagster_home` to your `.bashrc` (or
+   equivalent) and restarting your terminal.
+
+`dagster.yaml` is read only at process startup, so restart `dg dev` after editing it.
+
+## Step 4 — Start Dagster
+
+```bash
+uv run dg dev
+```
+
+Leave it running and open <http://localhost:3000>. Everything from here is driven from that UI.
+
+## Step 5 — Download data and train a model
+
+In the Dagster UI, materialise the data assets in order — this is what pulls the real data onto
+your laptop:
+
+1. **`power_time_series_and_metadata`** — pulls NGED telemetry from S3 into a local Delta table.
+2. **`h3_grid_weights`** — computes the spatial weights the NWP download needs (one-off).
+3. **`ecmwf_ens`** — downloads ECMWF ensemble weather; materialise the daily partitions across
+   your training window.
+4. **`eligible_time_series`** — determines which series have enough coverage for a fold.
+
+Then register an experiment and train a model. The full recipe — the run config for each job, what
+`smoke_test` versus `full_cv` does, and how the trained model is tracked in MLflow — is
+[Running an ML experiment end-to-end](ml_experimentation/dagster-workflow.md). Start there with a
+`smoke_test` run to check the whole pipeline is wired up before committing to a long training run.
+
+## Where to go next
+
+- [Running an ML experiment end-to-end](ml_experimentation/dagster-workflow.md) — the data-to-model
+  recipe in full, plus [Model configuration](ml_experimentation/model-configuration.md) for
+  choosing features and hyperparameters.
+- [Configuration reference](live_service/setup.md) — every `.env` setting, the storage-root model,
+  and how to point the data tables at real S3.
+- [Running the whole stack locally](live_service/local.md) — keeping the daemon and the 6-hourly
+  forecast schedule running continuously, and an optional MinIO rehearsal of the S3 code paths.
+- The [dashboard README](https://github.com/openclimatefix/nged-substation-forecast/tree/main/packages/dashboard#readme)
+  — Marimo apps for inspecting forecasts, and the `.env.s3` toggle for viewing production data.
+- [MLflow experiment tracking](https://openclimatefix.github.io/nged-substation-forecast/ml_experimentation/dagster-workflow/#viewing-results-in-the-mlflow-ui)
+  — viewing your training runs (`uv run mlflow ui --gunicorn-opts "--workers 1"`).

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,6 +44,10 @@ operational systems, rather than us silently working around the gap.
 
 ## Documentation
 
+> **Want to run this on your laptop?** Start with [Getting started](getting-started.md) — a single
+> walkthrough from a fresh clone to a running Dagster instance that downloads data and trains a
+> model.
+
 - [Background & Challenges](background/network.md) — NGED's network, project requirements, and data quality challenges
 - [Architecture Overview](architecture/overview.md) — design philosophy, technical components, and data flow
 - [Code Style](architecture/code-style.md) — code conventions

--- a/docs/live_service/local.md
+++ b/docs/live_service/local.md
@@ -11,10 +11,10 @@ identical to the AWS deployment.
 
 ## Step 1 — Repository and credentials
 
-Follow the [repository README's Setup section](https://github.com/openclimatefix/nged-substation-forecast#setup)
-for first-time repo setup (`uv`, `uv sync`, pre-commit hooks), and create a `.env` in the repo
-root containing the three NGED source-bucket credentials — the only values that are always
-required (see [Configuration reference](setup.md#the-env-file-and-nged-source-credentials)):
+Follow [Getting started on your laptop](../getting-started.md) for first-time setup (`uv`, `uv
+sync`, pre-commit hooks, and `cp .env.example .env`). At minimum, `.env` needs the three NGED
+source-bucket credentials — the only values that are always required (see
+[Configuration reference](setup.md#the-env-file-and-nged-source-credentials)):
 
 ```dotenv
 NGED_S3_BUCKET_URL=<nged source bucket url>
@@ -31,8 +31,9 @@ The 6-hourly schedule only fires while Dagster's daemon is running continuously,
 dev` needs to keep running (rather than being started and stopped around each manual step) and
 needs a persistent `DAGSTER_HOME` so its schedule state survives a restart:
 
-1. `mkdir ~/dagster_home/` and put the `dagster.yaml` shown in the repository README's
-   [Setup](https://github.com/openclimatefix/nged-substation-forecast#setup) section into it.
+1. `mkdir ~/dagster_home/` and put the `dagster.yaml` shown in
+   [Getting started → Give Dagster a persistent home](../getting-started.md#step-3-give-dagster-a-persistent-home)
+   into it.
 2. `export DAGSTER_HOME=~/dagster_home` (add to `.bashrc` so it persists across terminals).
 
 ## Step 3 — Start Dagster

--- a/docs/live_service/setup.md
+++ b/docs/live_service/setup.md
@@ -5,8 +5,8 @@ disk, or S3 — Simple Storage Service, AWS's object store) and **what credentia
 This page is the reference; the step-by-step journeys that *use* these settings live elsewhere
 and deliberately aren't repeated here:
 
-- [The repository README](https://github.com/openclimatefix/nged-substation-forecast#setup) owns
-  first-time repo setup — installing `uv`, `uv sync`, pre-commit hooks.
+- [Getting started on your laptop](../getting-started.md) owns first-time repo setup — installing
+  `uv`, `uv sync`, pre-commit hooks, creating `.env`, and materialising the first data and model.
 - [Running the whole stack locally](local.md) owns the laptop bring-up (persistent
   `DAGSTER_HOME`, `dg dev`, the optional MinIO rehearsal).
 - [Setting up the live service on AWS](aws.md) owns every AWS console step — buckets, IAM
@@ -101,9 +101,10 @@ per-table overrides).
 
 ### The `.env` file and NGED source credentials
 
-Create a `.env` file in the repo root. The three **NGED source-bucket** credentials are always
-required, in every environment — they authenticate reads of NGED's telemetry bucket, which is a
-*different* account and bucket from our own managed data tables:
+Create a `.env` file in the repo root by copying the committed template — `cp .env.example .env` —
+and filling in the values. The three **NGED source-bucket** credentials are always required, in
+every environment — they authenticate reads of NGED's telemetry bucket, which is a *different*
+account and bucket from our own managed data tables:
 
 ```dotenv
 NGED_S3_BUCKET_URL=<nged source bucket url>

--- a/docs/ml_experimentation/dagster-workflow.md
+++ b/docs/ml_experimentation/dagster-workflow.md
@@ -31,9 +31,9 @@ gridded NWP forecasts onto the H3 cells attached to each substation.
 **Trigger:** Materialise the daily partitions from `2024-04-01` up to today (or up to the end
 of your training window). Use "Materialise all" or select a date range in the Dagster UI.
 
-Downloads the 00Z ECMWF ENS run for each partition date, converts it to a Polars DataFrame,
-quantises it to 12-bit `Int16` storage, and appends it to `nwp_data.delta` (partitioned by
-`[nwp_model_id, init_time]`). The `pool="ECMWF"` concurrency limit prevents OOM errors when
+Downloads the 00Z ECMWF ENS run for each partition date, converts it to a Polars DataFrame, and
+appends it to `nwp_data.delta` (partitioned by `[nwp_model_id, init_time]`) as physical-unit
+`Float32` rounded to a 13-bit significand at write time by `delta_store.nwp`. The `pool="ECMWF"` concurrency limit prevents OOM errors when
 backfilling — Dagster schedules downloads one at a time if you materialise many partitions at
 once.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,6 +31,7 @@ plugins:
 
 nav:
   - Home: index.md
+  - Getting Started: getting-started.md
   - Documentation Guide: documentation-guide.md
   - Background & Challenges:
       - NGED Network: background/network.md

--- a/packages/dashboard/README.md
+++ b/packages/dashboard/README.md
@@ -23,7 +23,8 @@ Each app has a **Data source** toggle (`local` / `s3`) that switches which data 
 reads without restarting marimo, so you can compare a fully local pipeline against production
 data in one session.
 
-- **local** reads only the root `.env` — the same local-pipeline config the rest of the app uses.
+- **local** reads only the root `.env` — the same local-pipeline config the rest of the app uses
+  (set up in the [Getting started guide](https://openclimatefix.github.io/nged-substation-forecast/getting-started/)).
 - **s3** layers a git-ignored `packages/dashboard/.env.s3` on top of the root `.env`, overriding
   the data-path roots (`DATA_PATH_INTERNAL`, `DATA_PATH_DELIVERY`) and the `DATA_STORE_*`
   credentials to point at the real S3 buckets.


### PR DESCRIPTION
Closes #411.

Issue #411 asked for a root `.env.example` and docs about setting up `.env`. Per discussion on the issue, this folds in the broader goal: **a single "get started on your laptop" front door** that takes a newcomer from a fresh clone to a running Dagster instance that downloads data and trains a model.

## What's here

- **`.env.example`** (new, repo root) — a full-menu, `cp .env.example .env` template mirroring the style of `packages/dashboard/.env.s3.example`. The three required `NGED_S3_BUCKET_*` credentials are uncommented; every optional setting (storage roots, `DATA_STORE_*`, `MLFLOW_TRACKING_URI`, `SENTRY_*`) is listed commented-out with a one-line explanation, so the file doubles as a discoverable menu of what's configurable. Header cross-links the [Configuration reference](https://openclimatefix.github.io/nged-substation-forecast/live_service/setup/) and `packages/dashboard/.env.s3.example`.
- **`docs/getting-started.md`** (new) — the single canonical walkthrough: install → `cp .env.example .env` → persistent Dagster home → `dg dev` → materialise the data assets → train a model. It **delegates depth** (config reference, `dagster-workflow.md`, `local.md`) rather than duplicating it. Added to the top of the docs nav.

## Cross-links & de-duplication

- `README.md` `### Setup` shrinks to the install essentials + `cp .env.example .env` and points at the Getting started guide. The persistent-Dagster `dagster.yaml` block **moves out of the README** into `getting-started.md` (its new canonical home), so it isn't duplicated.
- `docs/index.md` gains a "want to run this on your laptop?" callout.
- `docs/live_service/local.md` and `docs/live_service/setup.md` now defer first-time setup to `getting-started.md`; `setup.md`'s `.env` section references `cp .env.example .env`.
- `.gitignore` notes that the committed `.env.example` documents the keys (mirrors the existing `.env.s3.example` note).
- The dashboard README links back to Getting started for setting up the root `.env`.

## Verification

- `uv run pymarkdown scan -r docs README.md CLAUDE.md metadata/README.md packages/*/README.md` — clean.
- `uv run mkdocs build --strict` — passes (no broken links; the Step 3 numbered list with indented `dagster.yaml` renders as a proper ordered list, spot-checked in the built HTML).
- Confirmed `.env.example` is tracked, not caught by the `.gitignore` `.env` rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)