### PR TITLE
Document the sub-agent issue routine in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,59 @@ must also:
 3. Close the GitHub issue; update the status banner on the roadmap page (and the milestone
    section in `docs/roadmap/index.md` if the arc changed).
 
+## Sub-agent routine
+
+When dispatching a sub-agent (or a fresh Claude Code/Desktop session) to solve a GitHub issue in
+this repo, give it these steps up front — a report back after step 1 is not finished work:
+
+1. **Set up an isolated worktree** so concurrent sessions don't collide:
+
+   ```bash
+   git worktree add .claude/worktrees/<branch-name> -b <branch-name>
+   cd .claude/worktrees/<branch-name>
+   ln -s /home/jack/dev/python/nged-substation-forecast/.env .env   # if it exists and isn't already there
+   ```
+
+   If several sub-agents run concurrently, also give each its own scratchpad subdirectory —
+   a shared scratchpad root means two agents writing e.g. `pr_body.md` can collide and one
+   agent's output gets briefly published under another's PR.
+
+2. **Implement**, following every convention in this file — including leaving every doc page
+   that touches the change consistent with the code as it now stands, describing only how the
+   code works *now* (see "Write about the present, not the past" above). For a docs change that
+   touches a link, run `uv run mkdocs build --strict` and read the rendered HTML under `site/`,
+   not just the linter — Python-Markdown has rendering gotchas that neither `pymarkdown scan`
+   nor a successful `mkdocs build` catches on their own.
+
+3. **Verify, all green before pushing**: `uv run ruff check .`, `uv run ruff format .`,
+   `uv run --all-packages ty check`, `uv run pytest`, plus (if docs were touched)
+   `uv run pymarkdown scan -r docs README.md CLAUDE.md packages/*/README.md` and
+   `uv run mkdocs build --strict`.
+
+4. **Push and open the PR** against `main`, with labels and `JackKelly` as assignee (`gh pr
+   create` can't set either — follow with `gh pr edit --add-label <label>` and `gh pr edit
+   --add-assignee JackKelly`), linking the issue so it closes on merge. Commit messages end
+   with `Co-Authored-By: Claude <noreply@anthropic.com>`.
+
+5. **Spawn a *new*, independent sub-agent to adversarially review the PR** — give it only the
+   PR number, not the implementer's reasoning, so it isn't anchored by it. Tailor the reviewer
+   brief to the issue: name the failure modes most worth attacking (the risky claim, a
+   behaviour change hiding inside a refactor, whether a new test would actually have failed on
+   `main`) rather than asking for a generic review.
+
+6. **Triage the review's findings** — verify each against the code rather than accepting it,
+   fix genuine defects, push, and record why any finding was rejected.
+
+7. **Stop and wait for Jack's review. Never merge.**
+
+Stay inside the issue's scope; report unrelated design mistakes rather than fixing them.
+
+**Why:** Jack reviews diffs in GitHub's UI and wants a PR to already have survived an
+adversarial pass by the time he looks at it, so his review is the last line of defence rather
+than the first. The fresh-reviewer requirement exists so the reviewer cannot be anchored by the
+implementer's rationale; the triage step exists because reviewer findings are often wrong and
+must not be applied uncritically.
+
 ## Architecture
 
 This is a `uv` workspace monorepo. The root `src/nged_substation_forecast/` is the Dagster application; all reusable logic lives in `packages/`.


### PR DESCRIPTION
## Summary
- Adds a "Sub-agent routine" section to CLAUDE.md, between "How planning works" and "Architecture", documenting the standing routine a sub-agent (or fresh session) should follow when solving a GitHub issue in this repo: isolated worktree setup, implement, verify, push PR with labels/assignee, adversarial review by a fresh independent agent, triage its findings, then stop for Jack's review.
- This was previously only captured in this session's local memory (not repo-visible), so a fresh session with no access to that memory namespace (e.g. a new Claude Desktop session) wouldn't know the routine. Moving it into CLAUDE.md makes it discoverable by any session that reads the repo's own instructions.

## Test plan
- [x] Pre-commit hooks (trim whitespace, ty, pymarkdown) passed on the commit.
- [x] Docs-only change with no code/links added — no need for `mkdocs build --strict`.