### PR TITLE
Stop Sentry auto-capturing ERROR logs as events

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -11,9 +11,30 @@ Run the network tests with ``uv run pytest --run-network`` (add ``-m network`` t
 See docs/architecture/testing.md.
 """
 
+import os
 from collections.abc import Iterable
 
 import pytest
+
+
+def pytest_configure(config: pytest.Config) -> None:
+    """Neutralise any real ``SENTRY_DSN`` for the whole test session.
+
+    A developer's ``.env`` carries a live Sentry DSN (see the Sentry setup how-to), and pydantic
+    reads it into ``Settings.sentry_dsn``. Importing the Dagster definitions module — which several
+    tests do — then runs ``init_sentry`` at import with that live DSN, arming the SDK for the rest
+    of the process. From then on any Sentry send in a test reaches the *real* project: for example
+    the deliberate ``report_power_freshness`` error path in ``test_sentry.py`` logs at ``ERROR``,
+    which the SDK's default log-to-event capture would ship (that capture is now also disabled in
+    ``init_sentry``, but this env override is the belt-and-braces guard that holds even for a code
+    path we haven't foreseen).
+
+    Forcing the env var empty overrides the ``.env`` file value (env vars outrank the dotenv source
+    in pydantic-settings), so every ``Settings`` built during the session sees an empty DSN and
+    ``init_sentry`` stays a no-op. This runs before collection imports any test module, so it lands
+    ahead of the import-time ``init_sentry`` call.
+    """
+    os.environ["SENTRY_DSN"] = ""
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -100,12 +100,14 @@ is configured — so laptops and CI stay silent by default.
 - **Error telemetry.** `init_sentry` initialises the SDK once per process at import of the Dagster
   definitions module, and a Dagster `@failure_hook` (`sentry_capture_failure`, attached to the
   scheduled asset jobs) reports a failed step's exception — traceback intact — from inside the run
-  worker. The explicit hook is used rather than relying on Sentry's logging integration alone
-  because Dagster logs a step failure without `exc_info`, so a purely log-based capture would yield
-  a message-only event with no stack trace. The hook is attached to the three *scheduled* asset
-  jobs, so it covers the whole unattended production workload; failures in a manual UI
-  materialisation, a replay backfill, or an experiment job are watched by the operator at the
-  Dagster UI, not routed to Sentry.
+  worker. The explicit hook is used rather than Sentry's log-to-event capture, which `init_sentry`
+  deliberately disables (it passes a `LoggingIntegration` with `event_level=None`): Dagster logs a
+  step failure without `exc_info`, so a purely log-based capture would yield a message-only event
+  with no stack trace, and — left at its default `event_level=ERROR` — it would turn *every* `ERROR`
+  log in the process into a Sentry event, including Dagster's own startup and ad-hoc-run logs. The
+  hook is attached to the three *scheduled* asset jobs, so it covers the whole unattended production
+  workload; because log capture is off, failures in a manual UI materialisation, a replay backfill,
+  or an experiment job are watched by the operator at the Dagster UI, not routed to Sentry.
 
 - **The missed-check-in alarm** — the *primary* production alert. After each successful *live*
   `live_forecasts` run, the asset sends one success check-in (a heartbeat) to a Sentry cron

--- a/src/nged_substation_forecast/_sentry.py
+++ b/src/nged_substation_forecast/_sentry.py
@@ -6,9 +6,12 @@ Sentry configuration:
 - **Error telemetry** — :func:`init_sentry` initialises the SDK once per process (a no-op unless
   ``Settings.sentry_dsn`` is set), and the :data:`sentry_capture_failure` Dagster failure hook
   reports the real exception (with traceback) from inside the run worker. The hook is used rather
-  than relying on Sentry's ``LoggingIntegration`` alone because Dagster logs a step failure without
-  ``exc_info``, so the log-based path would yield a message-only event with no stack trace. The hook
-  is attached to the *scheduled* asset jobs only, so it covers the unattended production workload;
+  than Sentry's ``LoggingIntegration`` log-to-event capture — which :func:`init_sentry` explicitly
+  disables — because Dagster logs a step failure without ``exc_info``, so the log-based path would
+  yield a message-only event with no stack trace, *and* would fire for every ``ERROR`` log anywhere
+  in the process (Dagster's own startup/step logs, ad-hoc materialisations, even a swallowed
+  telemetry error), swamping Sentry with events the design never intended to send. The hook is
+  attached to the *scheduled* asset jobs only, so it covers the unattended production workload;
   manual/backfill/experiment runs are watched by the operator at the Dagster UI, not Sentry.
 - **The missed-check-in alarm** — :func:`send_forecast_checkin` sends a *success-only* heartbeat to
   a Sentry cron monitor after each live ``live_forecasts`` run. It is gated on
@@ -37,6 +40,7 @@ from contracts.settings import Settings
 from dagster import HookContext, failure_hook
 from sentry_sdk.crons import capture_checkin
 from sentry_sdk.crons.consts import MonitorStatus
+from sentry_sdk.integrations.logging import LoggingIntegration
 
 if TYPE_CHECKING:
     from sentry_sdk._types import MonitorConfig
@@ -83,6 +87,15 @@ def init_sentry(settings: Settings) -> None:
     or CI unless a DSN is explicitly configured. Called once per process at import of the Dagster
     definitions module, so it runs in the daemon, the webserver, and every run worker.
 
+    Log-to-event capture is deliberately switched off: passing a ``LoggingIntegration`` with
+    ``event_level=None`` overrides the SDK's default integration (whose default ``event_level`` is
+    ``ERROR``), so ``ERROR``-level log records no longer become Sentry events. Without this, every
+    ``ERROR`` log anywhere in the process — Dagster's startup/step logs, ad-hoc materialisations,
+    even the swallowed telemetry error in :func:`report_power_freshness` — would be shipped as an
+    event, defeating the design where *only* the failure hook and the explicit freshness
+    ``capture_message`` reach Sentry. Breadcrumbs (the integration's default ``level=INFO``) are
+    kept, so log context still rides along with the events the two intended paths do send.
+
     Args:
         settings: The project settings carrying the Sentry DSN, environment, and sample rate.
     """
@@ -93,6 +106,7 @@ def init_sentry(settings: Settings) -> None:
         environment=settings.sentry_environment,
         traces_sample_rate=settings.sentry_traces_sample_rate,
         send_default_pii=False,
+        integrations=[LoggingIntegration(event_level=None)],
     )
 
 

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -95,6 +95,30 @@ def test_init_sentry_passes_environment_when_dsn_set(monkeypatch: pytest.MonkeyP
     assert calls[0]["send_default_pii"] is False
 
 
+def test_init_sentry_disables_log_to_event_capture(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A DSN ⇒ init installs a ``LoggingIntegration`` with event capture off (``event_level=None``).
+
+    This is the guard that keeps ``ERROR`` logs from anywhere in the process — Dagster's
+    startup/step logs, ad-hoc materialisations, the swallowed telemetry error in
+    ``report_power_freshness`` — from becoming Sentry events. Only the failure hook and the explicit
+    freshness ``capture_message`` should ever send. If someone drops the ``integrations`` argument,
+    the SDK's default ``LoggingIntegration`` (``event_level=ERROR``) comes back and this fails.
+    """
+    calls: list[dict[str, Any]] = []
+    monkeypatch.setattr(_sentry.sentry_sdk, "init", lambda **kw: calls.append(kw))
+    _sentry.init_sentry(_settings(sentry_dsn=_DSN))
+    (kwargs,) = calls
+    logging_integrations = [
+        integration
+        for integration in kwargs["integrations"]
+        if isinstance(integration, _sentry.LoggingIntegration)
+    ]
+    assert len(logging_integrations) == 1
+    # event_level=None ⇒ the integration builds no event handler, so ERROR logs aren't captured as
+    # events (only breadcrumbs, via the still-default level=INFO breadcrumb handler).
+    assert logging_integrations[0]._handler is None
+
+
 def test_send_forecast_checkin_is_noop_when_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:
     """``sentry_monitor_forecasts`` False (the default) ⇒ no check-in is sent."""
     calls: list[dict[str, Any]] = []


### PR DESCRIPTION
## Why

Whenever Dagster starts up on a laptop with a live `SENTRY_DSN` in `.env`, it was sending unexpected events to Sentry — including ones attributed to `__ephemeral_asset_job__` and to `tests.test_sentry` (`RuntimeError: sentry down`).

Root cause: `init_sentry` called `sentry_sdk.init(...)` **without** disabling default integrations, so Sentry's `LoggingIntegration` was active. Its default `event_level=ERROR` turns **every** `ERROR`-level log record anywhere in the process into a Sentry event. That silently defeated the telemetry design established in #63 / #410 / #412, where **only** two paths were meant to send:

- the `@failure_hook` (`sentry_capture_failure`) on the *scheduled* asset jobs, and
- the explicit freshness `capture_message` warning.

Instead, any `ERROR` log was shipped: Dagster's own startup/step logs, ad-hoc asset materialisations (`__ephemeral_asset_job__`), and — most visibly — the deliberately-swallowed telemetry error in `report_power_freshness`, which `tests/test_sentry.py` exercises. Running the test suite (or `dg dev`) with a real DSN in `.env` therefore leaked test-generated errors to the real project.

## What changed

1. **`init_sentry` disables log-to-event capture** — passes `LoggingIntegration(event_level=None)`, overriding the SDK default so `ERROR` logs no longer become events. Breadcrumbs (default `level=INFO`) are kept, so log context still accompanies the events the two intended paths send. A regression test (`test_init_sentry_disables_log_to_event_capture`) locks this in — it fails if someone drops the `integrations` argument and the default `event_level=ERROR` returns.

2. **Belt-and-braces test guard** — the repo-root `conftest.py` now forces `SENTRY_DSN` empty for the whole test session via `pytest_configure` (env vars outrank the dotenv source in pydantic-settings, verified empirically), so no test can reach the real Sentry project even through a code path we haven't foreseen — independent of fix (1).

3. **Docs** — the design page (`docs/architecture/production-deployment.md`) now states that log-to-event capture is *explicitly disabled*, which is what makes its existing "manual/backfill runs are not routed to Sentry" claim actually true.

## Verification

- `uv run pytest tests/test_sentry.py tests/test_checks.py` → 28 passed.
- Empirically confirmed a live DSN in `.env` reads as non-empty, and `SENTRY_DSN=""` in the environment overrides it to empty (the mechanism fix (2) relies on).
- `uv run ruff check`, `uv run ruff format --check`, `uv run --all-packages ty check`, and `pymarkdown` all pass (pre-commit clean).

## Context

- Follows up the Sentry integration work: #410 (error reporting + missed-check-in alarm) and #412 (freshness → Sentry warning).
- Original tracking issue: #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)