### PR TITLE
Add a plan-issue skill, and make plans/ one file per branch

### DIFF
--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: plan-issue
+description: >-
+  Turn a GitHub issue in openclimatefix/nged-substation-forecast into a reviewed implementation
+  plan, without writing any code. Reads the issue and its comments, decides whether the issue is
+  worth implementing at all, writes a plan that may overrule a stale issue body, has a fresh
+  sub-agent adversarially review that plan, triages the findings, and then stops for Jack's
+  review. Use this whenever Jack asks for a plan for an issue, says "plan issue N" or
+  "/plan-issue N", asks whether an issue is worth doing, or asks you to think through how to
+  implement an issue before touching code. Do not use it to implement an issue — that is the
+  "Sub-agent routine" in CLAUDE.md, which starts once a plan from this skill has been approved.
+---
+
+# Plan a GitHub issue
+
+The output of this skill is a **plan file and a recommendation**, never a code change. Planning
+and implementing are deliberately separate: Jack approves a plan before any code moves, so that
+his review of the eventual diff is checking execution rather than discovering the design for the
+first time.
+
+Take the issue number from the invocation (`/plan-issue 500`). If several are given, run the whole
+procedure once per issue, each on its own branch — do not merge them into one plan unless the
+issues turn out to be the same change, in which case say so explicitly in step 2.
+
+## 1. Gather
+
+Read all of this before forming an opinion:
+
+```bash
+gh issue view <N> --json number,title,body,labels,assignees,state,url
+gh issue view <N> --comments
+```
+
+- **The comments matter as much as the body.** An issue body is written once; the comments are
+  where it gets corrected. Where they disagree, the comments usually win.
+- **Follow the issue's links.** Most issues in this repo link to a `docs/` page (rendered site
+  links) and to the PR or review that spawned them. Read those, and read the code the issue
+  names — the issue's description of current behaviour is a claim to verify, not a fact.
+- **Check for work already in flight**, because sessions run in parallel:
+
+  ```bash
+  gh pr list --state open --search "<N>"
+  git branch -a --list '*issue-<N>*'
+  ```
+
+  If something is already open against the issue, stop and report that instead of planning.
+
+- **Read the relevant docs.** `docs/` holds prior discussion that predates the issue:
+  `docs/roadmap/` for the milestone arc and any "Implementation details" section covering this
+  work, `docs/architecture/` for why the current design is what it is, `docs/techniques/` for
+  method write-ups, `docs/design-philosophy/` for the rules the plan has to obey.
+
+## 2. Decide whether it is worth implementing
+
+This is a real gate, not a formality. State a clear verdict before writing any plan, and be
+willing to answer "no" or "not like this". Grounds for pushing back:
+
+- The issue's premise is **factually wrong** about the current code — the bug it describes is
+  already fixed, or never reproduced in the first place.
+- The issue is **stale**: it was written against a design that has since changed, so its proposed
+  fix targets code that no longer exists or no longer works that way.
+- The change **conflicts with a design principle** in
+  `docs/design-philosophy/design-principles.md`, and the trade is not worth it.
+- It is **subsumed** by another open issue, or its two halves belong in different issues.
+- The cost is out of proportion to the benefit at this project's stage.
+
+If the verdict is "not worth it" or "worth it, but not as described", say so, give the reasoning,
+and stop there rather than dutifully planning something you have just argued against. A short
+"here is why this issue should be closed / re-scoped / merged into #M" is a legitimate and
+valuable output of this skill.
+
+If the verdict is "worth it, roughly as described", continue — but you are still free to overrule
+any specific mechanism the issue proposes. Say plainly which parts of the issue body you are
+departing from and why.
+
+## 3. Write the plan
+
+The plan is a committed file on the issue's own branch, so set up the worktree now rather than
+leaving it to implementation — this is step 1 of CLAUDE.md's "Sub-agent routine", pulled forward:
+
+```bash
+git worktree add .claude/worktrees/<branch-name> -b <branch-name>
+cd .claude/worktrees/<branch-name>
+ln -s /home/jack/dev/python/nged-substation-forecast/.env .env   # if it exists and isn't already there
+```
+
+Then write the plan to **`plans/<branch-name>.md`** inside that worktree, and commit it.
+
+One worktree per issue means one checkout per branch, so `plans/` holds exactly one file on each
+branch and the "at most one plan" rule in `plans/README.md` holds without any coordination
+between parallel sessions. Committing it now rather than at implementation time is what makes the
+plan durable: it survives Claude Code shutting down, and it is already in the diff when the
+implementation PR opens, so the reviewer sees the plan next to the code that claims to follow it.
+It is deleted at ship time, with its content pasted into the PR body — the existing rule, not a
+new one.
+
+The plan covers:
+
+- **Verdict and departures** — the step-2 conclusion, and every point where the plan differs
+  from the issue body, each with its reason.
+- **What changes, file by file** — named files and functions, with what happens to each. Prefer
+  naming the actual symbols over describing the change in the abstract.
+- **Design-philosophy check** — how the change sits against
+  `docs/design-philosophy/inherent-stability.md`: does this code path run in production (degrade,
+  widen bands, record the degradation on the row) or in R&D (fail fast)? If it adds or edits an
+  asset check, confirm it is `WARN`/`blocking=False` and that its body cannot raise. Cite the
+  hypotheses in `docs/design-philosophy/engineering-hypotheses.md` by label (`H1`, `T1.2`) where
+  the change is meant to deliver one. If the plan trades away a principle from
+  `design-principles.md`, name the principle and say what is bought in return.
+- **Tests** — which tests get added or changed, and for each new test, *the assertion it makes
+  that would fail on `main` today*. A test that passes before and after the change is not a test
+  of this change.
+- **Docs to update** — every page left inconsistent by the change, written to describe how the
+  code works *now* (CLAUDE.md, "Write about the present, not the past"). Include ship-time
+  triage if this issue completes a roadmap item: promote surviving design decisions to their
+  permanent home, delete the "Implementation details" section, update the roadmap status banner.
+- **Verification commands** — the green-before-push set from CLAUDE.md, plus anything this
+  change specifically needs (for example `uv run pytest --run-network -m network` for
+  convention-sensitive NWP conversion code, or `uv run mkdocs build --strict` *and reading the
+  rendered HTML* for any change that touches links).
+- **Risks and open questions** — the things Jack should decide, stated as questions with your
+  recommendation attached.
+
+Do not paste large code blocks into the plan. Name the change; the implementer writes the code.
+
+## 4. Adversarial review by a fresh sub-agent
+
+Launch a **new** sub-agent. Give it the issue number and the path to the plan file, and **nothing
+about your reasoning** — it must not be anchored by the argument that produced the plan.
+
+Tailor the brief to this issue's specific failure modes rather than asking for a generic review.
+The attacks worth naming, when they apply:
+
+- Does the plan's description of *current* behaviour actually match the code on `main`?
+- Would each proposed test really have failed before the change?
+- Does the change fail closed anywhere production is supposed to degrade — in particular, can any
+  warning path now raise?
+- Is a refactor hiding a behaviour change inside it?
+- Does the plan miss a caller, a doc page, or a schema that this change invalidates?
+- Is the issue body stale in a way the plan inherited rather than caught?
+
+Ask the reviewer for findings with file/line evidence, and for an explicit verdict on each: real
+defect, or not.
+
+## 5. Triage the findings
+
+Verify each finding against the code rather than accepting it — **reviewer findings are often
+wrong, and applying them uncritically makes the plan worse**. Fix the genuine ones in the plan
+file. For each finding you reject, record the finding and the one-line reason it was rejected, in
+the plan file, so Jack can see what was considered and dismissed. Commit the updated plan, so the
+branch carries both the original plan and what the review did to it.
+
+## 6. Stop
+
+Report to Jack: the verdict from step 2, a short summary of the plan, what the review changed, and
+what it found that you rejected. Give the branch name and the path to the plan file.
+
+**Do not write any code, and do not open a PR.** Once Jack approves the plan, implementation runs
+under CLAUDE.md's "Sub-agent routine", resuming at its step 2 in the worktree this skill already
+created — implement, verify, PR, a second and independent adversarial review of the *diff*,
+triage, stop.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,8 +89,9 @@ Full description and a "which place do I use?" table: `docs/documentation-guide.
 - **`docs/design-philosophy/engineering-hypotheses.md`** holds the falsifiable claims the
   engineering is meant to deliver. Cite them by label (`H1`, `T1.2`); labels are append-only —
   never renumber.
-- **`plans/`** holds at most one file: the in-flight PR's mechanical checklist, deleted on
-  merge. Usually empty.
+- **`plans/`** holds at most one file: the in-flight branch's implementation plan, written by the
+  `plan-issue` skill before any code is touched and deleted on merge. One worktree per branch is
+  what keeps it to one file, so parallel sessions never collide. Usually empty on `main`.
 
 **Creating GitHub issues** — whenever you create an issue, also set:
 
@@ -145,6 +146,12 @@ must also:
 
 When dispatching a sub-agent (or a fresh Claude Code/Desktop session) to solve a GitHub issue in
 this repo, give it these steps up front — a report back after step 1 is not finished work:
+
+This routine starts from an **approved plan**. The `plan-issue` skill
+(`.claude/skills/plan-issue/`, invoked as `/plan-issue <N>`) is how you get one: it reads the
+issue, decides whether it is worth implementing at all, writes `plans/<branch-name>.md`, has a
+fresh sub-agent adversarially review the plan, and stops for Jack. It also does step 1 below, so
+when it hands over, the worktree and branch already exist and implementation resumes at step 2.
 
 1. **Set up an isolated worktree** so concurrent sessions don't collide:
 
@@ -620,6 +627,9 @@ The project is a new, green-field project. No one else is using this code yet. W
   all the downstream code.)
 - Our aim is to make the code well-organised and easy to use.
 - None of this code is "written in stone" or battle-tested.
+- We haven't trained any "serious" ML models yet, so a change that invalidates an existing trained
+  model or its saved config costs us a retrain, not a migration path. Don't design for backwards
+  compatibility with models we've already trained.
 - If you see a design mistake _anywhere_ in the code, then please flag that design mistake to me.
   I'd much rather end up with a project that's well engineered. (That said, if we're working on
   feature X, and you spot a mistake in some code that isn't obviously in scope for X, then please

--- a/docs/documentation-guide.md
+++ b/docs/documentation-guide.md
@@ -18,7 +18,7 @@ Planning content lives in five places with deliberately non-overlapping jobs:
 | **GitHub** ([issues](https://github.com/openclimatefix/nged-substation-forecast/issues) + the OCF Project board) | The **complete, ordered task list** — including quick tweaks and non-code tasks — plus all discussion. **Fine-grained prioritisation lives only in GitHub.** Epics map 1:1 to the [roadmap milestones](roadmap/index.md#milestones); dependencies are recorded as `blocked by` issue relationships. |
 | **[`docs/roadmap/`](roadmap/index.md)** | Design depth: What we plan to build and *why*. The milestone arc and inter-plan dependencies are recorded here; fine-grained task-level ordering is not. |
 | **`docs/`[techniques](techniques/index.md), [background](background/network.md), [architecture](architecture/overview.md), [ml_experimentation](ml_experimentation/index.md), [live_service](live_service/index.md)** | What is already built — design (`architecture/`) and operational how-to (`ml_experimentation/`, `live_service/`) alike. This is where content moves to from `docs/roadmap/` after implementation. |
-| **`plans/`** (repo root, not published) | At most **one** file: the mechanical checklist for the PR currently in flight, deleted when it merges. Usually empty. |
+| **`plans/`** (repo root, not published) | At most **one** file per branch: the implementation plan for the work in flight on that branch, written before any code is touched and deleted when it merges. One worktree per branch is what keeps it to one file. Usually empty on `main`. |
 
 **Relationship between `docs/roadmap/` and GitHub**: Every substantial 🚧 plan in the
 `docs/roadmap/` folder has a GitHub issue, and every dependency stated in `docs/roadmap/` exists as
@@ -63,4 +63,4 @@ roadmap items that apply them.
 | Record an assessment of work we decided **not** to do | [`docs/architecture/`](architecture/overview.md), with a `Status:` banner saying so — e.g. [Why Dagster, not Airflow?](architecture/why-dagster-not-airflow.md), [Could this codebase forecast another country?](architecture/adapting-to-another-geography.md). Not `docs/roadmap/`, which implies intent to build and is deleted on ship. |
 | Learn *how* to run/operate something already built, step by step | [`docs/ml_experimentation/`](ml_experimentation/index.md), [`docs/live_service/`](live_service/index.md) |
 | File a quick tweak or a non-code task | A GitHub issue only — no markdown needed |
-| Write the mechanical checklist for the PR in flight | `plans/` (single file, deleted on merge) |
+| Plan how to implement an issue, before writing code | `plans/<branch-name>.md` on that issue's branch (one file per branch, deleted on merge) |

--- a/plans/README.md
+++ b/plans/README.md
@@ -1,6 +1,8 @@
 # Temporary implementation plans
 
-This directory holds **at most one** file — the mechanical checklist for the PR currently in
-flight — deleted when that work merges (paste the plan, or a summary, into the PR body first),
-so the directory is usually empty. Everything durable belongs elsewhere, and nothing may link
-here from code or `docs/`: see "How planning works" in `docs/roadmap/index.md`.
+This directory holds **at most one** file — `<branch-name>.md`, the implementation plan for the
+work in flight on this branch, written by the `plan-issue` skill before any code is touched and
+deleted when that work merges (paste the plan, or a summary, into the PR body first). One worktree
+per branch is what keeps it to a single file, so parallel sessions never collide; on `main` the
+directory is empty. Everything durable belongs elsewhere, and nothing may link here from code or
+`docs/`: see "How planning works" in `docs/roadmap/index.md`.


### PR DESCRIPTION
> Written by Claude Code, at Jack's direction.

Encodes the planning routine Jack has been typing by hand into a skill, and adjusts the `plans/`
convention so a plan can live on the branch it belongs to.

## The skill

`.claude/skills/plan-issue/SKILL.md`, invoked as `/plan-issue <N>`:

1. **Gather** — the issue *and its comments* (comments are where a body gets corrected), the docs
   pages it links, the code it describes, and a check for a PR or branch already in flight against
   that issue.
2. **Decide whether it is worth implementing** — a real gate, not a formality. "No", "not like
   this" and "this is really #M" are valid, valuable outputs, and the skill says to stop there
   rather than dutifully planning something it has just argued against. Grounds for pushing back
   are listed: wrong premise, stale design, conflict with a design principle, subsumed by another
   issue, cost out of proportion.
3. **Write the plan** — verdict and departures from the issue body, changes file by file, a
   design-philosophy check (production degrades vs R&D fails fast, asset checks `WARN` and cannot
   raise, hypotheses cited by label, principles traded named), tests *with the assertion that
   would fail on `main` today*, docs left inconsistent, verification commands, and open questions
   with a recommendation attached.
4. **Adversarial review** by a fresh sub-agent given only the issue number and the plan path — no
   planner reasoning, so it cannot be anchored. The brief is tailored to the issue's failure modes.
5. **Triage** — verify each finding against the code, fix the genuine ones, and record every
   rejected finding with its one-line reason so Jack can see what was dismissed.
6. **Stop.** No code, no PR.

## The `plans/` change

`plans/` previously held at most one file globally. It now holds at most one file **per branch**,
`plans/<branch-name>.md`, and the skill pulls worktree creation forward from CLAUDE.md's
"Sub-agent routine" step 1 so the plan is committed on the issue's own branch from the moment it
is written.

One worktree per branch is what enforces the single-file rule, so parallel planning sessions never
collide. Committing the plan early is what makes it durable across Claude Code restarts and puts it
in the implementation PR's diff, next to the code that claims to follow it. Deletion at ship time,
with the content pasted into the PR body, is unchanged.

`plans/README.md` and `docs/documentation-guide.md` (both table rows) are updated to match, and
the "Sub-agent routine" now states that it starts from an approved plan and resumes at its step 2,
because the worktree already exists.

## One standing fact added to CLAUDE.md

The "This is a young project" section gains: no "serious" ML models have been trained yet, so a
change that invalidates an existing trained model or its saved config costs a retrain, not a
migration path. This was in Jack's hand-typed prompt every time; it belongs in CLAUDE.md, where it
applies to implementation as much as to planning, rather than being duplicated in the skill.

## Verification

`pymarkdown scan` clean over `docs`, `README.md`, `CLAUDE.md`, `packages/*/README.md`,
`plans/README.md` and `.claude/skills`; `mkdocs build --strict` clean, and the two rewritten
`documentation-guide.md` table rows were read back from the rendered HTML under `site/`. No Python
changed.
