### PR TITLE
Ground input-drift detection in Summer 2026; plan drought/long-window features

### DIFF
--- a/docs/design-philosophy/design-principles.md
+++ b/docs/design-philosophy/design-principles.md
@@ -477,17 +477,25 @@ the weather distributions, and the grid beneath the power data is changing fast 
 pumps).
 
 Great Britain's summer of 2026 is the concrete case, and it arrived while this page was being
-written. On the Met Office's provisional figures, July 2026 was the driest July in the England and
-Wales series that begins in 1836: England recorded 6.5 mm of rain, 10% of its long-term average,
-and southern England recorded 1.9 mm — 3% of average, and the driest month it has ever observed.
-The same month was the sunniest calendar month England and Wales have on record (a series starting
-in 1910) and the second-warmest July for the UK as a whole. At the season's halfway point the UK
-was running 1.8 °C above the seasonal norm on 42% of its average rainfall — warmer and drier than
-2025 at the same stage, and 2025 went on to be the UK's warmest summer on record. Every one of
-those is a real shift in the distribution of an input we feed the model, and not one of them is a
-fault. A naive "distribution changed" alarm would have fired continuously from May 2026 onwards
-while telling an operator nothing they could act on, which is exactly how such an alarm gets tuned
-into silence.
+written. All the figures here are the Met Office's provisional ones, current as of early August
+2026. July 2026 was the driest July in the England and Wales series that begins in 1836: England
+recorded 6.5 mm of rain, 10% of its long-term average, and southern England recorded 1.9 mm — 3% of
+average, and the driest month it has ever observed. The same month was the UK's sunniest July in a
+series running from 1910, and for England and Wales the sunniest *calendar month* ever observed; it
+was also the second-warmest July for the UK as a whole. Nor was this confined to one month: spring
+2026 was already the warmest on record for England and Wales, and at the summer's halfway point the
+UK was running 1.8 °C above the seasonal norm — warmer than 2025 at the same stage, and 2025 went
+on to be the UK's warmest summer on record. Every one of those is a real shift in the distribution
+of an input we feed the model, and not one of them is a fault. A naive "distribution changed" alarm
+would have fired continuously from spring 2026 onwards while telling an operator nothing they could
+act on, which is exactly how such an alarm gets tuned into silence.
+
+Note also how much the *choice of statistic* does here, which is part of why the design question is
+open. Summer rainfall to mid-July stood at 42% of the full season's long-term average against the
+roughly 50% normal for that date, which the Met Office fairly describes as just below average —
+even as the same season was producing individual months that broke 190-year records. A detector
+watching seasonal aggregates and one watching monthly or daily distributions would have told an
+operator entirely different stories about the same summer.
 
 The question to answer before adopting the practice is therefore whether the useful event is "the
 distribution changed" or "the model is extrapolating — being asked about conditions unlike anything

--- a/docs/design-philosophy/design-principles.md
+++ b/docs/design-philosophy/design-principles.md
@@ -473,14 +473,31 @@ model upgrade, a re-gridding, a re-metered substation. The case for it is strong
 horizon a forecast is not fully scoreable for a fortnight, so forecast *error* is a badly lagging
 indicator, while a shift in the *inputs* is visible the same day. But this is also the item with a
 genuinely open design question, because our inputs are **expected to drift**: climate change moves
-the weather distributions — a record-breaking hot, dry summer is climate signal, not sensor error —
-and the grid beneath the power data is changing fast (solar, EVs, heat pumps). A naive
-"distribution changed" alarm would either fire constantly or be tuned into silence. The question to
-answer before adopting the practice is whether the useful event is "the distribution changed" or
-"the model is extrapolating — being asked about conditions unlike anything it trained on". The two
-suggest different responses, and a record summer probably *should* be flagged — not as a fault, but
-as a legitimate reason for wider uncertainty bands, routing the signal into the in-band channel of
-principle 1 ("*the power forecast never stops*") rather than to a pager. We do not yet know the
+the weather distributions, and the grid beneath the power data is changing fast (solar, EVs, heat
+pumps).
+
+Great Britain's summer of 2026 is the concrete case, and it arrived while this page was being
+written. On the Met Office's provisional figures, July 2026 was the driest July in the England and
+Wales series that begins in 1836: England recorded 6.5 mm of rain, 10% of its long-term average,
+and southern England recorded 1.9 mm — 3% of average, and the driest month it has ever observed.
+The same month was the sunniest calendar month England and Wales have on record (a series starting
+in 1910) and the second-warmest July for the UK as a whole. At the season's halfway point the UK
+was running 1.8 °C above the seasonal norm on 42% of its average rainfall — warmer and drier than
+2025 at the same stage, and 2025 went on to be the UK's warmest summer on record. Every one of
+those is a real shift in the distribution of an input we feed the model, and not one of them is a
+fault. A naive "distribution changed" alarm would have fired continuously from May 2026 onwards
+while telling an operator nothing they could act on, which is exactly how such an alarm gets tuned
+into silence.
+
+The question to answer before adopting the practice is therefore whether the useful event is "the
+distribution changed" or "the model is extrapolating — being asked about conditions unlike anything
+it trained on". The two suggest different responses, and a summer like 2026's probably *should* be
+flagged — not as a fault, but as a legitimate reason for wider uncertainty bands, routing the
+signal into the in-band channel of principle 1 ("*the power forecast never stops*") rather than to
+a pager. There is also a model-side answer that is not monitoring at all: give the model features
+that let it *represent* the regime rather than merely detecting that it is unusual — the planned
+[weather-abnormality features](../roadmap/xgboost-improvements.md#weather-abnormality-climatology-z-score-features)
+are that answer, and the two are complementary rather than alternatives. We do not yet know the
 right design; working it out is the task.
 
 **Shadow (champion–challenger) deployment.** This means running a candidate model against live
@@ -506,9 +523,9 @@ first time a delivered table needs to change.
 answer to "detect a shift without picking an arbitrary fixed threshold", with decades of theory
 behind them. Fixed thresholds on a seasonal signal are either too loose in winter or too noisy in
 summer; SPC is designed for exactly that problem, and it answers "is the champion quietly
-degrading?" cheaply. It shares the open question raised under input drift detection above: a record summer will
-legitimately worsen
-forecast error, and the chart must not read that as a model regression.
+degrading?" cheaply. It shares the open question raised under input drift detection above: a summer
+like 2026's will legitimately worsen forecast error, and the chart must not read that as a model
+regression.
 
 **Naming poka-yoke.** Mistake-proofing, from manufacturing: design names and interfaces so the
 wrong usage fails to parse rather than being merely discouraged. The codebase already practises

--- a/docs/roadmap/xgboost-improvements.md
+++ b/docs/roadmap/xgboost-improvements.md
@@ -577,62 +577,89 @@ moment. A second family of features asks a different question: how abnormal has 
 climatological norm for that window, and the equivalent accumulated-temperature (or degree-day)
 anomaly, carry state that no instantaneous feature can hold. Great Britain's summer of 2026 is the
 regime in which the two diverge sharply: a single 25 °C afternoon tells the model nothing about
-whether the preceding quarter was
-[the driest on record since 1836](../design-philosophy/design-principles.md#industry-best-practices-we-have-not-yet-absorbed).
+whether the preceding quarter contained
+[the driest July England and Wales have recorded since their series began in 1836](../design-philosophy/design-principles.md#industry-best-practices-we-have-not-yet-absorbed).
 
 **Where the signal plausibly is**, in roughly descending order of confidence:
 
-- **Hydro.** `Hydro` is a real `time_series_type`, and run-of-river output is set by catchment
-  wetness — an accumulation over weeks to months — far more than by the rain falling during the
-  forecast window. This is the clearest physical case on the list, and the one where a 90-day
-  rainfall total is close to being the *primary* driver rather than a correction.
-- **Sustained-heat demand.** The Tier-2
+- **Sustained-heat demand** — the leading case for the v1 population, because most of that
+  population is demand. The Tier-2
   [effective temperature](#effective-smoothed-temperature-and-degree-day-features) smooths over
   roughly 1–3 days, which is building thermal inertia. A multi-week heat regime is a different
   thing: acclimatisation, cooling equipment bought partway through a hot summer and then kept, and
   ground and building-fabric temperatures that a three-day EWM cannot represent.
-- **Agricultural irrigation pumping.** Drought raises it, and the licence area carries arable load.
-  Real, but concentrated in a minority of series.
+- **Agricultural irrigation pumping.** Drought raises it, and the trial area sits in the EMids
+  licence area, which includes arable Lincolnshire. Treat that second clause as an assumption
+  rather than a finding: nothing in the metadata carries a land-use or customer-mix field, so it
+  needs confirming against NGED's own customer mix before anyone leans on it.
 - **PV soiling.** A long dry spell lets dust and pollen build up on panels and rain washes them
-  clean, so a "days since meaningful rain" feature has a genuine mechanism behind it. Expect it to
-  sit under the noise floor.
+  clean. Note that this partly overlaps work already assigned elsewhere: the capacity model absorbs
+  *average* soiling bias into the effective-capacity estimate
+  ([honest caveats of the convex route](capacity-estimation.md#honest-caveats-of-the-convex-route)),
+  so only the time-*varying* part is left for a feature to explain. That residue is small enough
+  that it will most likely sit under the noise floor, and a "days since meaningful rain" feature is
+  in any case a different construct from the accumulate-and-normalise family described here.
+- **Hydro.** Run-of-river output is set by catchment wetness — an accumulation over weeks to
+  months — far more than by the rain falling during the forecast window, so this is physically the
+  cleanest case of the four, and the one where a 90-day rainfall total approaches being a *primary*
+  driver rather than a correction. It is listed last because it has **no v1 exposure at all**:
+  `Hydro` is a valid `time_series_type` in the contract, but the
+  [32-series trial area](../index.md#scope) contains no hydro series, so the mechanism is
+  untestable until v2 widens the population.
 
-**Why this sits behind the instantaneous z-scores, and what it will and will not measure.** The
-obstacle is not the feature, it is the effective sample size. A 90-day accumulator moves slowly, so
-a training history of roughly 15 months of power data — against an ENS archive that only starts
-2024-04-01 — contains on the order of a *handful* of independent observations of it per series: one
-summer and one winter, not a distribution. A per-series booster will still happily split on it, and
-what it fits will largely be that particular year's idiosyncrasies, aliased with `day_of_year` and
-with any level drift over the same months. The instantaneous z-scores do not have this problem,
-because a heatwave anomaly recurs many times within a single year.
+**Why this sits behind the instantaneous z-scores, and what the leaderboard will actually tell
+you.** The obstacle is not the feature, it is the effective sample size *on the training side*. A
+90-day accumulator moves slowly, so the
+[leaderboard fold](../ml_experimentation/cross-validation-folds.md#current-state-a-single-fold)'s
+training window — 2024-04-01 to 2025-06-30, bounded below by the start of the ENS archive —
+contains a *handful* of independent observations of it per series: one summer and one winter, not a
+distribution. A per-series booster will still happily split on it, and what it fits will largely be
+that particular year's idiosyncrasies, aliased with the seasonal `local_time_of_year_sin`/`_cos`
+features and with any level drift over the same months. The instantaneous z-scores do not have this
+problem, because a heatwave anomaly recurs many times within a single year.
 
-The consequence is a *measurement* problem rather than a modelling one, and it is worth stating
-plainly before anyone registers the experiment: the value of a drought feature is out-of-sample
-robustness in a regime the training data barely contains, and a leaderboard scored on folds drawn
-from that same short history structurally cannot see it. This is the same argument the
-[monotone constraints](#monotone-constraints-for-the-generation-models) item makes — the win is
-"sane extrapolation in weather regimes the training year never saw" — and it should be judged the
-same way: expect roughly no leaderboard movement, and assess it on whether the model behaves
-sensibly when the accumulator is pushed to values the training set never held. It becomes a
-genuinely *measurable* feature only once
-[ERA5 pre-training](#explicitly-deferred-not-quick-or-not-skill) extends the effective history from
-one summer to several.
+The *validation* side is the opposite, and it is what makes this worth running rather than merely
+worth describing. The same fold validates on 2025-07-01 to 2026-06-30, which contains summer 2025
+(the UK's warmest on record) and spring 2026 (the warmest on record for England and Wales). This is
+a forward-chained split holding out genuinely extreme regimes, so the leaderboard *can* register a
+result here. What it cannot do is separate "the idea is wrong" from "one summer of training data
+was not enough to fit it" — so a loss is weak evidence rather than a verdict, and should be
+recorded as such in MLflow rather than closing the question.
 
-**Anchor it to init time, and source it from ERA5.** The accumulator is a property of the forecast
-*moment*, not of the target time — a 14-day window shifts a 90-day total only marginally — so it is
-the same number for every horizon in a run and should be computed once at `power_fcst_init_time`
-and broadcast, exactly like the
-[init-time-anchored features](#init-time-anchored-features-current-level-anchor-prerequisite-for-the-global-model).
-That anchoring also settles where the data comes from: a window reaching 90 days into the past
-cannot come from the forecast NWP trajectory at all, and stitching it together from archived ENS
-runs would ride the same uncut freshest-run join the residual-lag features flag. The clean source
-is the **ERA5 ingest** this item already depends on, which supplies the accumulation and its
-climatological norm from one table and one publication-time availability cut. Nothing here needs
-live data at forecast time beyond the ~5-day ERA5T latency, which is immaterial to a 90-day total.
+Two things follow for how to judge it. Expect a small or negative NMAE move, and pair the
+leaderboard number with an out-of-band check of whether the model still behaves sensibly when the
+accumulator is pushed past the values the training window held — the same "sane extrapolation in
+weather regimes the training year never saw" criterion the
+[monotone constraints](#monotone-constraints-for-the-generation-models) item is judged on. Note
+that this does not trade away principle 8 ("*every experiment is scored identically*"): the
+leaderboard measurement is unchanged and stays comparable, and the extrapolation check is an
+*additional* acceptance criterion rather than a substitute score. The feature becomes cleanly
+measurable only once [ERA5 pre-training](#explicitly-deferred-not-quick-or-not-skill) extends the
+training history from one summer to several.
 
-**Scope the first long-window experiment to precipitation**, since accumulated-heat effects are
-partly reachable by lengthening the effective-temperature EWM, which is a config change rather than
-a new data dependency and should be tried first as the cheap control.
+**Anchor it to init time, and source it from ERA5.** Compute the accumulator once at
+`power_fcst_init_time` and broadcast it across every horizon in the run, exactly like the
+[init-time-anchored features](#init-time-anchored-features-current-level-anchor-prerequisite-for-the-global-model)
+and for the same reason: an init-time anchor is never leaky and never null at any horizon. (A
+target-time-anchored variant, whose window slides with `valid_time`, is a genuinely different
+feature — over a 14-day horizon it moves a 30-day window by nearly half its length — and can be
+tried separately if the init-time version earns it.) The anchoring also settles where the data
+comes from: a window reaching 90 days into the past cannot come from the forecast NWP trajectory at
+all, and stitching it together from archived ENS runs would ride the same uncut freshest-run join
+the residual-lag features flag. The clean source is the **ERA5 ingest** this item already depends
+on, which supplies the accumulation and its climatological norm from one table and one
+publication-time availability cut. Nothing here needs live data at forecast time beyond the ~5-day
+ERA5T latency, which is immaterial to a 90-day total.
+
+**Scope the first long-window experiment to precipitation.** The accumulated-*heat* variant is
+tempting to reach for first as a cheap control, on the grounds that it is just a longer
+effective-temperature EWM — but that is wrong, and for the reason this section has already given.
+The Tier-2 effective temperature is computed from the NWP trajectory itself, and
+`_apply_rolling_mean_feature` groups by `nwp_init_time` precisely so that a window cannot span
+runs, so with a 15-day ENS run there is no multi-week EWM to configure: the heat accumulator
+carries the same ERA5 dependency as the precipitation one. The genuinely cheap control is to
+lengthen the EWM only as far as the trajectory allows (~7–10 days), which is a weaker experiment
+and should be labelled as one.
 
 ## Tier 4 — structural model changes (weeks)
 

--- a/docs/roadmap/xgboost-improvements.md
+++ b/docs/roadmap/xgboost-improvements.md
@@ -582,8 +582,28 @@ whether the preceding quarter contained
 
 **Where the signal plausibly is**, in roughly descending order of confidence:
 
-- **Sustained-heat demand** — the leading case for the v1 population, because most of that
-  population is demand. The Tier-2
+- **PV soiling** — the mechanism this project has already worked out in most detail, which is why
+  it leads. Dust, pollen and bird droppings accumulate on panel glass and a decent fall of rain
+  washes most of it off.
+  [Differentiable physics → Soiling](../techniques/differentiable-physics.md#soiling) makes the
+  central point for us: Britain's *long-run average* effect is small, but the loss tracks **time
+  since the last washing rainfall** rather than any climate mean, so a multi-month dry spell is
+  exactly the regime in which it stops being small — and that page says the correction is worth
+  adding for Great Britain, not only for dustier climates. The tabular feature is the state
+  variable of that model, `d_t`, taken directly: time since precipitation last exceeded a washing
+  threshold. Two things follow. It needs **no new data source** — `precipitation_surface` is
+  already among the ECMWF ENS variables we download, so the rainfall history sits in the archive
+  (though reconstructing a dry spell longer than one 15-day run still means stitching across
+  archived runs, and so inherits the availability-cut caveat below) — and it is the one member of
+  this family that needs no climatological normalisation at all, because "37 days since washing
+  rain" is already interpretable in absolute terms. Note the division of labour with capacity
+  estimation, which absorbs the long-run
+  *average* soiling bias into the effective-capacity estimate
+  ([honest caveats of the convex route](capacity-estimation.md#honest-caveats-of-the-convex-route)):
+  that leaves precisely the time-varying part for a feature to explain, and this is the cheap
+  XGBoost-era stand-in for the differentiable-physics treatment.
+- **Sustained-heat demand** — the largest case by *magnitude* for the v1 population, because most
+  of that population is demand. The Tier-2
   [effective temperature](#effective-smoothed-temperature-and-degree-day-features) smooths over
   roughly 1–3 days, which is building thermal inertia. A multi-week heat regime is a different
   thing: acclimatisation, cooling equipment bought partway through a hot summer and then kept, and
@@ -592,20 +612,29 @@ whether the preceding quarter contained
   licence area, which includes arable Lincolnshire. Treat that second clause as an assumption
   rather than a finding: nothing in the metadata carries a land-use or customer-mix field, so it
   needs confirming against NGED's own customer mix before anyone leans on it.
-- **PV soiling.** A long dry spell lets dust and pollen build up on panels and rain washes them
-  clean. Note that this partly overlaps work already assigned elsewhere: the capacity model absorbs
-  *average* soiling bias into the effective-capacity estimate
-  ([honest caveats of the convex route](capacity-estimation.md#honest-caveats-of-the-convex-route)),
-  so only the time-*varying* part is left for a feature to explain. That residue is small enough
-  that it will most likely sit under the noise floor, and a "days since meaningful rain" feature is
-  in any case a different construct from the accumulate-and-normalise family described here.
-- **Hydro.** Run-of-river output is set by catchment wetness — an accumulation over weeks to
-  months — far more than by the rain falling during the forecast window, so this is physically the
-  cleanest case of the four, and the one where a 90-day rainfall total approaches being a *primary*
-  driver rather than a correction. It is listed last because it has **no v1 exposure at all**:
-  `Hydro` is a valid `time_series_type` in the contract, but the
-  [32-series trial area](../index.md#scope) contains no hydro series, so the mechanism is
-  untestable until v2 widens the population.
+- **Hydro** — physically the cleanest mechanism of the four and the one where a 90-day rainfall
+  total approaches being a *primary* driver rather than a correction, but listed last because
+  there is so little of it on NGED's network. It has **no v1 exposure at all**: `Hydro` is a valid
+  `time_series_type` in the contract, but the [32-series trial area](../index.md#scope) contains no
+  hydro series. It does not gain much at v2 either. Wales has 170 MW of hydro across 380 sites
+  ([Energy Generation in Wales 2023](https://www.gov.wales/sites/default/files/publications/2025-02/energy-generation-in-wales-2023.pdf)),
+  but three-quarters of that sits in six large schemes in North and Mid Wales — SP Manweb
+  territory, not NGED's. In particular the 56 MW Rheidol scheme, the largest in England and Wales,
+  connects in the SP Energy Networks area. NGED's Welsh share is roughly 10–15 MW spread over
+  ~100–170 sites (South East and South West Wales, plus part of Powys), the largest being the
+  1.8 MW Ystradffn scheme in Carmarthenshire; the South West adds Mary Tavy (2.6 MW) and a handful
+  of other Dartmoor and Exmoor schemes, and the two Midlands areas add almost nothing.
+
+    The nuance runs in the feature's favour, though. What NGED has is overwhelmingly *sub-MW
+    run-of-river with no storage*, which is the **most** rainfall-sensitive kind — output tracks
+    catchment flow almost directly — whereas the large schemes inflating the Welsh totals are
+    reservoir and pumped storage, and far less weather-coupled. So the hydro NGED does have is
+    exactly the hydro this feature suits; there is simply not much of it, and most of it will
+    arrive embedded in primary-substation net demand rather than as its own time series. Settle
+    this against NGED's
+    [Embedded Capacity Register](https://connecteddata.nationalgrid.co.uk/dataset/embedded-capacity-register)
+    — every resource ≥50 kW with its generation type, updated monthly — rather than against the
+    figures quoted here, which are national statistics apportioned to licence areas by hand.
 
 **Why this sits behind the instantaneous z-scores, and what the leaderboard will actually tell
 you.** The obstacle is not the feature, it is the effective sample size *on the training side*. A

--- a/docs/roadmap/xgboost-improvements.md
+++ b/docs/roadmap/xgboost-improvements.md
@@ -491,7 +491,9 @@ Five scheduling notes specific to this page:
 ### Weather-abnormality (climatology z-score) features
 
 Give the booster a sense of whether the *forecast* weather is abnormal — a heatwave, an
-unusually warm spring, a storm — by feeding it, per weather variable, a standardised anomaly
+unusually warm spring, a storm, and (in
+[the long-window variant](#the-long-window-variant-drought-and-sustained-heat-state) below) a
+drought — by feeding it, per weather variable, a standardised anomaly
 `z = (x − μ) / σ` against a climatological norm for that calendar time. This promotes the
 [deferred feature-grammar note](#explicitly-deferred-not-quick-or-not-skill)'s
 weather-abnormality idea to a concrete experiment. The inductive-bias case is the one the
@@ -566,6 +568,71 @@ norm, and is not what this item builds.)
 [wind power-curve proxy](#linearised-physics-features-for-solar-and-wind)'s cut-out masking
 already encodes "storm" for wind, and raw pressure and wind speed cover the rest — so the first
 experiment carries a *temperature* anomaly only.
+
+#### The long-window variant: drought and sustained-heat state
+
+Everything above z-scores an *instantaneous* forecast value against its norm for that calendar
+moment. A second family of features asks a different question: how abnormal has the recent
+*accumulated* weather been? Total precipitation over the past 30 or 90 days as a fraction of the
+climatological norm for that window, and the equivalent accumulated-temperature (or degree-day)
+anomaly, carry state that no instantaneous feature can hold. Great Britain's summer of 2026 is the
+regime in which the two diverge sharply: a single 25 °C afternoon tells the model nothing about
+whether the preceding quarter was
+[the driest on record since 1836](../design-philosophy/design-principles.md#industry-best-practices-we-have-not-yet-absorbed).
+
+**Where the signal plausibly is**, in roughly descending order of confidence:
+
+- **Hydro.** `Hydro` is a real `time_series_type`, and run-of-river output is set by catchment
+  wetness — an accumulation over weeks to months — far more than by the rain falling during the
+  forecast window. This is the clearest physical case on the list, and the one where a 90-day
+  rainfall total is close to being the *primary* driver rather than a correction.
+- **Sustained-heat demand.** The Tier-2
+  [effective temperature](#effective-smoothed-temperature-and-degree-day-features) smooths over
+  roughly 1–3 days, which is building thermal inertia. A multi-week heat regime is a different
+  thing: acclimatisation, cooling equipment bought partway through a hot summer and then kept, and
+  ground and building-fabric temperatures that a three-day EWM cannot represent.
+- **Agricultural irrigation pumping.** Drought raises it, and the licence area carries arable load.
+  Real, but concentrated in a minority of series.
+- **PV soiling.** A long dry spell lets dust and pollen build up on panels and rain washes them
+  clean, so a "days since meaningful rain" feature has a genuine mechanism behind it. Expect it to
+  sit under the noise floor.
+
+**Why this sits behind the instantaneous z-scores, and what it will and will not measure.** The
+obstacle is not the feature, it is the effective sample size. A 90-day accumulator moves slowly, so
+a training history of roughly 15 months of power data — against an ENS archive that only starts
+2024-04-01 — contains on the order of a *handful* of independent observations of it per series: one
+summer and one winter, not a distribution. A per-series booster will still happily split on it, and
+what it fits will largely be that particular year's idiosyncrasies, aliased with `day_of_year` and
+with any level drift over the same months. The instantaneous z-scores do not have this problem,
+because a heatwave anomaly recurs many times within a single year.
+
+The consequence is a *measurement* problem rather than a modelling one, and it is worth stating
+plainly before anyone registers the experiment: the value of a drought feature is out-of-sample
+robustness in a regime the training data barely contains, and a leaderboard scored on folds drawn
+from that same short history structurally cannot see it. This is the same argument the
+[monotone constraints](#monotone-constraints-for-the-generation-models) item makes — the win is
+"sane extrapolation in weather regimes the training year never saw" — and it should be judged the
+same way: expect roughly no leaderboard movement, and assess it on whether the model behaves
+sensibly when the accumulator is pushed to values the training set never held. It becomes a
+genuinely *measurable* feature only once
+[ERA5 pre-training](#explicitly-deferred-not-quick-or-not-skill) extends the effective history from
+one summer to several.
+
+**Anchor it to init time, and source it from ERA5.** The accumulator is a property of the forecast
+*moment*, not of the target time — a 14-day window shifts a 90-day total only marginally — so it is
+the same number for every horizon in a run and should be computed once at `power_fcst_init_time`
+and broadcast, exactly like the
+[init-time-anchored features](#init-time-anchored-features-current-level-anchor-prerequisite-for-the-global-model).
+That anchoring also settles where the data comes from: a window reaching 90 days into the past
+cannot come from the forecast NWP trajectory at all, and stitching it together from archived ENS
+runs would ride the same uncut freshest-run join the residual-lag features flag. The clean source
+is the **ERA5 ingest** this item already depends on, which supplies the accumulation and its
+climatological norm from one table and one publication-time availability cut. Nothing here needs
+live data at forecast time beyond the ~5-day ERA5T latency, which is immaterial to a 90-day total.
+
+**Scope the first long-window experiment to precipitation**, since accumulated-heat effects are
+partly reachable by lengthening the effective-temperature EWM, which is a config change rather than
+a new data dependency and should be tried first as the cheap control.
 
 ## Tier 4 — structural model changes (weeks)
 

--- a/docs/roadmap/xgboost-improvements.md
+++ b/docs/roadmap/xgboost-improvements.md
@@ -580,6 +580,15 @@ regime in which the two diverge sharply: a single 25 °C afternoon tells the mod
 whether the preceding quarter contained
 [the driest July England and Wales have recorded since their series began in 1836](../design-philosophy/design-principles.md#industry-best-practices-we-have-not-yet-absorbed).
 
+This is also the corner of the feature space where the GB brief and the
+[India assessment](../architecture/adapting-to-another-geography.md#the-two-pilot-discoms-delhi-and-jaipur)
+converge, which is worth knowing before deciding how much to invest here. Everything below is a
+mild refinement in a rainy maritime climate and a first-order effect in an arid one — Rajasthan
+sits on the margin of the Thar desert, where soiling between monsoons is severe *and* unusually
+observable, because a sharp washing signal is what identifies a reversible cleanliness factor at
+all. Building these features for Great Britain is therefore cheaper than it looks on the GB
+business case alone.
+
 **Where the signal plausibly is**, in roughly descending order of confidence:
 
 - **PV soiling** — the mechanism this project has already worked out in most detail, which is why
@@ -596,8 +605,13 @@ whether the preceding quarter contained
   (though reconstructing a dry spell longer than one 15-day run still means stitching across
   archived runs, and so inherits the availability-cut caveat below) — and it is the one member of
   this family that needs no climatological normalisation at all, because "37 days since washing
-  rain" is already interpretable in absolute terms. Note the division of labour with capacity
-  estimation, which absorbs the long-run
+  rain" is already interpretable in absolute terms. The
+  [assessment of running this codebase over India](../architecture/adapting-to-another-geography.md#the-short-answer)
+  reaches the same conclusion from the opposite direction, and is worth reading alongside this
+  bullet: it argues that a reversible cleanliness factor is something "we should probably add for
+  Britain anyway", precisely because Britain's rainy *average* hides real dry-spell episodes, and
+  concludes that work done here would pay off in both countries. Note the division of labour with
+  capacity estimation, which absorbs the long-run
   *average* soiling bias into the effective-capacity estimate
   ([honest caveats of the convex route](capacity-estimation.md#honest-caveats-of-the-convex-route)):
   that leaves precisely the time-varying part for a feature to explain, and this is the cheap
@@ -611,30 +625,37 @@ whether the preceding quarter contained
 - **Agricultural irrigation pumping.** Drought raises it, and the trial area sits in the EMids
   licence area, which includes arable Lincolnshire. Treat that second clause as an assumption
   rather than a finding: nothing in the metadata carries a land-use or customer-mix field, so it
-  needs confirming against NGED's own customer mix before anyone leans on it.
-- **Hydro** — physically the cleanest mechanism of the four and the one where a 90-day rainfall
-  total approaches being a *primary* driver rather than a correction, but listed last because
-  there is so little of it on NGED's network. It has **no v1 exposure at all**: `Hydro` is a valid
+  needs confirming against NGED's own customer mix before anyone leans on it. Note how much easier
+  the same load is to model elsewhere: the
+  [India assessment](../architecture/adapting-to-another-geography.md#the-short-answer) calls
+  agricultural pumping "the happier case" there, because Indian agricultural feeders are largely
+  segregated and run to a published supply schedule, so a large unmetered load is partly known in
+  advance. GB offers no such segregation, which is exactly why this stays an inference from
+  weather rather than a measured quantity.
+- **Hydro** — physically the cleanest mechanism of the four, and the only one where a 90-day
+  rainfall total approaches being a *primary* driver rather than a correction. It is listed last
+  anyway, because NGED's network barely has any. It has **no v1 exposure**: `Hydro` is a valid
   `time_series_type` in the contract, but the [32-series trial area](../index.md#scope) contains no
-  hydro series. It does not gain much at v2 either. Wales has 170 MW of hydro across 380 sites
-  ([Energy Generation in Wales 2023](https://www.gov.wales/sites/default/files/publications/2025-02/energy-generation-in-wales-2023.pdf)),
-  but three-quarters of that sits in six large schemes in North and Mid Wales — SP Manweb
-  territory, not NGED's. In particular the 56 MW Rheidol scheme, the largest in England and Wales,
-  connects in the SP Energy Networks area. NGED's Welsh share is roughly 10–15 MW spread over
-  ~100–170 sites (South East and South West Wales, plus part of Powys), the largest being the
-  1.8 MW Ystradffn scheme in Carmarthenshire; the South West adds Mary Tavy (2.6 MW) and a handful
-  of other Dartmoor and Exmoor schemes, and the two Midlands areas add almost nothing.
+  hydro series. Nor does v2 rescue it. NGED's own
+  [Embedded Capacity Register](https://connecteddata.nationalgrid.co.uk/dataset/embedded-capacity-register)
+  (May 2026) lists **41 connected hydro sites totalling 25.7 MW** across all four licence areas —
+  South Wales 13.7 MW over 10 sites, South West 6.2 MW over 18, East Midlands 5.3 MW over 8, West
+  Midlands 0.5 MW over 5. For scale, the same register shows **5,669 MW of connected solar** and
+  1,416 MW of wind on that network, so hydro is under half a percent of the embedded solar
+  capacity.
 
-    The nuance runs in the feature's favour, though. What NGED has is overwhelmingly *sub-MW
-    run-of-river with no storage*, which is the **most** rainfall-sensitive kind — output tracks
-    catchment flow almost directly — whereas the large schemes inflating the Welsh totals are
-    reservoir and pumped storage, and far less weather-coupled. So the hydro NGED does have is
-    exactly the hydro this feature suits; there is simply not much of it, and most of it will
-    arrive embedded in primary-substation net demand rather than as its own time series. Settle
-    this against NGED's
-    [Embedded Capacity Register](https://connecteddata.nationalgrid.co.uk/dataset/embedded-capacity-register)
-    — every resource ≥50 kW with its generation type, updated monthly — rather than against the
-    figures quoted here, which are national statistics apportioned to licence areas by hand.
+    Two details from the register matter more than the headline total. First, it confirms the
+    physics is the *right* physics: 39 of the 44 hydro entries are `Hydro - Run of river` and 29
+    of the 41 connected sites join at 0.4 kV, so this is overwhelmingly small run-of-river with no
+    storage — the most rainfall-sensitive kind there is, output tracking catchment flow almost
+    directly. Second, it kills the feature's usefulness for hydro *specifically*: those 41 sites
+    are spread across **32 distinct primary substations**, so no primary is hydro-dominated and
+    every one of these schemes arrives diluted into a much larger net-demand signal rather than as
+    its own series. The largest connected schemes are Llyn Brianne (5.45 MW, Dyfed), Elan Valley
+    (4.0 MW, Powys), Chatsworth (3.7 MW, Derbyshire), Mary Tavy (2.6 MW, Devon) and Ystradffin
+    (1.99 MW, Dyfed). One entry is much larger — a 58.5 MW Cwm Rheidol scheme accepted to connect
+    in the South Wales area — but its target energisation date is 2037, well beyond any horizon
+    this roadmap plans for.
 
 **Why this sits behind the instantaneous z-scores, and what the leaderboard will actually tell
 you.** The obstacle is not the feature, it is the effective sample size *on the training side*. A


### PR DESCRIPTION
Two docs changes, both prompted by Great Britain's record-breaking summer of 2026.

## 1. `design-principles.md` — a worked example for input drift detection

The [input-drift-detection entry](https://openclimatefix.github.io/nged-substation-forecast/design-philosophy/design-principles/#industry-best-practices-we-have-not-yet-absorbed)
already argued that our inputs are *expected* to drift, and that "a record-breaking hot, dry summer
is climate signal, not sensor error" — but only as a hypothetical. Summer 2026 makes it real, so
the hypothetical is replaced with dated, attributable provisional Met Office figures:

- **England and Wales: driest July on record** (series from 1836). England 6.5 mm — 10% of average;
  southern England 1.9 mm — 3% of average, and its driest month ever observed.
- **England and Wales: sunniest calendar month ever observed** (series from 1910).
- UK and England second-warmest July; southern England warmest.
- At the season's halfway point the UK was 1.8 °C above the seasonal norm on 42% of average
  rainfall — warmer and drier than 2025 at the same stage, and 2025 went on to be the UK's warmest
  summer on record.

Sources: [Met Office — Historic July](https://www.metoffice.gov.uk/about-us/news-and-media/media-centre/weather-and-climate-news/2026/historic-july-sees-record-dryness-unprecedented-sunshine-and-exceptional-warmth),
[Met Office — Summer 2026 so far](https://www.metoffice.gov.uk/blog/2026/summer-2026-so-far-a-look-at-the-season-at-the-halfway-point-).

Note the deliberate hedge: summer 2026 is not over, so the docs claim **July's** records and the
season-to-date trajectory, not "the hottest and driest summer on record".

The example earns its place by supplying an argument the hypothetical could not: a naive
"distribution changed" alarm would have fired **continuously from May 2026 onwards** while telling
an operator nothing actionable — which is exactly how such an alarm gets tuned into silence. The
entry also now points at the model-side answer (features that let the model *represent* the regime
rather than merely detect that it is unusual), noting the two are complementary. The
statistical-process-control entry's "a record summer will legitimately worsen forecast error" is
made concrete against the same year.

## 2. `xgboost-improvements.md` — the missing long-window features

**Heatwaves were already planned**: the Tier-3 weather-abnormality (climatology z-score) item exists
specifically for "is this a heat wave?". **Multi-month accumulated state — droughts, sustained heat
— was not planned anywhere**, and is not expressible in the current feature grammar at any price:
rolling means run over the forecast NWP trajectory, so a 90-day window cannot be built from it.

Added as a `####` subsection of the existing z-score item rather than a new tier item, because it
wants the same normalisation (a raw 3-month rainfall total is near-useless unqualified — a dry
winter quarter is not a dry summer quarter) and the same ERA5 dependency.

What it records:

- **The physical case, ranked.** `Hydro` is a real `time_series_type` and run-of-river output is
  driven by catchment wetness, which is the one case where a 90-day rainfall total approaches being
  a *primary* driver. Then sustained-heat demand (the Tier-2 effective-temperature EWM smooths
  ~1–3 days, which is building thermal inertia, not a multi-week regime), agricultural irrigation
  pumping, and PV soiling.
- **The counter-case, which is the more important half.** A 90-day accumulator moves slowly, so
  ~15 months of power history against an ENS archive starting 2024-04-01 gives a *handful* of
  independent observations per series. A per-series booster will split on it and mostly fit that
  year's idiosyncrasies, aliased with `day_of_year`.
- **Which makes it a measurement problem, not a modelling one.** The feature's value is
  out-of-sample robustness in a regime the training data barely contains, and a leaderboard scored
  on folds drawn from that same short history *structurally cannot see it*. So it is judged like
  the monotone-constraints item — expect no NMAE movement; assess extrapolation behaviour — and
  becomes genuinely measurable only once ERA5 pre-training extends the history past one summer.
- **Init-time-anchored, sourced from ERA5.** It is the same number for every horizon in a run, and
  a 90-day lookback cannot come from the forecast trajectory at all.

## Verification

`uv run pymarkdown scan` and `uv run mkdocs build --strict` both pass. Every new cross-page and
intra-page anchor was verified to resolve in the rendered HTML, and the new bullet list was
spot-checked in the rendered output against the Python-Markdown list-parsing gotcha in `CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
