### PR TITLE
Resolve PROJECT_ROOT via uv.lock marker walk (fix non-editable installs)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,22 +48,16 @@ LABEL org.opencontainers.image.source="https://github.com/openclimatefix/nged-su
 
 ENV GIT_SHA="${GIT_SHA}" \
     PATH="/app/.venv/bin:${PATH}" \
-    PRODUCTION_MODEL_PATH="/app/data/production_model" \
-    CV_CONFIG_PATH="/app/conf/cv/default.yaml" \
-    NWP_METADATA_CSV_PATH="/app/metadata/nwp_metadata.csv"
-# CV_CONFIG_PATH/NWP_METADATA_CSV_PATH override contracts.settings.Settings' PROJECT_ROOT-
-# relative defaults, which resolve to a path *inside* .venv under this --no-editable install
-# (PROJECT_ROOT = Path(__file__).parents[4] assumes an editable-install directory depth) —
-# empirically confirmed necessary: without them, importing nged_substation_forecast.definitions
-# (which eagerly loads the CV config at module scope, in defs/cv_assets.py) fails with
-# FileNotFoundError: /app/.venv/conf/cv/default.yaml. cv_assets.py now reads CV_CONFIG_PATH
-# directly (not via a Settings() instance, to stay credential-free at import time), so this env
-# var is honoured; nwp_metadata_csv_path was already read via an instantiated Settings and so
-# needed no source change.
+    PRODUCTION_MODEL_PATH="/app/data/production_model"
 
 WORKDIR /app
 
+# contracts.settings.PROJECT_ROOT walks up to the nearest ancestor holding uv.lock, so copying
+# uv.lock here anchors every repo-relative default (conf/, metadata/) at /app — which is where
+# the COPYs below place those files. conf/ also keeps conf/model/ available so training jobs
+# (register_experiment_job) can run in-container.
 COPY --from=builder /app/.venv /app/.venv
+COPY uv.lock ./
 COPY data/production_model/ data/production_model/
 COPY conf/ conf/
 COPY metadata/ metadata/

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -209,6 +209,32 @@ regularly), switch to fetching the champion model from MLflow dynamically — at
 from disk on a cache hit so the live service survives an MLflow outage), exactly as it does for
 CV today.
 
+## Resolve repo-relative paths via a workspace marker, not directory depth
+
+`contracts.settings.PROJECT_ROOT` anchors every repo-relative default in `Settings` — the CV
+fold definitions (`conf/cv/default.yaml`), the NWP metadata CSV (`metadata/nwp_metadata.csv`),
+the local `data/` roots, and the `.env` location. It is resolved by walking up from the
+installed `settings.py` to the nearest ancestor directory holding `uv.lock` (the file that
+exists only at the uv workspace root), falling back to the current working directory when no
+ancestor qualifies.
+
+We resolve via a marker rather than a hard-coded directory depth (the previous
+`Path(__file__).parents[4]`) because the depth only held for an editable install. Under the
+production image's `uv sync --no-editable`, the installed file sits at
+`<venv>/lib/python3.14/site-packages/contracts/settings.py`, where the same depth silently
+resolved to the venv root and every default broke with `FileNotFoundError`
+([#287](https://github.com/openclimatefix/nged-substation-forecast/issues/287)). The marker
+walk handles both layouts: a dev checkout resolves to the repo root, and the production image
+resolves to `/app` because the Dockerfile copies `uv.lock` there alongside `conf/` and
+`metadata/` — so the image needs no per-path env-var overrides, and `conf/model/` stays
+available for running training jobs in-container.
+
+The fallback case — a wheel installed into a venv outside any workspace checkout — is a
+deployment shape we don't currently have. If one appears, it must either run with its working
+directory laid out like the repo root or set each path setting explicitly via its env var.
+(Packaging the resource files into a wheel via `importlib.resources` was considered for #287
+and deliberately deferred until such a target actually exists.)
+
 ## Run live inference in single-run mode, not bulk
 
 The `live_forecasts` asset engineers features in **single-run mode** — an explicit

--- a/packages/contracts/src/contracts/settings.py
+++ b/packages/contracts/src/contracts/settings.py
@@ -11,7 +11,41 @@ from contracts._uri import ObjectStoreOptions, uri_join
 url_adapter = TypeAdapter(AnyHttpUrl)
 
 
-PROJECT_ROOT: Final[Path] = Path(__file__).parents[4]
+def _find_project_root(start: Path) -> Path:
+    """Walk up from ``start`` to the uv workspace root, marked by its ``uv.lock`` file.
+
+    ``uv.lock`` exists only at the workspace root, so the first ancestor holding one is the
+    project root. This resolves correctly for every install mode that keeps the virtualenv
+    inside the repo: an editable install walks up from the source checkout, and a
+    non-editable install (``uv sync --no-editable``) walks up from
+    ``<repo>/.venv/lib/python*/site-packages/`` past the venv to the same root. The
+    production Docker image copies ``uv.lock`` to ``/app``, so there the root resolves to
+    ``/app``, where the image's ``COPY conf/`` / ``COPY metadata/`` place the resource files.
+
+    When no ancestor holds a ``uv.lock`` — a wheel installed into a venv outside any
+    workspace checkout — fall back to the current working directory. Such a deployment must
+    either run with its working directory at a directory laid out like the repo root, or set
+    each path setting explicitly via its environment variable (``CV_CONFIG_PATH``, etc.).
+
+    Args:
+        start: File or directory to walk up from (typically ``Path(__file__)``).
+
+    Returns:
+        The workspace root, or ``Path.cwd()`` if no ancestor contains ``uv.lock``.
+    """
+    for parent in start.resolve().parents:
+        if (parent / "uv.lock").is_file():
+            return parent
+    return Path.cwd()
+
+
+PROJECT_ROOT: Final[Path] = _find_project_root(Path(__file__))
+"""The repo root — anchor for the repo-relative defaults below (``conf/``, ``metadata/``,
+``data/``, ``.env``).
+
+Resolved by :func:`_find_project_root`; see its docstring for the per-install-mode behaviour
+and the caveat for wheels installed outside a workspace checkout.
+"""
 
 
 class DataQualitySettings(BaseSettings):

--- a/packages/contracts/tests/test_project_root.py
+++ b/packages/contracts/tests/test_project_root.py
@@ -1,0 +1,71 @@
+"""Regression tests for PROJECT_ROOT resolution under different install layouts.
+
+PROJECT_ROOT used to be ``Path(__file__).parents[4]`` — a hard-coded directory depth that only
+held for an editable install, and silently resolved to the venv root under a non-editable
+(``uv sync --no-editable``) install (issue #287). These tests pin the marker-based replacement:
+walk up to the nearest ancestor holding ``uv.lock``, falling back to the current working
+directory when no ancestor qualifies.
+"""
+
+from pathlib import Path
+
+import pytest
+from contracts.settings import PROJECT_ROOT, Settings, _find_project_root
+
+
+def test_project_root_is_the_workspace_root():
+    """In this dev checkout, PROJECT_ROOT holds the workspace marker and the resource files.
+
+    Also guards the repo layout itself: if ``conf/`` or ``metadata/`` move, the
+    PROJECT_ROOT-relative Settings defaults break, and this is the test that should fail.
+    """
+    assert (PROJECT_ROOT / "uv.lock").is_file()
+    assert (PROJECT_ROOT / "conf" / "cv" / "default.yaml").is_file()
+    assert (PROJECT_ROOT / "metadata" / "nwp_metadata.csv").is_file()
+
+
+def test_settings_defaults_anchor_at_project_root():
+    """The repo-resource Settings defaults are PROJECT_ROOT-relative (not venv-relative)."""
+    assert Settings.model_fields["cv_config_path"].default == (
+        PROJECT_ROOT / "conf" / "cv" / "default.yaml"
+    )
+    assert Settings.model_fields["nwp_metadata_csv_path"].default == (
+        PROJECT_ROOT / "metadata" / "nwp_metadata.csv"
+    )
+
+
+def test_find_project_root_from_in_repo_non_editable_venv(tmp_path: Path):
+    """A non-editable install whose venv sits inside the repo resolves to the repo root.
+
+    This is the exact layout that broke under ``parents[4]``: the installed module lives at
+    ``<repo>/.venv/lib/python3.14/site-packages/contracts/settings.py``, five levels below the
+    repo root rather than four.
+    """
+    repo = tmp_path / "repo"
+    installed_pkg = repo / ".venv" / "lib" / "python3.14" / "site-packages" / "contracts"
+    installed_pkg.mkdir(parents=True)
+    (repo / "uv.lock").touch()
+    settings_file = installed_pkg / "settings.py"
+    settings_file.touch()
+
+    assert _find_project_root(settings_file) == repo
+
+
+def test_find_project_root_outside_any_workspace_falls_back_to_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+):
+    """With no ``uv.lock`` in any ancestor, resolution falls back to the working directory.
+
+    This is the wheel-installed-outside-a-checkout case: such a deployment must either run
+    with its cwd at a directory laid out like the repo root, or set every path setting
+    explicitly via env vars (as documented on ``_find_project_root``).
+    """
+    installed_pkg = tmp_path / "venv" / "lib" / "python3.14" / "site-packages" / "contracts"
+    installed_pkg.mkdir(parents=True)
+    settings_file = installed_pkg / "settings.py"
+    settings_file.touch()
+    workdir = tmp_path / "workdir"
+    workdir.mkdir()
+    monkeypatch.chdir(workdir)
+
+    assert _find_project_root(settings_file) == workdir

--- a/packages/contracts/uv.lock
+++ b/packages/contracts/uv.lock
@@ -1,3 +1,0 @@
-version = 1
-revision = 3
-requires-python = ">=3.14"

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -64,9 +64,7 @@ from nged_data.storage import time_series_coverage
 # env var is read directly here (rather than instantiating Settings, which needs the .env
 # secrets) so the partition set can be built without any credentials — while still respecting
 # the same env var Settings' cv_config_path field would use, unlike reading
-# Settings.model_fields["cv_config_path"].default directly, which silently ignores it (that
-# default is also PROJECT_ROOT-relative, which only resolves correctly for an editable install;
-# a production image built with `uv sync --no-editable` must set CV_CONFIG_PATH explicitly).
+# Settings.model_fields["cv_config_path"].default directly, which silently ignores it.
 _cv_config = load_cv_config(
     Path(os.environ.get("CV_CONFIG_PATH", Settings.model_fields["cv_config_path"].default))
 )


### PR DESCRIPTION
Closes #287.

## What

`contracts.settings.PROJECT_ROOT` was `Path(__file__).parents[4]` — a hard-coded directory depth that only held for an editable install. Under `uv sync --no-editable` (the production image, or any wheel-based install) the installed file sits one level deeper, so `PROJECT_ROOT` silently resolved to the venv root and every repo-relative `Settings` default broke with `FileNotFoundError`.

`PROJECT_ROOT` is now resolved by walking up from `settings.py` to the nearest ancestor holding `uv.lock` (the file that exists only at the uv workspace root), falling back to `Path.cwd()` when no ancestor qualifies. This is correct for editable checkouts, in-repo non-editable venvs, and the production image alike, and is robust to future file moves.

## Changes

- **`settings.py`**: `_find_project_root(start)` marker walk; docstrings document per-install-mode behaviour and the cwd-fallback caveat.
- **Deleted a stray `packages/contracts/uv.lock`** — an empty (52-byte, zero-package) lockfile accidentally committed long ago in `6949c36`. uv never reads member-level lockfiles in a workspace, but it made `packages/contracts` look like a workspace root to the marker walk. The new regression test caught it immediately.
- **Dockerfile**: the `CV_CONFIG_PATH`/`NWP_METADATA_CSV_PATH` env-var workaround from #285 is removed; instead `COPY uv.lock ./` in the runtime stage anchors `PROJECT_ROOT` at `/app`, where `conf/` and `metadata/` are already copied. `conf/model/` stays in the image so training jobs (`register_experiment_job`) can run in-container.
- **Regression tests** (`test_project_root.py`): the dev checkout resolves to a root holding `uv.lock` + the resource files; a simulated in-repo non-editable venv (the exact layout that broke) resolves to the repo root; a simulated outside-workspace wheel falls back to cwd; `Settings` defaults anchor at `PROJECT_ROOT`.
- **Docs**: new section in [Production Deployment — Design](https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/) explaining the marker-walk resolution and recording that packaging the resource files into a wheel (`importlib.resources`) was considered and deliberately deferred until a repo-less install target actually exists.

## Verification

- `ruff`, `ty`, markdown lint, `mkdocs build --strict` all pass; full test suite: **394 passed, 1 skipped**.
- Rebuilt the production image with `scripts/build_and_verify_image.sh` (QEMU arm64): hermeticity check **passed** — with the env vars gone, the code location imports (the CV config loads at import, the exact site of the original `FileNotFoundError`), the model loads, and the run fails only at the expected NWP-availability lookup.
- Explicit in-container probe of the built image:

  ```text
  PROJECT_ROOT = /app
  cv_config_path -> /app/conf/cv/default.yaml exists: True
  nwp_metadata_csv_path -> /app/metadata/nwp_metadata.csv exists: True
  conf/model/xgboost.yaml exists: True
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)