### PR TITLE
Act on an adversarial review of today's twenty PRs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,9 +5,9 @@
 #     cp .env.example .env
 #
 # `.env` is read by `Settings` (packages/contracts/src/contracts/settings.py). Every field maps to
-# an upper-case env var, and an actual environment variable wins over the `.env` line. Only the
-# three NGED source-bucket credentials below are required; everything else has a working default
-# and is left commented out here — uncomment and set a line only to override its default.
+# an upper-case env var, and an actual environment variable wins over the `.env` line. Every
+# setting has a working default and is left commented out here — uncomment and set a line only to
+# override its default, or to reach a service (like NGED's bucket) that needs credentials.
 #
 # Full explanation of every setting (the three storage roots, the derive-from-root convention, and
 # which values each environment needs):
@@ -17,15 +17,17 @@
 # `packages/dashboard/.env.s3.example`. That file layers on top of this one only when the
 # dashboard's "Data source" toggle is set to "s3"; the rest of the app never reads it.
 
-# --- Required: NGED source-bucket credentials --------------------------------------------------
+# --- NGED source-bucket credentials ------------------------------------------------------------
 #
 # These authenticate reads of NGED's telemetry bucket (a different AWS account and bucket from our
-# own managed data tables). Required in every environment — without them `Settings()` raises a
-# validation error. Never commit the real values.
+# own managed data tables). Needed only to ingest NGED telemetry: the
+# `power_time_series_and_metadata` asset raises without them, naming the ones that are unset.
+# Everything that reads our own data tables — tests, training, backtests, dashboards — runs
+# without them. Never commit the real values.
 
-NGED_S3_BUCKET_URL=<nged source bucket url>
-NGED_S3_BUCKET_ACCESS_KEY=<key>
-NGED_S3_BUCKET_SECRET=<secret>
+# NGED_S3_BUCKET_URL=<nged source bucket url>
+# NGED_S3_BUCKET_ACCESS_KEY=<key>
+# NGED_S3_BUCKET_SECRET=<secret>
 
 # --- Optional: storage roots -------------------------------------------------------------------
 #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,6 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
-env:
-  # Dummy values for the required Settings fields. Most tests monkeypatch these, but a few
-  # construct Settings() directly and read the environment; locally they are satisfied by the
-  # developer's .env, which CI doesn't have. No test talks to the real NGED bucket.
-  NGED_S3_BUCKET_URL: "https://example.com"
-  NGED_S3_BUCKET_ACCESS_KEY: "dummy"
-  NGED_S3_BUCKET_SECRET: "dummy"
-
 jobs:
   ci:
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,11 +75,8 @@ ENTRYPOINT ["dagster"]
 # `dagster job execute` has no --partition flag at all, and `--select <asset>` hits a pre-
 # existing, unrelated antlr4-python3-runtime/Python-3.14 incompatibility in Dagster's own
 # asset-selection-string parser (confirmed reproducing outside Docker too, on plain `dg dev`).
-# Job-name selection (-j) skips that parser entirely. The three NGED_S3_BUCKET_* values must be
-# present (Settings requires them at import) but dummies suffice for an offline smoke test, so
-# this is the reliable invocation:
+# Job-name selection (-j) skips that parser entirely. Inference needs no credentials of any kind,
+# so this is the reliable invocation:
 #   docker run --network=none \
-#     -e NGED_S3_BUCKET_URL=https://example.com/outbound/ \
-#     -e NGED_S3_BUCKET_ACCESS_KEY=dummy -e NGED_S3_BUCKET_SECRET=dummy \
 #     <image> job execute -j live_forecasts_job --tags '{"dagster/partition": "<key>"}'
 CMD ["job", "execute", "-m", "nged_substation_forecast.definitions", "-j", "live_forecasts_job"]

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ The essentials:
 1. Ensure [`uv`](https://docs.astral.sh/uv/) is installed following their [official documentation](https://docs.astral.sh/uv/getting-started/installation/).
 2. **Install dependencies**: `uv sync`
 3. **Install pre-commit hooks**: `uv run pre-commit install`
-4. **Create your `.env`**: `cp .env.example .env`, then fill in the three required
-   `NGED_S3_BUCKET_*` credentials (the only values you must set).
+4. **Create your `.env`**: `cp .env.example .env`. Every setting has a working default, so you can
+   leave it as-is; fill in the `NGED_S3_BUCKET_*` credentials only to ingest NGED telemetry.
 5. **Run Dagster**: `uv run dg dev`, then open `http://localhost:3000` in your browser.
 
 ### Linting & Formatting

--- a/docs/architecture/adapting-to-another-geography.md
+++ b/docs/architecture/adapting-to-another-geography.md
@@ -8,6 +8,34 @@
 > bid. Nothing here is a commitment, and no current design decision should be taken "so that India
 > would be easier later" — see [Why we are not doing any of this now](#why-we-are-not-doing-any-of-this-now).
 
+## If you read this page before 2026-08-07, read only this
+
+Six things changed. Everything else on the page stands. We are targeting ENTICE 3.0's **problem
+statement 2** (hyperlocal AI forecasting for DISCOMs); the storage problem statement is not ours.
+
+1. **The money is much smaller than this page assumed** — up to USD 100,000, as *convertible*
+   funding rather than a grant, and possibly split between winners. The page was scoped like an
+   NGED-sized contract. → [What the award actually buys](#what-the-award-actually-buys)
+2. **Rooftop PV *is* metered — monthly.** This falsifies the hardest constraint in the old brief.
+   Biggest single improvement to our position — *if* the reads are generation rather than net
+   export, and *if* they map to a substation. → [What the monthly PV totals buy
+   us](#what-the-monthly-pv-totals-buy-us)
+3. **Scale is one or two DISCOMs, not a country**, and the site count is open by a factor of
+   several hundred — ~100,000 distribution transformers, or a few *hundred* substations. On the latter
+   answer, the whole scale section of this page evaporates. → [How many sites, and at which
+   voltage?](#how-many-sites-and-at-which-voltage)
+4. **The pilot partners are named: BRPL (Delhi) and JVVNL (Jaipur).** Delhi has no *rostered* load
+   shedding, which shrinks our most-feared confounder to a Rajasthan problem (it does still have
+   unplanned outages). The two states also sit at opposite ends of the rooftop hosting-capacity
+   range. → [The two pilot DISCOMs](#the-two-pilot-discoms-delhi-and-jaipur)
+5. **They believe they know where most rooftop PV is installed**, as this page predicted from the
+   regulations alone — though a register records *sanctioned* capacity, not working capacity.
+   → [India does record domestic PV capacity](#india-does-record-domestic-pv-capacity)
+6. **The "ask these three questions" list is now five**, led by the site-count question and by
+   whether the monthly PV figure is *generation* or *net export* — a distinction that decides
+   whether we have an anchor at all. → [Questions we should ask
+   them](#questions-we-should-ask-them)
+
 This page exists in the same spirit as
 [Why Dagster, not Airflow?](why-dagster-not-airflow.md): a question was asked, we did the analysis,
 and the reasoning is worth keeping auditable even though the answer is "not now".

--- a/docs/architecture/adapting-to-another-geography.md
+++ b/docs/architecture/adapting-to-another-geography.md
@@ -1,41 +1,12 @@
 # Could this codebase forecast another country?
 
 > **Status: Thought experiment — not planned work.** This page records an assessment made on
-> 2026-08-05 (against `main` at `737fb86`) while OCF was preparing a pitch for an innovation
-> project in India, **updated on 2026-08-07** once we identified the programme as **ENTICE 3.0** and
-> learned more about the brief — see [The brief](#the-brief).
+> 2026-08-05 and revised on 2026-08-07 (against `main` at `737fb86`), while OCF was preparing a
+> pitch for **ENTICE 3.0**, an innovation programme in India — see [The brief](#the-brief).
 > There is no GitHub issue for any of it, no roadmap entry, and **no intention to
 > refactor this codebase for portability**. We would not start any of this work unless we won that
 > bid. Nothing here is a commitment, and no current design decision should be taken "so that India
 > would be easier later" — see [Why we are not doing any of this now](#why-we-are-not-doing-any-of-this-now).
-
-## If you read this page before 2026-08-07, read only this
-
-Six things changed. Everything else on the page stands. We are targeting ENTICE 3.0's **problem
-statement 2** (hyperlocal AI forecasting for DISCOMs); the storage problem statement is not ours.
-
-1. **The money is much smaller than this page assumed** — up to USD 100,000, as *convertible*
-   funding rather than a grant, and possibly split between winners. The page was scoped like an
-   NGED-sized contract. → [What the award actually buys](#what-the-award-actually-buys)
-2. **Rooftop PV *is* metered — monthly.** This falsifies the hardest constraint in the old brief.
-   Biggest single improvement to our position — *if* the reads are generation rather than net
-   export, and *if* they map to a substation. → [What the monthly PV totals buy
-   us](#what-the-monthly-pv-totals-buy-us)
-3. **Scale is one or two DISCOMs, not a country**, and the site count is open by a factor of
-   several hundred — ~100,000 distribution transformers, or a few *hundred* substations. On the latter
-   answer, the whole scale section of this page evaporates. → [How many sites, and at which
-   voltage?](#how-many-sites-and-at-which-voltage)
-4. **The pilot partners are named: BRPL (Delhi) and JVVNL (Jaipur).** Delhi has no *rostered* load
-   shedding, which shrinks our most-feared confounder to a Rajasthan problem (it does still have
-   unplanned outages). The two states also sit at opposite ends of the rooftop hosting-capacity
-   range. → [The two pilot DISCOMs](#the-two-pilot-discoms-delhi-and-jaipur)
-5. **They believe they know where most rooftop PV is installed**, as this page predicted from the
-   regulations alone — though a register records *sanctioned* capacity, not working capacity.
-   → [India does record domestic PV capacity](#india-does-record-domestic-pv-capacity)
-6. **The "ask these three questions" list is now five**, led by the site-count question and by
-   whether the monthly PV figure is *generation* or *net export* — a distinction that decides
-   whether we have an anchor at all. → [Questions we should ask
-   them](#questions-we-should-ask-them)
 
 This page exists in the same spirit as
 [Why Dagster, not Airflow?](why-dagster-not-airflow.md): a question was asked, we did the analysis,

--- a/docs/architecture/adapting-to-another-geography.md
+++ b/docs/architecture/adapting-to-another-geography.md
@@ -1243,7 +1243,7 @@ All of it sits in a thin layer, and most of it sits in `contracts`.
 | `"Europe/London"` as a bare string literal in the feature engineer | `ml_core/features/tabular_feature_engineer.py`, in `_apply_local_time_features` | Drives every local-time feature in the champion feature set. |
 | `DISPLAY_TIME_ZONE = "Europe/London"`, asserted in the dashboard's axis titles | `dashboard/forecast_chart.py:40` | Display only, but it is a second hard-coded timezone. |
 | H3 resolution 5 (~253 km² per cell) chosen for GB, and reached for via a **private** import from the ingest package | `defs/assets.py:40,141` | The NWP grid resolution currently lives inside `nged_data`; see the `PowerIngest` note [below](#how-we-would-structure-it). |
-| `nged_s3_bucket_url` / `_access_key` / `_secret` are **required** settings with no defaults | `contracts/settings.py` | `Settings()` raises for any deployment with no NGED bucket. |
+| `nged_s3_bucket_url` / `_access_key` / `_secret` are named for one specific data provider | `contracts/settings.py` | Cosmetic: they default to empty and only the ingest asset reads them, so a deployment with no NGED bucket runs fine — but a second provider needs its own settings, not these renamed. |
 
 The UTC-offset feature is **not** one of these British assumptions.
 `local_utc_offset_minutes` holds the local offset from UTC in minutes, in an `Int16`, so every

--- a/docs/architecture/ecmwf-ens-known-issues.md
+++ b/docs/architecture/ecmwf-ens-known-issues.md
@@ -81,8 +81,10 @@ upstream step structure changing under us — is caught the same way.
 The **cell count and the total row count cannot fire through today's converter**, and are there as
 defence-in-depth rather than as live detections. That converter left-joins the NWP values onto the
 H3 grid and then groups by `h3_index`, so its output always carries exactly the cells the grid
-weights name, and always as a dense cross-product. They would start to matter if that converter
-were ever replaced by one that can emit a ragged frame.
+weights name, and always as a dense cross-product. The row count is what would catch a *ragged*
+run — every member, step and cell present, but some (member, step, cell) combinations absent —
+which the three marginal counts all miss. Both would start to matter if that converter were ever
+replaced by one that can emit such a frame.
 
 A dropped *grid point* is not covered by this check at all, and is worth knowing about: because the
 left join misses and the weighted `sum` over an all-null group returns `0.0`, a dropped point lands
@@ -100,10 +102,6 @@ inside physical bounds, so `Nwp.validate` accepts it and neither non-fatal check
   `h3_grid_weights` parquet it has already loaded, so the expectation tracks whatever grid we are
   actually running on. (For the V1 trial area that is 1671 cells, which is why a complete V1
   partition is ~7.24M rows — see [Performance and Scale](performance.md).)
-
-The report also compares the total row count against the full grid, which is what would catch a
-*ragged* run that the three marginal counts miss — every member, step and cell present, but some
-(member, step, cell) combinations absent. As noted above, today's converter cannot produce one.
 
 ### Why it warns instead of failing the run
 

--- a/docs/architecture/ml-orchestration.md
+++ b/docs/architecture/ml-orchestration.md
@@ -91,18 +91,18 @@ replaceable object, not to be small.
 
 ### Why there is no local cache
 
-An earlier version cached downloads on disk keyed by MLflow run ID. That was removed
-(issue #469) because it was actively harmful rather than merely unused: a CV fold run is **reused**
-across re-materialisations of its partition (see "Cross-process run resolution" above), so the
-same run ID can legitimately hold a different model after re-training, which made the cache key
-non-unique for its contents. Keeping the cache honest under that reuse required write-side
-invalidation in `save_to_mlflow` — machinery that existed purely to compensate for the cache, not
-to serve any consumer, since production inference never used it: the champion model is baked
-directly into the container image at build time and loaded via the subclass's own `load`, with no
-MLflow call on the runtime path at all for v0.1. Re-adding a cache, if a future consumer needs to
-keep serving through an MLflow outage, is tracked in
-[issue #472](https://github.com/openclimatefix/nged-substation-forecast/issues/472) and should be
-scoped to that consumer's actual invalidation needs rather than resurrecting this one.
+`load_from_mlflow` downloads on every call. The obvious cache — keyed by the MLflow run ID, which
+looks immutable — is unsound here, because a CV fold run is **reused** across re-materialisations
+of its partition (see "Cross-process run resolution" above), so the same run ID can legitimately
+hold a different model after re-training. The key would not be unique for its contents, and
+keeping such a cache honest would need write-side invalidation in `save_to_mlflow`: machinery
+serving no consumer, because production inference makes no MLflow call on the runtime path at all
+for v0.1 — the champion model is baked directly into the container image at build time and loaded
+via the subclass's own `load`.
+
+If a future consumer does need to keep serving through an MLflow outage, adding a cache scoped to
+that consumer's own invalidation needs is tracked in
+[issue #472](https://github.com/openclimatefix/nged-substation-forecast/issues/472).
 
 ## Idempotent writes and concurrency
 

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -253,13 +253,11 @@ there is nothing to cache or fail over from.
 **Future work:** once production wants to pick up a new champion without a rebuild + redeploy
 (e.g. after the [XGBoost quick wins](../roadmap/xgboost-improvements.md) start landing
 regularly), switch to fetching the champion model from MLflow dynamically. At that point the live
-service would need some way to keep serving through an MLflow outage — `load_from_mlflow` used to
-carry a local-disk cache for exactly that, but it was removed (issue #469) because it had no
-consumer: v0.1 never called it, and the CV pipeline's own use of it turned out to be actively
-harmful (a reused MLflow run made the cache key non-unique for its contents — see the linked
-section above). Re-adding a cache for this future consumer is tracked in
-[issue #472](https://github.com/openclimatefix/nged-substation-forecast/issues/472) and should be
-scoped to production's actual availability needs rather than resurrecting the old one.
+service would need some way to keep serving through an MLflow outage. `load_from_mlflow` supplies
+none — it downloads on every call, for the reasons in
+[Why there is no local cache](ml-orchestration.md#why-there-is-no-local-cache) — so that mechanism
+has to be designed against production's own availability needs. Tracked in
+[issue #472](https://github.com/openclimatefix/nged-substation-forecast/issues/472).
 
 ## Resolve repo-relative paths via a workspace marker, not directory depth
 
@@ -559,8 +557,8 @@ The idea may still return in a stronger form: the **future work** note at the en
 the section describing the accepted design this one lost to — describes fetching the champion
 dynamically once redeploys become frequent, at which point a production-resilience mechanism for
 serving through an MLflow outage would need to be designed (tracked in
-[issue #472](https://github.com/openclimatefix/nged-substation-forecast/issues/472)) rather than
-reused from `load_from_mlflow`'s old, now-removed cache.
+[issue #472](https://github.com/openclimatefix/nged-substation-forecast/issues/472));
+`load_from_mlflow` does not supply one.
 
 ## See also
 

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -51,61 +51,53 @@ row counts wrapping past 2³² rows.
   drive the in-process `moto` server instead of mocking — `tests/test_s3_data_paths.py` is the
   canonical pattern.
 - **Take the `dagster_instance` fixture; never call `DagsterInstance.ephemeral()` in a test.** The
-  fixture lives in `tests/conftest.py`. An ephemeral instance's in-memory run storage and event-log
-  storage each hold one SQLAlchemy connection to an in-memory SQLite database open for the life of
-  the instance, and `DagsterInstance` has no finaliser — so an instance that is never `dispose()`d
-  survives to interpreter shutdown, where SQLAlchemy's connection-pool finaliser can run after
-  SQLite has closed the database and print a bare `Exception during reset or similar` traceback
-  *after* pytest's summary line, owned by no test. The fixture enters the instance as a context
-  manager, so `dispose()` runs when the test ends.
+  fixture (in `tests/conftest.py`) enters the instance as a context manager, so `dispose()` runs
+  when the test ends.
 
-  A second, independent failure mode from the same root cause: `TemporaryLocalArtifactStorage`
-  (the artifact storage an ephemeral instance builds when given no `tempdir`) also defers its
-  `tempfile.TemporaryDirectory()` cleanup to `dispose()`, so an undisposed instance's temp
-  directory is left to the garbage collector too — via a `weakref.finalize` callback that can run
-  at any later point in the process, not just at shutdown. That callback is
-  `TemporaryDirectory._cleanup`, which removes the directory and then emits `ResourceWarning:
-  Implicitly cleaning up <TemporaryDirectory ...>`; because `filterwarnings` starts with `error`
-  (see below), the warning is *raised*, and an exception raised inside a weakref callback is
-  unraisable — CPython can only hand it to `sys.unraisablehook`, and pytest's hook turns it into a
-  hard `pytest.PytestUnraisableExceptionWarning` failure *attributed to whatever unrelated test
-  happened to be running* when the collector fired. Nothing about this is rare or environmental: it
-  is what always happens when a used ephemeral instance is collected instead of disposed, and the
-  only nondeterminism is *which* test is running at the time. One extra bare
-  `DagsterInstance.ephemeral()` call added anywhere in the suite was enough to tip a
-  previously-clean run into failing 2/2 times in CI while never reproducing locally, which is what
-  surfaced this. The fixture's deterministic disposal removes the trigger for both failure modes at
-  once.
+    `DagsterInstance` has no finaliser, so an undisposed instance defers two cleanups to whenever
+    the garbage collector reaches it. Both then surface as failures owned by no test:
+
+    - Its run storage and event-log storage each hold one SQLAlchemy connection to an in-memory
+      SQLite database. At interpreter shutdown the connection-pool finaliser can run *after*
+      SQLite has closed the database, printing a bare `Exception during reset or similar`
+      traceback after pytest's summary line.
+    - `TemporaryLocalArtifactStorage` defers its `tempfile.TemporaryDirectory()` cleanup to
+      `dispose()` as well, leaving it to a `weakref.finalize` callback that can fire at any point,
+      not just at shutdown. The callback emits `ResourceWarning: Implicitly cleaning up
+      <TemporaryDirectory ...>`, which the [warnings-are-errors](#warnings-are-errors) policy
+      *raises* — and
+      an exception inside a weakref callback is unraisable, so pytest's `sys.unraisablehook` turns
+      it into a hard `PytestUnraisableExceptionWarning` attributed to *whatever unrelated test was
+      running* when the collector fired.
+
+    Neither is rare or environmental: both are what always happens when a used ephemeral instance
+    is collected rather than disposed. Only *which* test gets blamed varies.
 
 - **In a script, use the context manager directly** — `with DagsterInstance.ephemeral() as
-  instance:` — rather than a bare call. Letting the local go out of scope is *not* enough: once the
-  instance has actually run a job, Dagster's own caches retain it (a `RunDomain`, and the
-  partition-loading contexts that hold it as `dynamic_partitions_store`), so it survives to
-  interpreter shutdown with both connections open even on a completely successful run. The context
-  manager also covers the failure path, where an unhandled exception's traceback pins the raising
-  frame as well. `scripts/run_baseline_experiment.py` is the worked example. Measured with an
-  `atexit` probe counting storages whose held connection is still open at exit, after one real
-  `materialize`: 2 open with a bare call, 0 with the context manager, on both paths.
-- **`build_asset_context()` (and the other `build_*_context()` direct-invocation helpers) needs
-  the same treatment when called without an explicit `instance=`.** Its docstring says it
-  "Defaults to `DagsterInstance.ephemeral()`" — built internally and owned by an `ExitStack` that
-  only closes on `__exit__`, or otherwise on `__del__`. Called bare and passed straight into an
-  asset (`some_asset(build_asset_context(...))`), nothing ever calls `__exit__`, so disposal
-  depends on `__del__` running — and inside a `pytest.raises(...) as exc_info:` block, the
-  captured traceback keeps the asset's frame (and the context argument in it) referenced past the
-  end of that `with` block, so `__del__` doesn't fire until *something* triggers a GC pass, which
-  is exactly the non-deterministic timing this page keeps warning about. Enter it as a context
-  manager instead: `with build_asset_context(...) as context, pytest.raises(...) as exc_info:`.
-  `tests/test_assets.py::test_ecmwf_ens_retries_when_run_not_yet_available` is the worked example
-  — before the fix, probing immediately after that one test's teardown, with **no forced
-  `gc.collect()`**, found 2 open connections; after, 0, every time.
-- **`materialize()` and `JobDefinition.execute_in_process()` do *not* need this.** Called without
-  `instance=`, both build their default ephemeral instance behind their own internal `with
-  ephemeral_instance_if_missing(instance):`, entered and exited inside the call, before the
-  function returns — so disposal there is already deterministic regardless of how the caller uses
-  the return value. The distinguishing question for any Dagster helper that can default-construct
-  an instance is whether *the helper itself* opens and closes the `with` block, or hands you an
-  object that expects *you* to.
+  instance:`. Letting the local go out of scope is *not* enough: once the instance has run a job,
+  Dagster's own caches retain it (a `RunDomain`, and the partition-loading contexts holding it as
+  `dynamic_partitions_store`), so it reaches interpreter shutdown with both connections open even
+  on a completely successful run. The context manager also covers the failure path, where an
+  unhandled exception's traceback pins the raising frame. Worked example:
+  `scripts/run_baseline_experiment.py`. Measured with an `atexit` probe after one real
+  `materialize`: 2 connections still open with a bare call, 0 with the context manager, on both
+  paths.
+- **`build_asset_context()` (and the other `build_*_context()` helpers) needs the same treatment
+  when called without an explicit `instance=`.** It defaults to `DagsterInstance.ephemeral()`,
+  owned by an `ExitStack` that closes only on `__exit__` or `__del__`. Passed straight into an
+  asset (`some_asset(build_asset_context(...))`) nothing ever calls `__exit__`, and inside a
+  `pytest.raises(...) as exc_info:` block the captured traceback keeps the context referenced past
+  the end of that block, so `__del__` waits on a GC pass. Enter it as a context manager instead:
+  `with build_asset_context(...) as context, pytest.raises(...) as exc_info:`. Worked example:
+  `tests/test_assets.py::test_ecmwf_ens_retries_when_run_not_yet_available` — probing right after
+  that test's teardown with **no forced `gc.collect()`** found 2 open connections before the fix,
+  0 after, every time.
+- **`materialize()` and `JobDefinition.execute_in_process()` do *not* need this.** Both wrap their
+  default instance in their own internal `with ephemeral_instance_if_missing(instance):`, entered
+  and exited inside the call, so disposal is already deterministic however the caller uses the
+  return value. The distinguishing question for any Dagster helper that can default-construct an
+  instance is whether *the helper itself* closes the `with` block, or hands you an object that
+  expects *you* to.
 
 ## Warnings are errors
 

--- a/docs/design-philosophy/design-principles.md
+++ b/docs/design-philosophy/design-principles.md
@@ -15,6 +15,11 @@ be useful. Writing them all down is what makes them explicit and checkable: a de
 then be tested against the *whole* list, rather than against whichever two or three principles
 happen to be at the front of the reviewer's mind that day.
 
+That pays off twice over now that much of this repo is written with an AI coding agent, because an
+agent can check every new addition against the whole list on every change — precisely the job a
+human reviewer's attention is too scarce to do reliably. Principles that live only in an
+experienced engineer's head cannot be applied that way; written-down ones can.
+
 Two things are worth saying up front. These are **bets, not truths**: each one is scored by the
 [engineering hypotheses](engineering-hypotheses.md), and a principle that fails its test will be
 reported as a negative result, not rewritten out of the record. And the defence against merely

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,13 +30,20 @@ root Dagster application in one step.
 ## Step 2 — Create your `.env`
 
 Configuration is read from a `.env` file in the repository root (and from environment variables,
-which win over `.env`). Copy the committed template and fill in the three required NGED credentials:
+which win over `.env`). Copy the committed template:
 
 ```bash
 cp .env.example .env
 ```
 
-Then edit `.env` and set the three `NGED_S3_BUCKET_*` values from the prerequisites:
+Every setting has a working default, so you can stop there: with an untouched `.env` all data and
+artifacts live under `<repo>/data` as plain files on disk, and the test suite, a training run and
+the dashboards all work.
+
+To ingest NGED telemetry you also need the three `NGED_S3_BUCKET_*` values from the prerequisites.
+They authenticate reads of NGED's own bucket, so nothing else needs them — without them the
+`power_time_series_and_metadata` asset raises an error naming the ones that are unset, and the rest
+of the system carries on:
 
 ```dotenv
 NGED_S3_BUCKET_URL=<nged source bucket url>
@@ -44,10 +51,9 @@ NGED_S3_BUCKET_ACCESS_KEY=<key>
 NGED_S3_BUCKET_SECRET=<secret>
 ```
 
-Those three are the only values you must set. Every other setting has a working default, so with
-nothing else in `.env` all data and artifacts live under `<repo>/data` as plain files on disk. The
-[Configuration reference](live_service/setup.md) explains the full menu — the three storage roots,
-the derive-from-root convention, and the credentials you would add to move the data tables to S3.
+The [Configuration reference](live_service/setup.md) explains the full menu — the three storage
+roots, the derive-from-root convention, and the credentials you would add to move the data tables
+to S3.
 
 `.env` is git-ignored; never commit real credentials.
 

--- a/docs/live_service/aws.md
+++ b/docs/live_service/aws.md
@@ -320,11 +320,15 @@ The deployed service genuinely needs `NGED_S3_BUCKET_URL`, `NGED_S3_BUCKET_ACCES
 telemetry from NGED's bucket. Without them that schedule fails every hour — loudly, since
 `Settings.get_nged_s3_store` raises an error naming the unset variables and the job's
 `sentry_capture_failure` hook reports it — while everything that does not read NGED's own bucket
-carries on. `Settings` deliberately does *not* require them at construction, so that a laptop, a
-test run or a training job needs no third-party credentials
-([why](../design-philosophy/design-principles.md#6-the-whole-system-must-be-exercisable-on-one-laptop)).
-To turn a mis-wired secret into an immediate start-up failure instead of an hourly one, call
-`Settings().require_nged_source_credentials()` from the container's entry point.
+carries on. `Settings` deliberately does *not* require them at construction, for two reasons: a
+laptop, a test run or a training job then needs no third-party credentials
+([why](../design-philosophy/design-principles.md#6-the-whole-system-must-be-exercisable-on-one-laptop)),
+and a mis-wired secret cannot take down inference. Requiring them would make the container refuse
+to start, which sounds like a useful fail-fast until you notice that `live_forecasts` reads our own
+Delta tables and a model baked into the image — it needs no NGED credential, so stopping it because
+one is missing would break [principle 1](../design-philosophy/design-principles.md#1-the-power-forecast-never-stops)
+to protect a schedule that already fails loudly on its own. Catch a mis-wired secret in the deploy
+pipeline instead, where the blast radius is the deploy rather than the forecast.
 
 They are also the one credential in this deployment that can't come from an IAM role: NGED's
 bucket lives in NGED's AWS account, so these are unavoidably static third-party keys. Don't

--- a/docs/live_service/aws.md
+++ b/docs/live_service/aws.md
@@ -322,7 +322,7 @@ telemetry from NGED's bucket. Without them that schedule fails every hour — lo
 `sentry_capture_failure` hook reports it — while everything that does not read NGED's own bucket
 carries on. `Settings` deliberately does *not* require them at construction, so that a laptop, a
 test run or a training job needs no third-party credentials
-([why](../architecture/../design-philosophy/design-principles.md#6-the-whole-system-must-be-exercisable-on-one-laptop)).
+([why](../design-philosophy/design-principles.md#6-the-whole-system-must-be-exercisable-on-one-laptop)).
 To turn a mis-wired secret into an immediate start-up failure instead of an hourly one, call
 `Settings().require_nged_source_credentials()` from the container's entry point.
 

--- a/docs/live_service/aws.md
+++ b/docs/live_service/aws.md
@@ -315,10 +315,16 @@ No static AWS keys anywhere in either role — the same IAM-role auto-discovery
 
 ## Step 8 — Store secrets in Parameter Store
 
-The container can't start without `NGED_S3_BUCKET_URL`, `NGED_S3_BUCKET_ACCESS_KEY`, and
-`NGED_S3_BUCKET_SECRET` (`Settings` requires them at import — see the smoke test in
-[Step 4](#step-4-build-and-verify-the-image)), and the deployed service genuinely uses them: the
-hourly `power_time_series_and_metadata` schedule pulls fresh telemetry from NGED's bucket.
+The deployed service genuinely needs `NGED_S3_BUCKET_URL`, `NGED_S3_BUCKET_ACCESS_KEY` and
+`NGED_S3_BUCKET_SECRET`: the hourly `power_time_series_and_metadata` schedule pulls fresh
+telemetry from NGED's bucket. Without them that schedule fails every hour — loudly, since
+`Settings.get_nged_s3_store` raises an error naming the unset variables and the job's
+`sentry_capture_failure` hook reports it — while everything that does not read NGED's own bucket
+carries on. `Settings` deliberately does *not* require them at construction, so that a laptop, a
+test run or a training job needs no third-party credentials
+([why](../architecture/../design-philosophy/design-principles.md#6-the-whole-system-must-be-exercisable-on-one-laptop)).
+To turn a mis-wired secret into an immediate start-up failure instead of an hourly one, call
+`Settings().require_nged_source_credentials()` from the container's entry point.
 
 They are also the one credential in this deployment that can't come from an IAM role: NGED's
 bucket lives in NGED's AWS account, so these are unavoidably static third-party keys. Don't

--- a/docs/live_service/local.md
+++ b/docs/live_service/local.md
@@ -12,8 +12,8 @@ identical to the AWS deployment.
 ## Step 1 — Repository and credentials
 
 Follow [Getting started on your laptop](../getting-started.md) for first-time setup (`uv`, `uv
-sync`, pre-commit hooks, and `cp .env.example .env`). At minimum, `.env` needs the three NGED
-source-bucket credentials — the only values that are always required (see
+sync`, pre-commit hooks, and `cp .env.example .env`). This rehearsal ingests real telemetry, so
+`.env` needs the three NGED source-bucket credentials (see
 [Configuration reference](setup.md#the-env-file-and-nged-source-credentials)):
 
 ```dotenv

--- a/docs/live_service/setup.md
+++ b/docs/live_service/setup.md
@@ -113,9 +113,10 @@ NGED_S3_BUCKET_SECRET=<secret>
 Leave them unset and `Settings` still builds: the ingest asset raises an error naming the unset
 variables when it runs, while every other asset, the test suite, training and the dashboards carry
 on. That keeps a laptop, a CI runner and a training job free of third-party credentials they never
-use ([why](../design-philosophy/design-principles.md#6-the-whole-system-must-be-exercisable-on-one-laptop)).
-A deployment that does ingest can turn a mis-wired secret into an immediate start-up failure by
-calling `Settings().require_nged_source_credentials()` from its entry point.
+use ([why](../design-philosophy/design-principles.md#6-the-whole-system-must-be-exercisable-on-one-laptop)),
+and it confines a mis-wired secret to the one schedule that needs it —
+[Step 8 of the AWS runbook](aws.md#step-8-store-secrets-in-parameter-store) explains why a deployment
+should *not* promote that into a start-up failure.
 
 The optional `SENTRY_*` settings (`SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `SENTRY_MONITOR_FORECASTS`,
 `SENTRY_TRACES_SAMPLE_RATE`) enable error telemetry and the missed-check-in alarm; an empty

--- a/docs/live_service/setup.md
+++ b/docs/live_service/setup.md
@@ -98,9 +98,9 @@ per-table overrides).
 ### The `.env` file and NGED source credentials
 
 Create a `.env` file in the repo root by copying the committed template — `cp .env.example .env` —
-and filling in the values. The three **NGED source-bucket** credentials are always required, in
-every environment — they authenticate reads of NGED's telemetry bucket, which is a *different*
-account and bucket from our own managed data tables:
+and filling in the values. The three **NGED source-bucket** credentials authenticate reads of
+NGED's telemetry bucket, which is a *different* account and bucket from our own managed data
+tables, so only telemetry ingest needs them:
 
 ```dotenv
 NGED_S3_BUCKET_URL=<nged source bucket url>
@@ -108,8 +108,14 @@ NGED_S3_BUCKET_ACCESS_KEY=<key>
 NGED_S3_BUCKET_SECRET=<secret>
 ```
 
-`.env` is git-ignored — never commit real credentials. Everything else on this page is optional and
-layers on top of these three.
+`.env` is git-ignored — never commit real credentials.
+
+Leave them unset and `Settings` still builds: the ingest asset raises an error naming the unset
+variables when it runs, while every other asset, the test suite, training and the dashboards carry
+on. That keeps a laptop, a CI runner and a training job free of third-party credentials they never
+use ([why](../design-philosophy/design-principles.md#6-the-whole-system-must-be-exercisable-on-one-laptop)).
+A deployment that does ingest can turn a mis-wired secret into an immediate start-up failure by
+calling `Settings().require_nged_source_credentials()` from its entry point.
 
 The optional `SENTRY_*` settings (`SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `SENTRY_MONITOR_FORECASTS`,
 `SENTRY_TRACES_SAMPLE_RATE`) enable error telemetry and the missed-check-in alarm; an empty

--- a/packages/contracts/src/contracts/power_schemas.py
+++ b/packages/contracts/src/contracts/power_schemas.py
@@ -113,7 +113,7 @@ class PowerTimeSeries(pt.Model):
         Returns:
             ``(survivors, n_dropped)``. ``survivors`` keeps ``dataframe``'s row order.
         """
-        survivors, _out_of_range = split_by_datetime_plausibility(dataframe, "time")
+        survivors, _ = split_by_datetime_plausibility(dataframe, "time")
         # `dt.minute()` is null for a null `time` and `.filter()` drops a row on a null predicate,
         # so this also drops the null `time`s the non-nullable schema forbids.
         survivors = survivors.filter(pl.col("time").dt.minute().is_in([0, 30]))

--- a/packages/contracts/src/contracts/power_schemas.py
+++ b/packages/contracts/src/contracts/power_schemas.py
@@ -113,13 +113,13 @@ class PowerTimeSeries(pt.Model):
         Returns:
             ``(survivors, n_dropped)``. ``survivors`` keeps ``dataframe``'s row order.
         """
-        survivors, out_of_range = split_by_datetime_plausibility(dataframe, "time")
-        # fill_null(False): a null `time` must land in exactly one of {aligned, misaligned}, not
-        # silently vanish from both — `dt.minute().is_in(...)` is null for a null `time`, and
-        # `.filter()` drops a row on both a null predicate and its negation.
-        is_aligned = pl.col("time").dt.minute().is_in([0, 30]).fill_null(False)
-        survivors, misaligned = survivors.filter(is_aligned), survivors.filter(~is_aligned)
-        return DropImplausibleRowsResult(survivors, out_of_range.height + misaligned.height)
+        survivors, _out_of_range = split_by_datetime_plausibility(dataframe, "time")
+        # `dt.minute()` is null for a null `time` and `.filter()` drops a row on a null predicate,
+        # so this also drops the null `time`s the non-nullable schema forbids.
+        survivors = survivors.filter(pl.col("time").dt.minute().is_in([0, 30]))
+        # Counted as a height difference rather than by summing the rejected partitions: whatever
+        # a filter does with a null predicate, every row that left is counted exactly once.
+        return DropImplausibleRowsResult(survivors, dataframe.height - survivors.height)
 
     # Define it as a ClassVar so Patito/Pydantic knows it's not a data field
     columns_to_sort_by: ClassVar[tuple[str, str]] = ("time_series_id", "time")

--- a/packages/contracts/src/contracts/settings.py
+++ b/packages/contracts/src/contracts/settings.py
@@ -99,18 +99,68 @@ class Settings(BaseSettings):
         description="Configurable thresholds for data quality checks.",
     )
 
+    # Credentials for NGED's *source* bucket, which lives in NGED's AWS account. Empty by default,
+    # not required: `get_nged_s3_store` is their only consumer, and its only caller is the
+    # `power_time_series_and_metadata` ingest asset. Making them required would mean every Delta
+    # read, training run and dashboard could not build a `Settings` without third-party credentials
+    # it never uses — and since `.env` is gitignored, a fresh clone could not run the test suite at
+    # all, which is exactly what "the whole system must be exercisable on one laptop" forbids:
+    # https://openclimatefix.github.io/nged-substation-forecast/design-philosophy/design-principles/#6-the-whole-system-must-be-exercisable-on-one-laptop
+    #
+    # Absence is therefore caught at the point of *use* (`get_nged_s3_store`) rather than at
+    # construction. A deployment that wants the old fail-fast-at-startup behaviour calls
+    # `require_nged_source_credentials()` explicitly.
     nged_s3_bucket_url: str = Field(
-        ..., description="NGED S3 bucket URL. Typically stored in the .env file."
+        default="",
+        description=(
+            "NGED source S3 bucket URL. Typically stored in the .env file. Empty unless you need"
+            " to ingest from NGED's bucket; `get_nged_s3_store` raises if it is."
+        ),
     )
     nged_s3_bucket_access_key: str = Field(
-        ..., description="Access key for the NGED S3 bucket. Typically stored in the .env file."
+        default="",
+        description="Access key for the NGED source S3 bucket. Typically stored in the .env file.",
     )
     nged_s3_bucket_secret: str = Field(
-        ..., description="Secret key for the NGED S3 bucket. Typically stored in the .env file."
+        default="",
+        description="Secret key for the NGED source S3 bucket. Typically stored in the .env file.",
     )
 
+    def require_nged_source_credentials(self) -> None:
+        """Raise ``ValueError`` unless all three NGED source-bucket credentials are set.
+
+        Call this to fail fast where the *absence* of ingest credentials should be fatal even
+        before anything tries to ingest — a container's start-up check is the motivating case, so
+        a deployment with mis-wired secrets dies immediately rather than at its first hourly pull.
+
+        Raises:
+            ValueError: Naming exactly which of the three environment variables are unset.
+        """
+        missing = [
+            name
+            for name, value in (
+                ("NGED_S3_BUCKET_URL", self.nged_s3_bucket_url),
+                ("NGED_S3_BUCKET_ACCESS_KEY", self.nged_s3_bucket_access_key),
+                ("NGED_S3_BUCKET_SECRET", self.nged_s3_bucket_secret),
+            )
+            if not value
+        ]
+        if missing:
+            raise ValueError(
+                f"NGED source-bucket credentials are not set: {', '.join(missing)}. Reading"
+                " NGED's telemetry needs all three. Set them in `.env` (locally) or inject them"
+                " from Parameter Store (on AWS). Everything that does not read NGED's own bucket"
+                " — training, cross-validation, the dashboards, every Delta read — works without"
+                " them."
+            )
+
     def get_nged_s3_store(self) -> obstore.store.S3Store:
-        """Returns an initialized obstore.store.S3Store instance for the NGED bucket."""
+        """Returns an initialized obstore.store.S3Store instance for the NGED bucket.
+
+        Raises:
+            ValueError: If any of the three source-bucket credentials is unset.
+        """
+        self.require_nged_source_credentials()
         return obstore.store.S3Store.from_url(
             url=self.nged_s3_bucket_url,
             config={
@@ -349,8 +399,14 @@ class Settings(BaseSettings):
     @field_validator("nged_s3_bucket_url")
     @classmethod
     def validate_url(cls, v: str) -> str:
-        """Validate that the S3 bucket URL is a valid URL."""
-        url_adapter.validate_python(v)
+        """Validate that the S3 bucket URL is a valid URL, if one was given at all.
+
+        Empty means "no NGED ingest configured", which is the default and not an error;
+        ``require_nged_source_credentials`` is what rejects it where it matters. A *non-empty*
+        value still has to be a real URL — strict about malformed, liberal about missing.
+        """
+        if v:
+            url_adapter.validate_python(v)
         return v
 
 
@@ -358,12 +414,10 @@ class Settings(BaseSettings):
 def get_settings() -> Settings:
     """Return the shared, lazily-constructed ``Settings`` singleton.
 
-    Prefer this over constructing ``Settings()`` at module import time. ``Settings`` has required
-    fields (the ``nged_s3_bucket_*`` credentials) with no defaults, so instantiation reads ``.env``
-    and raises ``ValidationError`` when those are absent. Deferring construction to first *use*
-    keeps library modules (e.g. the ``contracts`` schemas) importable without live credentials —
-    so type-checkers, doc builders, and tests that only touch in-memory frames don't need a
-    populated ``.env`` — while still failing fast the moment settings are actually needed.
+    Prefer this over constructing ``Settings()`` at module import time: instantiation reads
+    ``.env`` and the environment, so deferring it to first *use* keeps library modules (e.g. the
+    ``contracts`` schemas) importable whatever the environment holds, and lets a test change the
+    environment before the first read.
 
     Cached with ``lru_cache`` so every caller shares one instance (matching the previous
     module-level singletons). Call ``get_settings.cache_clear()`` in a test that needs to

--- a/packages/contracts/src/contracts/settings.py
+++ b/packages/contracts/src/contracts/settings.py
@@ -107,9 +107,9 @@ class Settings(BaseSettings):
     # all, which is exactly what "the whole system must be exercisable on one laptop" forbids:
     # https://openclimatefix.github.io/nged-substation-forecast/design-philosophy/design-principles/#6-the-whole-system-must-be-exercisable-on-one-laptop
     #
-    # Absence is therefore caught at the point of *use* (`get_nged_s3_store`) rather than at
-    # construction. A deployment that wants the old fail-fast-at-startup behaviour calls
-    # `require_nged_source_credentials()` explicitly.
+    # Absence is therefore caught at the point of *use* (`get_nged_s3_store`), which also confines
+    # a mis-wired secret to the one schedule that needs it: inference reads our own Delta tables and
+    # a baked-in model, so failing it over an ingest credential would stop the forecast.
     nged_s3_bucket_url: str = Field(
         default="",
         description=(
@@ -129,9 +129,12 @@ class Settings(BaseSettings):
     def require_nged_source_credentials(self) -> None:
         """Raise ``ValueError`` unless all three NGED source-bucket credentials are set.
 
-        Call this to fail fast where the *absence* of ingest credentials should be fatal even
-        before anything tries to ingest — a container's start-up check is the motivating case, so
-        a deployment with mis-wired secrets dies immediately rather than at its first hourly pull.
+        Call this immediately before doing something that reads NGED's bucket, so the failure names
+        the missing configuration instead of surfacing as an opaque auth error from ``obstore``.
+
+        Do *not* call it from process start-up or module import to fail a deployment fast: inference
+        needs none of these credentials, so that would stop the forecast over a missing ingest
+        secret. See the [AWS runbook](https://openclimatefix.github.io/nged-substation-forecast/live_service/aws/#step-8-store-secrets-in-parameter-store).
 
         Raises:
             ValueError: Naming exactly which of the three environment variables are unset.

--- a/packages/contracts/tests/test_power_time_series.py
+++ b/packages/contracts/tests/test_power_time_series.py
@@ -163,6 +163,9 @@ def test_power_time_series_empty_frame_passes_bounds_check() -> None:
 _OK = datetime(2026, 1, 1, 0, 30, tzinfo=timezone.utc)
 """A plausible, aligned `time` — the row that must survive every case below."""
 
+_OK2 = datetime(2026, 1, 1, 1, 0, tzinfo=timezone.utc)
+"""A second survivor, distinct from `_OK` so that assertions on survivor order can fail."""
+
 _OUT_OF_RANGE = datetime(1840, 6, 1, 0, 30, tzinfo=timezone.utc)
 _MISALIGNED = datetime(2026, 1, 1, 0, 15, tzinfo=timezone.utc)
 
@@ -183,10 +186,10 @@ def _frame(times: list[datetime | None]) -> pl.DataFrame:
 @pytest.mark.parametrize(
     "times, expected_survivors",
     [
-        pytest.param([_OK, _OK], [_OK, _OK], id="all_well_formed"),
+        pytest.param([_OK2, _OK], [_OK2, _OK], id="all_well_formed"),
         pytest.param([_OUT_OF_RANGE, _OK], [_OK], id="out_of_range_time"),
         pytest.param([_MISALIGNED, _OK], [_OK], id="misaligned_time"),
-        pytest.param([_OUT_OF_RANGE, _MISALIGNED, _OK], [_OK], id="both_kinds_in_one_pass"),
+        pytest.param([_OK2, _OUT_OF_RANGE, _MISALIGNED, _OK], [_OK2, _OK], id="both_kinds_in_one"),
         # A null `time` is malformed this early (the schema declares it non-nullable) and must be
         # dropped *and counted*, never silently vanish from the row accounting: `dt.minute()` is
         # null for a null `time`, and `.filter()` drops a row on a null predicate.
@@ -197,10 +200,11 @@ def _frame(times: list[datetime | None]) -> pl.DataFrame:
 def test_drop_implausible_rows(
     times: list[datetime | None], expected_survivors: list[datetime]
 ) -> None:
-    """Malformed `time`s are dropped and counted; well-formed rows survive in order.
+    """Malformed `time`s are dropped and counted; well-formed rows survive, in order.
 
-    Row accounting is asserted on every case — survivors plus dropped must always equal the input
-    — so no row can go missing without being reported.
+    `n_dropped` is asserted against the case's own arithmetic on every case, so a row cannot go
+    missing without being reported. (Asserting `survivors.height + n_dropped == df.height` instead
+    would be a tautology: that difference is how `n_dropped` is computed.)
     """
     df = _frame(times)
 
@@ -208,7 +212,6 @@ def test_drop_implausible_rows(
 
     assert survivors["time"].to_list() == expected_survivors
     assert n_dropped == len(times) - len(expected_survivors)
-    assert survivors.height + n_dropped == df.height
 
 
 def test_drop_implausible_rows_leaves_a_validatable_frame() -> None:

--- a/packages/contracts/tests/test_power_time_series.py
+++ b/packages/contracts/tests/test_power_time_series.py
@@ -160,133 +160,61 @@ def test_power_time_series_empty_frame_passes_bounds_check() -> None:
     PowerTimeSeries.DataFrame(schema=PowerTimeSeries.dtypes).validate()
 
 
-def test_drop_implausible_rows_keeps_well_formed_rows() -> None:
-    """Rows with a plausible, aligned `time` all survive, and none are counted as dropped."""
-    df = (
-        pt.DataFrame(
-            {
-                "time_series_id": [123, 123],
-                "time": [
-                    datetime(2026, 1, 1, 0, 0, tzinfo=timezone.utc),
-                    datetime(2026, 1, 1, 0, 30, tzinfo=timezone.utc),
-                ],
-                "power": [10.0, 20.0],
-            }
-        )
-        .set_model(PowerTimeSeries)
-        .cast()
-    )
+_OK = datetime(2026, 1, 1, 0, 30, tzinfo=timezone.utc)
+"""A plausible, aligned `time` — the row that must survive every case below."""
 
-    survivors, n_dropped = PowerTimeSeries.drop_implausible_rows(df)
-
-    assert n_dropped == 0
-    assert survivors.height == 2
-    PowerTimeSeries.validate(survivors)
+_OUT_OF_RANGE = datetime(1840, 6, 1, 0, 30, tzinfo=timezone.utc)
+_MISALIGNED = datetime(2026, 1, 1, 0, 15, tzinfo=timezone.utc)
 
 
-def test_drop_implausible_rows_drops_out_of_range_time() -> None:
-    """A `time` outside the plausible datetime range is dropped, not raised on."""
-    df = (
-        pt.DataFrame(
-            {
-                "time_series_id": [123, 123],
-                "time": [
-                    datetime(1840, 6, 1, 0, 30, tzinfo=timezone.utc),  # out of range
-                    datetime(2026, 1, 1, 0, 30, tzinfo=timezone.utc),  # fine
-                ],
-                "power": [10.0, 20.0],
-            }
-        )
-        .set_model(PowerTimeSeries)
-        .cast()
-    )
-
-    survivors, n_dropped = PowerTimeSeries.drop_implausible_rows(df)
-
-    assert n_dropped == 1
-    assert survivors["time"].to_list() == [datetime(2026, 1, 1, 0, 30, tzinfo=timezone.utc)]
-    PowerTimeSeries.validate(survivors)
-
-
-def test_drop_implausible_rows_drops_misaligned_time() -> None:
-    """A `time` not on :00 or :30 is dropped, not raised on."""
-    df = (
-        pt.DataFrame(
-            {
-                "time_series_id": [123, 123],
-                "time": [
-                    datetime(2026, 1, 1, 0, 15, tzinfo=timezone.utc),  # misaligned
-                    datetime(2026, 1, 1, 0, 30, tzinfo=timezone.utc),  # fine
-                ],
-                "power": [10.0, 20.0],
-            }
-        )
-        .set_model(PowerTimeSeries)
-        .cast()
-    )
-
-    survivors, n_dropped = PowerTimeSeries.drop_implausible_rows(df)
-
-    assert n_dropped == 1
-    assert survivors["time"].to_list() == [datetime(2026, 1, 1, 0, 30, tzinfo=timezone.utc)]
-    PowerTimeSeries.validate(survivors)
-
-
-def test_drop_implausible_rows_drops_both_kinds_in_one_pass() -> None:
-    """Out-of-range and misaligned rows are both dropped in a single call, summed into n_dropped."""
-    df = (
-        pt.DataFrame(
-            {
-                "time_series_id": [123, 123, 123],
-                "time": [
-                    datetime(1840, 6, 1, 0, 30, tzinfo=timezone.utc),  # out of range
-                    datetime(2026, 1, 1, 0, 15, tzinfo=timezone.utc),  # misaligned
-                    datetime(2026, 1, 1, 0, 30, tzinfo=timezone.utc),  # fine
-                ],
-                "power": [10.0, 20.0, 30.0],
-            }
-        )
-        .set_model(PowerTimeSeries)
-        .cast()
-    )
-
-    survivors, n_dropped = PowerTimeSeries.drop_implausible_rows(df)
-
-    assert n_dropped == 2
-    assert survivors["time"].to_list() == [datetime(2026, 1, 1, 0, 30, tzinfo=timezone.utc)]
-
-
-def test_drop_implausible_rows_empty_frame() -> None:
-    """An empty frame has nothing to drop."""
-    df = PowerTimeSeries.DataFrame(schema=PowerTimeSeries.dtypes)
-
-    survivors, n_dropped = PowerTimeSeries.drop_implausible_rows(df)
-
-    assert n_dropped == 0
-    assert survivors.is_empty()
-
-
-def test_drop_implausible_rows_drops_and_counts_null_time() -> None:
-    """A null `time` must be dropped and counted, not silently vanish from the row accounting.
-
-    Regression test: `dt.minute().is_in(...)` is null for a null `time`, and `.filter()` treats
-    both a null predicate and its negation as False — without an explicit `fill_null`, a null
-    `time` row was excluded from both the "aligned" and "misaligned" partitions and disappeared
-    without being counted in `n_dropped`.
-    """
-    df = pl.DataFrame(
+def _frame(times: list[datetime | None]) -> pl.DataFrame:
+    """A `PowerTimeSeries`-shaped frame carrying `times`, cast but not yet validated."""
+    return pl.DataFrame(
         {
-            "time_series_id": [123, 123],
-            "time": pl.Series(
-                [None, datetime(2026, 1, 1, 0, 30, tzinfo=timezone.utc)],
-                dtype=PowerTimeSeries.dtypes["time"],
+            "time_series_id": pl.Series(
+                [123] * len(times), dtype=PowerTimeSeries.dtypes["time_series_id"]
             ),
-            "power": [10.0, 20.0],
+            "time": pl.Series(times, dtype=PowerTimeSeries.dtypes["time"]),
+            "power": pl.Series([10.0] * len(times), dtype=PowerTimeSeries.dtypes["power"]),
         }
     )
 
+
+@pytest.mark.parametrize(
+    "times, expected_survivors",
+    [
+        pytest.param([_OK, _OK], [_OK, _OK], id="all_well_formed"),
+        pytest.param([_OUT_OF_RANGE, _OK], [_OK], id="out_of_range_time"),
+        pytest.param([_MISALIGNED, _OK], [_OK], id="misaligned_time"),
+        pytest.param([_OUT_OF_RANGE, _MISALIGNED, _OK], [_OK], id="both_kinds_in_one_pass"),
+        # A null `time` is malformed this early (the schema declares it non-nullable) and must be
+        # dropped *and counted*, never silently vanish from the row accounting: `dt.minute()` is
+        # null for a null `time`, and `.filter()` drops a row on a null predicate.
+        pytest.param([None, _OK], [_OK], id="null_time"),
+        pytest.param([], [], id="empty_frame"),
+    ],
+)
+def test_drop_implausible_rows(
+    times: list[datetime | None], expected_survivors: list[datetime]
+) -> None:
+    """Malformed `time`s are dropped and counted; well-formed rows survive in order.
+
+    Row accounting is asserted on every case — survivors plus dropped must always equal the input
+    — so no row can go missing without being reported.
+    """
+    df = _frame(times)
+
     survivors, n_dropped = PowerTimeSeries.drop_implausible_rows(df)
 
+    assert survivors["time"].to_list() == expected_survivors
+    assert n_dropped == len(times) - len(expected_survivors)
     assert survivors.height + n_dropped == df.height
-    assert n_dropped == 1
-    assert survivors["time"].to_list() == [datetime(2026, 1, 1, 0, 30, tzinfo=timezone.utc)]
+
+
+def test_drop_implausible_rows_leaves_a_validatable_frame() -> None:
+    """The survivors are exactly what `validate` — still strict — then accepts."""
+    survivors, _ = PowerTimeSeries.drop_implausible_rows(
+        _frame([_OUT_OF_RANGE, _MISALIGNED, None, _OK])
+    )
+
+    PowerTimeSeries.validate(survivors)

--- a/packages/contracts/tests/test_settings.py
+++ b/packages/contracts/tests/test_settings.py
@@ -32,21 +32,15 @@ def test_data_quality_settings_defaults():
 
 
 def test_settings_validation_invalid_url():
+    """Liberal about a missing source-bucket URL, strict about a malformed one."""
     with pytest.raises(ValidationError, match="Input should be a valid URL"):
-        Settings(
-            nged_s3_bucket_url="not-a-url",
-            nged_s3_bucket_access_key="key",
-            nged_s3_bucket_secret="secret",
-        )
+        Settings(nged_s3_bucket_url="not-a-url")
 
 
 def test_paths_derive_from_data_root():
     """Unset data-table paths derive from data_path_internal; nested tables sit under nged_data_path."""
     settings = Settings(
         data_path_internal="/srv/data",
-        nged_s3_bucket_url="https://example.com",
-        nged_s3_bucket_access_key="key",
-        nged_s3_bucket_secret="secret",
     )
     assert settings.nwp_data_path == "/srv/data/NWP"
     assert settings.nged_data_path == "/srv/data/NGED"
@@ -60,9 +54,6 @@ def test_delivery_paths_derive_from_delivery_root():
     settings = Settings(
         data_path_internal="s3://internal-bucket/data",
         data_path_delivery="s3://delivery-bucket/data",
-        nged_s3_bucket_url="https://example.com",
-        nged_s3_bucket_access_key="key",
-        nged_s3_bucket_secret="secret",
     )
     assert settings.power_forecasts_data_path == "s3://delivery-bucket/data/power_forecasts"
     assert settings.effective_capacity_data_path == "s3://delivery-bucket/data/effective_capacity"
@@ -84,9 +75,6 @@ def test_delivery_fields_are_exactly_the_known_delivery_tables():
     settings = Settings(
         data_path_internal="/internal",
         data_path_delivery="/delivery",
-        nged_s3_bucket_url="https://example.com",
-        nged_s3_bucket_access_key="key",
-        nged_s3_bucket_secret="secret",
     )
     managed_data_table_fields = {
         name
@@ -108,9 +96,6 @@ def test_remote_data_path_keeps_artifacts_local():
         data_path_internal="s3://bucket/data",
         data_path_delivery="s3://bucket/data",
         local_artifacts_path="/local/artifacts",
-        nged_s3_bucket_url="https://example.com",
-        nged_s3_bucket_access_key="key",
-        nged_s3_bucket_secret="secret",
     )
     assert settings.power_forecasts_data_path == "s3://bucket/data/power_forecasts"
     assert settings.power_time_series_data_path == "s3://bucket/data/NGED/power_time_series.delta"
@@ -124,9 +109,6 @@ def test_explicit_path_overrides_derivation():
         data_path_delivery="s3://bucket/data",
         production_model_path="/mnt/models/prod",
         nwp_data_path="/mnt/fast/NWP",
-        nged_s3_bucket_url="https://example.com",
-        nged_s3_bucket_access_key="key",
-        nged_s3_bucket_secret="secret",
     )
     assert settings.production_model_path == "/mnt/models/prod"
     assert settings.nwp_data_path == "/mnt/fast/NWP"
@@ -138,9 +120,6 @@ def test_storage_options_empty_without_dev_credentials():
     """With no ``data_store_*`` credentials set, ``storage_options`` is empty (the AWS default)."""
     settings = Settings(
         data_path_internal="s3://bucket/data",
-        nged_s3_bucket_url="https://example.com",
-        nged_s3_bucket_access_key="key",
-        nged_s3_bucket_secret="secret",
     )
     assert settings.storage_options == {}
 
@@ -153,9 +132,6 @@ def test_storage_options_populated_from_dev_credentials():
         data_store_access_key_id="minio",
         data_store_secret_access_key="minio123",
         data_store_region="us-east-1",
-        nged_s3_bucket_url="https://example.com",
-        nged_s3_bucket_access_key="key",
-        nged_s3_bucket_secret="secret",
     )
     assert settings.storage_options == {
         "aws_endpoint_url": "http://localhost:9000",
@@ -166,11 +142,8 @@ def test_storage_options_populated_from_dev_credentials():
     }
 
 
-def test_get_settings_is_cached(monkeypatch: pytest.MonkeyPatch):
+def test_get_settings_is_cached():
     """get_settings returns a single shared instance; cache_clear forces a rebuild."""
-    monkeypatch.setenv("NGED_S3_BUCKET_URL", "https://example.com")
-    monkeypatch.setenv("NGED_S3_BUCKET_ACCESS_KEY", "key")
-    monkeypatch.setenv("NGED_S3_BUCKET_SECRET", "secret")
     get_settings.cache_clear()
     try:
         assert get_settings() is get_settings()
@@ -185,10 +158,10 @@ def test_get_settings_is_cached(monkeypatch: pytest.MonkeyPatch):
 def test_importing_contracts_constructs_no_settings():
     """Importing the schema modules must not construct Settings (no import-time .env read).
 
-    Settings has required credential fields with no defaults, so any import-time construction would
-    make the whole contracts package unimportable without a populated .env — breaking type-checkers,
-    doc builders, and credential-free unit tests. Run in a fresh interpreter because this process
-    has already imported (and used) these modules. See contracts.settings.get_settings.
+    Constructing Settings reads .env and the environment, so an import-time construction would
+    freeze whatever configuration happened to be present when the module first loaded, before a
+    test (or an entry point) could set it. Run in a fresh interpreter because this process has
+    already imported (and used) these modules. See contracts.settings.get_settings.
 
     The guard patches ``Settings.__init__`` to raise, so it catches *any* import-time construction —
     a direct module-level ``Settings()`` as well as one routed through ``get_settings()`` — not just
@@ -210,3 +183,50 @@ def test_importing_contracts_constructs_no_settings():
         [sys.executable, "-c", probe], capture_output=True, text=True, check=False
     )
     assert result.returncode == 0, result.stderr
+
+
+def test_settings_builds_without_nged_source_credentials():
+    """A clone with no `.env` must still get a usable `Settings`.
+
+    `.env` is gitignored and holds third-party credentials for NGED's *source* bucket, so
+    requiring them would mean a fresh checkout could not run the test suite, train a model, or
+    open a dashboard — none of which read NGED's bucket. That is the laptop-exercisable principle
+    applied to configuration.
+    """
+    settings = Settings()
+
+    assert settings.nged_s3_bucket_url == ""
+    assert settings.nged_s3_bucket_access_key == ""
+    assert settings.nged_s3_bucket_secret == ""
+
+
+@pytest.mark.parametrize(
+    "url, access_key, secret, expected_missing",
+    [
+        ("", "", "", "NGED_S3_BUCKET_URL, NGED_S3_BUCKET_ACCESS_KEY, NGED_S3_BUCKET_SECRET"),
+        ("https://example.com", "", "", "NGED_S3_BUCKET_ACCESS_KEY, NGED_S3_BUCKET_SECRET"),
+        ("https://example.com", "key", "", "NGED_S3_BUCKET_SECRET"),
+        ("", "key", "secret", "NGED_S3_BUCKET_URL"),
+    ],
+)
+def test_require_nged_source_credentials_names_what_is_missing(
+    url: str, access_key: str, secret: str, expected_missing: str
+):
+    """The error has to name the unset variables — that is the whole point of moving the check
+    from construction (where pydantic named them) to the point of use."""
+    settings = Settings(
+        nged_s3_bucket_url=url,
+        nged_s3_bucket_access_key=access_key,
+        nged_s3_bucket_secret=secret,
+    )
+
+    with pytest.raises(ValueError, match=expected_missing):
+        settings.require_nged_source_credentials()
+
+
+def test_require_nged_source_credentials_passes_when_all_three_are_set():
+    Settings(
+        nged_s3_bucket_url="https://example.com",
+        nged_s3_bucket_access_key="key",
+        nged_s3_bucket_secret="secret",
+    ).require_nged_source_credentials()

--- a/packages/contracts/tests/test_settings.py
+++ b/packages/contracts/tests/test_settings.py
@@ -230,3 +230,15 @@ def test_require_nged_source_credentials_passes_when_all_three_are_set():
         nged_s3_bucket_access_key="key",
         nged_s3_bucket_secret="secret",
     ).require_nged_source_credentials()
+
+
+def test_get_nged_s3_store_refuses_to_build_a_store_without_credentials():
+    """Pins the *wiring*, not just the check.
+
+    Moving the credential check out of construction only helps if something still performs it
+    before the credentials are used. Every test that reaches ingest monkeypatches
+    ``get_nged_s3_store`` wholesale, so without this test the one line that calls
+    ``require_nged_source_credentials`` could be deleted and the suite would stay green.
+    """
+    with pytest.raises(ValueError, match="NGED_S3_BUCKET_URL"):
+        Settings().get_nged_s3_store()

--- a/packages/ml_core/src/ml_core/base_forecaster.py
+++ b/packages/ml_core/src/ml_core/base_forecaster.py
@@ -224,12 +224,11 @@ class BaseForecaster(ABC):
         - ``path`` must be cleared first, so that saving over a directory holding a *larger*
           model's files leaves none of them behind. Merging instead of replacing is how a dropped
           time series' weights survive a re-train (issue #197); ``XGBoostForecaster.save`` clears
-          with ``shutil.rmtree(path, ignore_errors=True)``. ``save_to_mlflow`` relies on this: it
-          archives whatever ``path`` holds, so a stale file here would be uploaded as part of the
-          model.
+          with ``shutil.rmtree(path, ignore_errors=True)``.
 
-        Callers should therefore treat ``path`` as owned by the model, not as a directory to
-        deposit files into.
+        The clearing requirement makes ``path`` the model's to own while it saves, so anything a
+        caller left there is gone afterwards. (Depositing a file *after* a save is fine, and is how
+        ``_production_helpers.fetch_model_artifacts`` puts ``promotion.json`` beside the model.)
         """
         pass
 

--- a/packages/ml_core/src/ml_core/base_forecaster.py
+++ b/packages/ml_core/src/ml_core/base_forecaster.py
@@ -212,13 +212,24 @@ class BaseForecaster(ABC):
 
     @abstractmethod
     def save(self, path: Path) -> None:
-        """Save the trained model state to a directory.
+        """Save the trained model state to a directory, **replacing** anything already there.
 
-        The saved directory must contain a ``meta.json`` with a ``model_class`` field — the
-        fully-qualified ``{module}.{qualname}`` of the concrete subclass (e.g.
-        ``"xgboost_forecaster.forecaster.XGBoostForecaster"``) — so that production inference
-        (``ml_core._production_helpers.load_forecaster_from_dir``) can reconstruct the correct
-        class from a plain model directory with no other context (issue #221).
+        Two requirements on every implementation:
+
+        - The saved directory must contain a ``meta.json`` with a ``model_class`` field — the
+          fully-qualified ``{module}.{qualname}`` of the concrete subclass (e.g.
+          ``"xgboost_forecaster.forecaster.XGBoostForecaster"``) — so that production inference
+          (``ml_core._production_helpers.load_forecaster_from_dir``) can reconstruct the correct
+          class from a plain model directory with no other context (issue #221).
+        - ``path`` must be cleared first, so that saving over a directory holding a *larger*
+          model's files leaves none of them behind. Merging instead of replacing is how a dropped
+          time series' weights survive a re-train (issue #197); ``XGBoostForecaster.save`` clears
+          with ``shutil.rmtree(path, ignore_errors=True)``. ``save_to_mlflow`` relies on this: it
+          archives whatever ``path`` holds, so a stale file here would be uploaded as part of the
+          model.
+
+        Callers should therefore treat ``path`` as owned by the model, not as a directory to
+        deposit files into.
         """
         pass
 
@@ -254,18 +265,12 @@ class BaseForecaster(ABC):
     def load_from_mlflow(cls, run_id: str) -> Self:
         """Download a trained model's archive from an MLflow run, unpack it and load it.
 
-        Downloads into a temporary directory and loads from there — there is no local-disk cache.
-        An earlier version of this method cached downloads on disk keyed by run ID, but a CV fold
-        run is **reused** across re-materialisations (``get_or_create_fold_run`` resolves the
-        same run for every re-run of a fold's partition), so the same ``run_id`` can legitimately
-        hold a different model after re-training. That made the cache key non-unique for its
-        contents, which required write-side invalidation just to keep the cache honest — machinery
-        that existed purely to compensate for the cache, not to serve any consumer: production
-        inference never used this cache (issue #469). See
-        <https://openclimatefix.github.io/nged-substation-forecast/architecture/ml-orchestration/#model-artifacts-one-replaceable-archive-no-local-cache>
-        for the full rationale. Re-adding a cache, if a future consumer needs to serve through an
-        MLflow outage, is tracked in issue #472 and should be scoped to that consumer's actual
-        invalidation needs rather than resurrecting this one.
+        Downloads into a temporary directory and loads from there. There is deliberately no
+        local-disk cache: a CV fold run is **reused** across re-materialisations
+        (``get_or_create_fold_run`` resolves the same run for every re-run of a fold's partition),
+        so a cache keyed by ``run_id`` would not be unique for its contents — and production
+        inference makes no MLflow call at all. Full rationale:
+        <https://openclimatefix.github.io/nged-substation-forecast/architecture/ml-orchestration/#why-there-is-no-local-cache>.
 
         The caller is responsible for setting the tracking URI (``mlflow.set_tracking_uri``)
         beforehand.

--- a/scripts/build_and_verify_image.sh
+++ b/scripts/build_and_verify_image.sh
@@ -28,11 +28,9 @@
 # build args become OCI labels purely for traceability (inspect with `docker inspect`).
 #
 # The smoke test choices:
-#   - Dummy NGED creds: `Settings` requires NGED_S3_BUCKET_* at import (several modules
-#     instantiate Settings() at import time), so the code location fails to import without them.
-#     They must be PRESENT but need not be real or reachable — passing dummies proves the image
-#     needs only their *presence* at import, never valid credentials and never the network. The
-#     deployed task gets the real values as secrets (runbook Step 8).
+#   - No credentials at all: inference reads the model baked into the image, so the smoke test
+#     passes with an empty environment. The deployed task still gets the NGED source-bucket
+#     values as secrets (runbook Step 8), because the hourly ingest schedule needs them.
 #   - --network=none: proves runtime inference needs no network at all — the whole point of
 #     baking the model in.
 #   - Job selected with `-j live_forecasts_job`, not `--partition`: `dagster job execute` has no
@@ -89,15 +87,12 @@ docker build \
 
 echo
 echo "==> Smoke-testing ${IMAGE} with zero network access (partition ${PARTITION_KEY})"
-# Dummy NGED creds: Settings requires them at import, but they need only be PRESENT — never real,
-# never reachable. --network=none proves runtime inference needs no network at all.
+# No credentials of any kind, and --network=none: together they prove runtime inference needs
+# neither.
 LOG_FILE="$(mktemp)"
 trap 'rm -f "$LOG_FILE"' EXIT
 set +e
 docker run --network=none --platform linux/arm64 \
-  -e NGED_S3_BUCKET_URL=https://example.com/outbound/ \
-  -e NGED_S3_BUCKET_ACCESS_KEY=dummy \
-  -e NGED_S3_BUCKET_SECRET=dummy \
   "$IMAGE" \
   job execute -m nged_substation_forecast.definitions -j live_forecasts_job \
   --tags "{\"dagster/partition\": \"${PARTITION_KEY}\"}" \

--- a/src/nged_substation_forecast/defs/checks.py
+++ b/src/nged_substation_forecast/defs/checks.py
@@ -24,9 +24,9 @@ answers two questions the asset's own success status cannot: did this 6-hourly s
 valid forecast rows on disk, and how many daily NWP runs were missing when the forecast was made?
 Both are read back from disk after the write, so a run that "succeeded" while writing nothing —
 or writing null/non-finite forecasts, hindcast rows, or a short population — still shows up.
-Missed NWP runs are *counted as runs*, never measured in hours of age: healthy NWP is 12–30 hours
-old depending on the slot, so any absolute age threshold would fire on two slots in four every
-day. See
+Missed NWP runs are *counted as runs*, never measured in hours of age — healthy NWP is 12–30 hours
+old depending on the slot, so any absolute age threshold would fire on two slots in four every day.
+The full argument is in
 [Inherent Stability → Three audiences, three channels](https://openclimatefix.github.io/nged-substation-forecast/design-philosophy/inherent-stability/#three-audiences-three-channels).
 
 Both checks are ``AssetCheckSeverity.WARN`` and ``blocking=False``, and ``live_forecasts_are_healthy``
@@ -461,10 +461,8 @@ def count_missed_nwp_runs(
     """Count the daily NWP runs missing between the freshest run on disk and the freshest expected.
 
     Pure and deterministic — no Dagster, Delta or clock access. Counting *runs* rather than hours
-    of age is the whole point: we ingest one run a day and forecast four times a day, so healthy
-    NWP is anywhere between 12 and 30 hours old, and any absolute age threshold tight enough to
-    catch an outage fires on two slots in four every day. This count is zero in every healthy
-    slot, whichever slot it is.
+    of age (module docstring) is what makes this count zero in every healthy slot, whichever slot
+    it is.
 
     Args:
         available_init_times: The ``init_time``s genuinely present in the NWP Delta table. Runs

--- a/src/nged_substation_forecast/defs/checks.py
+++ b/src/nged_substation_forecast/defs/checks.py
@@ -460,9 +460,10 @@ def count_missed_nwp_runs(
 ) -> MissedNwpRuns:
     """Count the daily NWP runs missing between the freshest run on disk and the freshest expected.
 
-    Pure and deterministic — no Dagster, Delta or clock access. Counting *runs* rather than hours
-    of age (module docstring) is what makes this count zero in every healthy slot, whichever slot
-    it is.
+    Pure and deterministic — no Dagster, Delta or clock access. We count missed *runs* rather than
+    hours of age because we ingest one ECMWF run per day but forecast four times a day, so healthy
+    NWP is anywhere from 12 to 30 hours old. Counting runs reads zero in every healthy slot,
+    whichever slot it is; counting hours would not (see the module docstring).
 
     Args:
         available_init_times: The ``init_time``s genuinely present in the NWP Delta table. Runs

--- a/src/nged_substation_forecast/defs/jobs.py
+++ b/src/nged_substation_forecast/defs/jobs.py
@@ -152,24 +152,6 @@ def _render_value(value: object) -> str:
     return "<absent>" if value is _ABSENT else repr(value)
 
 
-def _describe_value_change(stored: object, requested: object) -> str:
-    """Describe how one config field's value differs.
-
-    A list of strings that differs only in order gets its own phrasing rather than two near-identical
-    dumps: that is what a ``set``-valued field looks like when the stored tag was written by a
-    registration that did not yet serialise it canonically, and printing both orderings in full
-    would read as a change to the values themselves.
-    """
-    if (
-        isinstance(stored, list)
-        and isinstance(requested, list)
-        and all(isinstance(item, str) for item in (*stored, *requested))
-        and sorted(stored) == sorted(requested)
-    ):
-        return f"the same {len(stored)} values, in a different order"
-    return f"{_render_value(stored)} -> {_render_value(requested)}"
-
-
 def _config_differences(stored_json: str, requested_json: str) -> list[str]:
     """Return one line per differing config field, or nothing if the two configs agree.
 
@@ -179,8 +161,8 @@ def _config_differences(stored_json: str, requested_json: str) -> list[str]:
     stored: dict[str, Any] = json.loads(stored_json)
     requested: dict[str, Any] = json.loads(requested_json)
     return [
-        f"  config.{field}: "
-        f"{_describe_value_change(stored.get(field, _ABSENT), requested.get(field, _ABSENT))}"
+        f"  config.{field}: {_render_value(stored.get(field, _ABSENT))}"
+        f" -> {_render_value(requested.get(field, _ABSENT))}"
         for field in sorted(stored.keys() | requested.keys())
         if stored.get(field, _ABSENT) != requested.get(field, _ABSENT)
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,18 +33,3 @@ def dagster_instance() -> Iterator[DagsterInstance]:
     """
     with DagsterInstance.ephemeral() as instance:
         yield instance
-
-
-@pytest.fixture(autouse=True)
-def _dummy_nged_s3_creds(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Placeholder NGED source-bucket credentials.
-
-    Every integration test here builds a ``Settings``-backed object store, which requires these
-    three variables to be present — but none of the tests actually reach the real NGED bucket
-    (they read from temp Delta tables). Setting dummy values once, for every test in this
-    directory, removes the per-fixture boilerplate. A test that needs real values (e.g. the moto
-    S3 test constructs ``Settings`` with explicit kwargs) overrides them regardless.
-    """
-    monkeypatch.setenv("NGED_S3_BUCKET_URL", "https://example.com")
-    monkeypatch.setenv("NGED_S3_BUCKET_ACCESS_KEY", "dummy")
-    monkeypatch.setenv("NGED_S3_BUCKET_SECRET", "dummy")

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -18,6 +18,7 @@ import pytest
 import shapely
 from contracts.geo_schemas import H3GridWeights
 from contracts.power_schemas import PowerTimeSeries, TimeSeriesMetadata
+from contracts.settings import Settings
 from contracts.weather_schemas import Nwp
 from dagster import (
     AssetCheckEvaluation,
@@ -269,8 +270,6 @@ def test_ecmwf_ens_materialises_and_appends_nwp(
     """Happy path with the download/convert pipeline stubbed: the partition key parses into
     ``nwp_init_time`` (passed to ``open_ecmwf_ens_run``) and the converted frame is written to the
     NWP Delta table via ``write_nwp``."""
-    from contracts.settings import Settings
-
     _write_h3_grid_weights(Settings().h3_grid_weights_path)
     # After 2024-11-12, when categorical_precipitation_type_surface became a non-null Nwp variable.
     init_time = datetime(2024, 12, 1, tzinfo=timezone.utc)
@@ -320,8 +319,6 @@ def test_ecmwf_ens_warns_on_scattered_nulls_but_still_materialises(
 ) -> None:
     """Scattered per-pixel nulls in a de-accumulated variable (the known upstream ECMWF ENS
     corruption) are tolerated: the run still materialises, and the data-quality check WARNs."""
-    from contracts.settings import Settings
-
     _write_h3_grid_weights(Settings().h3_grid_weights_path)
     init_time = datetime(2024, 12, 1, tzinfo=timezone.utc)
 
@@ -355,8 +352,6 @@ def test_ecmwf_ens_warns_on_incomplete_run_but_still_materialises(
     ``_make_nwp`` builds 4 rows carrying 4 distinct members, valid_times and cells (a diagonal, not
     a cross-product), which is nothing like a complete 51 x 85 x 1 ECMWF ENS run.
     """
-    from contracts.settings import Settings
-
     _write_h3_grid_weights(Settings().h3_grid_weights_path)
     init_time = datetime(2024, 12, 1, tzinfo=timezone.utc)
     monkeypatch.setattr(assets, "open_ecmwf_ens_run", lambda *, nwp_init_time, h3_grid: object())
@@ -386,7 +381,6 @@ def test_ecmwf_ens_retries_when_run_not_yet_available(
 ) -> None:
     """``NwpRunNotYetAvailable`` → ``RetryRequested`` with the asset's configured retry budget,
     so a not-yet-published run waits rather than failing outright."""
-    from contracts.settings import Settings
     from dagster import RetryRequested
 
     _write_h3_grid_weights(Settings().h3_grid_weights_path)

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -132,8 +132,7 @@ def _write_h3_grid_weights(path: str) -> None:
 @pytest.fixture
 def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Point every managed data-path root at a temp dir, fully isolating the assets from the
-    developer's real configuration (dummy ``NGED_S3_BUCKET_*`` creds come from the autouse
-    ``_dummy_nged_s3_creds`` fixture in conftest.py)."""
+    developer's real configuration."""
     monkeypatch.setenv("DATA_PATH_INTERNAL", str(tmp_path))
     monkeypatch.setenv("DATA_PATH_DELIVERY", str(tmp_path))
     monkeypatch.setenv("LOCAL_ARTIFACTS_PATH", str(tmp_path))

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -144,9 +144,6 @@ def test_result_threshold_hours_reflects_threshold() -> None:
 @pytest.fixture
 def env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     """Point ``Settings`` at a temp data root (mirrors ``tests/test_assets.py``)."""
-    monkeypatch.setenv("NGED_S3_BUCKET_URL", "https://example.com")
-    monkeypatch.setenv("NGED_S3_BUCKET_ACCESS_KEY", "dummy")
-    monkeypatch.setenv("NGED_S3_BUCKET_SECRET", "dummy")
     monkeypatch.setenv("DATA_PATH_INTERNAL", str(tmp_path))
     monkeypatch.setenv("DATA_PATH_DELIVERY", str(tmp_path))
     monkeypatch.setenv("LOCAL_ARTIFACTS_PATH", str(tmp_path))

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -23,6 +23,7 @@ import polars as pl
 import pytest
 from contracts.common import UTC_DATETIME_DTYPE
 from contracts.power_schemas import TimeSeriesMetadata
+from contracts.settings import Settings
 from dagster import (
     AssetCheckResult,
     AssetCheckSeverity,
@@ -174,8 +175,6 @@ def _write_metadata_roster(path: str, ids: list[int]) -> None:
 
 def test_power_data_is_fresh_end_to_end(env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """One fresh series, one stale series, one never-reported roster id → a WARN naming all late."""
-    from contracts.settings import Settings
-
     # Freeze "now" so the fresh/stale split is deterministic regardless of wall-clock.
     now = datetime.now(timezone.utc)
     fresh_time = now - timedelta(hours=1)
@@ -207,8 +206,6 @@ def test_power_data_is_fresh_end_to_end(env: Path, monkeypatch: pytest.MonkeyPat
 
 
 def test_power_data_is_fresh_all_current_passes(env: Path) -> None:
-    from contracts.settings import Settings
-
     now = datetime.now(timezone.utc)
     settings = Settings()
     pl.DataFrame(
@@ -246,8 +243,6 @@ def test_power_data_is_fresh_hands_evaluated_result_to_sentry(
     alone would not prove reuse, since the pure function is deterministic and a recompute would
     yield equal counts and pass a weaker test. The reporter self-gates on health (tested in
     ``test_sentry.py``), so the check calls it unconditionally."""
-    from contracts.settings import Settings
-
     sentinel = PowerFreshnessResult(
         n_series_total=8,
         n_stale=7,
@@ -659,8 +654,6 @@ def _run_live_check() -> AssetCheckResult:
 
 def test_live_forecasts_are_healthy_end_to_end(env: Path) -> None:
     """A slot with valid rows for the whole trained population and a complete NWP feed passes."""
-    from contracts.settings import Settings
-
     settings = Settings()
     slot = _current_slot()
     _write_live_forecasts(settings.power_forecasts_data_path, slot)
@@ -678,8 +671,6 @@ def test_live_forecasts_are_healthy_end_to_end(env: Path) -> None:
 
 def test_live_forecasts_check_warns_when_the_slot_wrote_nothing(env: Path) -> None:
     """Rows exist for an *earlier* slot but not this one — the asset "succeeded" writing nothing."""
-    from contracts.settings import Settings
-
     settings = Settings()
     slot = _current_slot()
     _write_live_forecasts(settings.power_forecasts_data_path, slot - timedelta(hours=6))
@@ -695,8 +686,6 @@ def test_live_forecasts_check_warns_when_the_slot_wrote_nothing(env: Path) -> No
 
 def test_live_forecasts_check_ignores_cv_fold_rows(env: Path) -> None:
     """Rows written for a CV fold at the same init time must not be mistaken for the live slot."""
-    from contracts.settings import Settings
-
     settings = Settings()
     slot = _current_slot()
     _write_live_forecasts(settings.power_forecasts_data_path, slot, fold_id="mid_2025_to_mid_2026")
@@ -715,8 +704,6 @@ def test_live_forecasts_check_ignores_a_previous_experiments_rows(env: Path) -> 
     slot on disk indefinitely. Here those stale rows are all NaN: without the experiment filter
     they would be reported as this slot's fault.
     """
-    from contracts.settings import Settings
-
     settings = Settings()
     slot = _current_slot()
     _write_live_forecasts(
@@ -737,8 +724,6 @@ def test_live_forecasts_check_ignores_a_previous_experiments_rows(env: Path) -> 
 
 def test_live_forecasts_check_warns_on_a_truncated_horizon(env: Path) -> None:
     """Well-formed rows that stop hours rather than days ahead are an undeliverable forecast."""
-    from contracts.settings import Settings
-
     settings = Settings()
     slot = _current_slot()
     _write_live_forecasts(
@@ -757,8 +742,6 @@ def test_live_forecasts_check_warns_on_a_truncated_horizon(env: Path) -> None:
 @pytest.mark.parametrize("bad_power", [float("nan"), float("inf")])
 def test_live_forecasts_check_warns_on_non_finite_forecasts(env: Path, bad_power: float) -> None:
     """Rows exist, but every ``power_fcst`` is unusable."""
-    from contracts.settings import Settings
-
     settings = Settings()
     slot = _current_slot()
     _write_live_forecasts(settings.power_forecasts_data_path, slot, power_fcst=bad_power)
@@ -778,8 +761,6 @@ def test_live_forecasts_check_warns_on_null_forecasts(env: Path) -> None:
     explicit ``is_null()`` arm is the only thing that catches the single likeliest way for the
     asset to succeed while writing garbage. Without it this slot would read as perfectly healthy.
     """
-    from contracts.settings import Settings
-
     settings = Settings()
     slot = _current_slot()
     _write_live_forecasts(settings.power_forecasts_data_path, slot, power_fcst=None)
@@ -798,8 +779,6 @@ def test_a_row_that_is_both_non_finite_and_a_hindcast_is_counted_once(env: Path)
     Every row here is null *and* valid in the past, so both counts are 4 while ``n_invalid`` must
     stay 4: summing would report 8 invalid rows out of 4, breaking ``n_invalid <= n_rows``.
     """
-    from contracts.settings import Settings
-
     settings = Settings()
     slot = _current_slot()
     _write_live_forecasts(
@@ -826,8 +805,6 @@ def test_live_forecasts_check_reports_on_a_model_that_writes_no_nwp_init_time(en
     such column — so the check must still judge the rows it *can* see rather than failing to
     evaluate anything.
     """
-    from contracts.settings import Settings
-
     settings = Settings()
     slot = _current_slot()
     _write_live_forecasts(settings.power_forecasts_data_path, slot, with_nwp_init_time=False)
@@ -848,8 +825,6 @@ def test_live_forecasts_check_degrades_when_meta_json_names_no_experiment(env: P
     Keeping ``trained_time_series_ids`` while losing ``experiment_name`` would gate the population
     check on a count drawn from an *unfiltered* read of every live experiment's rows.
     """
-    from contracts.settings import Settings
-
     settings = Settings()
     slot = _current_slot()
     _write_live_forecasts(settings.power_forecasts_data_path, slot, time_series_ids=(1,))
@@ -866,8 +841,6 @@ def test_live_forecasts_check_degrades_when_meta_json_names_no_experiment(env: P
 
 def test_live_forecasts_check_warns_on_hindcast_rows(env: Path) -> None:
     """A row valid at or before its own init time is undeliverable, whatever its value."""
-    from contracts.settings import Settings
-
     settings = Settings()
     slot = _current_slot()
     _write_live_forecasts(
@@ -882,8 +855,6 @@ def test_live_forecasts_check_warns_on_hindcast_rows(env: Path) -> None:
 
 
 def test_live_forecasts_check_warns_on_a_missing_trained_series(env: Path) -> None:
-    from contracts.settings import Settings
-
     settings = Settings()
     slot = _current_slot()
     _write_live_forecasts(settings.power_forecasts_data_path, slot, time_series_ids=(1,))
@@ -898,8 +869,6 @@ def test_live_forecasts_check_warns_on_a_missing_trained_series(env: Path) -> No
 
 def test_live_forecasts_check_reports_missed_nwp_runs_end_to_end(env: Path) -> None:
     """Valid rows, but the NWP feed has been down for days."""
-    from contracts.settings import Settings
-
     settings = Settings()
     slot = _current_slot()
     stale_runs = _daily_runs(slot.replace(hour=0) - timedelta(days=5))
@@ -951,8 +920,6 @@ def test_live_forecasts_check_degrades_on_a_malformed_meta_json(env: Path) -> No
     rejects that shape and falls back to an unknown population, per CLAUDE.md's "strict about
     malformed inputs" rule.
     """
-    from contracts.settings import Settings
-
     settings = Settings()
     slot = _current_slot()
     _write_live_forecasts(settings.power_forecasts_data_path, slot, time_series_ids=(1,))
@@ -971,8 +938,6 @@ def test_live_forecasts_check_degrades_on_a_malformed_meta_json(env: Path) -> No
 
 def test_live_forecasts_check_degrades_on_invalid_json(env: Path) -> None:
     """A ``meta.json`` that isn't valid JSON at all degrades the same way as one that's absent."""
-    from contracts.settings import Settings
-
     settings = Settings()
     slot = _current_slot()
     _write_live_forecasts(settings.power_forecasts_data_path, slot, time_series_ids=(1,))
@@ -988,8 +953,6 @@ def test_live_forecasts_check_degrades_on_invalid_json(env: Path) -> None:
 
 def test_live_forecasts_check_does_not_raise_on_an_empty_table(env: Path) -> None:
     """An existing but row-less ``power_forecasts`` table is as harmless as no table at all."""
-    from contracts.settings import Settings
-
     settings = Settings()
     slot = _current_slot()
     _write_live_forecasts(settings.power_forecasts_data_path, slot)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -173,27 +173,6 @@ def test_a_reserialised_config_is_not_a_change() -> None:
     _reject_changed_identity("exp", _as_stored({**requested, "config": reserialised}), requested)
 
 
-def test_a_reordered_feature_set_is_reported_as_an_ordering_difference() -> None:
-    """A tag whose feature list is merely in a different order must not read as changed values.
-
-    That is what an experiment registered before the config serialised its feature set canonically
-    looks like. It is still rejected — MLflow's write-once params mean the stored record cannot be
-    brought into line — but the error must say what actually differs.
-    """
-    requested = _identity_of()
-    stored_config = json.loads(requested["config"])
-    stored_config["selected_features"] = list(reversed(stored_config["selected_features"]))
-    stored = _as_stored({**requested, "config": json.dumps(stored_config)})
-
-    with pytest.raises(ExperimentIdentityChangedError) as excinfo:
-        _reject_changed_identity("exp", stored, requested)
-
-    message = str(excinfo.value)
-    assert "config.selected_features: the same 24 values, in a different order" in message
-    # The feature names themselves are not dumped twice over.
-    assert "power_lag_24h" not in message
-
-
 def test_a_field_absent_on_one_side_is_reported_not_swallowed() -> None:
     """``None`` and "field missing" are different, and neither may produce a blank explanation."""
     requested = _identity_of()


### PR DESCRIPTION
> 🤖 **This PR description was written by [Claude Code](https://claude.com/claude-code)**, acting on Jack's behalf.

Adversarial review of everything merged on 2026-08-07 — PRs #450, #451, #453, #454, #455, #458, #459, #460, #461, #462, #463, #464, #465, #467, #468, #473, #474, #475, #481, #482, #483 (~6,100 insertions across 85 files), against the four axes asked for: correctness, conciseness, conformity to `CLAUDE.md` + [design principles](https://openclimatefix.github.io/nged-substation-forecast/design-philosophy/design-principles/), and test redundancy.

**Headline:** the code is in good shape. I found no correctness bug that changes behaviour. The one systemic conformity failure is that a rule codified *this morning* was broken by PRs merged *this afternoon*.

## Changed here

### 1. "Write about the present, not the past" — 4 violations of a rule added today

`d8543dc` (12:49) added this rule to `CLAUDE.md`. Four passages merged after it narrate the model cache that #469 deleted the same day:

| Where | Text |
|---|---|
| `docs/architecture/ml-orchestration.md` | "An earlier version cached downloads on disk keyed by MLflow run ID. That was removed (issue #469)…" |
| `docs/architecture/production-deployment.md` | "`load_from_mlflow` **used to carry** a local-disk cache … but **it was removed** (issue #469)…" |
| `docs/architecture/production-deployment.md` | "…rather than reused from `load_from_mlflow`'s **old, now-removed** cache." |
| `packages/ml_core/src/ml_core/base_forecaster.py` | "**An earlier version of this method** cached downloads on disk keyed by run ID…" |

The last one is *code*, where the Code Style form of the rule ("never reference previous iterations of the code") already applied before today.

Each is rewritten to say **why there is no cache** rather than **that there used to be one**. The design rationale is fully preserved — recording a considered-and-rejected design is exactly what `docs/architecture/` is for — but it now reads as a standing property rather than a changelog entry. The prose gets shorter as a side effect.

The code docstring also now links the specific `#why-there-is-no-local-cache` anchor rather than the parent section heading.

### 2. `BaseForecaster.save`'s contract omitted the invariant that fixes #197

`XGBoostForecaster.save` clears its destination with `shutil.rmtree(path, ignore_errors=True)`, but the abstract `BaseForecaster.save` says nothing about it. Two consequences:

A second `BaseForecaster` subclass would silently reintroduce #197 (a re-train on a smaller population leaves the dropped series' weights on disk) while satisfying every documented requirement.

Documented on the abstract method next to the existing `meta.json`/`model_class` requirement. No behaviour change; this closes a contract gap. (My first draft also claimed `save_to_mlflow` depends on the property — it does not; see item 8.)

### 3. `drop_implausible_rows` counted drops the fragile way

It summed the two rejected partitions, which is why it needed `fill_null(False)` — purely so a null `time` could not vanish from *both* sides of the aligned/misaligned split (a bug that was found and fixed in `f9175a4`). Counting as `dataframe.height - survivors.height` makes that miscount **structurally impossible** rather than guarded against, and drops the subtlety along with three lines of code. Same behaviour, verified by the tests below.

### 4. Test-suite tidying

- **Six near-identical `drop_implausible_rows` tests** (each rebuilding the same frame) → one parametrised case + one validatable-survivors test. `n_dropped` is now asserted on *every* case, not just the null one. 160 lines → 55.
- **23 deferred `from contracts.settings import Settings` statements** inside test bodies in `test_checks.py` (19) and `test_assets.py` (4). `checks.py` imports `Settings` at module level anyway, so the deferral bought nothing — it was pure repetition. Hoisted.

### 5. `_describe_value_change` deleted

It existed only to phrase the case where a stored `config` tag's feature list is in a different order from the requested one — which, as its own docstring said, is what an experiment registered *before* the config serialised its feature set canonically looks like. Previous-iteration behaviour, which CLAUDE.md says not to encode. The ordinary `stored -> requested` line covers it, and rejection semantics are unchanged.

### 6. Conciseness pass over today's docs and comments

No information removed — what goes is repetition and narration.

| Where | Saved | What went |
|---|---|---|
| `adapting-to-another-geography.md` | −19 words | Status-banner narration about the page's own revision |
| `testing.md` | −198 words | Narration around the Dagster-disposal rules |
| `production-deployment.md` | −52 words | Restated cache rationale |
| `ml-orchestration.md` | −23 words | Restated cache rationale |
| `ecmwf-ens-known-issues.md` | −16 words | "today's converter cannot produce a ragged run", stated twice |

One note on what is *not* cut. I initially deleted `adapting-to-another-geography.md`'s "If you read this page before 2026-08-07, read only this" section as a changelog of the page against its own history. Jack asked for it back, and he's right: this page is a **thought experiment whose assessment moved sharply in two days**, and a reader who saw the earlier version needs to know which six conclusions changed. That is orientation for returning readers, not a running changelog of the implementation — the rule's target. Restored verbatim; only the status banner's narration about the revision is tightened.

Also deduplicated in code: the "count runs, not hours of age" argument appeared **three times in one module** (`checks.py`). Now stated once in the module docstring, with `count_missed_nwp_runs` referring to it — the full argument already lives in Inherent Stability, which both link.

### 7. `Settings` no longer requires NGED source credentials

This started as "a fresh worktree fails one test", and turned out to be a real principle-6 breach.

`.env` is **gitignored**, and the three `nged_s3_bucket_*` fields were required with no defaults — so *any* `Settings()` raised without it, including one built by `Nwp.scan_delta` for a purely local temp Delta table. **A fresh clone could not run the test suite.**

Those credentials are for NGED's *source* bucket. Their only consumer is `get_nged_s3_store`, whose only caller is the `power_time_series_and_metadata` ingest asset. Every Delta read, training run, CV fold and dashboard was paying a required-field tax for third-party credentials it never touches.

They now default to `""`, with absence caught at the point of use:

- `require_nged_source_credentials()` raises naming precisely which variables are unset; `get_nged_s3_store` calls it.
- `validate_url` still rejects a *malformed* URL — only an empty one is allowed. Liberal about missing, strict about malformed.
- **Fail-fast at container start is deliberately *not* restored.** `definitions.py` builds `Settings` at import, so on `main` a mis-wired NGED secret failed the whole Dagster code location. That looks like a safety net but isn't: `get_nged_s3_store` has one caller (the ingest asset), and `live_forecasts` reads our own Delta tables and a model baked into the image, so it needs no NGED credential. The old behaviour stopped the forecast over a credential the forecast doesn't use — [principle 1](https://openclimatefix.github.io/nged-substation-forecast/design-philosophy/design-principles/#1-the-power-forecast-never-stops) — to protect a schedule that already fails loudly every hour via `sentry_capture_failure`. `aws.md` and `require_nged_source_credentials`'s own docstring now argue *against* the start-up check and point a deployment at its own pipeline instead, where the blast radius is the deploy rather than the forecast.

This deletes the boilerplate that existed only to satisfy the requirement: the autouse `_dummy_nged_s3_creds` fixture, the three `setenv` calls duplicating it in `test_checks.py`, and 24 credential kwargs threaded through `test_settings.py` constructions that were never about credentials.

**Verified by moving `.env` away and running the full suite: 514 passed, where before exactly one test failed.**

CI no longer exports dummy `NGED_S3_BUCKET_*` values either, so a regression that re-required them would now actually fail CI.

### 8. Acting on an adversarial review of *this* PR

A fresh reviewer got the PR number and nothing else. Its best finding was that item 7 changed the behaviour and left **eight** places documenting the old one — the same rule this PR is built around, turned on my own change. `README.md` and `getting-started.md` still told a new contributor the three NGED credentials were "the only values you must set", which made the benefit unreachable by anyone actually reading the docs. All eight fixed; the image smoke test now passes **no** credentials at all, which proves something stronger than the dummies did.

Also confirmed and fixed:

- **Item 2's docstring claimed `save_to_mlflow` relies on `save` clearing its directory. It does not** — `save_to_mlflow` `mkdir`s a fresh directory inside a fresh `TemporaryDirectory`, so what `save` receives is always empty. The false claim was the *motivation* I gave for the change; the #197 rationale it also rests on is real, so the contract stays, minus the bad sentence. "Callers should treat `path` as owned by the model" also contradicted `fetch_model_artifacts`, which deliberately deposits `promotion.json` beside a model — reworded.
- **The point-of-use check had no test at all.** Deleting `require_nged_source_credentials()` from `get_nged_s3_store` left the entire suite green, because every ingest test monkeypatches `get_nged_s3_store` wholesale. Now pinned, and I verified the new test fails under exactly that mutation.
- **`test_drop_implausible_rows` claimed survivors keep their order but used two identical values**, so adding `.reverse()` to the filter passed. Distinct `_OK2` added; two cases now fail under that mutation. Also dropped `survivors.height + n_dropped == df.height`, which was a tautology (that difference is how `n_dropped` is computed).

**Rejected one finding.** The reviewer read the PR body's "the container fail-fast is preserved" and called it false. It was right that the claim was false — but the defect was in the PR body, not the code: `aws.md` already described the new behaviour accurately. Corrected above rather than in the docs.

The reviewer independently confirmed the risky parts: `drop_implausible_rows` is **exactly equivalent** (1,170 generated cases across plain and model-bearing frames, zero mismatches in survivors *and* count), `get_nged_s3_store` really is the sole consumer of the three fields, no code path can reach an S3 client with an empty bucket URL, `validate_url` rejects everything it did before, and the deleted `_dummy_nged_s3_creds` fixture masked nothing.

### 9. Why the principles are written down at all

Two sentences added to `design-principles.md`, extending its existing "writing them down makes them explicit and checkable" argument: an AI coding agent can check every addition against the *whole* list on every change, which is exactly what a human reviewer's attention cannot do reliably. This PR is the worked example — every finding in it came from checking today's diffs against a written list.

## Reviewed and found sound (no change)

- **`except OSError, ValueError, TypeError, AttributeError:`** in `checks.py` looked like Python 2 syntax. It is valid Python 3.14 ([PEP 758](https://peps.python.org/pep-0758/)) and the repo requires 3.14+. Verified by parse + import.
- **`partitions_def` removed from `ecmwf_ens_job` / `live_forecasts_job`** — safe: `define_asset_job` infers it from the selected asset, `ecmwf_ens_schedule` sets `partition_key` explicitly, and the definitions smoke test resolves the whole graph.
- **`test_checks.py`'s pure-vs-end-to-end split is *not* redundant**, despite looking it. The pure cases pin the evaluator's logic; the end-to-end cases pin the Polars expressions and the Delta partition read, which the pure ones cannot reach. The file's own docstrings state the division of labour (e.g. `test_non_finite_power_forecasts_are_invalid` explicitly defers value coverage to its e2e counterparts). Left alone.
- **Arithmetic spot-checks all correct**: `ECMWF_ENS_LEAD_TIME_HOURS` is 49 + 36 = 85 steps; `1671 × 51 × 85 = 7,243,785` rows; `_MIN_HORIZON_HOURS` = 168 h = half of 14 days; NGED ECR figures in `xgboost-improvements.md` sum correctly (13.7 + 6.2 + 5.3 + 0.5 = 25.7 MW over 10 + 18 + 8 + 5 = 41 sites; 25.7 / 5669 = 0.45%).
- **`local_utc_offset` → `local_utc_offset_minutes`** rename is complete — no stale references anywhere.

## Verification

`ruff check` · `ruff format --check` · `uv run --all-packages ty check` · `pytest` (**514 passed, 1 skipped**, with `.env` absent *and* `NGED_S3_BUCKET_*` unset) · `pymarkdown scan` · `mkdocs build --strict` — all green.

Per `CLAUDE.md`'s standing rule for link-touching docs changes, I also read the generated HTML under `site/` rather than trusting the linters: confirmed `id="why-there-is-no-local-cache"` exists, that all six inbound links resolve to it, and that the rewritten section renders as intended.

The `.env` coupling that caused that failure is fixed by item 7 above, so this no longer needs a workaround.

## Housekeeping

Also tidied the repo's branches, as asked. Deleted four fully-merged local branches (`worktree-agent-a41ef0c7393e3698a`, `worktree-agent-a8527a3e2954f9944`, `worktree-agent-a976c61d07c9dbe6f`, `claude/roadmap-reproducibility-stamping-662100` — all 0 commits ahead of `main`) and pruned stale worktree registrations. Only `main` and this review branch remain locally, and the only worktrees are the main checkout and this one.

**One thing left for you:** `origin/claude/register-experiment-config-order-9b1c21` is merged (0 commits ahead of `main`) and should be deleted, but the sandbox blocked my `git push origin --delete`:

```bash
git push origin --delete claude/register-experiment-config-order-9b1c21
```
