### PR TITLE
Align PR #467's new test with the dagster_instance fixture from PR #465

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -433,39 +433,6 @@ for speed, but give each test a **function-scoped** fixture that `POST`s to `/mo
 recreates the bucket before the test body runs, so every test starts pristine and independent of
 execution order. `tests/test_s3_data_paths.py` is the canonical pattern.
 
-### Testing Gotcha: an undisposed `DagsterInstance.ephemeral()` risks flaky CI on Python 3.14.x
-
-`DagsterInstance.ephemeral()` (with no `tempdir` argument, the form used everywhere in this repo)
-backs its artifact storage with `dagster._core.storage.root.TemporaryLocalArtifactStorage`, which
-lazily creates a `tempfile.TemporaryDirectory()` on first access and defers cleanup to an explicit
-`instance.dispose()` call. Nothing in this repo's test suite calls `dispose()`, so every ephemeral
-instance's temp directory is cleaned up implicitly by the garbage collector instead — via a
-`weakref.finalize` callback that runs at an unpredictable point during a later test's setup, not
-inside the test that created the instance.
-
-On the CI runner's CPython 3.14.7, that GC-triggered path occasionally hits an upstream
-pathlib/weakref timing bug: the finalizer's own `ResourceWarning: Implicitly cleaning up
-<TemporaryDirectory ...>` becomes "unraisable" (sometimes chained through an `AttributeError` in
-`pathlib.PosixPath.__str__`, itself missing an internal `_str`/`_drv` attribute — a symptom of
-another object's finalizer partially tearing down state in the same GC pass). Pytest's
-`unraisableexception` plugin turns that into a hard failure, attributed to whichever unrelated
-test's *setup* happened to be running when the collector fired —
-`test_h3_grid_weights_materialises_and_writes_parquet` failing this way in CI (while passing
-locally on other 3.14.x patches, and in isolation) is the concrete case that surfaced this. The
-failure is timing-sensitive, not deterministic per test: it depends on how many ephemeral
-instances (and other GC-eligible objects) have accumulated by that point in the run, so adding an
-unrelated `DagsterInstance.ephemeral()` call anywhere in the suite can tip a previously-clean run
-into failing.
-
-**How to apply:** use `DagsterInstance.ephemeral()` as a context manager (`with
-DagsterInstance.ephemeral() as instance:`) rather than passing the bare expression inline —
-`DagsterInstance.__exit__` calls `dispose()`, which cleans up the temp directory explicitly and
-deterministically instead of leaving it to the collector. `tests/test_assets.py`'s
-`test_power_time_series_and_metadata_drops_and_reports_malformed_rows` is the worked example. The
-~30 pre-existing call sites across the test suite that still pass `instance=DagsterInstance.
-ephemeral()` inline have not been swept to this pattern; each remains a latent contributor to this
-flake until it is.
-
 ### Altair Gotcha: `ty` loses the chart type after a `mark_*()` call
 
 Altair decorates every `mark_*` method with `@use_signature`, whose return type is expressed

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -58,6 +58,19 @@ row counts wrapping past 2³² rows.
   SQLite has closed the database and print a bare `Exception during reset or similar` traceback
   *after* pytest's summary line, owned by no test. The fixture enters the instance as a context
   manager, so `dispose()` runs when the test ends.
+
+  A second, independent failure mode from the same root cause: `TemporaryLocalArtifactStorage`
+  (the artifact storage an ephemeral instance builds when given no `tempdir`) also defers its
+  `tempfile.TemporaryDirectory()` cleanup to `dispose()`, so an undisposed instance's temp
+  directory is left to the garbage collector too — via a `weakref.finalize` callback that can run
+  at any later point in the process, not just at shutdown. On the CI runner's CPython 3.14.7, that
+  GC-triggered path occasionally hit an upstream pathlib/weakref timing bug and turned into a hard
+  pytest failure *attributed to whatever unrelated test's setup happened to be running* when the
+  collector fired (`pytest.PytestUnraisableExceptionWarning`, since `filterwarnings` starts with
+  `error` — see below). One extra bare `DagsterInstance.ephemeral()` call added anywhere in the
+  suite was enough to tip a previously-clean run into failing 2/2 times in CI while never
+  reproducing locally, which is what surfaced this. The fixture's deterministic disposal removes
+  the trigger for both failure modes at once.
 - **In a script, use the context manager directly** — `with DagsterInstance.ephemeral() as
   instance:` — rather than a bare call. Letting the local go out of scope is *not* enough: once the
   instance has actually run a job, Dagster's own caches retain it (a `RunDomain`, and the

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -167,7 +167,7 @@ def test_power_time_series_and_metadata_ingests_and_writes(
 
 
 def test_power_time_series_and_metadata_drops_and_reports_malformed_rows(
-    env: Path, monkeypatch: pytest.MonkeyPatch
+    env: Path, monkeypatch: pytest.MonkeyPatch, dagster_instance: DagsterInstance
 ) -> None:
     """A row with a malformed `time` is dropped and counted, not allowed to abort ingestion of
     every other well-formed row in the batch."""
@@ -192,20 +192,16 @@ def test_power_time_series_and_metadata_drops_and_reports_malformed_rows(
     }
     monkeypatch.setattr(assets.Settings, "get_nged_s3_store", lambda self: _FakeS3Store(files))
 
-    # Context-manager form disposes the ephemeral instance's TemporaryDirectory-backed artifact
-    # storage on exit, rather than leaving it to the garbage collector — see the CI-flakiness
-    # gotcha in CLAUDE.md for why an undisposed instance matters here.
-    with DagsterInstance.ephemeral() as instance:
-        result = materialize([power_time_series_and_metadata], instance=instance)
-        assert result.success
+    result = materialize([power_time_series_and_metadata], instance=dagster_instance)
+    assert result.success
 
-        power = pl.read_delta(str(env / "NGED" / "power_time_series.delta"))
-        assert power.height == 1
-        assert power["time"][0] == datetime(2026, 3, 5, 12, 30, tzinfo=timezone.utc)
+    power = pl.read_delta(str(env / "NGED" / "power_time_series.delta"))
+    assert power.height == 1
+    assert power["time"][0] == datetime(2026, 3, 5, 12, 30, tzinfo=timezone.utc)
 
-        materialisations = result.asset_materializations_for_node("power_time_series_and_metadata")
-        metadata = {k: v for mat in materialisations for k, v in mat.metadata.items()}
-        assert metadata["n_implausible_power_rows_dropped"].value == 1
+    materialisations = result.asset_materializations_for_node("power_time_series_and_metadata")
+    metadata = {k: v for mat in materialisations for k, v in mat.metadata.items()}
+    assert metadata["n_implausible_power_rows_dropped"].value == 1
 
 
 def test_power_time_series_and_metadata_handles_no_new_data(


### PR DESCRIPTION
## Why

PR #467 (bounding `PowerTimeSeries.time`, adding the drop-and-report behaviour) was developed in an isolated branch/worktree that never rebased onto `main`. PR #465 ("Fix every pytest warning, and make new ones fail the suite") merged into `main` mid-session — about 40 minutes before #467 merged — and independently swept almost every `DagsterInstance.ephemeral()` call site in the test suite onto a new shared `dagster_instance` fixture (`tests/conftest.py`), documenting the rationale in `docs/architecture/testing.md`.

#467 hit CI flakiness (`test_h3_grid_weights_materialises_and_writes_parquet` failing at setup with `PytestUnraisableExceptionWarning`, unrelated to that test's own code) caused by exactly the pattern #465 was independently fixing elsewhere: an undisposed `DagsterInstance.ephemeral()`. Working without visibility into #465 (parallel, unmerged at the time), #467 fixed its one new test with a local `with DagsterInstance.ephemeral() as instance:` block and added a CLAUDE.md gotcha documenting the failure mode. That fix worked, but after both PRs landed on `main`, it left #467's new test as the only one *not* following the newly-established `dagster_instance` fixture convention, and left a CLAUDE.md section that duplicates — and is now stale relative to — `docs/architecture/testing.md`'s more thorough treatment.

## What this does

- Switches `test_power_time_series_and_metadata_drops_and_reports_malformed_rows` (`tests/test_assets.py`) to take the `dagster_instance` fixture, consistent with every other test in the file.
- Removes the redundant "Testing Gotcha: an undisposed `DagsterInstance.ephemeral()`..." section from `CLAUDE.md` (its "~30 call sites... not disposed" claim is also now stale — #465 fixed nearly all of them).
- Folds the specific failure mode #467 observed — a mid-suite `PytestUnraisableExceptionWarning` on CPython 3.14.7, attributed to an unrelated test — into `docs/architecture/testing.md`'s existing explanation, as a second piece of evidence for the same underlying rule (that doc's existing rationale was about an interpreter-shutdown SQLAlchemy traceback; this is a different, mid-suite consequence of the same root cause).

## Verification

- `uv run ruff check .` / `uv run ruff format .` — clean.
- `uv run --all-packages ty check` — clean.
- `uv run pytest` — 424 passed, 1 skipped.
- `uv run pymarkdown scan -r docs README.md CLAUDE.md metadata/README.md packages/*/README.md` — clean.
- `uv run mkdocs build --strict` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)