### PR TITLE
Allow the docs deploy to be triggered by hand

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,9 @@ on:
       - 'docs/**'      # Only run if you change the docs
       - 'mkdocs.yml'
       - 'src/**'       # Or if you change the source code (for mkdocstrings)
+  # Lets us re-deploy by hand from the Actions tab. GitHub drops queued events during an Actions
+  # outage and never backfills them, so a merge that lands mid-outage silently never publishes.
+  workflow_dispatch:
 
 # This permission is required so the action can push the built HTML to the gh-pages branch
 permissions:


### PR DESCRIPTION
## Problem

`docs.yml` only fires on `push` to `main`. GitHub Actions had a major outage on 2026-08-06; the push event for the #428 merge was dropped and Actions does not backfill events once it recovers. The merge therefore never published, and there was no way to re-trigger it:

- `gh workflow run docs.yml` — unavailable, no `workflow_dispatch` trigger.
- Re-running the last successful run — would check out the previous commit and redeploy the *old* build.
- An empty nudge commit straight to `main` — refused by the ruleset's required `ci` check.

The site was recovered by running `uv run mkdocs gh-deploy --force` from a laptop, which works but bypasses CI and force-pushes `gh-pages`.

## Fix

Add `workflow_dispatch` so the deploy can be re-run from the Actions tab.

Note this does not fire on merge: the paths filter covers `docs/**`, `mkdocs.yml` and `src/**`, not `.github/**`. It only buys the manual button for next time.