### PR TITLE
Add CI: per-PR quality gate and nightly network-test workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       # Installs the Python version pinned in .python-version; no setup-python step needed.
       - name: Set up uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+# Per-PR quality gate: lint, format, types, markdown, and the offline test suite.
+# The network-gated tests are NOT run here — they run in nightly_network_tests.yml.
+# Design rationale (including why this is a bespoke workflow rather than OCF's reusable
+# branch_ci.yml template):
+# https://openclimatefix.github.io/nged-substation-forecast/architecture/testing/#continuous-integration
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # Dummy values for the required Settings fields. Most tests monkeypatch these, but a few
+  # construct Settings() directly and read the environment; locally they are satisfied by the
+  # developer's .env, which CI doesn't have. No test talks to the real NGED bucket.
+  NGED_S3_BUCKET_URL: "https://example.com"
+  NGED_S3_BUCKET_ACCESS_KEY: "dummy"
+  NGED_S3_BUCKET_SECRET: "dummy"
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      # Installs the Python version pinned in .python-version; no setup-python step needed.
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v9
+        with:
+          enable-cache: true
+
+      # --all-packages so that `ty check` can resolve imports for leaf workspace members
+      # (e.g. dashboard, notebooks) that nothing depends on and a plain sync would omit.
+      # --locked fails the build if uv.lock is out of date with the pyproject.toml files.
+      - name: Install workspace
+        run: uv sync --locked --all-packages
+
+      # Every step below uses --no-sync: a bare `uv run` re-syncs to the root environment,
+      # silently uninstalling the extra workspace members added by --all-packages above.
+      - name: Lint (ruff check)
+        run: uv run --no-sync ruff check .
+
+      - name: Format (ruff format --check)
+        run: uv run --no-sync ruff format --check .
+
+      - name: Type-check (ty)
+        run: uv run --no-sync ty check
+
+      - name: Markdown lint (pymarkdown)
+        run: uv run --no-sync pymarkdown scan -r docs README.md CLAUDE.md metadata/README.md packages/*/README.md
+
+      - name: Test (pytest)
+        run: uv run --no-sync pytest

--- a/.github/workflows/nightly_network_tests.yml
+++ b/.github/workflows/nightly_network_tests.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v7
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v9
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 

--- a/.github/workflows/nightly_network_tests.yml
+++ b/.github/workflows/nightly_network_tests.yml
@@ -1,0 +1,42 @@
+name: Nightly network tests
+
+# Runs ONLY the network-gated tests (@pytest.mark.network) against the real Dynamical.org
+# catalog, to catch the "shared-convention blind spot" that the offline suite cannot see:
+# https://openclimatefix.github.io/nged-substation-forecast/architecture/testing/#network-gated-tests
+# Failures notify (GitHub emails the workflow author) but do not block PRs.
+# No secrets needed: the Dynamical.org ECMWF ENS catalog is public.
+
+on:
+  schedule:
+    # Daily at 05:38 UTC — off the top of the hour, when GitHub's cron queue is congested
+    # and scheduled runs get delayed or dropped. The exact hour doesn't matter: the test
+    # targets a three-day-old 00Z ECMWF run, which is always published by now.
+    - cron: "38 5 * * *"
+  workflow_dispatch:
+
+jobs:
+  network-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      # Dummy values for the required Settings fields, mirroring ci.yml: collection imports
+      # every test module, and a few construct Settings() directly. The network tests
+      # themselves never touch the NGED bucket.
+      NGED_S3_BUCKET_URL: "https://example.com"
+      NGED_S3_BUCKET_ACCESS_KEY: "dummy"
+      NGED_S3_BUCKET_SECRET: "dummy"
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v9
+        with:
+          enable-cache: true
+
+      - name: Install workspace
+        run: uv sync --locked
+
+      # Both flags are needed: --run-network lifts the collection-time skip gate, and
+      # -m network deselects everything else so this job runs only the network tests.
+      - name: Network-gated tests
+        run: uv run --no-sync pytest --run-network -m network

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -61,7 +61,8 @@ shape (dimension order, latitude orientation, longitude range, dtypes, units) an
 
 Mark such a test `@pytest.mark.network`. The root `conftest.py` skips every `network`-marked test
 unless the caller passes `--run-network`, so a plain `uv run pytest` (local dev and the per-PR CI)
-never touches the network. Run them explicitly — nightly CI or on demand — with:
+never touches the network. Run them explicitly — the nightly CI job (see
+[Continuous integration](#continuous-integration) below) or on demand — with:
 
 ```bash
 uv run pytest --run-network              # whole suite, network tests included
@@ -77,6 +78,63 @@ The gate is a collection hook, **not** an `addopts = "... -m 'not network'"`. py
 silently replace an `addopts` `-m "not network"` and re-include the network tests. A skip applied
 during collection cannot be overridden that way — the gate holds whatever `-m` the caller passes, and
 even `-m network` alone stays skipped until `--run-network` is added.
+
+## Continuous integration
+
+Two GitHub workflows in `.github/workflows/` run the checks described on this page:
+
+- **`ci.yml` — the per-PR quality gate.** Runs on every pull request and every push to `main`:
+  `ruff check`, `ruff format --check`, `ty check`, the `pymarkdown scan` command from CLAUDE.md,
+  and the offline test suite (plain `uv run pytest` — the network gate above keeps CI off the
+  network). The job installs with `uv sync --locked --all-packages`: `--all-packages` because
+  `ty` type-checks the source of every workspace member, including leaf packages that a plain
+  sync would omit, and `--locked` so the build fails loudly when `uv.lock` is stale. Every
+  subsequent step passes `uv run --no-sync`, because a bare `uv run` re-syncs to the root
+  environment and would silently uninstall those extra workspace members. The job also sets
+  dummy values for the three required `NGED_S3_*` `Settings` fields: most tests monkeypatch
+  them, but a few construct `Settings()` directly and locally rely on the developer's `.env`,
+  which CI doesn't have. The `ci` job is a required status check on `main` (configured in the
+  GitHub branch-protection settings, not in the workflow file).
+- **`nightly_network_tests.yml` — the nightly network job.** Runs *only* the network-gated
+  tests (`uv run pytest --run-network -m network`) on a daily schedule, plus
+  `workflow_dispatch` for on-demand runs. This is the only CI that touches the real
+  Dynamical.org catalog, and it needs no secrets — the catalog is public. A failure notifies
+  (GitHub emails the workflow author when a scheduled run fails) but deliberately does not
+  block PRs: a red nightly run signals drift in the upstream catalog's conventions, not a
+  defect in whatever PR happens to be open.
+
+### Why a bespoke workflow rather than OCF's template
+
+OCF's organisation template ([`openclimatefix/.github` →
+`workflow-templates/branch_ci.yml`](https://github.com/openclimatefix/.github/blob/main/workflow-templates/branch_ci.yml))
+is a thin caller of the org-wide reusable workflow
+[`branch_ci.yml`](https://github.com/openclimatefix/.github/blob/main/.github/workflows/branch_ci.yml).
+We deliberately don't use it, because it is built for OCF's standard single-package service
+repos and fits this repo poorly:
+
+- **Single-package assumptions.** The reusable workflow expects one `pyproject.toml` and one
+  test folder (its `tests_folder` input defaults to `src/tests`). This repo is a uv
+  *workspace* monorepo: the suite must run from the root so pytest collects `tests/` plus
+  every `packages/*/tests/`, and type-checking needs an `--all-packages` install (see above).
+- **Floating tool versions.** It lints and type-checks with `uvx ruff` / `uvx ty`, i.e.
+  whatever version is newest on the day the job runs — so org CI can disagree with the locked
+  dev-group versions used locally and by pre-commit, and a new upstream release can break CI
+  with no change in this repo. We run the locked versions via `uv run`.
+- **Missing checks, and no offline/network split.** It has no equivalent of
+  `ruff format --check` (formatting is opt-in and separate) or the `pymarkdown scan` command,
+  and no concept of this repo's network-gated nightly job.
+- **Container build baggage.** Roughly half the reusable workflow builds and publishes Docker
+  images to ghcr.io; this repo doesn't produce a container image.
+- **Trigger and pinning mismatch.** The template triggers on pushes to non-default branches,
+  whereas a required status check wants `pull_request` (+ push to `main`); and it pins the
+  reusable workflow `@main`, so upstream edits to the org workflow change this repo's CI
+  without any PR here.
+
+We did keep the template's good conventions: a concurrency group with `cancel-in-progress`, a
+cached `astral-sh/setup-uv`, and locked installs (`UV_LOCKED=1` there, `uv sync --locked`
+here). If OCF's reusable workflow ever grows first-class uv-workspace support, revisiting it
+would shrink `ci.yml` to a few lines — but until then the bespoke workflow is smaller than the
+configuration the template would need.
 
 ## NWP grid → H3 orientation coverage
 

--- a/docs/roadmap/engineering-health.md
+++ b/docs/roadmap/engineering-health.md
@@ -4,87 +4,10 @@
 > codebase review that don't change forecast behaviour. Each section is an independent,
 > roughly one-PR piece of work; sections are deleted as they ship. Mostly the v0.2 epic
 > [#138](https://github.com/openclimatefix/nged-substation-forecast/issues/138):
-> CI [#9](https://github.com/openclimatefix/nged-substation-forecast/issues/9) ·
 > NWP ingestion checks [#161](https://github.com/openclimatefix/nged-substation-forecast/issues/161) ·
 > Hydra removal [#228](https://github.com/openclimatefix/nged-substation-forecast/issues/228) ·
 > rigor tests [#229](https://github.com/openclimatefix/nged-substation-forecast/issues/229).
 > Task ordering lives in the GitHub Project board.
-
-## CI: run lint, types, and tests on every PR
-
-Issue: [#9](https://github.com/openclimatefix/nged-substation-forecast/issues/9)
-
-The only GitHub workflows are `docs.yml` (MkDocs deploy) and `contribution-bot.yml`. Code
-quality is enforced solely by local pre-commit hooks, so a contributor (or an agent) who skips
-hooks can merge broken code. Additionally, `uv run pytest` from the repo root currently
-**fails collection**: `tests/test_metrics.py` and `packages/ml_core/tests/test_metrics.py`
-share a module basename and there are no `__init__.py` files in the test dirs, so pytest's
-default import mode refuses to collect both. Nobody noticed because nothing runs the full
-suite from the root.
-
-This is the highest-value fix in the whole review: a few hours of work, permanent payoff, and
-a prerequisite for trusting every other piece of planned work.
-
-### Implementation details — CI (deleted when it ships)
-
-**1. Fix root pytest collection.** In `pyproject.toml` `[tool.pytest.ini_options]` add:
-
-```toml
-addopts = "--import-mode=importlib"
-```
-
-`importlib` mode allows duplicate test-file basenames without `__init__.py` files. Verify
-`uv run pytest --collect-only -q` succeeds from the root (~165 tests) before touching CI.
-If any test breaks under importlib mode, fix that test rather than renaming files.
-
-**2. Add `.github/workflows/ci.yml`.** Trigger: `pull_request` + `push` to `main`. Single job
-on `ubuntu-latest`:
-
-```yaml
-concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
-```
-
-Steps:
-
-1. `actions/checkout@v4`
-2. `astral-sh/setup-uv@v5` with `enable-cache: true`
-3. `uv sync --all-packages --dev` (workspace root alone doesn't install package test deps)
-4. `uv run ruff check .`
-5. `uv run ruff format --check .`
-6. `uv run ty check`
-7. `uv run pymarkdown scan -r docs README.md CLAUDE.md metadata/README.md packages/*/README.md`
-   (same command as CLAUDE.md / pre-commit)
-8. `uv run pytest` — with dummy env for the required `Settings` fields, since a few tests
-   construct `Settings()` directly (`tests/test_trained_cv_model.py:186`) and rely on the
-   local `.env` which CI doesn't have:
-
-   ```yaml
-   env:
-     NGED_S3_BUCKET_URL: "https://example.com"
-     NGED_S3_BUCKET_ACCESS_KEY: "dummy"
-     NGED_S3_BUCKET_SECRET: "dummy"
-   ```
-
-   (Most tests already monkeypatch these — see `tests/test_cv_assets.py:80` — the job-level
-   env just covers the stragglers.)
-
-Notes:
-
-- Python version comes from `requires-python` / `.python-version` via uv; no setup-python
-  needed.
-- The full-stack MLflow-server test (`tests/test_metrics.py`) spawns a real
-  `mlflow server` subprocess — `mlflow` (full) is already in the dev group, so it should run
-  in CI. If it proves flaky on runners, gate it behind `-m integration` and split into a
-  separate non-required job, but try it as-is first.
-
-**3. Branch protection.** After the workflow is green on `main`, mark the CI job as a required
-status check in the GitHub repo settings (manual step, note it in the PR description).
-
-**Verification.** (1) `uv run pytest` from the repo root passes locally after step 1. (2) Open
-the PR; the CI workflow runs and passes. (3) Push a deliberately broken commit to the PR
-branch (e.g. an unused import) and confirm the workflow fails, then revert.
 
 ## NWP ingestion: completeness checks and Dagster metrics
 

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -35,7 +35,7 @@ Technical plans change as we learn more — treat this as a best-estimate, not a
   (runbooks, alert-on-absence, infra-as-code, NGED landing-zone probing, game days).
 - [XGBoost improvements](xgboost-improvements.md) — the v0.5 experiment backlog: four effort
   tiers, ordered best bang-for-the-buck within each tier, targeting the 3–10 day user band.
-- [Engineering health](engineering-health.md) — CI, reproducibility stamping, NWP
+- [Engineering health](engineering-health.md) — reproducibility stamping, NWP
   ingestion checks, Hydra removal, and scientific-rigor tests.
 - [Capacity estimation](capacity-estimation.md) — the v0.7 head-to-head between candidate
   estimators of the time-varying effective capacity of metered generators: a
@@ -77,7 +77,8 @@ AWS — see [Live service](live-service.md).
 
 - More unit tests, including scientific-rigor tests (CV-windowing no-lookahead,
   leaderboard-fairness, determinism)
-- CI on GitHub (ruff + ty + pytest on every PR)
+- CI on GitHub (ruff + ty + pytest on every PR) ✅ (per-PR gate + nightly network tests; see
+  [Testing → Continuous integration](../architecture/testing.md#continuous-integration))
 - Improve documentation
 - Verify daylight savings time handling is correct
 - Reproducibility stamping: git SHA + Delta table versions on every MLflow run

--- a/packages/geo/src/geo/h3.py
+++ b/packages/geo/src/geo/h3.py
@@ -1,6 +1,5 @@
 """H3-related utilities for geospatial operations."""
 
-import os  # CI break test: deliberately unused import
 import logging
 
 import h3.api.basic_int as h3

--- a/packages/geo/src/geo/h3.py
+++ b/packages/geo/src/geo/h3.py
@@ -1,5 +1,6 @@
 """H3-related utilities for geospatial operations."""
 
+import os  # CI break test: deliberately unused import
 import logging
 
 import h3.api.basic_int as h3


### PR DESCRIPTION
Closes #9.

## What this adds

- **`.github/workflows/ci.yml`** — per-PR quality gate (also on push to `main`): `ruff check`, `ruff format --check`, `ty check`, the `pymarkdown scan` command from CLAUDE.md, and the offline test suite. Installs with `uv sync --locked --all-packages` (so `ty` can see leaf workspace members and a stale `uv.lock` fails loudly) and runs every step with `uv run --no-sync` (a bare `uv run` would re-sync back to the root-only environment). Dummy `NGED_S3_*` env vars cover the few tests that construct `Settings()` directly and locally rely on `.env`.
- **`.github/workflows/nightly_network_tests.yml`** — daily scheduled job (plus `workflow_dispatch`) running only the network-gated tests: `uv run pytest --run-network -m network`. Note the command differs from the one in the issue comment (`pytest -m network`): the gate is a collection hook, so `-m network` alone still skips everything — `--run-network` is required. No secrets needed: the Dynamical.org catalog is public (the repo `.env` holds only NGED S3 + Sentry vars). Failures notify (GitHub emails the workflow author) but don't block PRs.

## Why not OCF's template

Per the issue body we considered copying [`openclimatefix/.github` → `workflow-templates/branch_ci.yml`](https://github.com/openclimatefix/.github/blob/main/workflow-templates/branch_ci.yml), which delegates to the org-wide reusable `branch_ci.yml`. We deliberately went bespoke; the full rationale is now durably documented in [Testing → Why a bespoke workflow rather than OCF's template](https://openclimatefix.github.io/nged-substation-forecast/architecture/testing/#why-a-bespoke-workflow-rather-than-ocfs-template). In short: the template assumes a single-package repo (one `pyproject.toml`, `src/tests`), lints/type-checks with floating `uvx` tool versions that can disagree with our locked dev-group versions, lacks `ruff format --check`/`pymarkdown` and any offline/network split, spends half the workflow building Docker images we don't produce, and pins the reusable workflow `@main` so org-side edits would change our CI without a PR here. We kept its good conventions: concurrency group with `cancel-in-progress`, cached `setup-uv`, locked installs.

## Ship-time triage

- Durable design promoted to [docs/architecture/testing.md → Continuous integration](https://openclimatefix.github.io/nged-substation-forecast/architecture/testing/#continuous-integration).
- The CI section (including "Implementation details") is deleted from `docs/roadmap/engineering-health.md`; the deleted section is pasted below. The page keeps its remaining 🚧 items (#161, #228, #229).
- Roadmap index: v0.2 "CI on GitHub" item ticked; "CI" removed from the engineering-health blurb.

Note: step 1 of the roadmap plan (`--import-mode=importlib` to fix root pytest collection) had already shipped before this PR; only the workflow steps remained.

## Verification

- Full local dry-run of every CI step in a CI-like environment (no `.env`, no `SENTRY_DSN`, dummy `NGED_S3_*` vars): ruff check/format, `ty check`, `pymarkdown scan` all pass; `pytest` → **390 passed, 1 skipped (the network-gated test) in 34 s** — including the full-stack MLflow-server test, so no `-m integration` split was needed.
- `uv run mkdocs build --strict` passes and the rendered HTML of the new docs section was inspected (all list items render as real `<li>`s — the Python-Markdown list gotcha).
- On this PR: CI workflow runs green, then a deliberately broken commit was pushed to confirm the workflow fails, then reverted. *(Being verified now — see PR checks/comments.)*

## Manual follow-ups (Jack)

1. **Branch protection:** once this is merged and green on `main`, mark the `ci` job as a required status check in the repo settings.
2. **Nightly smoke run:** after merge, trigger `nightly_network_tests.yml` once via `workflow_dispatch` (the workflow only becomes dispatchable once it exists on the default branch). I'll note the result here if I'm around when it lands.

<details>
<summary>Deleted roadmap section (docs/roadmap/engineering-health.md → "CI: run lint, types, and tests on every PR")</summary>

## CI: run lint, types, and tests on every PR

Issue: [#9](https://github.com/openclimatefix/nged-substation-forecast/issues/9)

The only GitHub workflows are `docs.yml` (MkDocs deploy) and `contribution-bot.yml`. Code
quality is enforced solely by local pre-commit hooks, so a contributor (or an agent) who skips
hooks can merge broken code. Additionally, `uv run pytest` from the repo root currently
**fails collection**: `tests/test_metrics.py` and `packages/ml_core/tests/test_metrics.py`
share a module basename and there are no `__init__.py` files in the test dirs, so pytest's
default import mode refuses to collect both. Nobody noticed because nothing runs the full
suite from the root.

This is the highest-value fix in the whole review: a few hours of work, permanent payoff, and
a prerequisite for trusting every other piece of planned work.

### Implementation details — CI (deleted when it ships)

**1. Fix root pytest collection.** In `pyproject.toml` `[tool.pytest.ini_options]` add:

```toml
addopts = "--import-mode=importlib"
```

`importlib` mode allows duplicate test-file basenames without `__init__.py` files. Verify
`uv run pytest --collect-only -q` succeeds from the root (~165 tests) before touching CI.
If any test breaks under importlib mode, fix that test rather than renaming files.

**2. Add `.github/workflows/ci.yml`.** Trigger: `pull_request` + `push` to `main`. Single job
on `ubuntu-latest`:

```yaml
concurrency:
  group: ci-${{ github.ref }}
  cancel-in-progress: true
```

Steps:

1. `actions/checkout@v4`
2. `astral-sh/setup-uv@v5` with `enable-cache: true`
3. `uv sync --all-packages --dev` (workspace root alone doesn't install package test deps)
4. `uv run ruff check .`
5. `uv run ruff format --check .`
6. `uv run ty check`
7. `uv run pymarkdown scan -r docs README.md CLAUDE.md metadata/README.md packages/*/README.md`
   (same command as CLAUDE.md / pre-commit)
8. `uv run pytest` — with dummy env for the required `Settings` fields, since a few tests
   construct `Settings()` directly (`tests/test_trained_cv_model.py:186`) and rely on the
   local `.env` which CI doesn't have:

   ```yaml
   env:
     NGED_S3_BUCKET_URL: "https://example.com"
     NGED_S3_BUCKET_ACCESS_KEY: "dummy"
     NGED_S3_BUCKET_SECRET: "dummy"
   ```

   (Most tests already monkeypatch these — see `tests/test_cv_assets.py:80` — the job-level
   env just covers the stragglers.)

Notes:

- Python version comes from `requires-python` / `.python-version` via uv; no setup-python
  needed.
- The full-stack MLflow-server test (`tests/test_metrics.py`) spawns a real
  `mlflow server` subprocess — `mlflow` (full) is already in the dev group, so it should run
  in CI. If it proves flaky on runners, gate it behind `-m integration` and split into a
  separate non-required job, but try it as-is first.

**3. Branch protection.** After the workflow is green on `main`, mark the CI job as a required
status check in the GitHub repo settings (manual step, note it in the PR description).

**Verification.** (1) `uv run pytest` from the repo root passes locally after step 1. (2) Open
the PR; the CI workflow runs and passes. (3) Push a deliberately broken commit to the PR
branch (e.g. an unused import) and confirm the workflow fails, then revert.


</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
