### PR TITLE
Cite the upstream ty issue in the numpy `.view()` gotcha

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -432,13 +432,15 @@ from silently changing which rules the repo enforces.
 
 ### numpy Gotcha: `ty` mis-types `.view(np.uint32)` — pass `np.dtype(np.uint32)` instead
 
-`ndarray.view` is overloaded, and one overload takes `DTypeT | _HasDType[DTypeT]` with `DTypeT`
-bound to `np.dtype`. Since ty 0.0.69, ty matches a bare scalar type against that overload and
-solves `DTypeT` as `type[np.uint32]`, in violation of the bound, so `arr.view(np.uint32)` infers
-as `ndarray[_AnyShape, type[unsignedinteger[_32Bit]]]` instead of
-`ndarray[_AnyShape, dtype[unsignedinteger[_32Bit]]]`. Every subsequent operation on that array
-then fails — a bit-mask check reports `unsupported-operator: Unsupported & operation`. The code
-is correct at runtime; only the inferred type is wrong.
+Since ty 0.0.67, `arr.view(np.uint32)` infers as
+`ndarray[_AnyShape, type[unsignedinteger[_32Bit]]]` instead of
+`ndarray[_AnyShape, dtype[unsignedinteger[_32Bit]]]`, so every subsequent operation on that array
+fails — a bit-mask check reports `unsupported-operator: Unsupported & operation`. `ndarray.view`
+is overloaded, and the inferred type looks like the overload taking
+`DTypeT | _HasDType[DTypeT]` (with `DTypeT` bound to `np.dtype`) matched with `DTypeT` solved as
+`type[np.uint32]`, in violation of that bound. The code is correct at runtime — pyright infers
+`dtype[unsignedinteger[_32Bit]]` — and this is upstream ty bug
+[astral-sh/ty#4208](https://github.com/astral-sh/ty/issues/4208).
 
 **How to apply:** pass a real dtype object — `arr.view(np.dtype(np.uint32))` — which is the same
 call at runtime and which ty resolves to the correct `ndarray[..., dtype[uint32]]`. Prefer this
@@ -446,7 +448,9 @@ over a `# ty: ignore` comment: the suppression would have to sit on the line tha
 array, which can be several lines away from the `.view()` call that actually causes it.
 Annotating the intermediate as `npt.NDArray[np.uint32]` does not work — it raises
 `invalid-assignment` instead. The significand-rounding tests in `packages/delta_store/tests/`
-are the worked examples.
+are the worked examples. Nothing warns when the upstream bug is fixed, so the signal to delete
+this section is astral-sh/ty#4208 closing; the `np.dtype(...)` calls themselves can stay, because
+they are correct either way.
 
 ### Marimo Notebooks
 


### PR DESCRIPTION
Follow-up to #461, which added the `numpy Gotcha: ty mis-types .view(np.uint32)` section to `CLAUDE.md`. That section was written before the bug had been reported upstream, so it had no issue to point at and no signal for when to delete it. It is now [astral-sh/ty#4208](https://github.com/astral-sh/ty/issues/4208).

Two corrections came out of minimising the repro for that report:

- **The regression landed in ty 0.0.67, not 0.0.69.** Bisecting across releases against the same file and the same numpy 2.5.1: 0.0.65 and 0.0.66 inferred `ndarray[_AnyShape, Unknown]` for the dtype argument — equally wrong, but `Unknown` silently absorbed everything downstream, so no error surfaced. 0.0.67 started solving it to `type[uint32]`, which is what makes `&` fail.

- **The bound-violation explanation is now stated as an observation, not a root cause.** I tried three times to reduce it to a stdlib-only repro — including one modelling numpy's exact `view` overload set, its deliberately-unbounded `_HasDType` protocol and its `_dtype = dtype` alias — and ty correctly rejected the bound violation every time. So something more specific to numpy's real definitions is involved, and the section now says the inferred type *looks like* that overload matched with `DTypeT` solved as `type[np.uint32]`.

Also notes that pyright infers `dtype[unsignedinteger[_32Bit]]`, which is the confirmation that the code is right and the inference is wrong, and records that nothing will warn when the bug is fixed — so #4208 closing is the signal to delete the section. The `np.dtype(...)` calls in the tests can stay either way; they are correct regardless.

Docs only, no code change. `pymarkdown scan CLAUDE.md` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)