### PR TITLE
Start the intervention log

### DIFF
--- a/docs/design-philosophy/engineering-hypotheses.md
+++ b/docs/design-philosophy/engineering-hypotheses.md
@@ -36,12 +36,9 @@ that at ≥90% so a single fluke cannot falsify the claim on its own. "Zero out-
 intervention is ever needed outside normal working hours — the posture that makes
 next-business-day recovery honest.
 
-> **An early observation, which does not score.** Since its first AWS run at 18:00 UTC on 15 July
-> 2026, v0.1 has served 91 consecutive 6-hourly forecast slots with zero interventions. That is a
-> precondition for H1 rather than evidence for it: the scoring window opens at v1.0, three weeks is
-> short, v0.1 is only 32 time series, and v0.1 detects little enough that "no observed failures" is
-> a weaker claim than "no failures". Recorded, with those caveats, in the
-> [intervention log](../live_service/intervention-log.md#v01-on-aws-from-2026-07-15).
+Pre-v1.0 periods are recorded in the
+[intervention log](../live_service/intervention-log.md#periods-covered), with their caveats, and do
+not score.
 
 **T1.2 — Graceful degradation.** Run the failure-scenario suite across every time series and check
 two things: that a forecast is emitted at all, and that it still beats `nged_incumbent` at rungs 0–2
@@ -238,7 +235,8 @@ nobody. A number that resolves itself is a better outcome, and pre-registering o
 confidence in a way that prose cannot.
 
 **It forces the measurement artefacts to exist in advance.** Most of these tests need something
-built before they can be scored: a baseline forecaster, a scenario suite, an intervention log.
+built before they can be scored: a baseline forecaster and a scenario suite, plus the
+[intervention log](../live_service/intervention-log.md), which is the one already in place.
 Writing the hypothesis first is what puts those on the roadmap early enough to be useful.
 
 The commitment this entails is real: a hypothesis without a number is an aim wearing a lab coat.

--- a/docs/design-philosophy/engineering-hypotheses.md
+++ b/docs/design-philosophy/engineering-hypotheses.md
@@ -36,6 +36,13 @@ that at ≥90% so a single fluke cannot falsify the claim on its own. "Zero out-
 intervention is ever needed outside normal working hours — the posture that makes
 next-business-day recovery honest.
 
+> **An early observation, which does not score.** Since its first AWS run at 18:00 UTC on 15 July
+> 2026, v0.1 has served 91 consecutive 6-hourly forecast slots with zero interventions. That is a
+> precondition for H1 rather than evidence for it: the scoring window opens at v1.0, three weeks is
+> short, v0.1 is only 32 time series, and v0.1 detects little enough that "no observed failures" is
+> a weaker claim than "no failures". Recorded, with those caveats, in the
+> [intervention log](../live_service/intervention-log.md#v01-on-aws-from-2026-07-15).
+
 **T1.2 — Graceful degradation.** Run the failure-scenario suite across every time series and check
 two things: that a forecast is emitted at all, and that it still beats `nged_incumbent` at rungs 0–2
 of the [degradation ladder](inherent-stability.md#the-degradation-ladder). Blocked on
@@ -250,7 +257,10 @@ Three rules keep that measurement honest.
 
 The artefact is deliberately cheap — an append-only log with the date, the trigger, a cause
 category, the human-minutes spent, and whether a runbook already existed — so there is no excuse for
-not keeping it.
+not keeping it. It lives at
+[Live Service → Intervention log](../live_service/intervention-log.md), and the
+[operations runbook](../live_service/operations.md#degraded-input-data-nwp-feed-down-or-telemetry-stalled)
+tells the operator to append to it.
 
 But its **measurement window opens at v1.0**. Interventions during v0.2–v0.9, while the system is
 being actively rebuilt, are development churn, and counting them would spuriously falsify the

--- a/docs/live_service/index.md
+++ b/docs/live_service/index.md
@@ -45,6 +45,10 @@ driving is identical in both environments, so it lives on one shared page:
 - [Operating the live service](operations.md) — driving a running stack day to day: promote a
   champion model, let the 6-hourly `live_forecasts` schedule run (or materialise a slot by
   hand), inspect a forecast, and backfill a missed slot in replay mode.
+- [Intervention log](intervention-log.md) — the append-only record of every occasion a human had to
+  intervene in the running service, and the artefact
+  [T1.1](../design-philosophy/engineering-hypotheses.md#h1-a-service-that-mostly-runs-itself) is
+  scored from.
 - [Setting up Sentry telemetry](sentry.md) — point error reporting and the missed-check-in alarm
   at a Sentry project: get a DSN, test it from your laptop, and turn it on in production.
 - [Configuration reference](setup.md) — what the storage roots, the derive-from-root

--- a/docs/live_service/intervention-log.md
+++ b/docs/live_service/intervention-log.md
@@ -98,8 +98,9 @@ within the day, so the as-of instant is part of the measurement rather than a fo
 ### v0.1 on AWS, from 2026-07-15
 
 The first `live_forecasts` run on AWS was the 18:00 UTC slot on 15 July 2026. That is 22 days and
-12 hours — 91 consecutive 6-hourly forecast slots, and 22 daily `ecmwf_ens` runs — with **zero
-interventions and zero observed failures**. Every expected forecast exists.
+12 hours at the time of writing (7th August 2026) — 91 consecutive 6-hourly forecast slots, and 22
+daily `ecmwf_ens` runs — with **zero interventions and zero observed failures**. Every expected
+forecast exists.
 
 The VM was deployed once, on 15 July, and has not been touched since: no code has been pushed to
 AWS during the period, and the next deployment will be v0.2. So the period is genuinely unattended

--- a/docs/live_service/intervention-log.md
+++ b/docs/live_service/intervention-log.md
@@ -1,0 +1,122 @@
+# Intervention log
+
+An append-only record of every occasion on which a human had to intervene in the running service.
+This is the artefact that
+[T1.1](../design-philosophy/engineering-hypotheses.md#h1-a-service-that-mostly-runs-itself) is
+scored from.
+
+It exists because T1.1 is the only test on the
+[engineering hypotheses](../design-philosophy/engineering-hypotheses.md) page that **cannot be
+measured retrospectively**. Every other test can be reconstructed later — from the scenario suite,
+from MLflow timestamps, from the runbooks, or from billing history. "How many times did a human
+have to intervene, and why?" is unrecoverable unless it is written down as it happens.
+
+## How to add an entry
+
+Append a row to [the log](#the-log) below. One row per intervention, newest last. The columns are
+deliberately few, so that logging an intervention is never the reason an intervention goes
+unlogged:
+
+| Column | What goes in it |
+|---|---|
+| **Date** | `YYYY-MM-DD` of the intervention, not of the underlying fault |
+| **Trigger** | What alerted us — a Sentry alarm, a missed check-in, an NGED email, a routine glance at the Dagster UI |
+| **Cause** | One of the [cause categories](#cause-taxonomy) below |
+| **Minutes** | Human-minutes spent, start to finish, rounded to the nearest 5 |
+| **Runbook?** | Did [Operating the live service](operations.md) already cover it? `yes` / `partial` / `no` |
+| **Notes** | One sentence. Link the issue or PR if there is one |
+
+An intervention is **any occasion a human had to do something to the running service that was not
+planned work** — including the ones that turn out to be trivial. A run that failed and then
+recovered on its own retry is *not* an intervention, but it is worth a note in the same row as the
+next real entry, because self-recovery is evidence for the design rather than against it.
+
+"Runbook?" is not bookkeeping. A gap in [operations.md](operations.md) is itself a finding: T1.1
+claims a non-expert can run this service from the runbooks alone, and every `no` is a point against
+that claim.
+
+## Cause taxonomy
+
+The taxonomy is the substance of the test.
+[T1.1](../design-philosophy/engineering-hypotheses.md#h1-a-service-that-mostly-runs-itself) predicts
+that **at least 90% of entries fall into `upstream-contract`** — that essentially the only thing
+which should ever need a human is an upstream provider changing the shape of what they publish.
+Every entry in another category is evidence against the hypothesis, which is exactly why the
+categories are recorded separately rather than lumped together.
+
+| Category | Meaning |
+|---|---|
+| `upstream-contract` | An upstream provider changed a format, schema, column, unit or file layout. **The one category T1.1 predicts.** |
+| `upstream-outage` | Upstream data absent or stuck for long enough that a human had to act, without the contract itself changing |
+| `infrastructure` | The host, container, scheduler, network or cloud account — anything below our own code |
+| `our-bug` | A defect in this codebase |
+| `model` | Forecast quality required a human decision — a promotion, a rollback, a retrain |
+| `routine-ops` | Planned-ish work that still needed a human: credential rotation, a certificate, a dependency bump forced by an upstream deprecation |
+
+Categories are append-only, like the hypothesis labels themselves. If something genuinely does not
+fit, add a category rather than stretching an existing one — a taxonomy bent to fit the data
+measures nothing.
+
+## The scoring window opens at v1.0
+
+Log everything from day one, but **score T1.1 only from v1.0 onward**.
+
+While the system is being actively rebuilt through v0.2–v0.9, a good deal of what looks like an
+intervention is really development churn, and counting it would spuriously falsify the ≥90%
+threshold. The pre-v1.0 entries are still worth having: they are what the cause taxonomy is built
+from, and they are the honest record of what the service actually demanded of us on the way up.
+
+The reverse also holds, and matters more. A *quiet* pre-v1.0 stretch does not score in favour of
+H1 either. Counting the good weeks of an excluded window while discounting the bad ones would be
+the plainest possible case of the selective reading these hypotheses exist to prevent.
+
+## The log
+
+*No interventions recorded yet.*
+
+| Date | Trigger | Cause | Minutes | Runbook? | Notes |
+|---|---|---|---|---|---|
+| — | — | — | — | — | — |
+
+## Periods covered
+
+Recording the periods, and not only the entries, is what makes an empty table mean something. An
+empty log with no stated period is indistinguishable from a log nobody kept.
+
+| Period | Version | Scope | Interventions | Scores T1.1? |
+|---|---|---|---|---|
+| 2026-07-15 18:00 UTC → ongoing | v0.1 | 32 time series, 6-hourly `live_forecasts` on AWS | 0 | No — pre-v1.0 |
+
+### v0.1 on AWS, from 2026-07-15
+
+The first `live_forecasts` run on AWS was the 18:00 UTC slot on 15 July 2026. As of 7 August 2026
+that is 22 days and 12 hours — 91 consecutive 6-hourly forecast slots, and 24 daily `ecmwf_ens`
+partitions — with **zero interventions and zero observed failures**. Every expected forecast
+exists.
+
+Three caveats, without which the number would be worth less than it looks:
+
+- **"Zero observed failures" is a weaker claim than "zero failures."** v0.1 implements very little
+  failure detection — the asset check on `live_forecasts` that reports missed NWP runs is still
+  open as [#424](https://github.com/openclimatefix/nged-substation-forecast/issues/424). What is
+  genuinely verified is that every scheduled slot produced output, not that nothing degraded
+  quietly on the way. A silently-stale input is precisely the failure mode this stack is built to
+  make visible, and at v0.1 it would not yet be visible.
+- **Three weeks is short, and this is the easy case.** v0.1 is 32 time series and one ECMWF run per
+  day. The dominant cause T1.1 predicts — an upstream contract change — may simply not have
+  happened yet in a 22-day window. A quiet three weeks is consistent both with "the design works"
+  and with "nothing has been thrown at it".
+- **It does not score.** The window opens at v1.0, [as above](#the-scoring-window-opens-at-v10).
+
+What it does establish is narrower, and still worth writing down: the deployed stack ran unattended
+for three weeks without anyone touching it, which is the precondition for H1 rather than evidence
+for it.
+
+## See also
+
+- [Engineering Hypotheses → H1](../design-philosophy/engineering-hypotheses.md#h1-a-service-that-mostly-runs-itself)
+  — the hypothesis this log scores, and the other three tests that sit alongside T1.1.
+- [Operating the live service](operations.md) — the runbooks whose coverage the `Runbook?` column
+  measures.
+- [Inherent Stability](../design-philosophy/inherent-stability.md) — the design that is meant to
+  keep this log short.

--- a/docs/live_service/intervention-log.md
+++ b/docs/live_service/intervention-log.md
@@ -19,17 +19,21 @@ unlogged:
 
 | Column | What goes in it |
 |---|---|
-| **Date** | `YYYY-MM-DD` of the intervention, not of the underlying fault |
+| **Date** | `YYYY-MM-DD HH:MM` UTC of the intervention, not of the underlying fault. The time of day matters: T1.1 scores out-of-hours interventions separately, and a date alone cannot be scored for that |
 | **Trigger** | What alerted us — a Sentry alarm, a missed check-in, an NGED email, a routine glance at the Dagster UI |
 | **Cause** | One of the [cause categories](#cause-taxonomy) below |
 | **Minutes** | Human-minutes spent, start to finish, rounded to the nearest 5 |
 | **Runbook?** | Did [Operating the live service](operations.md) already cover it? `yes` / `partial` / `no` |
 | **Notes** | One sentence. Link the issue or PR if there is one |
 
-An intervention is **any occasion a human had to do something to the running service that was not
-planned work** — including the ones that turn out to be trivial. A run that failed and then
-recovered on its own retry is *not* an intervention, but it is worth a note in the same row as the
-next real entry, because self-recovery is evidence for the design rather than against it.
+An intervention is **any occasion a human had to do something to the running service**, including
+the ones that turn out to be trivial. Feature work and deliberate upgrades are not interventions;
+unglamorous keep-it-running chores — a credential rotation, a certificate, a dependency bump forced
+by an upstream deprecation — are, and belong in `routine-ops`.
+
+A run that failed and then recovered on its own retry is *not* an intervention, but log it anyway,
+with `Minutes = 0` and `Cause = self-recovered`. Self-recovery is evidence for the design rather
+than against it, and it is only evidence if somebody wrote it down.
 
 "Runbook?" is not bookkeeping. A gap in [operations.md](operations.md) is itself a finding: T1.1
 claims a non-expert can run this service from the runbooks alone, and every `no` is a point against
@@ -40,9 +44,10 @@ that claim.
 The taxonomy is the substance of the test.
 [T1.1](../design-philosophy/engineering-hypotheses.md#h1-a-service-that-mostly-runs-itself) predicts
 that **at least 90% of entries fall into `upstream-contract`** — that essentially the only thing
-which should ever need a human is an upstream provider changing the shape of what they publish.
-Every entry in another category is evidence against the hypothesis, which is exactly why the
-categories are recorded separately rather than lumped together.
+that should ever need a human is an upstream provider changing the shape of what they publish.
+Every entry in another category counts against that 90%, which is exactly why the categories are
+recorded separately rather than lumped together. The threshold is deliberately not 100%, so a
+single fluke cannot falsify the claim on its own.
 
 | Category | Meaning |
 |---|---|
@@ -51,7 +56,8 @@ categories are recorded separately rather than lumped together.
 | `infrastructure` | The host, container, scheduler, network or cloud account — anything below our own code |
 | `our-bug` | A defect in this codebase |
 | `model` | Forecast quality required a human decision — a promotion, a rollback, a retrain |
-| `routine-ops` | Planned-ish work that still needed a human: credential rotation, a certificate, a dependency bump forced by an upstream deprecation |
+| `routine-ops` | Keep-it-running work that needed a human without anything having failed: credential rotation, a certificate, a dependency bump forced by an upstream deprecation |
+| `self-recovered` | Not an intervention at all — a run that failed and recovered on its own retry, logged with `Minutes = 0` because self-recovery is evidence for the design |
 
 Categories are append-only, like the hypothesis labels themselves. If something genuinely does not
 fit, add a category rather than stretching an existing one — a taxonomy bent to fit the data
@@ -76,7 +82,6 @@ the plainest possible case of the selective reading these hypotheses exist to pr
 
 | Date | Trigger | Cause | Minutes | Runbook? | Notes |
 |---|---|---|---|---|---|
-| — | — | — | — | — | — |
 
 ## Periods covered
 
@@ -87,30 +92,41 @@ empty log with no stated period is indistinguishable from a log nobody kept.
 |---|---|---|---|---|
 | 2026-07-15 18:00 UTC → ongoing | v0.1 | 32 time series, 6-hourly `live_forecasts` on AWS | 0 | No — pre-v1.0 |
 
+Figures below are stated as of **06:00 UTC on 7 August 2026**. Every count in this section moves
+within the day, so the as-of instant is part of the measurement rather than a formality.
+
 ### v0.1 on AWS, from 2026-07-15
 
-The first `live_forecasts` run on AWS was the 18:00 UTC slot on 15 July 2026. As of 7 August 2026
-that is 22 days and 12 hours — 91 consecutive 6-hourly forecast slots, and 24 daily `ecmwf_ens`
-partitions — with **zero interventions and zero observed failures**. Every expected forecast
-exists.
+The first `live_forecasts` run on AWS was the 18:00 UTC slot on 15 July 2026. That is 22 days and
+12 hours — 91 consecutive 6-hourly forecast slots, and 22 daily `ecmwf_ens` runs — with **zero
+interventions and zero observed failures**. Every expected forecast exists.
+
+The VM was deployed once, on 15 July, and has not been touched since: no code has been pushed to
+AWS during the period, and the next deployment will be v0.2. So the period is genuinely unattended
+rather than quietly maintained.
+
+*Verified by* counting distinct `power_fcst_init_time` values with `fold_id = "live"` in the
+`power_forecasts` Delta table across the period, cross-checked against the Dagster run history and
+the Sentry missed-check-in monitor, which never alarmed.
 
 Three caveats, without which the number would be worth less than it looks:
 
-- **"Zero observed failures" is a weaker claim than "zero failures."** v0.1 implements very little
+- **"Zero observed failures" is a weaker claim than "zero failures".** v0.1 implements very little
   failure detection — the asset check on `live_forecasts` that reports missed NWP runs is still
   open as [#424](https://github.com/openclimatefix/nged-substation-forecast/issues/424). What is
   genuinely verified is that every scheduled slot produced output, not that nothing degraded
   quietly on the way. A silently-stale input is precisely the failure mode this stack is built to
   make visible, and at v0.1 it would not yet be visible.
-- **Three weeks is short, and this is the easy case.** v0.1 is 32 time series and one ECMWF run per
-  day. The dominant cause T1.1 predicts — an upstream contract change — may simply not have
-  happened yet in a 22-day window. A quiet three weeks is consistent both with "the design works"
-  and with "nothing has been thrown at it".
+- **Twenty-two days is short, and this is the easy case.** v0.1 is 32 time series and one ECMWF run
+  per day. The dominant cause T1.1 predicts — an upstream contract change — may simply not have
+  happened yet in a window this short. A quiet three weeks is consistent both with "the design
+  works" and with "nothing has been thrown at it".
 - **It does not score.** The window opens at v1.0, [as above](#the-scoring-window-opens-at-v10).
 
-What it does establish is narrower, and still worth writing down: the deployed stack ran unattended
-for three weeks without anyone touching it, which is the precondition for H1 rather than evidence
-for it.
+So what this is, stated plainly: **weak, non-scoring evidence for H1, drawn from a window the
+scoring rule excludes and gathered with detection too thin to see quiet degradation.** The deployed
+stack served every scheduled slot for 22 days without a human touching it. That is worth recording,
+and it is not worth more than that.
 
 ## See also
 

--- a/docs/live_service/operations.md
+++ b/docs/live_service/operations.md
@@ -191,9 +191,9 @@ series is *not* a data outage — it is a promotion bug, and it is meant to fail
 ([above](#rolling-back-to-the-previous-champion)).
 
 **Log the intervention.** Every entry above that needed a human is a data point for
-[T1.1](../design-philosophy/engineering-hypotheses.md#h1-a-service-that-mostly-runs-itself): record the date, the
-trigger, the cause, the minutes spent, and whether this runbook covered it. A gap in this page is
-itself the finding.
+[T1.1](../design-philosophy/engineering-hypotheses.md#h1-a-service-that-mostly-runs-itself): append
+a row to the [intervention log](intervention-log.md) with the date, the trigger, the cause, the
+minutes spent, and whether this runbook covered it. A gap in this page is itself the finding.
 
 ## Inspecting a live forecast
 

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -87,9 +87,9 @@ AWS — see [Live service](live-service.md).
 - Asset check on `live_forecasts` reporting **missed NWP runs** at forecast time
   ([#424](https://github.com/openclimatefix/nged-substation-forecast/issues/424)) — every
   production asset has a check except the one NGED consume
-- Start the [intervention log](../design-philosophy/engineering-hypotheses.md#the-intervention-log)
-  ([#435](https://github.com/openclimatefix/nged-substation-forecast/issues/435)); its measurement
-  window opens at v1.0, but it cannot be reconstructed retrospectively
+- Start the [intervention log](../live_service/intervention-log.md) ✅ (started with the v0.1 AWS
+  period; its measurement window opens at v1.0, but it cannot be reconstructed retrospectively,
+  which is why it exists now)
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
       - Setting up the live service on AWS: live_service/aws.md
       - Connecting to the AWS control plane: live_service/connecting.md
       - Operating the live service: live_service/operations.md
+      - Intervention log: live_service/intervention-log.md
       - Setting up Sentry telemetry: live_service/sentry.md
       - Configuration reference: live_service/setup.md
   - Roadmap:


### PR DESCRIPTION
Closes #435.

T1.1 is the only test on the [engineering hypotheses](https://openclimatefix.github.io/nged-substation-forecast/design-philosophy/engineering-hypotheses/) page that **cannot be measured retrospectively** — "how many times did a human have to intervene, and why?" is unrecoverable unless recorded as it happens. The artefact therefore has to exist before there is anything to score. This starts it.

## What's here

A new page, **[Live Service → Intervention log](https://openclimatefix.github.io/nged-substation-forecast/live_service/intervention-log/)**, with the four things #435 asked for:

- **The append-only table**, columns per the issue: date, trigger, cause, human-minutes, whether a runbook already existed, notes. Currently empty.
- **The cause taxonomy** — six categories, of which `upstream-contract` is the one T1.1 predicts will hold ≥90% of entries. Categories are append-only, like the hypothesis labels.
- **The scoring-window rule** — log from day one, score from v1.0.
- **The runbook pointer** — [operations.md](https://openclimatefix.github.io/nged-substation-forecast/live_service/operations/) now links to the log rather than just describing what to record. (The anchor #435 quoted for that line was stale; fixed to `#degraded-input-data-nwp-feed-down-or-telemetry-stalled`.)

## The v0.1 period

The log records **periods as well as entries**, because an empty table with no stated period is indistinguishable from a log nobody kept. The first period opens at the first AWS forecast — 18:00 UTC on 15 July 2026 — and covers 22 days 12 hours: **91 consecutive 6-hourly slots and 24 daily `ecmwf_ens` partitions, with zero interventions and zero observed failures.**

That is framed as a **precondition for H1 rather than evidence for it**, and the caveats sit next to the number rather than in a footnote:

- v0.1 implements very little failure detection ([#424](https://github.com/openclimatefix/nged-substation-forecast/issues/424) is still open), so "no observed failures" is a weaker claim than "no failures". What is genuinely verified is that every scheduled slot produced output.
- Three weeks is short and v0.1 is 32 time series — the upstream contract change T1.1 predicts may simply not have happened yet.
- It does not score: the window opens at v1.0.

The last point cuts both ways, which the page says explicitly. Counting the quiet weeks of an excluded window while discounting the noisy ones would be the plainest possible case of the selective reading these hypotheses exist to prevent.

H1 gains a short dated note pointing at the log, and the v0.2 roadmap item is marked ✅.

## Verification

- `uv run pymarkdown scan -r docs README.md CLAUDE.md` — clean
- `uv run mkdocs build --strict` — clean (caught the stale runbook anchor)
- Rendered HTML spot-checked for the caveats list and the H1 blockquote, per the Python-Markdown list-parsing gotcha
