### PR TITLE
Upload the trained model to MLflow as a single replaceable archive artifact

### DIFF
--- a/docs/architecture/ml-orchestration.md
+++ b/docs/architecture/ml-orchestration.md
@@ -41,15 +41,48 @@ The complementary decision — the resolved config is stamped onto the MLflow ex
 registration and read back by the assets, never re-read from YAML — is explained in
 [Running an experiment end-to-end](../ml_experimentation/dagster-workflow.md).
 
-## Model artifacts: MLflow artifact store, no local cache
+## Model artifacts: one replaceable archive, no local cache
 
 Trained models live in MLflow's artifact store, wrapped by two concrete `BaseForecaster`
 methods (`save_to_mlflow` / `load_from_mlflow`) that delegate to each subclass's own disk
 `save`/`load` — subclasses stay MLflow-free. `load_from_mlflow` downloads straight into a
 temporary directory and loads from there; there is no local-disk cache.
 
-An earlier version cached downloads on disk keyed by MLflow run ID. That was removed (issue
-#469) because it was actively harmful rather than merely unused: a CV fold run is **reused**
+### One archive file, not a directory of files
+
+`save_to_mlflow` packs the model directory into a single `model.tar.gz` and logs that one file
+to the run's artifact root. `load_from_mlflow` and the production download path
+(`ml_core._production_helpers.fetch_model_artifacts`) each unpack it into a temporary directory.
+Subclass `save`/`load` never see the archive: they stay directory-based and MLflow-free, so the
+Docker bake path (`load_forecaster_from_dir`) is unaffected.
+
+The archive exists because **MLflow's directory upload merges rather than replaces**, and MLflow
+exposes no public artifact-delete API. Verified empirically against MLflow 3.15.1: re-uploading
+`{a.ubj, meta.json}` with `log_artifacts` over an existing `{a.ubj, b.ubj, meta.json}` leaves
+`b.ubj` in place, while re-logging a same-name single artifact overwrites it outright. A fold run
+is **reused** across re-materialisations of its partition (see "Cross-process run resolution"
+above), so with a directory upload, re-training a fold on a *smaller* population would strand the
+dropped series' model files in the run permanently — downloaded on every subsequent load and
+baked into the container image. One replaceable file makes that accumulation impossible at the
+source (issue #470).
+
+Two properties are worth keeping in mind when reading the code:
+
+- The run holding exactly one model file is the load-bearing invariant, not an implementation
+  detail. Logging any *second* per-model file alongside the archive would reopen the merge
+  problem for that file.
+
+- A model's population is still read from its own `meta.json`, never from a directory listing —
+  the archive removes the accumulation, but the population contract stands on its own (the
+  train==predict invariant; see `BaseForecaster.trained_time_series_ids`).
+
+The cost is losing per-file browsing of model artifacts in the MLflow UI, which is negligible for
+a directory of opaque model blobs.
+
+### Why there is no local cache
+
+An earlier version cached downloads on disk keyed by MLflow run ID. That was removed
+(issue #469) because it was actively harmful rather than merely unused: a CV fold run is **reused**
 across re-materialisations of its partition (see "Cross-process run resolution" above), so the
 same run ID can legitimately hold a different model after re-training, which made the cache key
 non-unique for its contents. Keeping the cache honest under that reuse required write-side

--- a/docs/architecture/ml-orchestration.md
+++ b/docs/architecture/ml-orchestration.md
@@ -76,8 +76,18 @@ Two properties are worth keeping in mind when reading the code:
   the archive removes the accumulation, but the population contract stands on its own (the
   train==predict invariant; see `BaseForecaster.trained_time_series_ids`).
 
-The cost is losing per-file browsing of model artifacts in the MLflow UI, which is negligible for
-a directory of opaque model blobs.
+Two costs come with this. The first is losing per-file browsing of model artifacts in the MLflow
+UI, which is negligible for a directory of opaque model blobs. The second is that both sides now
+hold the model twice at once in their temporary directory — the model directory plus the archive
+when saving, the archive plus its unpacked contents when loading — so a machine running these
+assets needs roughly twice the model's size in free temp space. At V2 scale (~2,500 series) that
+is a few GB, which matters mainly if `TMPDIR` is a memory-backed filesystem inside a container.
+
+The archive is written at gzip level 1 rather than `tarfile`'s default of 9. Measured on 40 real
+boosters (77 MB of `.ubj`), level 1 takes 0.7 s for a 2.7x reduction and level 9 takes 14.9 s for
+3.5x, so the default would spend about fifteen minutes of CPU per fold at V2 scale to save a
+fifth of the bytes. Boosters are already dense and the archive is transient — it exists to be one
+replaceable object, not to be small.
 
 ### Why there is no local cache
 

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -203,7 +203,7 @@ feature, not a limitation.
 
 This is deliberately simpler than depending on `BaseForecaster.load_from_mlflow` at runtime (the
 mechanism the CV pipeline already uses — see
-[ML orchestration: model artifacts](ml-orchestration.md#model-artifacts-mlflow-artifact-store-no-local-cache)):
+[ML orchestration: model artifacts](ml-orchestration.md#model-artifacts-one-replaceable-archive-no-local-cache)):
 v0.1 has no MLflow tracking server to reach from the runtime container in the first place, so
 there is nothing to cache or fail over from.
 
@@ -504,7 +504,7 @@ runtime needs MLflow.)
 Rejecting this design says nothing against MLflow itself — MLflow remains the backbone of ML
 experimentation: training runs log their models, configs, and metrics to it, and the champion
 is *chosen* from an MLflow leaderboard (see
-[ML orchestration: model artifacts](ml-orchestration.md#model-artifacts-mlflow-artifact-store-no-local-cache)
+[ML orchestration: model artifacts](ml-orchestration.md#model-artifacts-one-replaceable-archive-no-local-cache)
 for the design, and [ML experimentation](../ml_experimentation/index.md) for the day-to-day
 workflow). The boundary this rejection draws is between ML R&D and production: research uses
 MLflow constantly, while production's hot path never touches it. MLflow's job ends at the

--- a/docs/ml_experimentation/dagster-workflow.md
+++ b/docs/ml_experimentation/dagster-workflow.md
@@ -142,7 +142,7 @@ Experiment "xgboost_smoke_test"
 **What the asset does:**
 
 1. Loads the fold's model back from MLflow (a fresh download each time — no local cache, see
-   [ML orchestration: model artifacts](../architecture/ml-orchestration.md#model-artifacts-mlflow-artifact-store-no-local-cache))
+   [ML orchestration: model artifacts](../architecture/ml-orchestration.md#model-artifacts-one-replaceable-archive-no-local-cache))
    and reads its `trained_time_series_ids` — the population it scores (the train==predict
    invariant). Raises if the loaded model has no trained series.
 2. Forecasts the **inclusive validation window** across **all ~51 NWP ensemble members** (the

--- a/packages/ml_core/src/ml_core/_production_helpers.py
+++ b/packages/ml_core/src/ml_core/_production_helpers.py
@@ -170,7 +170,7 @@ def fetch_model_artifacts(run_id: str, dest: Path) -> None:
     Downloads and unpacks into a temporary directory first, so a failed or interrupted download
     never touches ``dest`` — only a fully-downloaded model is moved into place (via ``rmtree`` +
     ``move``). The run holds the model as a single archive artifact
-    (``BaseForecaster._MLFLOW_MODEL_ARTIFACT``), so ``dest`` gets exactly the files the last
+    (``ml_core.base_forecaster._MLFLOW_MODEL_ARTIFACT``), so ``dest`` gets exactly the files the last
     ``save_to_mlflow`` wrote and can never inherit a stale file from an earlier, larger model.
 
     Also writes a ``promotion.json`` (``{"mlflow_run_id", "promoted_at"}``) into ``dest`` for

--- a/packages/ml_core/src/ml_core/_production_helpers.py
+++ b/packages/ml_core/src/ml_core/_production_helpers.py
@@ -17,13 +17,12 @@ from pathlib import Path
 from typing import Literal, Sequence, cast
 
 import hydra
-import mlflow
 import patito as pt
 import polars as pl
 from contracts.common import UTC_DATETIME_DTYPE
 from contracts.power_schemas import PowerTimeSeries
 
-from ml_core.base_forecaster import _MLFLOW_ARTIFACT_PATH, BaseForecaster
+from ml_core.base_forecaster import BaseForecaster, _download_and_unpack_model
 from ml_core.features._nwp import NWP_PUBLICATION_DELAY_HOURS
 
 AvailabilityModeType = Literal["live", "replay"]
@@ -166,14 +165,18 @@ def load_forecaster_from_dir(path: Path) -> BaseForecaster:
 
 
 def fetch_model_artifacts(run_id: str, dest: Path) -> None:
-    """Download an MLflow run's saved model artifacts to ``dest``, replacing it atomically.
+    """Download and unpack an MLflow run's saved model into ``dest``, replacing it atomically.
 
-    Downloads into a temporary directory first, so a failed or interrupted download never
-    touches ``dest`` — only a fully-downloaded model is moved into place (via ``rmtree`` +
-    ``move``). Also writes a ``promotion.json`` (``{"mlflow_run_id", "promoted_at"}``) into
-    ``dest`` for provenance; a ``BaseForecaster.load`` implementation reads its own population
-    from its saved record (e.g. ``XGBoostForecaster`` from ``meta.json``'s
-    ``trained_time_series_ids``), never from a directory listing, so this extra file is harmless.
+    Downloads and unpacks into a temporary directory first, so a failed or interrupted download
+    never touches ``dest`` — only a fully-downloaded model is moved into place (via ``rmtree`` +
+    ``move``). The run holds the model as a single archive artifact
+    (``BaseForecaster._MLFLOW_MODEL_ARTIFACT``), so ``dest`` gets exactly the files the last
+    ``save_to_mlflow`` wrote and can never inherit a stale file from an earlier, larger model.
+
+    Also writes a ``promotion.json`` (``{"mlflow_run_id", "promoted_at"}``) into ``dest`` for
+    provenance; a ``BaseForecaster.load`` implementation reads its own population from its saved
+    record (e.g. ``XGBoostForecaster`` from ``meta.json``'s ``trained_time_series_ids``), never
+    from a directory listing, so this extra file is harmless.
 
     The caller is responsible for setting the tracking URI (``mlflow.set_tracking_uri``)
     beforehand.
@@ -183,10 +186,7 @@ def fetch_model_artifacts(run_id: str, dest: Path) -> None:
         dest: Directory to populate — typically ``Settings.production_model_path``.
     """
     with tempfile.TemporaryDirectory() as tmp_dir:
-        mlflow.artifacts.download_artifacts(
-            run_id=run_id, artifact_path=_MLFLOW_ARTIFACT_PATH, dst_path=tmp_dir
-        )
-        downloaded_dir = Path(tmp_dir) / _MLFLOW_ARTIFACT_PATH
+        downloaded_dir = _download_and_unpack_model(run_id, Path(tmp_dir))
         promotion = {
             "mlflow_run_id": run_id,
             "promoted_at": datetime.now(timezone.utc).isoformat(),

--- a/packages/ml_core/src/ml_core/base_forecaster.py
+++ b/packages/ml_core/src/ml_core/base_forecaster.py
@@ -8,6 +8,7 @@ import mlflow
 import patito as pt
 from contracts.ml_schemas import AllFeatures
 from contracts.power_schemas import PowerForecast
+from mlflow.exceptions import MlflowException
 from pydantic import BaseModel
 
 from ml_core.features import FeatureEngineer, TabularFeatureEngineer
@@ -28,8 +29,15 @@ A run holding exactly *one* model file is what the fix rests on: logging a secon
 artifact alongside this archive would reopen the merge problem for that artifact.
 """
 
-_UNPACK_DIR_NAME: Final[str] = "unpacked_model"
-"""Sub-directory the downloaded archive is extracted into, next to the archive itself."""
+_ARCHIVE_COMPRESSLEVEL: Final[int] = 1
+"""gzip level used for the model archive — the fastest, not ``tarfile``'s default of 9.
+
+Measured on 40 real XGBoost boosters (500 estimators, depth 6, 24 features; 77 MB of ``.ubj``):
+level 1 takes 0.7 s for a 2.7x reduction, level 9 takes 14.9 s for 3.5x. Level 9 would put ~15
+minutes of pure CPU on every ``trained_cv_model`` materialisation at V2 scale (~2,500 series)
+to save a fifth of the bytes. Boosters are already dense, and the archive is transient — it
+exists to be one replaceable object, not to be small — so the fastest level is the right trade.
+"""
 
 
 def _archive_model_dir(model_dir: Path, archive_path: Path) -> None:
@@ -42,7 +50,7 @@ def _archive_model_dir(model_dir: Path, archive_path: Path) -> None:
         model_dir: The directory a subclass's ``save`` just wrote.
         archive_path: Where to write the ``.tar.gz`` (must not be inside ``model_dir``).
     """
-    with tarfile.open(archive_path, "w:gz") as tar:
+    with tarfile.open(archive_path, "w:gz", compresslevel=_ARCHIVE_COMPRESSLEVEL) as tar:
         for item in sorted(model_dir.iterdir()):
             tar.add(item, arcname=item.name)
 
@@ -51,8 +59,8 @@ def _download_and_unpack_model(run_id: str, work_dir: Path) -> Path:
     """Download an MLflow run's model archive into ``work_dir`` and unpack it.
 
     Shared by ``BaseForecaster.load_from_mlflow`` and
-    ``ml_core._production_helpers.fetch_model_artifacts`` — the two consumers of a run's saved
-    model — so the archive layout is defined in exactly one place.
+    ``ml_core._production_helpers.fetch_model_artifacts``, the two readers of a run's saved
+    model, so the archive layout is defined in exactly one place.
 
     The caller is responsible for setting the tracking URI (``mlflow.set_tracking_uri``)
     beforehand.
@@ -60,19 +68,33 @@ def _download_and_unpack_model(run_id: str, work_dir: Path) -> Path:
     Args:
         run_id: The MLflow run the model was saved under.
         work_dir: A scratch directory (typically a ``TemporaryDirectory``) to download and
-            extract into.
+            extract into. Needs room for the archive *and* its unpacked contents.
 
     Returns:
         The directory holding the unpacked model, ready to hand to a subclass's ``load``. It
         contains only what the archive held, so a stale file from an earlier, larger model
         cannot appear in it.
+
+    Raises:
+        MlflowException: The run holds no model archive — either nothing was ever saved to it,
+            or it was written before the model became a single archive artifact, in which case
+            the fold must be re-trained.
     """
-    archive_path = Path(
-        mlflow.artifacts.download_artifacts(
-            run_id=run_id, artifact_path=_MLFLOW_MODEL_ARTIFACT, dst_path=str(work_dir)
+    try:
+        archive_path = Path(
+            mlflow.artifacts.download_artifacts(
+                run_id=run_id, artifact_path=_MLFLOW_MODEL_ARTIFACT, dst_path=str(work_dir)
+            )
         )
-    )
-    model_dir = work_dir / _UNPACK_DIR_NAME
+    except MlflowException as error:
+        raise MlflowException(
+            f"MLflow run {run_id} has no {_MLFLOW_MODEL_ARTIFACT} artifact. Either no model was "
+            "ever saved to this run, or it was saved before the model became a single archive "
+            "artifact — re-materialise `trained_cv_model` for this fold to rewrite it."
+        ) from error
+    # Unpack beside the archive rather than over it: download_artifacts has already claimed the
+    # archive's own name inside work_dir.
+    model_dir = work_dir / "unpacked_model"
     model_dir.mkdir()
     with tarfile.open(archive_path, "r:gz") as tar:
         tar.extractall(model_dir, filter="data")

--- a/packages/ml_core/src/ml_core/base_forecaster.py
+++ b/packages/ml_core/src/ml_core/base_forecaster.py
@@ -1,3 +1,4 @@
+import tarfile
 import tempfile
 from abc import ABC, abstractmethod
 from pathlib import Path
@@ -11,8 +12,71 @@ from pydantic import BaseModel
 
 from ml_core.features import FeatureEngineer, TabularFeatureEngineer
 
-_MLFLOW_ARTIFACT_PATH: Final[str] = "model"
-"""Sub-path under an MLflow run's artifact root where the model directory is stored."""
+_MLFLOW_MODEL_ARTIFACT: Final[str] = "model.tar.gz"
+"""Name of the single artifact, at an MLflow run's artifact root, holding the saved model.
+
+The whole model directory is uploaded as **one archive file** rather than as a directory of
+files, because MLflow's directory upload (``log_artifacts``) *merges* into a run's artifact
+store instead of replacing it, while re-logging a single artifact of the same name overwrites
+it (both verified empirically against MLflow 3.15.1). CV fold runs are reused across
+re-materialisations, so a directory upload lets a re-training on a **smaller** population leave
+the dropped series' files behind in the run forever — MLflow exposes no public artifact-delete
+API to clean them up. One replaceable archive makes that accumulation impossible. See
+<https://openclimatefix.github.io/nged-substation-forecast/architecture/ml-orchestration/#one-archive-file-not-a-directory-of-files>.
+
+A run holding exactly *one* model file is what the fix rests on: logging a second per-model
+artifact alongside this archive would reopen the merge problem for that artifact.
+"""
+
+_UNPACK_DIR_NAME: Final[str] = "unpacked_model"
+"""Sub-directory the downloaded archive is extracted into, next to the archive itself."""
+
+
+def _archive_model_dir(model_dir: Path, archive_path: Path) -> None:
+    """Write everything in ``model_dir`` into a gzipped tar at ``archive_path``.
+
+    Members are stored by bare filename (no leading directory component), so unpacking the
+    archive reproduces ``model_dir``'s contents directly in the destination directory.
+
+    Args:
+        model_dir: The directory a subclass's ``save`` just wrote.
+        archive_path: Where to write the ``.tar.gz`` (must not be inside ``model_dir``).
+    """
+    with tarfile.open(archive_path, "w:gz") as tar:
+        for item in sorted(model_dir.iterdir()):
+            tar.add(item, arcname=item.name)
+
+
+def _download_and_unpack_model(run_id: str, work_dir: Path) -> Path:
+    """Download an MLflow run's model archive into ``work_dir`` and unpack it.
+
+    Shared by ``BaseForecaster.load_from_mlflow`` and
+    ``ml_core._production_helpers.fetch_model_artifacts`` — the two consumers of a run's saved
+    model — so the archive layout is defined in exactly one place.
+
+    The caller is responsible for setting the tracking URI (``mlflow.set_tracking_uri``)
+    beforehand.
+
+    Args:
+        run_id: The MLflow run the model was saved under.
+        work_dir: A scratch directory (typically a ``TemporaryDirectory``) to download and
+            extract into.
+
+    Returns:
+        The directory holding the unpacked model, ready to hand to a subclass's ``load``. It
+        contains only what the archive held, so a stale file from an earlier, larger model
+        cannot appear in it.
+    """
+    archive_path = Path(
+        mlflow.artifacts.download_artifacts(
+            run_id=run_id, artifact_path=_MLFLOW_MODEL_ARTIFACT, dst_path=str(work_dir)
+        )
+    )
+    model_dir = work_dir / _UNPACK_DIR_NAME
+    model_dir.mkdir()
+    with tarfile.open(archive_path, "r:gz") as tar:
+        tar.extractall(model_dir, filter="data")
+    return model_dir
 
 
 class BaseForecasterConfig(BaseModel):
@@ -129,23 +193,30 @@ class BaseForecaster(ABC):
         pass
 
     def save_to_mlflow(self, run_id: str) -> None:
-        """Upload this trained model's artifacts to the given MLflow run.
+        """Upload this trained model to the given MLflow run, as one replaceable archive.
 
-        Writes the model to a temporary directory via ``save`` (the subclass's own format), then
-        uploads that directory to the run's artifact store under ``model/``. The caller is
-        responsible for setting the tracking URI (``mlflow.set_tracking_uri``) beforehand.
+        Writes the model to a temporary directory via ``save`` (the subclass's own format),
+        packs that directory into a single ``model.tar.gz`` and logs *that one file* to the
+        run's artifact root. Logging one archive rather than a directory of files is what makes
+        a re-upload **replace** the previous model instead of merging with it — see
+        ``_MLFLOW_MODEL_ARTIFACT``. The caller is responsible for setting the tracking URI
+        (``mlflow.set_tracking_uri``) beforehand.
 
         Args:
-            run_id: The MLflow run to attach the artifacts to.
+            run_id: The MLflow run to attach the artifact to.
         """
         with tempfile.TemporaryDirectory() as tmp_dir:
-            self.save(Path(tmp_dir))
+            model_dir = Path(tmp_dir) / "model"
+            model_dir.mkdir()
+            self.save(model_dir)
+            archive_path = Path(tmp_dir) / _MLFLOW_MODEL_ARTIFACT
+            _archive_model_dir(model_dir, archive_path)
             with mlflow.start_run(run_id=run_id):
-                mlflow.log_artifacts(tmp_dir, artifact_path=_MLFLOW_ARTIFACT_PATH)
+                mlflow.log_artifact(str(archive_path))
 
     @classmethod
     def load_from_mlflow(cls, run_id: str) -> Self:
-        """Download a trained model's artifacts from an MLflow run and load it.
+        """Download a trained model's archive from an MLflow run, unpack it and load it.
 
         Downloads into a temporary directory and loads from there — there is no local-disk cache.
         An earlier version of this method cached downloads on disk keyed by run ID, but a CV fold
@@ -155,7 +226,7 @@ class BaseForecaster(ABC):
         contents, which required write-side invalidation just to keep the cache honest — machinery
         that existed purely to compensate for the cache, not to serve any consumer: production
         inference never used this cache (issue #469). See
-        <https://openclimatefix.github.io/nged-substation-forecast/architecture/ml-orchestration/#model-artifacts-mlflow-artifact-store-no-local-cache>
+        <https://openclimatefix.github.io/nged-substation-forecast/architecture/ml-orchestration/#model-artifacts-one-replaceable-archive-no-local-cache>
         for the full rationale. Re-adding a cache, if a future consumer needs to serve through an
         MLflow outage, is tracked in issue #472 and should be scoped to that consumer's actual
         invalidation needs rather than resurrecting this one.
@@ -170,12 +241,7 @@ class BaseForecaster(ABC):
             The reconstructed, trained forecaster.
         """
         with tempfile.TemporaryDirectory() as tmp_dir:
-            mlflow.artifacts.download_artifacts(
-                run_id=run_id,
-                artifact_path=_MLFLOW_ARTIFACT_PATH,
-                dst_path=tmp_dir,
-            )
-            return cls.load(Path(tmp_dir) / _MLFLOW_ARTIFACT_PATH)
+            return cls.load(_download_and_unpack_model(run_id, Path(tmp_dir)))
 
     @abstractmethod
     def train(self, data: pt.LazyFrame[AllFeatures], time_series_ids: list[int]) -> None:

--- a/packages/ml_core/tests/test_base_forecaster.py
+++ b/packages/ml_core/tests/test_base_forecaster.py
@@ -1,45 +1,68 @@
-"""Tests for ``BaseForecaster``'s MLflow persistence, against file-based MLflow.
+"""Tests for the MLflow model-artifact plumbing, against file-based MLflow.
 
-Uses a tiny fake ``BaseForecaster`` (rather than a concrete model) so the tests stay focused on
-the shared behaviour — artifact upload/download — and free of any model-library dependency.
+Covers ``BaseForecaster.save_to_mlflow``/``load_from_mlflow`` and the third consumer of the same
+archive layout, ``ml_core._production_helpers.fetch_model_artifacts`` — they are tested together
+here because they share one on-the-wire format and one fake forecaster.
+
+That fake (rather than a concrete model) keeps the tests focused on the shared behaviour —
+archive upload/download — and free of any model-library dependency. It writes one file per
+``time_series_id``, mirroring ``XGBoostForecaster``'s one-``.ubj``-per-series layout, which is
+what makes a *shrinking* population observable as files that must vanish from the run.
 """
 
+import json
 from pathlib import Path
-from typing import Self
+from typing import Self, Sequence
 
 import mlflow
 import patito as pt
 import pytest
 from contracts.ml_schemas import AllFeatures
 from contracts.power_schemas import PowerForecast
+from mlflow.tracking import MlflowClient
+from ml_core._production_helpers import fetch_model_artifacts
 from ml_core.base_forecaster import BaseForecaster, BaseForecasterConfig
 
 pytestmark = pytest.mark.integration
 
 
 class _FakeForecaster(BaseForecaster):
-    """Minimal forecaster whose entire trained state is a single string payload on disk."""
+    """Minimal forecaster: a string payload plus one file per trained ``time_series_id``."""
 
     MODEL_NAME = "fake"
     MODEL_VERSION = 1
 
-    def __init__(self, model_params: BaseForecasterConfig, payload: str = "") -> None:
+    def __init__(
+        self,
+        model_params: BaseForecasterConfig,
+        payload: str = "",
+        series: Sequence[int] = (),
+    ) -> None:
         super().__init__(model_params)
         self.payload = payload
+        self._series = sorted(series)
 
     @property
     def trained_time_series_ids(self) -> list[int]:
-        return []
+        return self._series
 
     def save(self, path: Path) -> None:
         path.mkdir(parents=True, exist_ok=True)
         (path / "payload.txt").write_text(self.payload)
+        (path / "meta.json").write_text(
+            json.dumps({"trained_time_series_ids": self._series, "model_class": "fake"})
+        )
+        for ts_id in self._series:
+            (path / f"{ts_id}.part").write_text(f"model for {ts_id}")
 
     @classmethod
     def load(cls, path: Path) -> Self:
-        instance = cls(BaseForecasterConfig(selected_features=set()))
-        instance.payload = (path / "payload.txt").read_text()
-        return instance
+        meta = json.loads((path / "meta.json").read_text())
+        return cls(
+            BaseForecasterConfig(selected_features=set()),
+            payload=(path / "payload.txt").read_text(),
+            series=meta["trained_time_series_ids"],
+        )
 
     def train(
         self, data: pt.LazyFrame[AllFeatures], time_series_ids: list[int]
@@ -76,10 +99,26 @@ def test_trained_time_series_ids_is_abstract() -> None:
         _MissingPopulation(BaseForecasterConfig(selected_features=set()))
 
 
-def _save(run_id: str, payload: str) -> None:
-    """Save a ``_FakeForecaster`` carrying ``payload`` into an existing MLflow run."""
-    forecaster = _FakeForecaster(BaseForecasterConfig(selected_features=set()), payload=payload)
+def _save(run_id: str, payload: str, series: Sequence[int] = ()) -> None:
+    """Save a ``_FakeForecaster`` carrying ``payload`` and ``series`` into an existing run."""
+    forecaster = _FakeForecaster(
+        BaseForecasterConfig(selected_features=set()), payload=payload, series=series
+    )
     forecaster.save_to_mlflow(run_id)
+
+
+def _artifact_file_paths(run_id: str) -> list[str]:
+    """Every artifact *file* reachable in the run, recursively, as artifact-root-relative paths."""
+    client = MlflowClient()
+    paths: list[str] = []
+    dirs_to_walk = [""]
+    while dirs_to_walk:
+        for info in client.list_artifacts(run_id, dirs_to_walk.pop()):
+            if info.is_dir:
+                dirs_to_walk.append(info.path)
+            else:
+                paths.append(info.path)
+    return sorted(paths)
 
 
 @pytest.fixture
@@ -90,13 +129,23 @@ def saved_run(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> str:
     experiment_id = mlflow.create_experiment("base_forecaster_test")
     with mlflow.start_run(experiment_id=experiment_id) as run:
         run_id = run.info.run_id
-    _save(run_id, "hello-model")
+    _save(run_id, "hello-model", series=[10, 20, 30])
     return run_id
 
 
 def test_save_load_round_trip(saved_run: str) -> None:
     loaded = _FakeForecaster.load_from_mlflow(saved_run)
     assert loaded.payload == "hello-model"
+    assert loaded.trained_time_series_ids == [10, 20, 30]
+
+
+def test_the_model_is_stored_as_a_single_archive_artifact(saved_run: str) -> None:
+    """The run holds exactly one model file — the archive — not a directory of model files.
+
+    This is the property that makes a re-upload replace rather than merge (issue #470): MLflow
+    overwrites a same-name single artifact but merges a directory upload.
+    """
+    assert _artifact_file_paths(saved_run) == ["model.tar.gz"]
 
 
 def test_re_saving_to_the_same_run_is_reflected_on_the_next_load(saved_run: str) -> None:
@@ -111,6 +160,48 @@ def test_re_saving_to_the_same_run_is_reflected_on_the_next_load(saved_run: str)
     assert _FakeForecaster.load_from_mlflow(saved_run).payload == "hello-model"
 
     # Re-train into the *same* run, exactly as a re-materialised fold does.
-    _save(saved_run, "retrained-model")
+    _save(saved_run, "retrained-model", series=[10, 20, 30])
 
     assert _FakeForecaster.load_from_mlflow(saved_run).payload == "retrained-model"
+
+
+def test_re_saving_a_smaller_model_leaves_no_trace_of_the_dropped_series(
+    saved_run: str, tmp_path: Path
+) -> None:
+    """Re-training a reused run on a smaller population must not leave the dropped series behind.
+
+    The regression this issue exists to prevent (issue #470). A directory upload
+    (``log_artifacts``) *merges*, and MLflow has no public artifact-delete API, so series 30's
+    file would survive in the run forever — downloaded on every subsequent load and baked into
+    the production container image. Uploading one same-name archive replaces it instead.
+    """
+    _save(saved_run, "smaller-model", series=[10, 20])
+
+    # Nothing in the run's artifact store mentions the dropped series...
+    assert _artifact_file_paths(saved_run) == ["model.tar.gz"]
+
+    # ...and nothing the download path materialises does either, on either consumer.
+    assert _FakeForecaster.load_from_mlflow(saved_run).trained_time_series_ids == [10, 20]
+
+    dest = tmp_path / "production_model"
+    fetch_model_artifacts(saved_run, dest)
+    assert not (dest / "30.part").exists()
+    assert sorted(p.name for p in dest.iterdir()) == [
+        "10.part",
+        "20.part",
+        "meta.json",
+        "payload.txt",
+        "promotion.json",
+    ]
+
+
+def test_fetch_model_artifacts_unpacks_the_archive_into_dest(
+    saved_run: str, tmp_path: Path
+) -> None:
+    """The production download path lands a plain model directory, not an archive file."""
+    dest = tmp_path / "production_model"
+    fetch_model_artifacts(saved_run, dest)
+
+    assert not (dest / "model.tar.gz").exists()
+    assert _FakeForecaster.load(dest).payload == "hello-model"
+    assert json.loads((dest / "promotion.json").read_text())["mlflow_run_id"] == saved_run

--- a/packages/ml_core/tests/test_base_forecaster.py
+++ b/packages/ml_core/tests/test_base_forecaster.py
@@ -1,8 +1,8 @@
 """Tests for the MLflow model-artifact plumbing, against file-based MLflow.
 
-Covers ``BaseForecaster.save_to_mlflow``/``load_from_mlflow`` and the third consumer of the same
-archive layout, ``ml_core._production_helpers.fetch_model_artifacts`` — they are tested together
-here because they share one on-the-wire format and one fake forecaster.
+Covers ``BaseForecaster.save_to_mlflow``/``load_from_mlflow`` and the third function that touches
+the same archive layout, ``ml_core._production_helpers.fetch_model_artifacts`` — they are tested
+together here because they share one on-the-wire format and one fake forecaster.
 
 That fake (rather than a concrete model) keeps the tests focused on the shared behaviour —
 archive upload/download — and free of any model-library dependency. It writes one file per
@@ -19,6 +19,7 @@ import patito as pt
 import pytest
 from contracts.ml_schemas import AllFeatures
 from contracts.power_schemas import PowerForecast
+from mlflow.exceptions import MlflowException
 from mlflow.tracking import MlflowClient
 from ml_core._production_helpers import fetch_model_artifacts
 from ml_core.base_forecaster import BaseForecaster, BaseForecasterConfig
@@ -144,6 +145,11 @@ def test_the_model_is_stored_as_a_single_archive_artifact(saved_run: str) -> Non
 
     This is the property that makes a re-upload replace rather than merge (issue #470): MLflow
     overwrites a same-name single artifact but merges a directory upload.
+
+    The assertion covers the run's *whole* artifact listing, which is deliberately stricter than
+    the invariant: nothing else logs artifacts to a fold run today, and a second artifact turning
+    up here is worth a deliberate look rather than a silent pass, since any *per-model* file
+    logged alongside the archive would reopen the merge problem for that file.
     """
     assert _artifact_file_paths(saved_run) == ["model.tar.gz"]
 
@@ -193,6 +199,21 @@ def test_re_saving_a_smaller_model_leaves_no_trace_of_the_dropped_series(
         "payload.txt",
         "promotion.json",
     ]
+
+
+def test_loading_a_run_with_no_archive_says_what_to_do_about_it(saved_run: str) -> None:
+    """A run holding no model archive fails with an actionable message, not MLflow's raw one.
+
+    The case that matters is a run written before the model became a single archive artifact:
+    MLflow's own error says only that the path was not found, which gives an operator
+    re-materialising an old fold nothing to act on. (``saved_run`` is depended on for the
+    tracking URI it sets up, not for the model it holds.)
+    """
+    with mlflow.start_run(experiment_id=mlflow.create_experiment("empty_run")) as run:
+        empty_run_id = run.info.run_id
+
+    with pytest.raises(MlflowException, match="re-materialise `trained_cv_model`"):
+        _FakeForecaster.load_from_mlflow(empty_run_id)
 
 
 def test_fetch_model_artifacts_unpacks_the_archive_into_dest(

--- a/packages/xgboost_forecaster/src/xgboost_forecaster/forecaster.py
+++ b/packages/xgboost_forecaster/src/xgboost_forecaster/forecaster.py
@@ -200,10 +200,9 @@ class XGBoostForecaster(BaseForecaster):
         """Save all Boosters as .ubj files plus a meta.json with the full config.
 
         Clears ``path`` first, so re-saving a smaller model over a directory that already holds a
-        bigger one's ``.ubj`` files can never leave the dropped series' boosters behind on disk —
-        this is the "merge instead of replace" defect class that made MLflow's artifact store
-        accumulate stale boosters, issue #197. (MLflow's own artifact upload merges independently
-        of this — see ``load``'s docstring for that remaining hazard, which this does not reach.)
+        bigger one's ``.ubj`` files can never leave the dropped series' boosters behind on disk
+        (issue #197). The same replace-don't-merge property holds through MLflow, because
+        ``BaseForecaster.save_to_mlflow`` uploads this directory as a single archive artifact.
         """
         shutil.rmtree(path, ignore_errors=True)
         path.mkdir(parents=True, exist_ok=True)
@@ -224,11 +223,12 @@ class XGBoostForecaster(BaseForecaster):
         """Reconstruct an XGBoostForecaster from a saved directory.
 
         ``meta.json``'s ``trained_time_series_ids`` — not whatever ``.ubj`` files happen to be in
-        the directory — decides the population. The two can disagree: an MLflow run's artifact
-        directory is written with ``log_artifacts``, which *merges* rather than replaces, so
-        re-training a reused CV fold run on a **smaller** population leaves the dropped series'
-        boosters behind. Globbing would resurrect them, silently scoring those series with a
-        superseded model and breaking the train==predict invariant (see
+        the directory — decides the population, because a model's population is the model's own
+        frozen record and not a directory listing (issue #197). A directory can hold files this
+        model did not write: ``ml_core._production_helpers.fetch_model_artifacts`` adds a
+        ``promotion.json``, and a hand-assembled directory can hold anything. Globbing would let
+        such a file enlarge the population, silently scoring a series with a model that was never
+        trained for it and breaking the train==predict invariant (see
         ``BaseForecaster.trained_time_series_ids``).
         """
         meta = json.loads((path / "meta.json").read_text())

--- a/packages/xgboost_forecaster/tests/test_forecaster.py
+++ b/packages/xgboost_forecaster/tests/test_forecaster.py
@@ -196,20 +196,16 @@ def test_save_clears_stale_ubj_files_from_a_prior_save(tmp_path: Path) -> None:
 def test_load_ignores_ubj_files_not_in_meta_json(tmp_path: Path) -> None:
     """``meta.json`` decides the population, not whatever ``.ubj`` files are lying around.
 
-    ``save`` clearing ``path`` first (see
-    ``test_save_clears_stale_ubj_files_from_a_prior_save``) closes the local-directory route to a
-    stale ``.ubj`` file, but an MLflow run's *remote* artifact directory is written with
-    ``log_artifacts``, which *merges* rather than replaces — a hazard ``save`` cannot reach.
-    Re-training a reused CV fold run on a smaller population therefore still leaves the dropped
-    series' boosters in the run's artifact store; loading them back would silently score those
-    series with a superseded model, breaking the train==predict invariant. This test simulates
-    that merge directly, since it does not go through ``save``.
+    A model's population is the model's own frozen record, not a directory listing, so a booster
+    that ``save`` did not write must not enlarge it — loading such a series would score it with a
+    model that was never trained for it, breaking the train==predict invariant. This test writes
+    the extra booster directly rather than through ``save``, since ``save`` clears its
+    destination (see ``test_save_clears_stale_ubj_files_from_a_prior_save``).
     """
     save_dir = tmp_path / "m"
     _trained(_make_df(ts_ids=[10, 20])).save(save_dir)
-    # Simulate a stale booster left behind by MLflow's artifact-merge (not save, which now clears
-    # its destination first — see above): a real trained booster, written directly rather than
-    # through save, for a series not in this directory's meta.json.
+    # A real trained booster for a series absent from this directory's meta.json, written
+    # directly rather than through save.
     stale_booster = _trained(_make_df(ts_ids=[30]))._models[30]
     stale_booster.save_model(str(save_dir / "30.ubj"))
 


### PR DESCRIPTION
Closes #470.

## The problem

`BaseForecaster.save_to_mlflow` uploaded the model with `mlflow.log_artifacts`, which **merges**
into a run's artifact directory rather than replacing it. Because a CV fold run is reused across
re-materialisations, re-training a fold on a **smaller** population left the dropped series' model
files behind in the run — and MLflow exposes no public artifact-delete API, so they could never be
cleaned up. They were then downloaded on every subsequent load and baked into the container image
by `fetch_model_artifacts`.

PR #464 (issue #197) defused the *danger* by having `XGBoostForecaster.load` read its population
from `meta.json` rather than globbing `*.ubj`, so a stale file can no longer be silently served.
That fix stands unchanged; this PR stops the accumulation at the source.

## The change

`save_to_mlflow` packs the model directory into a single `model.tar.gz` and logs **that one file**
to the run's artifact root. A same-name single artifact overwrites cleanly, so a re-upload
replaces rather than merges.

- `load_from_mlflow` and `ml_core._production_helpers.fetch_model_artifacts` share one
  `_download_and_unpack_model` helper, so the archive layout is defined in exactly one place.
- Subclass `save`/`load` stay directory-based and MLflow-free — `load_forecaster_from_dir` and
  the Docker bake path are untouched by this change.
- `_production_helpers` no longer imports `mlflow` at all.

### Verified empirically (MLflow 3.15.1)

Re-confirmed the issue's premise directly against a file-based tracking store:

| upload | before | after re-upload of a *smaller* model |
|---|---|---|
| `log_artifacts` (directory) | `{a.ubj, b.ubj, meta.json}` | `{a.ubj, b.ubj, meta.json}` — `b.ubj` **survives** |
| `log_artifact` (one same-name file) | `model.tar.gz` (20 bytes) | `model.tar.gz` — contents **replaced** |

## Cost

Per-file browsing of model artifacts in the MLflow UI is lost; the run now shows one
`model.tar.gz` instead of a browsable `model/` directory. Negligible for a directory of opaque
`.ubj` blobs, and noted as such in the docs.

## Tests

`packages/ml_core/tests/test_base_forecaster.py` — the fake forecaster now writes one file per
`time_series_id` (mirroring `XGBoostForecaster`'s one-`.ubj`-per-series layout), which is what
makes a shrinking population observable. Added:

- `test_the_model_is_stored_as_a_single_archive_artifact` — the run holds exactly one model file.
- `test_re_saving_a_smaller_model_leaves_no_trace_of_the_dropped_series` — **the regression this
  issue exists to prevent**. Re-saves a smaller population into the same run and asserts the
  dropped series is absent from the run's artifact listing, from `load_from_mlflow`'s population,
  and from what `fetch_model_artifacts` lands on disk. Confirmed to fail against the pre-fix
  `log_artifacts` implementation.
- `test_fetch_model_artifacts_unpacks_the_archive_into_dest` — the production download path lands
  a plain model directory, not an archive file.

The `fetch_model_artifacts` tests live in this file rather than `test_production_helpers.py`
because they exercise the same archive plumbing and share the fake forecaster. The existing
end-to-end coverage of the download path with a real `XGBoostForecaster`
(`tests/test_promoted_model.py`) is unchanged and still passes.

Existing tests were updated only where their docstrings described the now-removed merge hazard;
none were relaxed. `ruff check`, `ruff format`, `ty check`, `pytest` (443 passed, 1 skipped),
`pymarkdown` and `mkdocs build --strict` all green.

## Docs

`docs/architecture/ml-orchestration.md` gains a "One archive file, not a directory of files"
subsection with the rationale and the empirical result. The section heading changed, so its
anchor did too — all five inbound links (two docstrings, three docs pages) were retargeted.

**Adjacent one-line fix:** the same section had a pre-existing instance of the wrapped-`#` heading
gotcha documented in CLAUDE.md — `(issue` / `#469)` split across a line break rendered `#469)` as
an `<h1>` and broke the paragraph in two. Rewrapped so the `#` is no longer at line start;
verified by reading the generated HTML under `site/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)