### PR TITLE
Add docs page explaining our approach to MLops

### DIFF
--- a/docs/ml_experimentation/index.md
+++ b/docs/ml_experimentation/index.md
@@ -7,6 +7,9 @@ roadmap.
 
 ## Documents
 
+- [Our approach to MLops](mlops-approach.md) — why we automate experiments, and why the model
+  that wins the evaluation is deployed bit-for-bit, with nothing rewritten on the way to
+  production.
 - [Running an ML experiment end-to-end](dagster-workflow.md) — step-by-step recipe for going
   from raw data to a trained, MLflow-tracked model using the Dagster pipeline; explains why
   `trained_cv_model` reads config from MLflow rather than YAML.

--- a/docs/ml_experimentation/mlops-approach.md
+++ b/docs/ml_experimentation/mlops-approach.md
@@ -1,0 +1,37 @@
+# Our Approach to MLops
+
+A short explainer for readers who are new to modern MLops tooling: what this project's
+experiment automation changes, and why it makes the path to production safer rather than
+riskier.
+
+Modern MLops changes two things:
+
+1. **Throughput.** The grunt work of an experiment — assembling features, training,
+   cross-validating, recording results — is automated, so a small team can run hundreds of
+   experiments per month instead of one or two. Humans are still the ones deciding what to
+   try; the machinery does the running. (See
+   [Running an ML experiment end-to-end](dagster-workflow.md).)
+2. **No translation gap.** The artifact we experimented on *is* the artifact we deploy. There
+   is no "now rewrite the research code for production" step, because every experiment runs on
+   the production pipeline from the start.
+
+## An analogy
+
+Traditional ML R&D is a chef inventing dishes in their home kitchen: every winning recipe has
+to be laboriously re-created on the restaurant's equipment before it can go on the menu, and
+much is lost (or silently changed) in translation. We are building the restaurant where R&D
+happens on the service line itself: hundreds of tastings a month, every dish judged by the
+same tasting panel, and the winning dish on the menu the same night — because nothing about it
+needs translating.
+
+## Nothing gets rewritten on the way to production
+
+The model that wins the evaluation is, bit for bit, the model we deploy — not a
+re-implementation of it. Promotion to production takes minutes, and that speed is a
+*consequence* of rigour, not a trade against it: by the time promotion is on the table, the
+candidate has already been trained, cross-validated (see
+[Cross-validation folds](cross-validation-folds.md)), and evaluated on the same pipeline,
+under the same standardised protocol, as every model before it.
+
+In this world, a notebook's job shrinks to deciding what to try. Notebooks are for thinking;
+the pipeline is for running.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -58,6 +58,7 @@ nav:
       - Testing: architecture/testing.md
   - ML Experimentation:
       - Overview: ml_experimentation/index.md
+      - Our approach to MLops: ml_experimentation/mlops-approach.md
       - Model configuration: ml_experimentation/model-configuration.md
       - Running an experiment end-to-end: ml_experimentation/dagster-workflow.md
       - Cross-validation folds: ml_experimentation/cross-validation-folds.md


### PR DESCRIPTION
Adds a short explainer page, [Our approach to MLops](https://openclimatefix.github.io/nged-substation-forecast/ml_experimentation/mlops-approach/), aimed at readers who are new to modern MLops tooling. It covers:

1. The two things modern MLops changes: experiment **throughput** (hundreds of automated experiments per month instead of one or two manual ones) and the absence of a **translation gap** between research and production.
2. A restaurant-kitchen analogy: traditional ML R&D is a chef inventing dishes in their home kitchen, where every winning recipe must be laboriously re-created before it can go on the menu; we are building the restaurant where R&D happens on the service line itself.
3. The headline consequence: **nothing gets rewritten on the way to production** — the model that wins the evaluation is, bit for bit, the model we deploy, and the speed of promotion is a consequence of rigour, not a trade against it.

The page lives under **ML Experimentation** (linked first in that section's document list, and added to the MkDocs nav) because it motivates the experimentation methodology documented there, cross-linking to the end-to-end Dagster workflow and cross-validation-folds pages.

`pymarkdown scan` and `mkdocs build --strict` both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)