### PR TITLE
Fix #431: state the whole-hour assumption behind local_utc_offset

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ about how it used to work, what a change replaced, or which issue changed it —
 in git, in the PR and in the issue tracker, and repeating it here turns every page into a running
 changelog and makes the docs unreadable. When a change invalidates a passage, rewrite the passage
 to describe the new behaviour rather than appending a note about what changed. This is the
-"comments must reflect current state only" rule under Code Style, applied to prose.
+"comments and docs must reflect current state only" rule under Code Style, applied to prose.
 
 ## How planning works
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -498,6 +498,27 @@ the rendered HTML rather than trusting the linter alone. See also the nested-sub
 gotcha (4 spaces, not 2) tracked in memory — same root cause class: Python-Markdown's list
 parsing is stricter than CommonMark and stricter than `pymarkdown`'s default checks.
 
+### MkDocs Gotcha: a wrapped link whose continuation line starts with `#` renders as a heading
+
+CommonMark requires a space after `#` for a line to start an ATX heading (`#5` is just text,
+`# 5` is a heading). Python-Markdown does not enforce that space, so any line that happens to
+start with `#` — for any reason — is parsed as a heading. A markdown link wrapped across the
+80-ish-character line length this repo's prose otherwise isn't held to can put the `#123](url)`
+half of `[issue #123](url)` at the start of a line, and Python-Markdown reads it as a heading
+rather than as the second half of a link. The rendered page gets a stray `<h1>`/`<h2>` containing
+the raw URL, the link text before the wrap point left dangling as plain text, and the paragraph
+split in two. Neither `pymarkdown scan` nor `mkdocs build --strict` catches this — both pass on a
+source file that renders visibly broken.
+
+**How to apply:** when a link's markdown source wraps across a line break, make sure the
+continuation line does not begin with `#`; keep `[text](url)` together on one line, or wrap
+before `[` rather than inside it. This is the same root cause as the list-continuation gotcha
+above — Python-Markdown is stricter/weirder than CommonMark in ways the linters don't catch — so
+it generalises to a standing rule, not just this one wrapping case: **any docs PR that touches
+links should run `uv run mkdocs build --strict` and then actually read the generated HTML under
+`site/`**, not just trust a clean `pymarkdown scan` plus a successful `mkdocs build`. Both of
+those can pass on rendering that is visibly wrong; only reading the HTML catches it.
+
 ## This is a young project
 
 The project is a new, green-field project. No one else is using this code yet. Which means:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,6 +70,13 @@ if it leaves a sentence without a clear subject/verb. Prefer "We split storage a
 buckets so that..." over "Two buckets, not one — split so that...". The full form is more
 readable and no less concise in practice.
 
+**Write about the present, not the past.** The docs describe how the code works *now*. Don't write
+about how it used to work, what a change replaced, or which issue changed it — that history lives
+in git, in the PR and in the issue tracker, and repeating it here turns every page into a running
+changelog and makes the docs unreadable. When a change invalidates a passage, rewrite the passage
+to describe the new behaviour rather than appending a note about what changed. This is the
+"comments must reflect current state only" rule under Code Style, applied to prose.
+
 ## How planning works
 
 Full description and a "which place do I use?" table: `docs/documentation-guide.md`. In brief:
@@ -226,8 +233,8 @@ Each `BaseForecaster` also carries a `feature_engineer: ClassVar[FeatureEngineer
 - **Patito** for all DataFrame schema definitions and validation. Use Patito type annotations (`pt.DataFrame[Schema]`, `pt.LazyFrame[Schema]`) whenever a function consumes or returns data that conforms to an existing schema — whether the function is public or private. Don't invent a new schema just to annotate a private helper; if no existing schema fits, use plain `pl.DataFrame` / `pl.LazyFrame`.
 - **Prefer small functions.** Extract private helpers (`_name`) rather than letting a function body grow long, even if that means more parameters. A well-named helper with a clear docstring beats a long inline block. Eight parameters is acceptable when each is distinct and the division of labour is clear.
 - **Ruff**: 100-char line length, double quotes, Google-style docstrings.
-- **Comments must reflect current state only** — never reference previous iterations of the
-  code or deleted files.
+- **Comments and docs must reflect current state only** — never reference previous iterations of
+  the code or deleted files. See "Write about the present, not the past" under Docs.
 - **Code links only to durable docs** — `docs/design-philosophy/`, `docs/background/`, `docs/techniques/`,
   `docs/architecture/`, `docs/ml_experimentation/`, `docs/live_service/`. Never link from code *or* docs to `plans/`
   files, and never from code to `docs/roadmap/` pages or to any

--- a/conf/model/xgboost.yaml
+++ b/conf/model/xgboost.yaml
@@ -25,7 +25,7 @@ model_params:
     - "local_day_of_week_sin"
     - "local_day_of_week_cos"
     - "local_day_of_week"
-    - "local_utc_offset"
+    - "local_utc_offset_minutes"
     - "temperature_2m"
     - "dew_point_temperature_2m"
     - "wind_speed_10m"

--- a/docs/architecture/adapting-to-another-geography.md
+++ b/docs/architecture/adapting-to-another-geography.md
@@ -1241,24 +1241,30 @@ All of it sits in a thin layer, and most of it sits in `contracts`.
 | `LIST_OF_TIME_SERIES_TYPES` — 22 NGED categories, re-exported as the `AllFeatures` enum | `contracts/power_schemas.py` | Propagates into the ML schema. |
 | Power bounded to ±1000 MW; `max_mw_threshold` / `min_mw_threshold` sized to GB primaries | `contracts/power_schemas.py`, `contracts/settings.py` | Secondary substations are far smaller; thresholds are meaningless as set. |
 | The GB outline | `geo/great_britain/load.py` | Add a sibling region loader; swap one import in `defs/assets.py`. |
-| `"Europe/London"` as a bare string literal in the feature engineer | `ml_core/features/tabular_feature_engineer.py:350` | Drives every local-time feature in the champion feature set. |
+| `"Europe/London"` as a bare string literal in the feature engineer | `ml_core/features/tabular_feature_engineer.py`, in `_apply_local_time_features` | Drives every local-time feature in the champion feature set. |
 | `DISPLAY_TIME_ZONE = "Europe/London"`, asserted in the dashboard's axis titles | `dashboard/forecast_chart.py:40` | Display only, but it is a second hard-coded timezone. |
 | H3 resolution 5 (~253 km² per cell) chosen for GB, and reached for via a **private** import from the ingest package | `defs/assets.py:40,141` | The NWP grid resolution currently lives inside `nged_data`; see the `PowerIngest` note [below](#how-we-would-structure-it). |
 | `nged_s3_bucket_url` / `_access_key` / `_secret` are **required** settings with no defaults | `contracts/settings.py` | `Settings()` raises for any deployment with no NGED bucket. |
 
 The exercise also surfaced a **latent correctness wart**, though a milder one than it first looks.
-`local_utc_offset` is computed as
-`(base_utc_offset + dst_offset).dt.total_seconds() // 3600` cast to `Int8`
-([`tabular_feature_engineer.py:358`](https://github.com/openclimatefix/nged-substation-forecast/blob/main/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py)),
-so it can only ever represent whole-hour offsets. Note that `//` floors rather than truncates, so a
-negative fractional offset moves *away* from zero.
+`local_utc_offset` used to be computed as
+`(base_utc_offset + dst_offset).dt.total_seconds() // 3600` cast to `Int8`, so it could only ever
+represent whole-hour offsets, and because `//` floors rather than truncates, a negative fractional
+offset moved *away* from zero.
 
 In any single-timezone deployment this costs nothing: the feature is constant across the dataset,
 so mapping UTC+5:30 to `5` discards no information a model could have used. The genuine failure
 mode is **collision** in a mixed-offset deployment — India (+5:30) and Nepal (+5:45) both land on
-`5`, silently merging two distinct zones — and, more immediately, legibility: neither the `// 3600`
-nor the `Int8` states the whole-hour assumption it depends on. Tracked as
-[issue #431](https://github.com/openclimatefix/nged-substation-forecast/issues/431).
+`5`, silently merging two distinct zones.
+
+We fixed the legibility half of this in
+[issue #431](https://github.com/openclimatefix/nged-substation-forecast/issues/431). The offset is
+still whole hours in an `Int8`, but `_whole_hour_utc_offset` now looks the offset up in a mapping
+of the whole-hour offsets rather than dividing, so a sub-hour offset raises instead of being
+rounded away. A mixed-offset deployment therefore fails loudly at the point the collision would
+happen, and whoever hits it has the docstring's explanation in front of them. Widening the feature
+to minutes remains the fix for actually *supporting* such a deployment; it needs a `MODEL_VERSION`
+bump and a retrain, so it waits until there is a deployment that needs it.
 
 ### What is hard-wired to half-hourly
 
@@ -1716,10 +1722,10 @@ not win. The correct move is to leave the British assumptions hard-coded and *le
 is a large part of what makes them legible — and to pay the refactoring cost only once there is a
 second consumer to amortise it against.
 
-The two exceptions are the `local_utc_offset` whole-hour assumption and the private
-`_H3_RESOLUTION` import, both described above. Neither is really a portability concern — they are
-ordinary code-quality items that happened to surface here — so both can be fixed on their own
-merits whenever convenient, independently of anything on this page.
+The one exception left is the private `_H3_RESOLUTION` import, described above. It is not really a
+portability concern — it is an ordinary code-quality item that happened to surface here — so it can
+be fixed on its own merits whenever convenient, independently of anything on this page. The
+`local_utc_offset` whole-hour assumption was the other such item, and it has since been fixed.
 
 **What would change our mind:**
 

--- a/docs/architecture/adapting-to-another-geography.md
+++ b/docs/architecture/adapting-to-another-geography.md
@@ -1246,18 +1246,18 @@ All of it sits in a thin layer, and most of it sits in `contracts`.
 | H3 resolution 5 (~253 km² per cell) chosen for GB, and reached for via a **private** import from the ingest package | `defs/assets.py:40,141` | The NWP grid resolution currently lives inside `nged_data`; see the `PowerIngest` note [below](#how-we-would-structure-it). |
 | `nged_s3_bucket_url` / `_access_key` / `_secret` are **required** settings with no defaults | `contracts/settings.py` | `Settings()` raises for any deployment with no NGED bucket. |
 
-One thing this exercise did change is the UTC-offset feature, which is **not** a British assumption.
+The UTC-offset feature is **not** one of these British assumptions.
 `local_utc_offset_minutes` holds the local offset from UTC in minutes, in an `Int16`, so every
-offset an inhabited time zone uses is represented exactly: India's +5:30 is `330` and Nepal's +5:45
-is `345`, two distinct values rather than one merged bucket, and Australia's +9:30 (`570`) stays
-distinct from +9:00 (`540`). A mixed-offset deployment is therefore representable, and the column
-name states its own units.
+offset in scope is represented exactly and sub-hour zones stay distinct: India's +5:30 is `330` and
+Nepal's +5:45 is `345`, and Australia's +9:30 (`570`) does not collide with +9:00 (`540`). A
+mixed-offset deployment is representable, and the column name states its own units.
 
-Minutes stop just short of covering IANA in full, because IANA carries local mean time for the era
-before each zone standardised, and LMT offsets are not whole minutes — `Europe/London` ran on
-UTC−0:01:15 until 1847. `_local_utc_offset_minutes` divides only when the division is exact and
-raises otherwise, so that residue is explicit rather than quietly floored. In practice only a
-pre-1848 timestamp can reach it.
+The one thing an adapted deployment would need to revisit is the era bound on
+`PowerTimeSeries.time` ([issue
+#466](https://github.com/openclimatefix/nged-substation-forecast/issues/466)), which is what
+guarantees the offset is a whole number of minutes. Zones standardised at different dates, and IANA
+carries local mean time for the era before each one did: `Europe/London` runs on UTC−0:01:15 until
+1847, where `Asia/Kolkata` carries local mean time until 1906.
 
 ### What is hard-wired to half-hourly
 

--- a/docs/architecture/adapting-to-another-geography.md
+++ b/docs/architecture/adapting-to-another-geography.md
@@ -1252,12 +1252,13 @@ offset in scope is represented exactly and sub-hour zones stay distinct: India's
 Nepal's +5:45 is `345`, and Australia's +9:30 (`570`) does not collide with +9:00 (`540`). A
 mixed-offset deployment is representable, and the column name states its own units.
 
-The one thing an adapted deployment would need to revisit is the era bound on
-`PowerTimeSeries.time` ([issue
-#466](https://github.com/openclimatefix/nged-substation-forecast/issues/466)), which is what
-guarantees the offset is a whole number of minutes. Zones standardised at different dates, and IANA
-carries local mean time for the era before each one did: `Europe/London` runs on UTC−0:01:15 until
-1847, where `Asia/Kolkata` carries local mean time until 1906.
+The one thing an adapted deployment would need to revisit is the era bound that
+[issue 466](https://github.com/openclimatefix/nged-substation-forecast/issues/466) puts on
+`PowerTimeSeries.time`, which is what keeps the offset a whole number of minutes. A handful of IANA
+offsets are not. Each zone leaves mean solar time at its own date, so the era that needs excluding
+differs by geography: `Europe/London` runs on UTC−0:01:15 until 1847, whereas `Asia/Kolkata` runs
+on mean-time offsets of +5:53:20 and +5:21:10 until 1906. Nor is it only the deep past — Liberia
+kept UTC−0:44:30 as legal time until 1972.
 
 ### What is hard-wired to half-hourly
 

--- a/docs/architecture/adapting-to-another-geography.md
+++ b/docs/architecture/adapting-to-another-geography.md
@@ -1246,25 +1246,18 @@ All of it sits in a thin layer, and most of it sits in `contracts`.
 | H3 resolution 5 (~253 km² per cell) chosen for GB, and reached for via a **private** import from the ingest package | `defs/assets.py:40,141` | The NWP grid resolution currently lives inside `nged_data`; see the `PowerIngest` note [below](#how-we-would-structure-it). |
 | `nged_s3_bucket_url` / `_access_key` / `_secret` are **required** settings with no defaults | `contracts/settings.py` | `Settings()` raises for any deployment with no NGED bucket. |
 
-The exercise also surfaced a **latent correctness wart**, though a milder one than it first looks.
-`local_utc_offset` used to be computed as
-`(base_utc_offset + dst_offset).dt.total_seconds() // 3600` cast to `Int8`, so it could only ever
-represent whole-hour offsets, and because `//` floors rather than truncates, a negative fractional
-offset moved *away* from zero.
+One thing this exercise did change is the UTC-offset feature, which is **not** a British assumption.
+`local_utc_offset_minutes` holds the local offset from UTC in minutes, in an `Int16`, so every
+offset an inhabited time zone uses is represented exactly: India's +5:30 is `330` and Nepal's +5:45
+is `345`, two distinct values rather than one merged bucket, and Australia's +9:30 (`570`) stays
+distinct from +9:00 (`540`). A mixed-offset deployment is therefore representable, and the column
+name states its own units.
 
-In any single-timezone deployment this costs nothing: the feature is constant across the dataset,
-so mapping UTC+5:30 to `5` discards no information a model could have used. The genuine failure
-mode is **collision** in a mixed-offset deployment — India (+5:30) and Nepal (+5:45) both land on
-`5`, silently merging two distinct zones.
-
-We fixed the legibility half of this in
-[issue #431](https://github.com/openclimatefix/nged-substation-forecast/issues/431). The offset is
-still whole hours in an `Int8`, but `_whole_hour_utc_offset` now looks the offset up in a mapping
-of the whole-hour offsets rather than dividing, so a sub-hour offset raises instead of being
-rounded away. A mixed-offset deployment therefore fails loudly at the point the collision would
-happen, and whoever hits it has the docstring's explanation in front of them. Widening the feature
-to minutes remains the fix for actually *supporting* such a deployment; it needs a `MODEL_VERSION`
-bump and a retrain, so it waits until there is a deployment that needs it.
+Minutes stop just short of covering IANA in full, because IANA carries local mean time for the era
+before each zone standardised, and LMT offsets are not whole minutes — `Europe/London` ran on
+UTC−0:01:15 until 1847. `_local_utc_offset_minutes` divides only when the division is exact and
+raises otherwise, so that residue is explicit rather than quietly floored. In practice only a
+pre-1848 timestamp can reach it.
 
 ### What is hard-wired to half-hourly
 
@@ -1722,10 +1715,9 @@ not win. The correct move is to leave the British assumptions hard-coded and *le
 is a large part of what makes them legible — and to pay the refactoring cost only once there is a
 second consumer to amortise it against.
 
-The one exception left is the private `_H3_RESOLUTION` import, described above. It is not really a
+The one exception is the private `_H3_RESOLUTION` import, described above. It is not really a
 portability concern — it is an ordinary code-quality item that happened to surface here — so it can
-be fixed on its own merits whenever convenient, independently of anything on this page. The
-`local_utc_offset` whole-hour assumption was the other such item, and it has since been fixed.
+be fixed on its own merits whenever convenient, independently of anything on this page.
 
 **What would change our mind:**
 

--- a/docs/architecture/adapting-to-another-geography.md
+++ b/docs/architecture/adapting-to-another-geography.md
@@ -1253,7 +1253,7 @@ Nepal's +5:45 is `345`, and Australia's +9:30 (`570`) does not collide with +9:0
 mixed-offset deployment is representable, and the column name states its own units.
 
 The one thing an adapted deployment would need to revisit is the era bound that
-[issue 466](https://github.com/openclimatefix/nged-substation-forecast/issues/466) puts on
+[issue #466](https://github.com/openclimatefix/nged-substation-forecast/issues/466) puts on
 `PowerTimeSeries.time`, which is what keeps the offset a whole number of minutes. A handful of IANA
 offsets are not. Each zone leaves mean solar time at its own date, so the era that needs excluding
 differs by geography: `Europe/London` runs on UTC−0:01:15 until 1847, whereas `Asia/Kolkata` runs

--- a/docs/ml_experimentation/model-configuration.md
+++ b/docs/ml_experimentation/model-configuration.md
@@ -94,7 +94,7 @@ DST). Electricity demand follows human behaviour, which tracks local time not UT
 | `local_day_of_week_sin` | Sine of day-of-week (7 day period) |
 | `local_day_of_week_cos` | Cosine of day-of-week (7 day period) |
 | `local_day_of_week` | Integer day-of-week (0 = Monday) |
-| `local_utc_offset` | UTC offset in hours (e.g. 0 or 1 for GB) |
+| `local_utc_offset_minutes` | UTC offset in minutes (0 or 60 for GB; 330 for India's +5:30) |
 
 ### Static derived features
 

--- a/docs/ml_experimentation/model-configuration.md
+++ b/docs/ml_experimentation/model-configuration.md
@@ -89,7 +89,7 @@ DST). Electricity demand follows human behaviour, which tracks local time not UT
 |---|---|
 | `local_time_of_day_sin` | Sine of fraction of day (24 h period) |
 | `local_time_of_day_cos` | Cosine of fraction of day (24 h period) |
-| `local_time_of_year_sin` | Sine of fraction of year (ordinal day of year over a fixed 366-day period, so a given calendar date lands at the same fraction whether or not it falls in a leap year) |
+| `local_time_of_year_sin` | Sine of fraction of year (ordinal day of year divided by 366, so a given calendar date's fraction shifts by one day's worth after 29 February in a leap year) |
 | `local_time_of_year_cos` | Cosine of fraction of year (see `local_time_of_year_sin`) |
 | `local_day_of_week_sin` | Sine of day-of-week (7 day period) |
 | `local_day_of_week_cos` | Cosine of day-of-week (7 day period) |

--- a/docs/ml_experimentation/model-configuration.md
+++ b/docs/ml_experimentation/model-configuration.md
@@ -89,11 +89,11 @@ DST). Electricity demand follows human behaviour, which tracks local time not UT
 |---|---|
 | `local_time_of_day_sin` | Sine of fraction of day (24 h period) |
 | `local_time_of_day_cos` | Cosine of fraction of day (24 h period) |
-| `local_time_of_year_sin` | Sine of fraction of year (365.25 day period) |
-| `local_time_of_year_cos` | Cosine of fraction of year (365.25 day period) |
+| `local_time_of_year_sin` | Sine of fraction of year (ordinal day of year over a fixed 366-day period, so a given calendar date lands at the same fraction whether or not it falls in a leap year) |
+| `local_time_of_year_cos` | Cosine of fraction of year (see `local_time_of_year_sin`) |
 | `local_day_of_week_sin` | Sine of day-of-week (7 day period) |
 | `local_day_of_week_cos` | Cosine of day-of-week (7 day period) |
-| `local_day_of_week` | Integer day-of-week (0 = Monday) |
+| `local_day_of_week` | Day-of-week name as a categorical (`Monday`–`Sunday`) |
 | `local_utc_offset_minutes` | UTC offset in minutes (0 or 60 for GB; 330 for India's +5:30) |
 
 ### Static derived features

--- a/packages/contracts/src/contracts/ml_schemas.py
+++ b/packages/contracts/src/contracts/ml_schemas.py
@@ -101,12 +101,9 @@ class AllFeatures(pt.Model):
         dtype=pl.Int16,
         allow_missing=True,
         description=(
-            "Offset of the local time zone from UTC, in minutes (0 or 60 for GB). Minutes "
-            "represent every offset an inhabited time zone has used since standardisation, so "
-            "sub-hour zones stay distinct: India's +5:30 is 330 and Nepal's +5:45 is 345. Int16 "
-            "spans the real extremes, -720 (Etc/GMT+12) to +840 (Pacific/Kiritimati). The feature "
-            "engineer raises rather than rounding if an offset is not a whole number of minutes, "
-            "which only pre-standardisation local mean time is."
+            "Offset of the local time zone from UTC, in minutes (0 or 60 for GB). Minutes keep "
+            "sub-hour zones distinct: India's +5:30 is 330 and Nepal's +5:45 is 345. Int16 spans "
+            "the real extremes, -720 (Etc/GMT+12) to +840 (Pacific/Kiritimati)."
         ),
     )
     local_time_of_day_sin: float | None = _FEATURE_DTYPE

--- a/packages/contracts/src/contracts/ml_schemas.py
+++ b/packages/contracts/src/contracts/ml_schemas.py
@@ -97,7 +97,17 @@ class AllFeatures(pt.Model):
 
     # Temporal features. `local` means "in the local timezone", e.g. "Europe/London". We use `local`
     # as the main input feature, because it's the local time that mostly drives demand.
-    local_utc_offset: int | None = pt.Field(dtype=pl.Int8, allow_missing=True)
+    local_utc_offset: int | None = pt.Field(
+        dtype=pl.Int8,
+        allow_missing=True,
+        description=(
+            "Offset of the local time zone from UTC, in whole hours (0 or 1 for GB). Whole hours "
+            "are sufficient because we deploy in a single time zone, where the feature is "
+            "constant; they would collide in a mixed-offset deployment (India's +5:30 and Nepal's "
+            "+5:45 both become 5). The feature engineer raises rather than rounding if the offset "
+            "is not a whole hour, so this dtype cannot silently lose a sub-hour component."
+        ),
+    )
     local_time_of_day_sin: float | None = _FEATURE_DTYPE
     local_time_of_day_cos: float | None = _FEATURE_DTYPE
     local_time_of_year_sin: float | None = _FEATURE_DTYPE

--- a/packages/contracts/src/contracts/ml_schemas.py
+++ b/packages/contracts/src/contracts/ml_schemas.py
@@ -25,7 +25,7 @@ TimeFeature = Literal[
     "local_day_of_week_sin",
     "local_day_of_week_cos",
     "local_day_of_week",
-    "local_utc_offset",
+    "local_utc_offset_minutes",
 ]
 
 SafeInputBaseColumn = Literal[
@@ -97,15 +97,16 @@ class AllFeatures(pt.Model):
 
     # Temporal features. `local` means "in the local timezone", e.g. "Europe/London". We use `local`
     # as the main input feature, because it's the local time that mostly drives demand.
-    local_utc_offset: int | None = pt.Field(
-        dtype=pl.Int8,
+    local_utc_offset_minutes: int | None = pt.Field(
+        dtype=pl.Int16,
         allow_missing=True,
         description=(
-            "Offset of the local time zone from UTC, in whole hours (0 or 1 for GB). Whole hours "
-            "are sufficient because we deploy in a single time zone, where the feature is "
-            "constant; they would collide in a mixed-offset deployment (India's +5:30 and Nepal's "
-            "+5:45 both become 5). The feature engineer raises rather than rounding if the offset "
-            "is not a whole hour, so this dtype cannot silently lose a sub-hour component."
+            "Offset of the local time zone from UTC, in minutes (0 or 60 for GB). Minutes "
+            "represent every offset an inhabited time zone has used since standardisation, so "
+            "sub-hour zones stay distinct: India's +5:30 is 330 and Nepal's +5:45 is 345. Int16 "
+            "spans the real extremes, -720 (Etc/GMT+12) to +840 (Pacific/Kiritimati). The feature "
+            "engineer raises rather than rounding if an offset is not a whole number of minutes, "
+            "which only pre-standardisation local mean time is."
         ),
     )
     local_time_of_day_sin: float | None = _FEATURE_DTYPE

--- a/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py
+++ b/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py
@@ -22,7 +22,6 @@ Nullify Leaky Lags Rationale:
 
 import math
 from datetime import datetime
-from typing import Final
 
 import patito as pt
 import polars as pl
@@ -40,9 +39,6 @@ from ml_core.features._nwp import (
 from ml_core.features._parsed_features import STATIC_FEATURE_REGISTRY, ParsedFeatures
 from ml_core.features.feature_engineer import FeatureEngineer
 from weather_utils import select_analysis_proxy
-
-_SECONDS_PER_MINUTE: Final[int] = 60
-"""Seconds in a minute, used to convert a UTC offset from seconds to minutes."""
 
 
 def _attach_nearest_nwp_cell(
@@ -336,39 +332,17 @@ def _apply_rolling_mean_feature(lf: pl.LazyFrame, base_col: str, window_hours: i
 
 
 def _local_utc_offset_minutes(local_time: pl.Expr) -> pl.Expr:
-    """Returns the local offset from UTC in minutes, raising on a sub-minute offset.
+    """Returns the local offset from UTC in minutes.
 
-    Minutes represent every offset any inhabited time zone has used since standardisation, so the
-    feature is faithful rather than approximate: India's +5:30 is ``330`` and Nepal's +5:45 is
-    ``345``, two distinct values, and Australia's +9:30 (``570``) does not collide with +9:00
-    (``540``). A mixed-offset deployment is therefore representable. ``Int16`` is ample — the real
-    extremes are ``Etc/GMT+12`` (−720) and ``Pacific/Kiritimati`` (+840).
+    Minutes represent every offset in scope exactly, so sub-hour zones stay distinct rather than
+    collapsing into one another: India's +5:30 is ``330`` and Nepal's +5:45 is ``345``, and
+    Australia's +9:30 (``570``) does not collide with +9:00 (``540``). ``Int16`` is ample — the
+    real extremes are ``Etc/GMT+12`` (−720) and ``Pacific/Kiritimati`` (+840).
 
-    Minutes are not quite the whole story, which is why the guard is here. IANA carries local mean
-    time for the era before each zone standardised, and LMT offsets are not whole minutes:
-    ``Europe/London`` ran on UTC−0:01:15 — −75 seconds — until 1847. A plain division would floor
-    that to −2 minutes, so widening from hours to minutes narrows the assumption without
-    eliminating it. Rather than leave a smaller silent floor, we divide only when the division is
-    exact: ``replace_strict`` is passed no ``default``, so a non-zero residue raises
-    ``InvalidOperationError`` when the frame is collected. Because the residue is provably zero,
-    adding it back leaves the value unchanged; it is added rather than computed as a column of its
-    own so that projection pushdown cannot keep the offset while pruning the check.
-
-    Why it raises rather than degrading. The time zone is a constant in our own source, so the way
-    to reach a sub-minute offset is to change that constant — a code change, which makes this a
-    contract violation (our own bug) rather than the outside world misbehaving, the one category
-    the inherent-stability rules reserve raising for. A ``valid_time`` before 1848 also reaches it,
-    and nothing bounds ``PowerTimeSeries.time`` at the Patito boundary, so a corrupt feed could in
-    principle deliver one — but such a row is already silently poisoning every other local-time
-    feature, and no timestamp in the era we forecast can fire the guard.
-
-    If a feature set does not request ``local_utc_offset_minutes``, Polars prunes the expression
-    and the check does not run. That is harmless, because a column nobody asked for cannot be
-    silently wrong, but it does mean the guard protects the feature rather than the pipeline.
-
-    The check stays inside the Polars expression, so it forces no extra ``.collect()`` and no
-    Python round-trip over the data: a modulo and a hash lookup per row, a few nanoseconds against
-    the ~36 ns per row the surrounding time-zone conversion already costs.
+    Whole minutes depend on the era bound on ``PowerTimeSeries.time`` (issue #466). The only
+    offsets that are *not* whole minutes are IANA's pre-standardisation local mean time —
+    ``Europe/London`` ran on UTC−0:01:15 until 1847 — and a timestamp that old is malformed input,
+    which belongs at the contract boundary rather than being defended against here.
 
     Args:
         local_time: An expression yielding a time-zone-aware datetime in the local time zone.
@@ -379,13 +353,8 @@ def _local_utc_offset_minutes(local_time: pl.Expr) -> pl.Expr:
     See the portability review for the wider picture,
     <https://openclimatefix.github.io/nged-substation-forecast/architecture/adapting-to-another-geography/>.
     """
-    offset_seconds = (
-        local_time.dt.base_utc_offset() + local_time.dt.dst_offset()
-    ).dt.total_seconds()
-    zero_residue = (offset_seconds % _SECONDS_PER_MINUTE).replace_strict(
-        {0: 0}, return_dtype=pl.Int16
-    )
-    return (offset_seconds // _SECONDS_PER_MINUTE + zero_residue).cast(pl.Int16)
+    offset = local_time.dt.base_utc_offset() + local_time.dt.dst_offset()
+    return offset.dt.total_minutes().cast(pl.Int16)
 
 
 def _apply_local_time_features(lf: pl.LazyFrame) -> pl.LazyFrame:

--- a/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py
+++ b/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py
@@ -339,9 +339,10 @@ def _local_utc_offset_minutes(local_time: pl.Expr) -> pl.Expr:
     Australia's +9:30 (``570``) does not collide with +9:00 (``540``). ``Int16`` is ample — the
     real extremes are ``Etc/GMT+12`` (−720) and ``Pacific/Kiritimati`` (+840).
 
-    Whole minutes depend on the era bound on ``PowerTimeSeries.time`` (issue #466). The only
-    offsets that are *not* whole minutes are IANA's pre-standardisation local mean time —
-    ``Europe/London`` ran on UTC−0:01:15 until 1847 — and a timestamp that old is malformed input,
+    Whole minutes depend on the era bound that issue #466 puts on ``PowerTimeSeries.time``. A
+    handful of IANA offsets are not whole minutes — mean solar time before a zone standardised,
+    such as ``Europe/London`` at UTC−0:01:15 until 1847, and Liberia's UTC−0:44:30, which stood as
+    legal time until 1972 — and this truncates them. A timestamp from that era is malformed input,
     which belongs at the contract boundary rather than being defended against here.
 
     Args:

--- a/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py
+++ b/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py
@@ -21,6 +21,7 @@ Nullify Leaky Lags Rationale:
 """
 
 import math
+from collections.abc import Mapping
 from datetime import datetime
 from typing import Final
 
@@ -42,9 +43,9 @@ from ml_core.features.feature_engineer import FeatureEngineer
 from weather_utils import select_analysis_proxy
 
 _SECONDS_PER_HOUR: Final[int] = 60 * 60
-"""Seconds in an hour, used to convert a UTC offset from seconds to hours."""
+"""Seconds in an hour, used to express a whole-hour UTC offset in seconds."""
 
-_WHOLE_HOUR_UTC_OFFSETS: Final[dict[int, int]] = {
+_WHOLE_HOUR_UTC_OFFSETS: Final[Mapping[int, int]] = {
     hours * _SECONDS_PER_HOUR: hours for hours in range(-12, 15)
 }
 """Every whole-hour UTC offset any IANA time zone uses, in seconds, mapped to that offset in hours.
@@ -358,18 +359,27 @@ def _whole_hour_utc_offset(local_time: pl.Expr) -> pl.Expr:
     collide — India (+5:30) and Nepal (+5:45) would both land on ``5``, silently merging two
     distinct zones, as would Australia's +9:30 and +9:00. That is the case this guard catches.
 
-    Why it raises rather than degrading. The time zone is a constant in our own source, so no
-    external input can produce a sub-hour offset here: only a code change can, which makes this a
-    contract violation (our own bug) rather than the outside world misbehaving. That is the one
-    category the inherent-stability rules reserve raising for. On GB data the guard can never fire,
-    so it cannot destabilise the live service.
+    Why it raises rather than degrading. The time zone is a constant in our own source, so the way
+    to reach a sub-hour offset is to change that constant — a code change, which makes this a
+    contract violation (our own bug) rather than the outside world misbehaving, the one category
+    the inherent-stability rules reserve raising for. There is one way a *timestamp* can reach it:
+    ``Europe/London`` ran on local mean time, UTC−0:01:15, until 1847, so a ``valid_time`` before
+    1848 raises here. Nothing bounds ``PowerTimeSeries.time`` at the Patito boundary, so a corrupt
+    feed could in principle deliver one — but such a row is already silently poisoning every other
+    local-time feature, and no timestamp in the era we forecast can fire the guard.
 
     ``replace_strict`` is passed no ``default``, so any offset outside the mapping — sub-hour, or
     an implausible whole-hour value — raises ``InvalidOperationError`` when the frame is collected.
+    Note that this makes the guard conditional on the column surviving projection pushdown: if a
+    feature set does not request ``local_utc_offset``, Polars prunes the whole expression and the
+    check does not run. That is harmless, because a column nobody asked for cannot be silently
+    wrong, but it does mean the guard protects the feature rather than the pipeline.
+
     Keeping the check inside the Polars expression means it forces no extra ``.collect()`` and no
-    Python round-trip over the data: it is one hash lookup per row, about 7 ns, measured against
-    the ``// 3600`` it replaces over a 47M-row frame. Looking the offset up rather than dividing
-    it also makes the floor-versus-truncate question moot, because we never divide.
+    Python round-trip over the data: it is one hash lookup per row. Over a 47M-row frame the
+    lookup measured a few nanoseconds per row more than the ``// 3600`` it replaces, against the
+    ~36 ns per row the surrounding time-zone conversion already costs. Looking the offset up
+    rather than dividing it also makes the floor-versus-truncate question moot: we never divide.
 
     Args:
         local_time: An expression yielding a time-zone-aware datetime in the local time zone.

--- a/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py
+++ b/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py
@@ -22,6 +22,7 @@ Nullify Leaky Lags Rationale:
 
 import math
 from datetime import datetime
+from typing import Final
 
 import patito as pt
 import polars as pl
@@ -39,6 +40,19 @@ from ml_core.features._nwp import (
 from ml_core.features._parsed_features import STATIC_FEATURE_REGISTRY, ParsedFeatures
 from ml_core.features.feature_engineer import FeatureEngineer
 from weather_utils import select_analysis_proxy
+
+_SECONDS_PER_HOUR: Final[int] = 60 * 60
+"""Seconds in an hour, used to convert a UTC offset from seconds to hours."""
+
+_WHOLE_HOUR_UTC_OFFSETS: Final[dict[int, int]] = {
+    hours * _SECONDS_PER_HOUR: hours for hours in range(-12, 15)
+}
+"""Every whole-hour UTC offset any IANA time zone uses, in seconds, mapped to that offset in hours.
+
+The range spans the real extremes, ``Etc/GMT+12`` (−12:00) to ``Pacific/Kiritimati`` (+14:00).
+Sub-hour offsets are **deliberately absent**: see ``_whole_hour_utc_offset`` for why we assume
+whole hours and how that assumption is enforced.
+"""
 
 
 def _attach_nearest_nwp_cell(
@@ -331,6 +345,47 @@ def _apply_rolling_mean_feature(lf: pl.LazyFrame, base_col: str, window_hours: i
     return lf.join(rolled, on=join_keys, how="left")
 
 
+def _whole_hour_utc_offset(local_time: pl.Expr) -> pl.Expr:
+    """Returns the local UTC offset in whole hours, raising if the offset is not a whole hour.
+
+    We represent the offset as a whole number of hours, in an ``Int8``, and state that assumption
+    here rather than leaving it implicit in a division.
+
+    Why whole hours are enough. We deploy in a single time zone, so this feature takes the same
+    value in every row at any given instant, and rounding a fractional zone to whole hours would
+    discard no information a model could use: UTC+5:30 recorded as ``5`` is just a constant with a
+    different name. Whole hours are only insufficient in a **mixed-offset** deployment, where they
+    collide — India (+5:30) and Nepal (+5:45) would both land on ``5``, silently merging two
+    distinct zones, as would Australia's +9:30 and +9:00. That is the case this guard catches.
+
+    Why it raises rather than degrading. The time zone is a constant in our own source, so no
+    external input can produce a sub-hour offset here: only a code change can, which makes this a
+    contract violation (our own bug) rather than the outside world misbehaving. That is the one
+    category the inherent-stability rules reserve raising for. On GB data the guard can never fire,
+    so it cannot destabilise the live service.
+
+    ``replace_strict`` is passed no ``default``, so any offset outside the mapping — sub-hour, or
+    an implausible whole-hour value — raises ``InvalidOperationError`` when the frame is collected.
+    Keeping the check inside the Polars expression means it forces no extra ``.collect()`` and no
+    Python round-trip over the data: it is one hash lookup per row, about 7 ns, measured against
+    the ``// 3600`` it replaces over a 47M-row frame. Looking the offset up rather than dividing
+    it also makes the floor-versus-truncate question moot, because we never divide.
+
+    Args:
+        local_time: An expression yielding a time-zone-aware datetime in the local time zone.
+
+    Returns:
+        An ``Int8`` expression holding the offset from UTC in hours.
+
+    See the portability review for the wider picture,
+    <https://openclimatefix.github.io/nged-substation-forecast/architecture/adapting-to-another-geography/>.
+    """
+    offset_seconds = (
+        local_time.dt.base_utc_offset() + local_time.dt.dst_offset()
+    ).dt.total_seconds()
+    return offset_seconds.replace_strict(_WHOLE_HOUR_UTC_OFFSETS, return_dtype=pl.Int8)
+
+
 def _apply_local_time_features(lf: pl.LazyFrame) -> pl.LazyFrame:
     """Applies local time features (time of day, day of week, time of year) to the LazyFrame.
 
@@ -350,14 +405,7 @@ def _apply_local_time_features(lf: pl.LazyFrame) -> pl.LazyFrame:
         .dt.convert_time_zone("Europe/London")
     )
 
-    lf = lf.with_columns(
-        local_utc_offset=(
-            (
-                pl.col("local_time").dt.base_utc_offset() + pl.col("local_time").dt.dst_offset()
-            ).dt.total_seconds()
-            // 3600
-        ).cast(pl.Int8)
-    )
+    lf = lf.with_columns(local_utc_offset=_whole_hour_utc_offset(pl.col("local_time")))
 
     local_hour_float = pl.col("local_time").dt.hour() + pl.col("local_time").dt.minute() / 60.0
     local_year_fraction = pl.col("local_time").dt.ordinal_day() / 366.0

--- a/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py
+++ b/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py
@@ -21,7 +21,6 @@ Nullify Leaky Lags Rationale:
 """
 
 import math
-from collections.abc import Mapping
 from datetime import datetime
 from typing import Final
 
@@ -42,18 +41,8 @@ from ml_core.features._parsed_features import STATIC_FEATURE_REGISTRY, ParsedFea
 from ml_core.features.feature_engineer import FeatureEngineer
 from weather_utils import select_analysis_proxy
 
-_SECONDS_PER_HOUR: Final[int] = 60 * 60
-"""Seconds in an hour, used to express a whole-hour UTC offset in seconds."""
-
-_WHOLE_HOUR_UTC_OFFSETS: Final[Mapping[int, int]] = {
-    hours * _SECONDS_PER_HOUR: hours for hours in range(-12, 15)
-}
-"""Every whole-hour UTC offset any IANA time zone uses, in seconds, mapped to that offset in hours.
-
-The range spans the real extremes, ``Etc/GMT+12`` (−12:00) to ``Pacific/Kiritimati`` (+14:00).
-Sub-hour offsets are **deliberately absent**: see ``_whole_hour_utc_offset`` for why we assume
-whole hours and how that assumption is enforced.
-"""
+_SECONDS_PER_MINUTE: Final[int] = 60
+"""Seconds in a minute, used to convert a UTC offset from seconds to minutes."""
 
 
 def _attach_nearest_nwp_cell(
@@ -346,46 +335,46 @@ def _apply_rolling_mean_feature(lf: pl.LazyFrame, base_col: str, window_hours: i
     return lf.join(rolled, on=join_keys, how="left")
 
 
-def _whole_hour_utc_offset(local_time: pl.Expr) -> pl.Expr:
-    """Returns the local UTC offset in whole hours, raising if the offset is not a whole hour.
+def _local_utc_offset_minutes(local_time: pl.Expr) -> pl.Expr:
+    """Returns the local offset from UTC in minutes, raising on a sub-minute offset.
 
-    We represent the offset as a whole number of hours, in an ``Int8``, and state that assumption
-    here rather than leaving it implicit in a division.
+    Minutes represent every offset any inhabited time zone has used since standardisation, so the
+    feature is faithful rather than approximate: India's +5:30 is ``330`` and Nepal's +5:45 is
+    ``345``, two distinct values, and Australia's +9:30 (``570``) does not collide with +9:00
+    (``540``). A mixed-offset deployment is therefore representable. ``Int16`` is ample — the real
+    extremes are ``Etc/GMT+12`` (−720) and ``Pacific/Kiritimati`` (+840).
 
-    Why whole hours are enough. We deploy in a single time zone, so this feature takes the same
-    value in every row at any given instant, and rounding a fractional zone to whole hours would
-    discard no information a model could use: UTC+5:30 recorded as ``5`` is just a constant with a
-    different name. Whole hours are only insufficient in a **mixed-offset** deployment, where they
-    collide — India (+5:30) and Nepal (+5:45) would both land on ``5``, silently merging two
-    distinct zones, as would Australia's +9:30 and +9:00. That is the case this guard catches.
+    Minutes are not quite the whole story, which is why the guard is here. IANA carries local mean
+    time for the era before each zone standardised, and LMT offsets are not whole minutes:
+    ``Europe/London`` ran on UTC−0:01:15 — −75 seconds — until 1847. A plain division would floor
+    that to −2 minutes, so widening from hours to minutes narrows the assumption without
+    eliminating it. Rather than leave a smaller silent floor, we divide only when the division is
+    exact: ``replace_strict`` is passed no ``default``, so a non-zero residue raises
+    ``InvalidOperationError`` when the frame is collected. Because the residue is provably zero,
+    adding it back leaves the value unchanged; it is added rather than computed as a column of its
+    own so that projection pushdown cannot keep the offset while pruning the check.
 
     Why it raises rather than degrading. The time zone is a constant in our own source, so the way
-    to reach a sub-hour offset is to change that constant — a code change, which makes this a
+    to reach a sub-minute offset is to change that constant — a code change, which makes this a
     contract violation (our own bug) rather than the outside world misbehaving, the one category
-    the inherent-stability rules reserve raising for. There is one way a *timestamp* can reach it:
-    ``Europe/London`` ran on local mean time, UTC−0:01:15, until 1847, so a ``valid_time`` before
-    1848 raises here. Nothing bounds ``PowerTimeSeries.time`` at the Patito boundary, so a corrupt
-    feed could in principle deliver one — but such a row is already silently poisoning every other
-    local-time feature, and no timestamp in the era we forecast can fire the guard.
+    the inherent-stability rules reserve raising for. A ``valid_time`` before 1848 also reaches it,
+    and nothing bounds ``PowerTimeSeries.time`` at the Patito boundary, so a corrupt feed could in
+    principle deliver one — but such a row is already silently poisoning every other local-time
+    feature, and no timestamp in the era we forecast can fire the guard.
 
-    ``replace_strict`` is passed no ``default``, so any offset outside the mapping — sub-hour, or
-    an implausible whole-hour value — raises ``InvalidOperationError`` when the frame is collected.
-    Note that this makes the guard conditional on the column surviving projection pushdown: if a
-    feature set does not request ``local_utc_offset``, Polars prunes the whole expression and the
-    check does not run. That is harmless, because a column nobody asked for cannot be silently
-    wrong, but it does mean the guard protects the feature rather than the pipeline.
+    If a feature set does not request ``local_utc_offset_minutes``, Polars prunes the expression
+    and the check does not run. That is harmless, because a column nobody asked for cannot be
+    silently wrong, but it does mean the guard protects the feature rather than the pipeline.
 
-    Keeping the check inside the Polars expression means it forces no extra ``.collect()`` and no
-    Python round-trip over the data: it is one hash lookup per row. Over a 47M-row frame the
-    lookup measured a few nanoseconds per row more than the ``// 3600`` it replaces, against the
-    ~36 ns per row the surrounding time-zone conversion already costs. Looking the offset up
-    rather than dividing it also makes the floor-versus-truncate question moot: we never divide.
+    The check stays inside the Polars expression, so it forces no extra ``.collect()`` and no
+    Python round-trip over the data: a modulo and a hash lookup per row, a few nanoseconds against
+    the ~36 ns per row the surrounding time-zone conversion already costs.
 
     Args:
         local_time: An expression yielding a time-zone-aware datetime in the local time zone.
 
     Returns:
-        An ``Int8`` expression holding the offset from UTC in hours.
+        An ``Int16`` expression holding the offset from UTC in minutes.
 
     See the portability review for the wider picture,
     <https://openclimatefix.github.io/nged-substation-forecast/architecture/adapting-to-another-geography/>.
@@ -393,7 +382,10 @@ def _whole_hour_utc_offset(local_time: pl.Expr) -> pl.Expr:
     offset_seconds = (
         local_time.dt.base_utc_offset() + local_time.dt.dst_offset()
     ).dt.total_seconds()
-    return offset_seconds.replace_strict(_WHOLE_HOUR_UTC_OFFSETS, return_dtype=pl.Int8)
+    zero_residue = (offset_seconds % _SECONDS_PER_MINUTE).replace_strict(
+        {0: 0}, return_dtype=pl.Int16
+    )
+    return (offset_seconds // _SECONDS_PER_MINUTE + zero_residue).cast(pl.Int16)
 
 
 def _apply_local_time_features(lf: pl.LazyFrame) -> pl.LazyFrame:
@@ -415,7 +407,7 @@ def _apply_local_time_features(lf: pl.LazyFrame) -> pl.LazyFrame:
         .dt.convert_time_zone("Europe/London")
     )
 
-    lf = lf.with_columns(local_utc_offset=_whole_hour_utc_offset(pl.col("local_time")))
+    lf = lf.with_columns(local_utc_offset_minutes=_local_utc_offset_minutes(pl.col("local_time")))
 
     local_hour_float = pl.col("local_time").dt.hour() + pl.col("local_time").dt.minute() / 60.0
     local_year_fraction = pl.col("local_time").dt.ordinal_day() / 366.0

--- a/packages/ml_core/tests/test_features.py
+++ b/packages/ml_core/tests/test_features.py
@@ -16,7 +16,7 @@ from ml_core.features.tabular_feature_engineer import (
     _apply_local_time_features,
     _apply_rolling_mean_feature,
     _engineer_features,
-    _whole_hour_utc_offset,
+    _local_utc_offset_minutes,
 )
 
 
@@ -261,8 +261,8 @@ def test_apply_local_time_features():
 
     result = _apply_local_time_features(df.lazy()).collect()
 
-    assert "local_utc_offset" in result.columns
-    assert result["local_utc_offset"].to_list() == [0.0, 1.0]
+    assert "local_utc_offset_minutes" in result.columns
+    assert result["local_utc_offset_minutes"].to_list() == [0, 60]
 
     # In winter, 12:00 UTC is 12:00 local.
     # In summer, 12:00 UTC is 13:00 local.
@@ -276,8 +276,8 @@ def test_apply_local_time_features():
     # 2023-07-10 is a Monday (1)
     assert result["local_day_of_week"].to_list() == ["Tuesday", "Monday"]
 
-    # local_utc_offset is a whole-hour offset, matching the AllFeatures Int8 dtype.
-    assert result["local_utc_offset"].dtype == pl.Int8
+    # The offset is in minutes, matching the AllFeatures Int16 dtype.
+    assert result["local_utc_offset_minutes"].dtype == pl.Int16
 
 
 def test_apply_local_time_features_dst_transitions():
@@ -293,9 +293,9 @@ def test_apply_local_time_features_dst_transitions():
             "valid_time": [
                 # Spring forward: 01:00 UTC, clocks jump 01:00 GMT -> 02:00 BST.
                 datetime(2023, 3, 26, 0, 30, tzinfo=timezone.utc),  # 00:30 GMT, offset 0
-                datetime(2023, 3, 26, 1, 0, tzinfo=timezone.utc),  # 02:00 BST, offset 1
+                datetime(2023, 3, 26, 1, 0, tzinfo=timezone.utc),  # 02:00 BST, offset 60
                 # Fall back: 01:00 UTC, clocks drop 02:00 BST -> 01:00 GMT (the 01:00 hour repeats).
-                datetime(2023, 10, 29, 0, 30, tzinfo=timezone.utc),  # 01:30 BST, offset 1
+                datetime(2023, 10, 29, 0, 30, tzinfo=timezone.utc),  # 01:30 BST, offset 60
                 datetime(2023, 10, 29, 1, 0, tzinfo=timezone.utc),  # 01:00 GMT, offset 0
                 datetime(2023, 10, 29, 1, 30, tzinfo=timezone.utc),  # 01:30 GMT, offset 0
             ]
@@ -305,7 +305,7 @@ def test_apply_local_time_features_dst_transitions():
     result = _apply_local_time_features(df.lazy()).collect()
 
     # The offset flips at exactly the transition instant, in both directions.
-    assert result["local_utc_offset"].to_list() == [0, 1, 1, 0, 0]
+    assert result["local_utc_offset_minutes"].to_list() == [0, 60, 60, 0, 0]
 
     # The cyclical time-of-day feature reflects the *local* wall clock, including the jump.
     # Spring-forward: 01:00 UTC -> 02:00 BST, so local_time_of_day_sin = sin(2/24 * 2pi) = 0.5.
@@ -316,61 +316,45 @@ def test_apply_local_time_features_dst_transitions():
     assert result["local_time_of_day_cos"][2] == pytest.approx(result["local_time_of_day_cos"][4])
 
 
-def test_whole_hour_utc_offset_gb():
-    """The GB path: both British offsets are whole hours, so the guard passes silently."""
-    lf = pl.LazyFrame(
-        {
-            "valid_time": [
-                datetime(2023, 1, 10, 12, 0, tzinfo=timezone.utc),  # GMT, UTC+0
-                datetime(2023, 7, 10, 12, 0, tzinfo=timezone.utc),  # BST, UTC+1
-            ]
-        }
-    ).with_columns(local_time=pl.col("valid_time").dt.convert_time_zone("Europe/London"))
-
-    result = lf.select(local_utc_offset=_whole_hour_utc_offset(pl.col("local_time"))).collect()
-
-    assert result["local_utc_offset"].to_list() == [0, 1]
-    assert result["local_utc_offset"].dtype == pl.Int8
-
-
 @pytest.mark.parametrize(
-    ("time_zone", "month"),
+    ("time_zone", "month", "expected_minutes"),
     [
-        ("Asia/Kolkata", 1),  # UTC+5:30 — would collide with Nepal's +5:45 if we rounded.
-        ("Asia/Kathmandu", 1),  # UTC+5:45.
-        ("Australia/Adelaide", 6),  # UTC+9:30 — would collide with UTC+9:00.
-        ("America/St_Johns", 1),  # UTC-3:30 — the negative case a floored division moved to -4.
+        ("Europe/London", 1, 0),  # GMT.
+        ("Europe/London", 7, 60),  # BST.
+        ("Asia/Kolkata", 1, 330),  # UTC+5:30.
+        ("Asia/Kathmandu", 1, 345),  # UTC+5:45 — distinct from India's +5:30, not merged into it.
+        ("Australia/Adelaide", 6, 570),  # UTC+9:30 — distinct from UTC+9:00 (540).
+        ("America/St_Johns", 1, -210),  # UTC-3:30 — the case a floored division moved to -4 hours.
     ],
 )
-def test_whole_hour_utc_offset_rejects_sub_hour_zone(time_zone: str, month: int):
-    """A sub-hour offset is a contract violation, so it raises instead of being rounded away.
-
-    Only a code change to the hard-coded time zone can reach this state, which is why raising is
-    the right response rather than degrading. See ``_whole_hour_utc_offset``.
-    """
+def test_local_utc_offset_minutes_is_faithful(time_zone: str, month: int, expected_minutes: int):
+    """Every offset an inhabited zone uses is represented exactly, sub-hour zones included."""
     lf = pl.LazyFrame(
         {"valid_time": [datetime(2023, month, 10, 12, 0, tzinfo=timezone.utc)]}
     ).with_columns(local_time=pl.col("valid_time").dt.convert_time_zone(time_zone))
 
-    # Match on the message: `InvalidOperationError` is also what a *different* failure earlier in
-    # the same expression raises (e.g. `base_utc_offset` on a tz-naive column), so without this
-    # the test could pass for the wrong reason.
-    with pytest.raises(pl.exceptions.InvalidOperationError, match="incomplete mapping"):
-        lf.select(local_utc_offset=_whole_hour_utc_offset(pl.col("local_time"))).collect()
+    result = lf.select(offset=_local_utc_offset_minutes(pl.col("local_time"))).collect()
+
+    assert result["offset"].to_list() == [expected_minutes]
+    assert result["offset"].dtype == pl.Int16
 
 
-def test_apply_local_time_features_raises_on_sub_hour_offset():
-    """The guard is wired into the production entry point, not just available beside it.
+def test_apply_local_time_features_raises_on_sub_minute_offset():
+    """A sub-minute offset raises rather than being floored, through the production entry point.
 
-    ``_apply_local_time_features`` hard-codes ``Europe/London``, which reaches a sub-hour offset
-    for one input: London ran on local mean time, UTC-0:01:15, until 1847. That makes this the
-    only way to exercise the guard through the function that production actually calls — and it
-    pins the wiring, which a test of ``_whole_hour_utc_offset`` alone would not.
+    Minutes cover every offset an inhabited zone has used since standardisation, but not the local
+    mean time IANA carries for the era before it: ``Europe/London`` ran on UTC-0:01:15 until 1847,
+    which a plain division would floor to -2 minutes. ``_apply_local_time_features`` hard-codes
+    ``Europe/London``, so a pre-1848 timestamp is both the only input that reaches the guard and
+    the only way to pin the guard to the function production actually calls.
     """
     lf = pl.LazyFrame(
         {"valid_time": [datetime(1840, 6, 1, 12, 0, tzinfo=timezone.utc)]}
     ).with_columns(pl.col("valid_time").cast(pl.Datetime("us", "UTC")))
 
+    # Match on the message: `InvalidOperationError` is also what a *different* failure earlier in
+    # the same expression raises (e.g. `base_utc_offset` on a tz-naive column), so without this
+    # the test could pass for the wrong reason.
     with pytest.raises(pl.exceptions.InvalidOperationError, match="incomplete mapping"):
         _apply_local_time_features(lf).collect()
 

--- a/packages/ml_core/tests/test_features.py
+++ b/packages/ml_core/tests/test_features.py
@@ -16,6 +16,7 @@ from ml_core.features.tabular_feature_engineer import (
     _apply_local_time_features,
     _apply_rolling_mean_feature,
     _engineer_features,
+    _whole_hour_utc_offset,
 )
 
 
@@ -313,6 +314,46 @@ def test_apply_local_time_features_dst_transitions():
     # clock (01:30), the repeated hour, so their time-of-day features are identical.
     assert result["local_time_of_day_sin"][2] == pytest.approx(result["local_time_of_day_sin"][4])
     assert result["local_time_of_day_cos"][2] == pytest.approx(result["local_time_of_day_cos"][4])
+
+
+def test_whole_hour_utc_offset_gb():
+    """The GB path: both British offsets are whole hours, so the guard passes silently."""
+    lf = pl.LazyFrame(
+        {
+            "valid_time": [
+                datetime(2023, 1, 10, 12, 0, tzinfo=timezone.utc),  # GMT, UTC+0
+                datetime(2023, 7, 10, 12, 0, tzinfo=timezone.utc),  # BST, UTC+1
+            ]
+        }
+    ).with_columns(local_time=pl.col("valid_time").dt.convert_time_zone("Europe/London"))
+
+    result = lf.select(local_utc_offset=_whole_hour_utc_offset(pl.col("local_time"))).collect()
+
+    assert result["local_utc_offset"].to_list() == [0, 1]
+    assert result["local_utc_offset"].dtype == pl.Int8
+
+
+@pytest.mark.parametrize(
+    ("time_zone", "month"),
+    [
+        ("Asia/Kolkata", 1),  # UTC+5:30 — would collide with Nepal's +5:45 if we rounded.
+        ("Asia/Kathmandu", 1),  # UTC+5:45.
+        ("Australia/Adelaide", 6),  # UTC+9:30 — would collide with UTC+9:00.
+        ("America/St_Johns", 1),  # UTC-3:30 — the negative case a floored division moved to -4.
+    ],
+)
+def test_whole_hour_utc_offset_rejects_sub_hour_zone(time_zone: str, month: int):
+    """A sub-hour offset is a contract violation, so it raises instead of being rounded away.
+
+    Only a code change to the hard-coded time zone can reach this state, which is why raising is
+    the right response rather than degrading. See ``_whole_hour_utc_offset``.
+    """
+    lf = pl.LazyFrame(
+        {"valid_time": [datetime(2023, month, 10, 12, 0, tzinfo=timezone.utc)]}
+    ).with_columns(local_time=pl.col("valid_time").dt.convert_time_zone(time_zone))
+
+    with pytest.raises(pl.exceptions.InvalidOperationError):
+        lf.select(local_utc_offset=_whole_hour_utc_offset(pl.col("local_time"))).collect()
 
 
 def test_parsed_features_from_selected_features():

--- a/packages/ml_core/tests/test_features.py
+++ b/packages/ml_core/tests/test_features.py
@@ -339,26 +339,6 @@ def test_local_utc_offset_minutes_is_faithful(time_zone: str, month: int, expect
     assert result["offset"].dtype == pl.Int16
 
 
-def test_apply_local_time_features_raises_on_sub_minute_offset():
-    """A sub-minute offset raises rather than being floored, through the production entry point.
-
-    Minutes cover every offset an inhabited zone has used since standardisation, but not the local
-    mean time IANA carries for the era before it: ``Europe/London`` ran on UTC-0:01:15 until 1847,
-    which a plain division would floor to -2 minutes. ``_apply_local_time_features`` hard-codes
-    ``Europe/London``, so a pre-1848 timestamp is both the only input that reaches the guard and
-    the only way to pin the guard to the function production actually calls.
-    """
-    lf = pl.LazyFrame(
-        {"valid_time": [datetime(1840, 6, 1, 12, 0, tzinfo=timezone.utc)]}
-    ).with_columns(pl.col("valid_time").cast(pl.Datetime("us", "UTC")))
-
-    # Match on the message: `InvalidOperationError` is also what a *different* failure earlier in
-    # the same expression raises (e.g. `base_utc_offset` on a tz-naive column), so without this
-    # the test could pass for the wrong reason.
-    with pytest.raises(pl.exceptions.InvalidOperationError, match="incomplete mapping"):
-        _apply_local_time_features(lf).collect()
-
-
 def test_parsed_features_from_selected_features():
     selected = {
         "power_lag_24h",

--- a/packages/ml_core/tests/test_features.py
+++ b/packages/ml_core/tests/test_features.py
@@ -352,8 +352,27 @@ def test_whole_hour_utc_offset_rejects_sub_hour_zone(time_zone: str, month: int)
         {"valid_time": [datetime(2023, month, 10, 12, 0, tzinfo=timezone.utc)]}
     ).with_columns(local_time=pl.col("valid_time").dt.convert_time_zone(time_zone))
 
-    with pytest.raises(pl.exceptions.InvalidOperationError):
+    # Match on the message: `InvalidOperationError` is also what a *different* failure earlier in
+    # the same expression raises (e.g. `base_utc_offset` on a tz-naive column), so without this
+    # the test could pass for the wrong reason.
+    with pytest.raises(pl.exceptions.InvalidOperationError, match="incomplete mapping"):
         lf.select(local_utc_offset=_whole_hour_utc_offset(pl.col("local_time"))).collect()
+
+
+def test_apply_local_time_features_raises_on_sub_hour_offset():
+    """The guard is wired into the production entry point, not just available beside it.
+
+    ``_apply_local_time_features`` hard-codes ``Europe/London``, which reaches a sub-hour offset
+    for one input: London ran on local mean time, UTC-0:01:15, until 1847. That makes this the
+    only way to exercise the guard through the function that production actually calls — and it
+    pins the wiring, which a test of ``_whole_hour_utc_offset`` alone would not.
+    """
+    lf = pl.LazyFrame(
+        {"valid_time": [datetime(1840, 6, 1, 12, 0, tzinfo=timezone.utc)]}
+    ).with_columns(pl.col("valid_time").cast(pl.Datetime("us", "UTC")))
+
+    with pytest.raises(pl.exceptions.InvalidOperationError, match="incomplete mapping"):
+        _apply_local_time_features(lf).collect()
 
 
 def test_parsed_features_from_selected_features():

--- a/packages/ml_core/tests/test_features.py
+++ b/packages/ml_core/tests/test_features.py
@@ -4,6 +4,7 @@ import patito as pt
 import polars as pl
 import pytest
 from pydantic import ValidationError
+from contracts.ml_schemas import AllFeatures
 from contracts.power_schemas import PowerTimeSeries, TimeSeriesMetadata
 from ml_core.features._lags import _apply_power_lag, _nullify_leaky_lags
 from ml_core.features._nwp import _upsample_nwp_to_half_hourly
@@ -324,11 +325,11 @@ def test_apply_local_time_features_dst_transitions():
         ("Asia/Kolkata", 1, 330),  # UTC+5:30.
         ("Asia/Kathmandu", 1, 345),  # UTC+5:45 — distinct from India's +5:30, not merged into it.
         ("Australia/Adelaide", 6, 570),  # UTC+9:30 — distinct from UTC+9:00 (540).
-        ("America/St_Johns", 1, -210),  # UTC-3:30 — the case a floored division moved to -4 hours.
+        ("America/St_Johns", 1, -210),  # UTC-3:30 — negative and sub-hour.
     ],
 )
 def test_local_utc_offset_minutes_is_faithful(time_zone: str, month: int, expected_minutes: int):
-    """Every offset an inhabited zone uses is represented exactly, sub-hour zones included."""
+    """Every offset in scope is represented exactly, sub-hour and negative zones included."""
     lf = pl.LazyFrame(
         {"valid_time": [datetime(2023, month, 10, 12, 0, tzinfo=timezone.utc)]}
     ).with_columns(local_time=pl.col("valid_time").dt.convert_time_zone(time_zone))
@@ -336,7 +337,8 @@ def test_local_utc_offset_minutes_is_faithful(time_zone: str, month: int, expect
     result = lf.select(offset=_local_utc_offset_minutes(pl.col("local_time"))).collect()
 
     assert result["offset"].to_list() == [expected_minutes]
-    assert result["offset"].dtype == pl.Int16
+    # Pin the produced dtype to the contract, not to a literal, so the two cannot drift apart.
+    assert result["offset"].dtype == AllFeatures.dtypes["local_utc_offset_minutes"] == pl.Int16
 
 
 def test_parsed_features_from_selected_features():

--- a/scripts/run_baseline_experiment.py
+++ b/scripts/run_baseline_experiment.py
@@ -55,7 +55,7 @@ SELECTED_FEATURES: list[str] = [
     "local_day_of_week_sin",
     "local_day_of_week_cos",
     "local_day_of_week",
-    "local_utc_offset",
+    "local_utc_offset_minutes",
     "temperature_2m",
     "dew_point_temperature_2m",
     "wind_speed_10m",


### PR DESCRIPTION
Closes #431, taking the **full fix**: the UTC-offset feature is widened to minutes, so sub-hour
zones are represented faithfully rather than collapsed.

## What changed

`local_utc_offset` (whole hours, `Int8`) becomes **`local_utc_offset_minutes`** (minutes, `Int16`),
computed as `(base_utc_offset + dst_offset).dt.total_minutes()`.

India's +5:30 is now `330` and Nepal's +5:45 is `345` — two distinct values rather than both
collapsing to `5` — and Australia's +9:30 (`570`) no longer collides with +9:00 (`540`). The old
`// 3600` also *floored*, so Newfoundland's −3:30 became `-4`; it is now exactly `-210`. `Int16`
spans the real extremes, −720 (`Etc/GMT+12`) to +840 (`Pacific/Kiritimati`).

**No `MODEL_VERSION` bump and no retrain**, per Jack: only a dummy model has been trained and the
leaderboard is not yet populated.

## ⚠️ Two things to look at before merging

**1. The column is renamed — flagging it so it is easy to veto.** `local_utc_offset` holding
minutes would be a units trap, so the name now states its units. This is a breaking change, which
CLAUDE.md permits in this project, and every reference moves with it: the `TimeFeature` literal and
the `AllFeatures` field in `contracts/ml_schemas.py`, `conf/model/xgboost.yaml`,
`scripts/run_baseline_experiment.py`, `docs/ml_experimentation/model-configuration.md` and the
tests. Feature names are matched as strings, so a missed reference would be a real bug; a full-repo
grep confirms no bare `local_utc_offset` survives, and `test_ml_schemas.py` already fails if
`TimeFeature` and the `AllFeatures` fields disagree. Say the word and I will revert just the rename.

**2. There is a real, if vanishingly unlikely, window before #466 lands.** Whole-minute offsets are
guaranteed by the era bound that
[#466](https://github.com/openclimatefix/nged-substation-forecast/issues/466) puts on
`PowerTimeSeries.time`. That issue is **not merged**, so between this PR landing and that one there
is a window in which a pre-1848 `valid_time` would yield a floored offset (`Europe/London` ran on
UTC−0:01:15 until 1847, which truncates to `-1`) instead of being rejected as malformed input. Per
Jack's decision no guard is added to close the window — the contract bound is the fix, and it is
the right place for it. Stating it plainly rather than glossing it.

## The sub-minute residue, and why there is no guard

IANA offsets are not all whole minutes, so widening from hours to minutes narrows the assumption
without eliminating it. An earlier revision of this branch carried an expression-level guard that
raised on a non-whole-minute offset; it was **removed on Jack's call**, because #466 rejects such a
timestamp at the Patito boundary, and CLAUDE.md puts strictness about malformed input at the
contract boundary rather than deep inside the feature pipeline. With the residue impossible the
conversion is exact, the floor-versus-truncate question does not arise, and the whole expression
collapses to a single `dt.total_minutes()` call — no lookup table, no division, no constant, and
about forty lines of defensive docstring deleted.

Worth knowing, and now recorded in the docstring: the non-whole-minute offsets are **not** only the
deep past. `Africa/Monrovia` ran on UTC−0:44:30 as Liberia's legal time until **January 1972**,
inside the Unix epoch. Verified against `zoneinfo`. An adapted deployment that set its era bound at
1970 would get a silently wrong `-44`, so the bound needs to be later than that — the docs now say
so instead of claiming only pre-1850s local mean time is at risk.

## Correctness

`dt.total_minutes()` truncates toward zero rather than flooring, which is identical for every
whole-minute offset, i.e. for everything in scope. Verified by an independent `zoneinfo` oracle
sweep over 599 IANA zones × 9,496 instants (1970–2035): the only genuine disagreement is
`Africa/Monrovia` above. Thirteen other zones differ only because Polars' bundled chrono-tz is a
different tzdata vintage from the system's — pre-existing environmental skew that affects
`local_time` conversion equally, not this change.

## Tests

- `test_local_utc_offset_minutes_is_faithful` — parametrised over `Europe/London` (0 and 60),
  `Asia/Kolkata` (330), `Asia/Kathmandu` (345), `Australia/Adelaide` (570) and `America/St_Johns`
  (−210). It pins the dtype to `AllFeatures.dtypes[...]` as well as to `Int16`, so the expression
  and the contract cannot drift apart.
- `test_apply_local_time_features` and `test_apply_local_time_features_dst_transitions` assert the
  new name, minute values and `Int16` through the production entry point, so an hours-based
  computation cannot be re-inlined at the call site without failing.

No existing test was relaxed.

## Docs

- `docs/architecture/adapting-to-another-geography.md` — rewritten to describe only current
  behaviour, and to tell an adapted deployment what it would need to revisit (each zone leaves mean
  solar time at its own date: London 1847, Kolkata 1906, Liberia 1972).
- `docs/ml_experimentation/model-configuration.md` — feature-table row updated to minutes.
- **`CLAUDE.md`** — Jack asked for the rule to be made durable, so the Code Style bullet "Comments
  must reflect current state only" is widened to name docs, and the Docs section gains **"Write
  about the present, not the past"** in his terms: the docs describe how the code works now, that
  history lives in git and the issue tracker, and repeating it turns every page into a running
  changelog.

## This round: codify the HTML-inspection rule, and fix two more stale doc rows

**`CLAUDE.md` gains a standing rule**, not just a one-off fix. The wrapped-link-becomes-a-heading
bug (previous section) is now its own "MkDocs Gotcha" section, alongside the existing
list-continuation one it cross-references rather than duplicates. It states the general rule:
any docs PR touching links should build with `mkdocs build --strict` **and then read the generated
HTML under `site/`**, because a clean `pymarkdown scan` plus a successful `mkdocs build` can both
pass on rendering that is visibly broken — as the previous round found out.

**Two more `docs/ml_experimentation/model-configuration.md` rows fixed**, brought into scope by
Jack (both were one line above what an earlier round of this PR touched):

- `local_day_of_week` was described as "Integer day-of-week (0 = Monday)". The code
  (`replace_strict` over `dt.weekday()`, cast to `pl.Enum`) actually produces a categorical of day
  *names* (`"Monday"`–`"Sunday"`); there is no integer and no 0-indexing.
- `local_time_of_year_sin`/`_cos` said "365.25 day period" where the code divides
  `dt.ordinal_day()` by `366.0`. Fixed to describe the actual behaviour — and a first pass at that
  fix claimed a given calendar date lands at the same fraction in a leap year as a non-leap year,
  which is false for every date after 29 February (2023-03-01 → 0.16393, 2024-03-01 → 0.16667);
  caught by a follow-up review and corrected to say the fraction shifts by one day's worth instead.

This PR's own docs changes were checked against the new rule: `mkdocs build --strict` (exit 0),
then the generated HTML for both touched pages was read directly — clean tables, clean paragraphs,
the `#466` link intact, no stray headings.

## Verification

All six commands green on the final pushed state (`544f69c`):

```
uv run ruff check .                # All checks passed!
uv run ruff format .               # 200 files left unchanged
uv run --all-packages ty check     # All checks passed!
uv run pytest                      # 401 passed, 1 skipped
uv run pymarkdown scan -r docs ... # clean
uv run mkdocs build --strict       # exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

