### PR TITLE
Reject re-registering an experiment under a changed config

### DIFF
--- a/docs/ml_experimentation/dagster-workflow.md
+++ b/docs/ml_experimentation/dagster-workflow.md
@@ -72,16 +72,31 @@ verify the full pipeline is wired up before committing to a potentially long `fu
 
 1. Loads `base_model_config` with OmegaConf and merges `config_overrides` onto `model_params`.
 2. Instantiates the `BaseForecasterConfig` subclass via Hydra.
-3. Creates the MLflow experiment (or resolves the existing one if the name already exists) and
-   stamps four tags onto it: the resolved config as JSON (`config`), the fully-qualified Python
-   class path of the forecaster (`forecaster_target`), the class path of the config class
-   (`config_target`), and your `description`.
+3. Creates the MLflow experiment (or resolves the existing one if the name already exists), and
+   rejects the registration outright if that name is already registered under a *different*
+   config — see "An experiment's identity is its config" below.
 4. Creates the experiment's parent run (`cv_summary`) and logs the config as flattened params.
-5. Adds dynamic partition keys (`"{experiment_name}__{fold_id}"`) to the `cv_experiment_folds`
+5. Stamps four tags onto the experiment: the resolved config as JSON (`config`), the
+   fully-qualified Python class path of the forecaster (`forecaster_target`), the class path of
+   the config class (`config_target`), and your `description`.
+6. Adds dynamic partition keys (`"{experiment_name}__{fold_id}"`) to the `cv_experiment_folds`
    partition set, one per fold included in the `run_mode`.
 
-The job is **idempotent**: re-running it with the same `experiment_name` resolves the existing
-MLflow experiment and partition keys rather than creating duplicates.
+The job is **idempotent** for a given config: re-running it with the same `experiment_name`
+resolves the existing MLflow experiment and partition keys rather than creating duplicates. You
+may freely re-run it to edit the `description` or to add the other run mode's folds.
+
+### An experiment's identity is its config
+
+Re-running the job with the same `experiment_name` but a **changed** config is refused, with an
+error naming the fields that differ. Register the new config under a new `experiment_name`.
+
+Every fold of an experiment must be trained and scored under one config, or the experiment's
+leaderboard row silently mixes two different models: folds already materialised cannot be
+un-trained, and `trained_cv_model` reads the config back from the experiment's `config` tag (see
+"Why `trained_cv_model` reads config from MLflow, not from YAML" below), so re-pointing that tag
+mid-flight would change what later folds train on. The refusal happens before anything is
+written, so a rejected re-registration leaves the experiment exactly as it was.
 
 ## Step 6 — Materialise `trained_cv_model`
 
@@ -307,7 +322,9 @@ source for the experiment's config.
 
 1. **Immutability.** The YAML on disk is mutable — someone could edit it between registering
    the experiment and training fold 2. Reading from MLflow guarantees every fold of the same
-   experiment trains on exactly the config that was registered, no matter when it runs.
+   experiment trains on exactly the config that was registered, no matter when it runs. The tag
+   is immutable in turn: re-registering the experiment name under a changed config is refused
+   rather than re-pointing it (see step 5 above).
 
 2. **Process independence.** Each `trained_cv_model` materialisation is a separate Dagster
    process. There is no live handle to pass between the job and the asset; the MLflow experiment

--- a/packages/ml_core/src/ml_core/base_forecaster.py
+++ b/packages/ml_core/src/ml_core/base_forecaster.py
@@ -7,7 +7,7 @@ import mlflow
 import patito as pt
 from contracts.ml_schemas import AllFeatures
 from contracts.power_schemas import PowerForecast
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer
 
 from ml_core.features import FeatureEngineer, TabularFeatureEngineer
 
@@ -36,6 +36,15 @@ class BaseForecasterConfig(BaseModel):
     Model identity (name and version) lives on the ``BaseForecaster`` class itself as
     ``MODEL_NAME`` and ``MODEL_VERSION`` — those are properties of the implementation, not
     the experiment config.
+
+    **Serialisation must be canonical.** A config is compared and stored as its serialised form:
+    ``register_experiment`` stamps ``model_dump_json()`` onto the MLflow experiment as the
+    ``config`` tag and compares a re-registration against it, and logs ``flatten_config(...)`` as
+    write-once MLflow params. Python's per-process string hash randomisation means a ``set``
+    iterates in a different order in every process, so a set dumped straight to a list would make
+    two dumps of the *same* config differ — a re-registration would then look like a config change
+    and its param write would be rejected. ``selected_features`` is therefore serialised sorted. A
+    subclass that adds a set-valued (or otherwise unordered) field must do the same.
     """
 
     selected_features: set[str]
@@ -44,6 +53,11 @@ class BaseForecasterConfig(BaseModel):
     weather_source: str = ""
     training_strategy: str = ""
     random_seed: int = 0
+
+    @field_serializer("selected_features")
+    def _serialise_selected_features(self, selected_features: set[str]) -> list[str]:
+        """Serialise the feature set sorted, so two dumps of the same config always match."""
+        return sorted(selected_features)
 
 
 class BaseForecaster(ABC):

--- a/src/nged_substation_forecast/defs/jobs.py
+++ b/src/nged_substation_forecast/defs/jobs.py
@@ -139,15 +139,56 @@ def _identity_tags(
     }
 
 
-def _describe_config_change(stored_json: str, requested_json: str) -> list[str]:
-    """Return one ``field: registered -> requested`` line per differing config field."""
+_ABSENT: Final[object] = object()
+"""Sentinel for a config field present on only one side of an identity comparison.
+
+A sentinel rather than ``None``, so a field that is genuinely ``null`` on one side and missing on
+the other is reported as the difference it is.
+"""
+
+
+def _render_value(value: object) -> str:
+    """Render one config value for the rejection message."""
+    return "<absent>" if value is _ABSENT else repr(value)
+
+
+def _describe_value_change(stored: object, requested: object) -> str:
+    """Describe how one config field's value differs.
+
+    A list of strings that differs only in order gets its own phrasing rather than two near-identical
+    dumps: that is what a ``set``-valued field looks like when the stored tag was written by a
+    registration that did not yet serialise it canonically, and printing both orderings in full
+    would read as a change to the values themselves.
+    """
+    if (
+        isinstance(stored, list)
+        and isinstance(requested, list)
+        and all(isinstance(item, str) for item in (*stored, *requested))
+        and sorted(stored) == sorted(requested)
+    ):
+        return f"the same {len(stored)} values, in a different order"
+    return f"{_render_value(stored)} -> {_render_value(requested)}"
+
+
+def _config_differences(stored_json: str, requested_json: str) -> list[str]:
+    """Return one line per differing config field, or nothing if the two configs agree.
+
+    Compares the *parsed* JSON, not the raw strings, so a difference in key order or JSON
+    formatting is not mistaken for a config change.
+    """
     stored: dict[str, Any] = json.loads(stored_json)
     requested: dict[str, Any] = json.loads(requested_json)
     return [
-        f"  config.{field}: {stored.get(field, '<absent>')!r} -> {requested.get(field, '<absent>')!r}"
+        f"  config.{field}: "
+        f"{_describe_value_change(stored.get(field, _ABSENT), requested.get(field, _ABSENT))}"
         for field in sorted(stored.keys() | requested.keys())
-        if stored.get(field) != requested.get(field)
+        if stored.get(field, _ABSENT) != requested.get(field, _ABSENT)
     ]
+
+
+def _target_difference(tag: IdentityTagType, stored: str, requested: str) -> list[str]:
+    """Return the difference line for a class-target tag, or nothing if it is unchanged."""
+    return [] if stored == requested else [f"  {tag}: {stored!r} -> {requested!r}"]
 
 
 def _reject_changed_identity(
@@ -167,6 +208,9 @@ def _reject_changed_identity(
     experiment ``get_or_create_experiment`` creates as its self-healing fallback, which this
     registration is entitled to complete.
 
+    The decision to reject *is* the list of differences to report, so the error can never claim a
+    change it cannot then name.
+
     Args:
         experiment_name: The MLflow experiment name, for the error message.
         stored_tags: The existing experiment's tags (empty for a brand-new experiment).
@@ -175,22 +219,18 @@ def _reject_changed_identity(
     Raises:
         ExperimentIdentityChangedError: If any identity tag is already set to a different value.
     """
-    changed = [
-        tag
-        for tag in IDENTITY_TAGS
-        if tag in stored_tags and stored_tags[tag] != requested_tags[tag]
-    ]
-    if not changed:
-        return
     differences = [
         line
-        for tag in changed
+        for tag in IDENTITY_TAGS
+        if tag in stored_tags
         for line in (
-            _describe_config_change(stored_tags[tag], requested_tags[tag])
+            _config_differences(stored_tags[tag], requested_tags[tag])
             if tag == "config"
-            else [f"  {tag}: {stored_tags[tag]!r} -> {requested_tags[tag]!r}"]
+            else _target_difference(tag, stored_tags[tag], requested_tags[tag])
         )
     ]
+    if not differences:
+        return
     raise ExperimentIdentityChangedError(
         f"MLflow experiment {experiment_name!r} is already registered with a different"
         " configuration. An experiment's identity is its configuration — every fold must be"
@@ -249,6 +289,10 @@ def register_experiment(context: OpExecutionContext, config: RegisterExperimentC
     # experiment tagged with a config that its params contradict. The check above should make such
     # a rejection unreachable, but an experiment registered before that check existed may already
     # carry params that disagree with its tag, and the ordering keeps even that case one-sided.
+    # log_params is not itself atomic — a batch containing one conflicting key still writes the
+    # batch's other keys before raising — so this bounds the damage to the params rather than
+    # eliminating it. Reaching that requires an experiment whose tags failed to write on an earlier
+    # registration, which is why the tags are the last thing written.
     parent_run_id = get_or_create_parent_run(experiment_id)
     with mlflow.start_run(run_id=parent_run_id):
         mlflow.log_params(flatten_config(forecaster_config))

--- a/src/nged_substation_forecast/defs/jobs.py
+++ b/src/nged_substation_forecast/defs/jobs.py
@@ -6,7 +6,8 @@ dynamic partition set rather than producing a data artifact. Their ops use ``OpE
 which needs the Dagster instance.
 """
 
-from typing import Any, Literal, cast
+import json
+from typing import Any, Final, Literal, cast
 
 import hydra
 import mlflow
@@ -94,6 +95,111 @@ def _class_target(obj: type | object) -> str:
     return f"{cls.__module__}.{cls.__qualname__}"
 
 
+IdentityTagType = Literal["config", "forecaster_target", "config_target"]
+"""Type annotation for the experiment tags that together define an experiment's identity."""
+
+IDENTITY_TAGS: Final[tuple[IdentityTagType, ...]] = ("config", "forecaster_target", "config_target")
+"""Runtime tuple — iterated when comparing a re-registration against the stored identity.
+
+The ``description`` tag is deliberately absent: prose about an experiment is not part of what
+makes it that experiment, so it stays freely editable by re-registering.
+"""
+
+IdentityTagsType = dict[IdentityTagType, str]
+"""An experiment's identity, as the tag values that carry it."""
+
+
+class ExperimentIdentityChangedError(ValueError):
+    """Raised when re-registering an existing experiment under a changed config.
+
+    A distinct subclass so a caller (or a test) can tell "this experiment name is already taken by
+    a different config" apart from the ordinary ``ValueError``s raised while resolving the config
+    itself.
+    """
+
+
+def _identity_tags(
+    forecaster_cls: type[BaseForecaster], forecaster_config: BaseForecasterConfig
+) -> IdentityTagsType:
+    """Return the experiment tags that define this experiment's identity.
+
+    Args:
+        forecaster_cls: The resolved forecaster class.
+        forecaster_config: The resolved config, with ``experiment_name`` already stamped.
+
+    Returns:
+        The ``config``/``forecaster_target``/``config_target`` tag values. ``config`` is the
+        canonical JSON dump — see ``BaseForecasterConfig`` on why serialisation must be
+        order-stable for this comparison to mean anything.
+    """
+    return {
+        "config": forecaster_config.model_dump_json(),
+        "forecaster_target": _class_target(forecaster_cls),
+        "config_target": _class_target(forecaster_config),
+    }
+
+
+def _describe_config_change(stored_json: str, requested_json: str) -> list[str]:
+    """Return one ``field: registered -> requested`` line per differing config field."""
+    stored: dict[str, Any] = json.loads(stored_json)
+    requested: dict[str, Any] = json.loads(requested_json)
+    return [
+        f"  config.{field}: {stored.get(field, '<absent>')!r} -> {requested.get(field, '<absent>')!r}"
+        for field in sorted(stored.keys() | requested.keys())
+        if stored.get(field) != requested.get(field)
+    ]
+
+
+def _reject_changed_identity(
+    experiment_name: str, stored_tags: dict[str, str], requested_tags: IdentityTagsType
+) -> None:
+    """Raise if re-registering ``experiment_name`` would change its identity.
+
+    An experiment's identity **is** its config: every fold of an experiment must be trained and
+    scored under one config, or its leaderboard row silently mixes two different models. Folds
+    already materialised under the old config cannot be un-trained, and the assets read the config
+    back from the experiment tag (``load_experiment_forecaster``), so re-pointing that tag mid-flight
+    would poison every comparison built on the experiment. A changed config is therefore a *new*
+    experiment, and the only correct answer is to reject it — before anything has been written.
+
+    Called with the experiment's stored tags before any write, so a rejection leaves MLflow exactly
+    as it found it. A tag absent from ``stored_tags`` is not a change: that is the untagged
+    experiment ``get_or_create_experiment`` creates as its self-healing fallback, which this
+    registration is entitled to complete.
+
+    Args:
+        experiment_name: The MLflow experiment name, for the error message.
+        stored_tags: The existing experiment's tags (empty for a brand-new experiment).
+        requested_tags: The identity this registration is asking for, from ``_identity_tags``.
+
+    Raises:
+        ExperimentIdentityChangedError: If any identity tag is already set to a different value.
+    """
+    changed = [
+        tag
+        for tag in IDENTITY_TAGS
+        if tag in stored_tags and stored_tags[tag] != requested_tags[tag]
+    ]
+    if not changed:
+        return
+    differences = [
+        line
+        for tag in changed
+        for line in (
+            _describe_config_change(stored_tags[tag], requested_tags[tag])
+            if tag == "config"
+            else [f"  {tag}: {stored_tags[tag]!r} -> {requested_tags[tag]!r}"]
+        )
+    ]
+    raise ExperimentIdentityChangedError(
+        f"MLflow experiment {experiment_name!r} is already registered with a different"
+        " configuration. An experiment's identity is its configuration — every fold must be"
+        " trained and scored under the same one — so a changed configuration is a new experiment."
+        " Register it under a new experiment_name.\nDifferences (registered -> requested):\n"
+        + "\n".join(differences)
+    )
+
+
 def _fold_ids_for_run_mode(run_mode: str, cv_config: CvConfig) -> list[str]:
     """Return the fold ids a run mode expands to (read from the CV config, never hard-coded).
 
@@ -109,10 +215,17 @@ def _fold_ids_for_run_mode(run_mode: str, cv_config: CvConfig) -> list[str]:
 def register_experiment(context: OpExecutionContext, config: RegisterExperimentConfig) -> None:
     """Create the MLflow experiment + parent run and add the experiment's CV partition keys.
 
-    Idempotent: re-running with the same ``experiment_name`` resolves the existing experiment,
-    parent run, and partition keys rather than duplicating them. Materialises no assets — the
-    user materialises ``trained_cv_model`` / ``cv_power_forecasts`` for the new partitions
-    afterwards.
+    Idempotent for the *same* config: re-running with the same ``experiment_name`` resolves the
+    existing experiment, parent run, and partition keys rather than duplicating them, and may
+    freely update the ``description`` and add the other run mode's folds. Re-running with a
+    **changed** config is rejected outright — see ``_reject_changed_identity``. Materialises no
+    assets — the user materialises ``trained_cv_model`` / ``cv_power_forecasts`` for the new
+    partitions afterwards.
+
+    Raises:
+        ExperimentIdentityChangedError: If ``experiment_name`` is already registered under a
+            different config. Raised before any MLflow write, so the experiment is left exactly
+            as it was.
     """
     settings = Settings()
     mlflow.set_tracking_uri(settings.mlflow_tracking_uri)
@@ -120,17 +233,22 @@ def register_experiment(context: OpExecutionContext, config: RegisterExperimentC
     forecaster_cls, forecaster_config = _resolve_forecaster_config(
         config.base_model_config, config.config_overrides, config.experiment_name
     )
+    identity_tags = _identity_tags(forecaster_cls, forecaster_config)
 
+    # get_or_create_experiment writes nothing when the name already exists, so the check below
+    # still runs before this registration's first write. On a brand-new name it creates the
+    # (untagged) experiment, which has no stored identity to conflict with.
     experiment_id = get_or_create_experiment(config.experiment_name)
     client = MlflowClient()
-    client.set_experiment_tag(experiment_id, "config", forecaster_config.model_dump_json())
-    client.set_experiment_tag(experiment_id, "description", config.description)
-    # Stamp class identity so assets can reconstruct the exact forecaster + config subclass from
-    # MLflow alone (the config JSON above carries no class identifier). See
-    # load_experiment_forecaster.
-    client.set_experiment_tag(experiment_id, "forecaster_target", _class_target(forecaster_cls))
-    client.set_experiment_tag(experiment_id, "config_target", _class_target(forecaster_config))
+    _reject_changed_identity(
+        config.experiment_name, mlflow.get_experiment(experiment_id).tags, identity_tags
+    )
 
+    # Log the params before the experiment tags. MLflow params are write-once, so this is the one
+    # write the tracking store can reject; doing it first means a rejection can never leave the
+    # experiment tagged with a config that its params contradict. The check above should make such
+    # a rejection unreachable, but an experiment registered before that check existed may already
+    # carry params that disagree with its tag, and the ordering keeps even that case one-sided.
     parent_run_id = get_or_create_parent_run(experiment_id)
     with mlflow.start_run(run_id=parent_run_id):
         mlflow.log_params(flatten_config(forecaster_config))
@@ -143,6 +261,13 @@ def register_experiment(context: OpExecutionContext, config: RegisterExperimentC
                 **provenance_tags("register"),
             }
         )
+
+    # The identity tags carry the resolved config as JSON plus the class identity the JSON itself
+    # lacks, so assets can reconstruct the exact forecaster + config subclass from MLflow alone.
+    # See load_experiment_forecaster.
+    for tag_name, tag_value in identity_tags.items():
+        client.set_experiment_tag(experiment_id, tag_name, tag_value)
+    client.set_experiment_tag(experiment_id, "description", config.description)
 
     cv_config = load_cv_config(settings.cv_config_path)
     fold_ids = _fold_ids_for_run_mode(config.run_mode, cv_config)

--- a/tests/test_forecaster_config_serialisation.py
+++ b/tests/test_forecaster_config_serialisation.py
@@ -1,0 +1,77 @@
+"""The canonical-serialisation invariant every ``BaseForecasterConfig`` subclass must satisfy.
+
+A config is compared and stored as its *serialised* form: ``register_experiment`` stamps
+``model_dump_json()`` onto the MLflow experiment as the ``config`` tag and compares a
+re-registration against it, and logs ``flatten_config(...)`` as write-once MLflow params. Both
+therefore have to be a pure function of the config's values, and nothing else.
+
+``BaseForecasterConfig`` states this as an invariant on its subclasses; this module is what makes
+it enforceable rather than merely documented. It lives in the app tier, not in
+``packages/ml_core``, because enforcing it means importing every concrete forecaster — a
+dependency ``ml_core`` itself must not take on.
+"""
+
+from typing import get_origin
+
+import pytest
+from ml_core.base_forecaster import BaseForecasterConfig
+from xgboost_forecaster import XGBoostConfig
+
+_CONFIG_CLASSES: list[type[BaseForecasterConfig]] = [
+    BaseForecasterConfig,
+    *BaseForecasterConfig.__subclasses__(),
+]
+"""Every config class to hold to the invariant.
+
+``__subclasses__()`` only sees classes that have been imported, hence the explicit
+``XGBoostConfig`` import above; it is what picks up a *future* forecaster automatically.
+"""
+
+
+def test_every_concrete_forecaster_config_is_covered() -> None:
+    """Guard against the list silently emptying out if an import is dropped."""
+    assert XGBoostConfig in _CONFIG_CLASSES
+
+
+def _set_valued_fields(config_cls: type[BaseForecasterConfig]) -> set[str]:
+    """Names of ``config_cls``'s fields whose declared type is a set."""
+    return {
+        name
+        for name, field in config_cls.model_fields.items()
+        if get_origin(field.annotation) in (set, frozenset)
+    }
+
+
+def _fields_with_a_serialiser(config_cls: type[BaseForecasterConfig]) -> set[str]:
+    """Names of ``config_cls``'s fields that declare their own serialiser."""
+    return {
+        field
+        for decorator in config_cls.__pydantic_decorators__.field_serializers.values()
+        for field in decorator.info.fields
+    }
+
+
+@pytest.mark.parametrize("config_cls", _CONFIG_CLASSES, ids=lambda cls: cls.__name__)
+def test_every_set_valued_field_declares_a_serialiser(
+    config_cls: type[BaseForecasterConfig],
+) -> None:
+    """A set-valued field must pin its own serialisation order.
+
+    A ``set`` of strings iterates in a different order in every process (hash randomisation), and
+    Dagster launches each job run in its own process, so a set left to serialise itself makes two
+    dumps of the *same* config differ — which reads as a config change and collides with MLflow's
+    write-once params.
+    """
+    assert _set_valued_fields(config_cls) <= _fields_with_a_serialiser(config_cls)
+
+
+@pytest.mark.parametrize("config_cls", _CONFIG_CLASSES, ids=lambda cls: cls.__name__)
+def test_the_declared_serialiser_actually_sorts(
+    config_cls: type[BaseForecasterConfig],
+) -> None:
+    """Declaring a serialiser is not enough — it has to produce a canonical order."""
+    features = {"wind_speed_10m", "power_lag_24h", "hour_of_day", "temperature_2m"}
+
+    dumped = config_cls(selected_features=features).model_dump(mode="json")
+
+    assert dumped["selected_features"] == sorted(features)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1,18 +1,26 @@
 """Unit tests for the pure helpers in ``defs/jobs.py``.
 
-These call ``_resolve_forecaster_config`` (against the real ``conf/model/xgboost.yaml``) and
-``_fold_ids_for_run_mode`` (against a synthetic CV config) directly — no MLflow, Dagster, or
-Settings — so they stay in the fast, unmarked unit tier. The job wiring itself is covered by the
-integration test in ``test_register_experiment_job.py``.
+These call ``_resolve_forecaster_config`` (against the real ``conf/model/xgboost.yaml``),
+``_fold_ids_for_run_mode`` (against a synthetic CV config) and the identity helpers directly — no
+MLflow, Dagster, or Settings — so they stay in the fast, unmarked unit tier. The job wiring itself
+is covered by the integration test in ``test_register_experiment_job.py``.
 """
 
+import json
 from datetime import date
+from typing import Any
 
+import pytest
 from contracts.hydra_schemas import CvConfig, CvFoldConfig
+from ml_core._cv_helpers import flatten_config
 from xgboost_forecaster import XGBoostConfig, XGBoostForecaster
 
 from nged_substation_forecast.defs.jobs import (
+    ExperimentIdentityChangedError,
+    IdentityTagsType,
     _fold_ids_for_run_mode,
+    _identity_tags,
+    _reject_changed_identity,
     _resolve_forecaster_config,
 )
 
@@ -81,3 +89,79 @@ def test_full_cv_uses_the_leaderboard_folds() -> None:
 
 def test_register_only_uses_the_leaderboard_folds() -> None:
     assert _fold_ids_for_run_mode("register_only", _mixed_fold_config()) == ["fold_0", "fold_1"]
+
+
+def _identity_of(**overrides: Any) -> IdentityTagsType:
+    """The identity tags a registration of ``conf/model/xgboost.yaml`` would ask for."""
+    forecaster_cls, config = _resolve_forecaster_config(_BASE_CONFIG, overrides, "exp")
+    return _identity_tags(forecaster_cls, config)
+
+
+def _as_stored(tags: IdentityTagsType, **extra: str) -> dict[str, str]:
+    """Widen an identity to the open tag mapping MLflow returns for an existing experiment."""
+    return {**tags, **extra}
+
+
+def test_identity_tags_serialise_the_feature_set_sorted() -> None:
+    """The ``config`` tag must not depend on the feature set's iteration order.
+
+    ``selected_features`` is a ``set``, and a set of strings iterates in a different order in every
+    process (hash randomisation). Since Dagster launches each job run in its own process, an
+    order-sensitive dump would make a re-registration of an *unchanged* config look changed —
+    rejected by the identity check, and by MLflow's write-once params before that. Sorted output is
+    the canonical form that makes the comparison mean what it says. Asserted against the base
+    YAML's whole feature set (two dozen features), so the assertion cannot pass by an accident of
+    hash ordering.
+    """
+    _, config = _resolve_forecaster_config(_BASE_CONFIG, {}, "exp")
+
+    dumped = json.loads(_identity_tags(XGBoostForecaster, config)["config"])
+
+    assert dumped["selected_features"] == sorted(config.selected_features)
+
+
+def test_the_override_lists_order_does_not_change_the_identity() -> None:
+    features = ["power_lag_24h", "hour_of_day", "temperature_2m"]
+
+    assert _identity_of(selected_features=features) == _identity_of(
+        selected_features=list(reversed(features))
+    )
+
+
+def test_unchanged_identity_is_accepted() -> None:
+    """A re-registration of the same config passes — and the description is free to differ."""
+    tags = _identity_of(n_estimators=7)
+
+    _reject_changed_identity("exp", _as_stored(tags, description="unrelated"), tags)
+
+
+def test_absent_identity_tags_are_accepted() -> None:
+    """An untagged experiment (get_or_create_experiment's fallback) is completable, not a clash."""
+    _reject_changed_identity("exp", {}, _identity_of())
+
+
+def test_changed_config_is_rejected_and_names_the_changed_field() -> None:
+    with pytest.raises(ExperimentIdentityChangedError) as excinfo:
+        _reject_changed_identity(
+            "exp", _as_stored(_identity_of(n_estimators=7)), _identity_of(n_estimators=300)
+        )
+
+    message = str(excinfo.value)
+    assert "'exp'" in message
+    assert "config.n_estimators: 7 -> 300" in message
+    # Only the field that actually changed is reported.
+    assert "max_depth" not in message
+
+
+def test_changed_forecaster_class_is_rejected() -> None:
+    stored = _as_stored(_identity_of(), forecaster_target="some.other.Forecaster")
+
+    with pytest.raises(ExperimentIdentityChangedError, match="forecaster_target"):
+        _reject_changed_identity("exp", stored, _identity_of())
+
+
+def test_flattened_config_params_are_order_stable() -> None:
+    """The write-once MLflow params must not vary with feature-set iteration order either."""
+    _, config = _resolve_forecaster_config(_BASE_CONFIG, {}, "exp")
+
+    assert flatten_config(config)["selected_features"] == str(sorted(config.selected_features))

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -160,6 +160,53 @@ def test_changed_forecaster_class_is_rejected() -> None:
         _reject_changed_identity("exp", stored, _identity_of())
 
 
+def test_a_reserialised_config_is_not_a_change() -> None:
+    """The comparison is on the parsed JSON, so key order and formatting are not a config change.
+
+    Otherwise a stored tag written by an older serialisation of the same values — a field added
+    with a default, or reordered in the model class — would falsely make the experiment
+    un-re-registerable, and would do it while naming no differing field at all.
+    """
+    requested = _identity_of(n_estimators=7)
+    reserialised = json.dumps(dict(reversed(list(json.loads(requested["config"]).items()))))
+
+    _reject_changed_identity("exp", _as_stored({**requested, "config": reserialised}), requested)
+
+
+def test_a_reordered_feature_set_is_reported_as_an_ordering_difference() -> None:
+    """A tag whose feature list is merely in a different order must not read as changed values.
+
+    That is what an experiment registered before the config serialised its feature set canonically
+    looks like. It is still rejected — MLflow's write-once params mean the stored record cannot be
+    brought into line — but the error must say what actually differs.
+    """
+    requested = _identity_of()
+    stored_config = json.loads(requested["config"])
+    stored_config["selected_features"] = list(reversed(stored_config["selected_features"]))
+    stored = _as_stored({**requested, "config": json.dumps(stored_config)})
+
+    with pytest.raises(ExperimentIdentityChangedError) as excinfo:
+        _reject_changed_identity("exp", stored, requested)
+
+    message = str(excinfo.value)
+    assert "config.selected_features: the same 24 values, in a different order" in message
+    # The feature names themselves are not dumped twice over.
+    assert "power_lag_24h" not in message
+
+
+def test_a_field_absent_on_one_side_is_reported_not_swallowed() -> None:
+    """``None`` and "field missing" are different, and neither may produce a blank explanation."""
+    requested = _identity_of()
+    stored_config = json.loads(requested["config"])
+    del stored_config["ml_flow_experiment_id"]  # its value on the requested side is null
+    stored = _as_stored({**requested, "config": json.dumps(stored_config)})
+
+    with pytest.raises(ExperimentIdentityChangedError) as excinfo:
+        _reject_changed_identity("exp", stored, requested)
+
+    assert "config.ml_flow_experiment_id: <absent> -> None" in str(excinfo.value)
+
+
 def test_flattened_config_params_are_order_stable() -> None:
     """The write-once MLflow params must not vary with feature-set iteration order either."""
     _, config = _resolve_forecaster_config(_BASE_CONFIG, {}, "exp")

--- a/tests/test_register_experiment_job.py
+++ b/tests/test_register_experiment_job.py
@@ -161,6 +161,14 @@ def test_re_registration_with_a_changed_config_leaves_no_half_written_state(
         raise_on_error=False,
     )
     assert not result.success
+    # Assert *why* it failed, so the test cannot pass on an unrelated error. Dagster wraps the op's
+    # exception in a DagsterExecutionStepExecutionError, so the original is the `cause`.
+    failure = result.failure_data_for_node("register_experiment")
+    assert failure is not None and failure.error is not None
+    cause = failure.error.cause
+    assert cause is not None
+    assert cause.cls_name == "ExperimentIdentityChangedError"
+    assert "config.n_estimators: 7 -> 300" in cause.message
 
     experiment_after = mlflow.get_experiment_by_name("exp_changed")
     assert experiment_after is not None

--- a/tests/test_register_experiment_job.py
+++ b/tests/test_register_experiment_job.py
@@ -9,7 +9,7 @@ from pathlib import Path
 
 import mlflow
 import pytest
-from dagster import DagsterInstance, RunConfig
+from dagster import DagsterInstance, ExecuteInProcessResult, RunConfig
 from mlflow.tracking import MlflowClient
 
 from nged_substation_forecast.defs.cv_assets import CV_EXPERIMENT_FOLDS_NAME
@@ -27,20 +27,39 @@ def mlflow_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     mlflow.set_tracking_uri(tracking_uri)
 
 
-def _run(instance: DagsterInstance, experiment_name: str, run_mode: str) -> None:
-    result = register_experiment_job.execute_in_process(
+def _execute(
+    instance: DagsterInstance,
+    experiment_name: str,
+    run_mode: str,
+    config_overrides: dict[str, object] | None = None,
+    description: str = "a test experiment",
+    raise_on_error: bool = True,
+) -> ExecuteInProcessResult:
+    return register_experiment_job.execute_in_process(
         run_config=RunConfig(
             ops={
                 "register_experiment": RegisterExperimentConfig(
                     experiment_name=experiment_name,
                     base_model_config="conf/model/xgboost.yaml",
+                    config_overrides=config_overrides or {},
                     run_mode=run_mode,
-                    description="a test experiment",
+                    description=description,
                 )
             }
         ),
         instance=instance,
+        raise_on_error=raise_on_error,
     )
+
+
+def _run(
+    instance: DagsterInstance,
+    experiment_name: str,
+    run_mode: str,
+    config_overrides: dict[str, object] | None = None,
+    description: str = "a test experiment",
+) -> None:
+    result = _execute(instance, experiment_name, run_mode, config_overrides, description)
     assert result.success
 
 
@@ -102,3 +121,48 @@ def test_re_registration_is_idempotent(mlflow_env: None, dagster_instance: Dagst
     assert experiment is not None
     _parent_run(experiment.experiment_id)  # asserts exactly one parent run
     assert _partition_keys(dagster_instance) == ["exp_idem__mid_2025_to_mid_2026"]
+
+
+def test_re_registration_may_update_the_description(
+    mlflow_env: None, dagster_instance: DagsterInstance
+) -> None:
+    """The description is prose about the experiment, not part of what makes it that experiment."""
+    _run(dagster_instance, "exp_desc", run_mode="full_cv", description="first")
+    _run(dagster_instance, "exp_desc", run_mode="full_cv", description="second")
+
+    experiment = mlflow.get_experiment_by_name("exp_desc")
+    assert experiment is not None
+    assert experiment.tags["description"] == "second"
+
+
+def test_re_registration_with_a_changed_config_leaves_no_half_written_state(
+    mlflow_env: None, dagster_instance: DagsterInstance
+) -> None:
+    """A changed config is rejected, and the rejection writes nothing.
+
+    The experiment's ``config`` tag is what ``load_experiment_forecaster`` reconstructs the
+    forecaster from, so a failed registration that had already rewritten it would leave the
+    experiment describing a config its parent run's params contradict — and every later fold would
+    train on the config of a registration that *failed*.
+    """
+    _run(dagster_instance, "exp_changed", run_mode="full_cv", config_overrides={"n_estimators": 7})
+
+    experiment = mlflow.get_experiment_by_name("exp_changed")
+    assert experiment is not None
+    tags_before = dict(experiment.tags)
+    params_before = dict(_parent_run(experiment.experiment_id).data.params)
+    assert params_before["n_estimators"] == "7"
+
+    result = _execute(
+        dagster_instance,
+        "exp_changed",
+        run_mode="full_cv",
+        config_overrides={"n_estimators": 300},
+        raise_on_error=False,
+    )
+    assert not result.success
+
+    experiment_after = mlflow.get_experiment_by_name("exp_changed")
+    assert experiment_after is not None
+    assert dict(experiment_after.tags) == tags_before
+    assert dict(_parent_run(experiment_after.experiment_id).data.params) == params_before


### PR DESCRIPTION
## Summary

`register_experiment` wrote the experiment's `config` tag **before** logging the flattened config
as MLflow params. Params are write-once, so re-registering an existing experiment with a changed
config raised at the param step — *after* the tag had already been re-pointed. The job reported
failure while leaving the experiment tagged with the **new** config and its parent run's params
still describing the **old** one. `_mlflow_runs.load_experiment_forecaster` reconstructs the
forecaster class and config from that tag, so a failed registration left behind state that later
folds would act on.

Closes #471.

## Which fix option, and why

The issue offered three, plus the prior question of whether a changed-config re-registration
should succeed at all. **It should not** — so I took **option 2** (validate before writing
anything), in the strong form: a changed config is a *clean rejection*, not an update made safe.

An experiment's identity **is** its config. Folds already materialised under the old config cannot
be un-trained, and `trained_cv_model` reads the config back from the experiment tag on every fold,
so re-pointing that tag mid-flight would leave one experiment's leaderboard row silently averaging
two different models. `docs/ml_experimentation/dagster-workflow.md` already promised the opposite —
"every fold of the same experiment trains on exactly the config that was registered" — and the tag
being rewritable was the hole in that promise. Making the update *safe* would have preserved the
hazard and merely stopped it corrupting state on the way through; refusing it closes the hazard.

- **Option 1 (reorder the writes) — taken as well, but not on its own.** It is genuinely cheap and
  it is the right belt-and-braces, so the params are now logged before the tags: the one write the
  tracking store can reject happens first, and a rejection can no longer leave the tag contradicting
  the params. But on its own it only converts a corrupting failure into a clean one; the user is
  still met with `Changing param values is not allowed` and no hint that the real answer is a new
  experiment name. The identity check should make that MLflow rejection unreachable, but the
  ordering still matters for an experiment registered *before* this PR, which may already carry
  params that disagree with its tag.
- **Option 3 (move the flattened config out of params) — rejected.** That is the right treatment
  when a value is *legitimately mutable* across re-runs, which is why it was correct for #197's
  fold-run counters. An experiment's config is the opposite: it is exactly the immutable,
  identifying config that MLflow params are for, and the write-once rule is that semantic stated
  by the tracking store. Making the config a tag would have discarded the one mechanism that was
  (clumsily) enforcing the invariant this PR now enforces properly.

Re-registration stays useful for everything that is *not* identity: the same config with a
different `description`, or with the other `run_mode`'s folds added, still succeeds.

## The latent bug this uncovered: `set[str]` does not serialise deterministically

`BaseForecasterConfig.selected_features` is a `set[str]`, and Python's per-process string hash
randomisation means a set iterates in a different order in every process. Verified empirically —
five subprocesses, five different orderings of the same feature set, in both `model_dump_json()`
and `flatten_config()`:

```
['hour_of_day', 'wind_speed_10m', 'power_lag_24h', 'temperature_2m']
['temperature_2m', 'hour_of_day', 'power_lag_24h', 'wind_speed_10m']
['wind_speed_10m', 'hour_of_day', 'temperature_2m', 'power_lag_24h']
```

Two consequences, and the second is a pre-existing production bug:

1. The identity comparison this PR adds would be meaningless — an *unchanged* config would look
   changed roughly always.
2. **Already broken today**, independent of this PR: Dagster launches each job run in its own
   process, so re-registering an experiment with an unchanged config already fails at
   `mlflow.log_params` on `selected_features` — and, in the old write order, does so after the tag
   has been rewritten. The existing `test_re_registration_is_idempotent` cannot see this because
   `execute_in_process` runs both registrations in one process, where set iteration order is
   stable.

Fixed at the source with a `@field_serializer` on `BaseForecasterConfig.selected_features` that
sorts, so `model_dump_json()` and `flatten_config()` are both canonical. This is a prerequisite of
the main fix rather than a drive-by: without it, "has the config changed?" cannot be answered.
Documented on the class that a subclass adding a set-valued field must do the same.

## What changed

`src/nged_substation_forecast/defs/jobs.py`

- `IDENTITY_TAGS` / `IdentityTagType` / `IdentityTagsType` — the three tags that carry an
  experiment's identity (`config`, `forecaster_target`, `config_target`). `description` is
  deliberately not among them.
- `_identity_tags(...)` builds them; `_reject_changed_identity(...)` raises the new
  `ExperimentIdentityChangedError` if any is already set to a different value, with a
  `config.n_estimators: 7 -> 300` line per differing field. Both are pure, so they unit-test
  without MLflow.
- A tag *absent* from the stored tags is not a conflict: that is the untagged experiment
  `get_or_create_experiment` creates as its self-healing fallback, and this registration is
  entitled to complete it.
- The op now resolves the config, checks identity, logs params, and only then writes the tags.
  `get_or_create_experiment` writes nothing for an existing name, so the check still runs before
  this registration's first write.

`packages/ml_core/src/ml_core/base_forecaster.py` — the `selected_features` field serialiser.

`docs/ml_experimentation/dagster-workflow.md` — step 5's numbered list reordered to match, an
"An experiment's identity is its config" section, and the "Immutability" bullet strengthened now
that the tag really is immutable.

## Test plan

Each new test verified to fail against the pre-fix code (reverted the fix and confirmed):

- `tests/test_register_experiment_job.py::test_re_registration_with_a_changed_config_leaves_no_half_written_state`
  — the test the issue asks for: registers with `n_estimators=7`, re-registers with `300`, asserts
  the run fails **and** that both the experiment's tags and the parent run's params are byte-identical
  to before. Against the pre-fix code it reproduces the issue exactly: `MlflowException: Changing
  param values is not allowed. Param with key='n_estimators' was already logged with value='7' ...
  Attempted logging new value '300'`, with the `config` tag already rewritten.
- `tests/test_register_experiment_job.py::test_re_registration_may_update_the_description` — the
  other side of the rule: description is not identity.
- `tests/test_jobs.py` — six unit tests over the pure helpers: unchanged identity accepted, absent
  tags accepted, changed config rejected naming only the changed field, changed
  `forecaster_target` rejected, override-list order irrelevant to identity, and two order-stability
  tests. The order-stability tests assert against `sorted(...)` over the base YAML's full
  two-dozen-feature set rather than comparing two dumps — a dump-vs-dump comparison passes within
  a single process even without the serialiser, so it would have been no guard at all.

No existing test was relaxed. `test_re_registration_is_idempotent` is unchanged and still passes.

- [x] `uv run ruff check .`
- [x] `uv run ruff format .`
- [x] `uv run --all-packages ty check`
- [x] `uv run pytest` (449 passed, 1 skipped)
- [x] `uv run pymarkdown scan -r docs README.md CLAUDE.md packages/*/README.md`
- [x] `uv run mkdocs build --strict`, and read the rendered HTML for the edited section

## Follow-up: adversarial review

An independent review of the pushed branch found four things worth acting on. All four are fixed
in the second commit; each fix has a test verified to fail against the first commit.

1. **The reject decision and its explanation used different comparisons.** `changed` compared the
   raw JSON of the `config` tag; `_describe_config_change` compared the *parsed* fields. Any
   difference that was textual-only — a key reordered, or a field absent on one side whose
   counterpart is `null` (`ml_flow_experiment_id` is already such a field) — made the first
   non-empty and the second empty, so the user got `Differences (registered -> requested):` with
   nothing after it. Reproduced verbatim against the first commit. Worse, it was also a **false
   rejection**: a semantically identical config was refused, and the docs then told the user the
   answer was to invent a new experiment name. The differences are now computed once, from the
   parsed JSON, and *are* the decision to reject — an empty explanation is structurally
   impossible.

2. **Every pre-existing experiment reported a bogus 1.5 kB `selected_features` "change".** Their
   stored tag has the feature list in set-iteration order; the request now produces it sorted, so
   the rejection printed the same 24 names twice in two different orders while claiming the config
   had changed. Now reported as `config.selected_features: the same 24 values, in a different
   order`. The rejection itself stands — see the transitional note below.

3. **`mlflow.log_params` is not atomic**: a batch containing one conflicting key still writes the
   batch's other keys before raising. The identity check normally makes a conflicting batch
   unreachable, but a registration whose *tag* write failed leaves an untagged experiment that the
   deliberate "absent tag is not a conflict" rule lets through. So logging params first bounds the
   damage rather than eliminating it — the write-ordering comment now says so instead of
   overclaiming.

4. **The regression test asserted only `not result.success`**, so it would have passed on an
   unrelated failure. It now asserts the error is an `ExperimentIdentityChangedError` naming the
   changed field.

Also added `tests/test_forecaster_config_serialisation.py`: the "a subclass that adds a set-valued
field must serialise it canonically" invariant was docstring-only, and this whole PR exists because
that invariant was silently violated. It now fails a build. It lives in the app tier rather than in
`ml_core` because enforcing it means importing every concrete forecaster — a dependency `ml_core`
must not take on — and it asserts the serialiser actually sorts, not merely that one is declared.

**Not taken: an escape hatch for repairing an already-corrupted experiment.** The review noted that
under the pre-fix code, an experiment corrupted by this bug (tag = new config, params = old) could
be repaired by re-registering with the *old* config, and that the identity check now forecloses
that path. Mechanically true, but the repair never worked for a real experiment: its params carry
`selected_features` in whatever order the process that wrote them happened to use, so any
re-registration — in either direction — collides on that param before reaching the config field
that was actually corrupted. The check removes a repair path that was already unreachable in
practice.

## Reported, not fixed (out of scope)

**Experiments registered before this PR cannot be re-registered at all.** Two independent reasons,
both rooted in MLflow's inability to delete or update a param:

- Their params hold `selected_features` in a non-canonical order, which no longer matches what
  this code produces. The identity check rejects first (now with an honest "same values, in a
  different order" message); were it to pass, `log_params` would reject next.
- An experiment whose tag was already corrupted by this bug is now pinned to whatever config the
  failed registration left behind, since the identity check compares against that tag.

Neither can be repaired in place. The remedy in both cases is to register under a fresh
`experiment_name`. Same shape as the note in PR #464, and it affects a handful of dev experiments
in a project with no external users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
