### PR TITLE
Move conditional CLAUDE.md content into six on-demand skills

### DIFF
--- a/.claude/skills/code-style/SKILL.md
+++ b/.claude/skills/code-style/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: code-style
+description: >-
+  This repo's code conventions, which Jack cares about and expects to be followed: Python 3.14+,
+  Polars only (pandas banned), Patito schemas, ruff configuration and its traps, naming, how
+  expressive a type hint has to be, `Final` on constants, comment and doc-link rules, and Polars
+  style. Load before writing or editing any Python in this repo — a new module, a new function, a
+  refactor, a test — and before reviewing Python for style, or answering a question about what the
+  house style is.
+---
+
+# Code style
+
+**The rules live in one file: `docs/architecture/code-style.md`. Read it now, in full, before
+writing or editing Python.** It is deliberately the only copy — this skill exists to make sure it
+gets read, not to restate it, because two copies of a style guide drift apart and then nobody
+knows which one is binding.
+
+What is in there, so you know what you are getting:
+
+| Section | Covers |
+|---|---|
+| General Principles | Python 3.14+, modularity, small functions (and when extra parameters are fine), re-using existing tools, tests |
+| Formatting & Linting (Ruff) | line length, quotes, docstring convention, import rules, how `select`/`ignore` are maintained, two `per-file-ignores` traps |
+| Type hints and signatures | how expressive a signature must be — `Literal` aliases, `TypedDict`, named aliases — and `Final` on every constant |
+| Comments, docstrings and links | current-state-only rule, which docs code may link to, MkDocs-compatible constant docstrings |
+| Data Handling | Polars/Patito/Xarray choices, lazy-evaluation contract, Patito friction budget, the 2³² row-count rule |
+| Polars style | `.cast` vs `.with_columns`, keyword-argument column naming, `Type`-suffixed `Literal` aliases |
+| Gotchas that fail silently | which sibling skill to load for which trap |
+| Error Handling | exception style, Sentry, validation at boundaries |
+
+Two rules there are enforced by nothing and fail silently, so they are the ones to be deliberate
+about: **never row-count a table that can exceed 2³² rows with Polars** (counts wrap with no
+error), and **comments must describe only how the code works now** — never a previous iteration or
+a deleted file.
+
+If you are about to write Polars or Patito code, load **`polars-patito-gotchas`** as well; the
+style rules and the traps are separate documents on purpose.
+
+## When you change the rules
+
+Edit `docs/architecture/code-style.md` — never copy a rule into `CLAUDE.md` or into this skill.
+The page is published at
+<https://openclimatefix.github.io/nged-substation-forecast/architecture/code-style/> and is linked
+from `docs/index.md`, `docs/design-philosophy/index.md` and `design-principles.md`, so it is the
+version humans read too.

--- a/.claude/skills/github-graphql/SKILL.md
+++ b/.claude/skills/github-graphql/SKILL.md
@@ -1,14 +1,11 @@
 ---
 name: github-graphql
 description: >-
-  Concrete gh api graphql invocations for the GitHub operations this repo's issue/PR workflow
-  needs but plain gh issue/pr commands can't do: attaching a sub-issue to its parent epic,
-  reordering sub-issues within a parent, setting an issue's org-level Type, and setting a GitHub
-  Projects (v2) field (Status/Project/Area) on an item. Use this skill whenever you're about to
-  run one of those four operations for openclimatefix/nged-substation-forecast — e.g. when
-  the `github-issue-pr-workflow` skill says to attach/position a sub-issue, set Type, or
-  set project fields, or whenever you'd otherwise reach for `gh api graphql` and aren't sure of
-  the mutation name, its input fields, or how to obtain the node IDs it needs.
+  Concrete `gh api graphql` invocations for the four GitHub operations plain `gh issue`/`gh pr`
+  can't do: attaching a sub-issue to its parent epic, reordering sub-issues, setting an issue's
+  org-level Type, and setting a Projects (v2) field (Status/Project/Area). Load before running any
+  of them for openclimatefix/nged-substation-forecast, or whenever you'd reach for `gh api graphql`
+  and aren't sure of the mutation name, its input fields, or how to get the node IDs it needs.
 ---
 
 # GitHub GraphQL cheatsheet
@@ -20,11 +17,9 @@ normally works with. Get a node ID with:
 gh issue view <number> --json id --jq .id   # works for PRs too via `gh pr view`
 ```
 
-All commands below assume the repo `openclimatefix/nged-substation-forecast`; swap the owner/name
-if pointed at a different repo. Each mutation's input fields were confirmed against GitHub's live
-schema via `gh api graphql` introspection (`{ __type(name: "<MutationName>Input") { inputFields {
-name } } }`) — re-check with the same technique if a call below ever starts failing, since GitHub
-occasionally adds/renames fields.
+All commands assume `openclimatefix/nged-substation-forecast`; swap the owner/name for another
+repo. If a call starts failing, re-check its input fields by introspection — GitHub occasionally
+renames them: `{ __type(name: "<MutationName>Input") { inputFields { name } } }`.
 
 ## Attach a sub-issue to its parent
 

--- a/.claude/skills/github-graphql/SKILL.md
+++ b/.claude/skills/github-graphql/SKILL.md
@@ -6,7 +6,7 @@ description: >-
   reordering sub-issues within a parent, setting an issue's org-level Type, and setting a GitHub
   Projects (v2) field (Status/Project/Area) on an item. Use this skill whenever you're about to
   run one of those four operations for openclimatefix/nged-substation-forecast — e.g. when
-  CLAUDE.md's "Creating GitHub issues" section says to attach/position a sub-issue, set Type, or
+  the `github-issue-pr-workflow` skill says to attach/position a sub-issue, set Type, or
   set project fields, or whenever you'd otherwise reach for `gh api graphql` and aren't sure of
   the mutation name, its input fields, or how to obtain the node IDs it needs.
 ---

--- a/.claude/skills/github-graphql/SKILL.md
+++ b/.claude/skills/github-graphql/SKILL.md
@@ -18,8 +18,9 @@ gh issue view <number> --json id --jq .id   # works for PRs too via `gh pr view`
 ```
 
 All commands assume `openclimatefix/nged-substation-forecast`; swap the owner/name for another
-repo. If a call starts failing, re-check its input fields by introspection — GitHub occasionally
-renames them: `{ __type(name: "<MutationName>Input") { inputFields { name } } }`.
+repo. Every mutation's input fields below were confirmed against GitHub's live schema by
+introspection. If a call starts failing, re-check the same way — GitHub occasionally adds or
+renames fields: `{ __type(name: "<MutationName>Input") { inputFields { name } } }`.
 
 ## Attach a sub-issue to its parent
 

--- a/.claude/skills/github-issue-pr-workflow/SKILL.md
+++ b/.claude/skills/github-issue-pr-workflow/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: github-issue-pr-workflow
+description: >-
+  The checklist for creating a GitHub issue or PR in openclimatefix/nged-substation-forecast —
+  the fields `gh issue create` / `gh pr create` cannot set (labels, org issue Type, OCF project 33
+  and its Status/Project/Area fields, sub-issue attachment and ordering, the JackKelly assignee) —
+  plus the never-squash-merge rule and ship-time triage. Load before running `gh issue create`,
+  `gh pr create` or `gh pr merge`, or when a PR completes a roadmap item.
+---
+
+# Creating issues and PRs, and shipping them
+
+## Creating GitHub issues
+
+Whenever you create an issue, also set:
+
+- **Labels** and **Type** (org issue type: Task / Bug / Feature / Spike / Epic / …) — pick
+  whatever fits the issue.
+- Add it to the **OCF project** (org project 33, `gh project item-add 33 --owner
+  openclimatefix --url <issue-url>`) and set the project fields **Status = Todo**,
+  **Project = NGED**, **Area = ML**.
+- If it is a sub-issue, attach it to its parent epic **and position it appropriately in the
+  parent's sub-issue order** (execution order, respecting `blocked by` chains) — the
+  `reprioritizeSubIssue` GraphQL mutation with `afterId`/`beforeId`.
+- **Body** — if (and only if) the docs already contain a plan for the issue (e.g. a
+  `docs/roadmap/` section), the body may be *just* a link to that rendered docs section and
+  nothing more; don't duplicate the plan. Otherwise, write a self-contained body.
+- When the body links to a docs page, link to the **rendered site**
+  (`https://openclimatefix.github.io/nged-substation-forecast/...`), never a `github.com`
+  blob path.
+
+`gh issue create` can't set any of these: use `gh issue edit --add-label` for labels, the
+`updateIssueIssueType` GraphQL mutation for Type, and `gh project item-edit` (or the
+`updateProjectV2ItemFieldValue` mutation) for the project fields.
+
+## Creating pull requests
+
+Whenever you create a PR, also set:
+
+- **Labels** — pick whatever fits (e.g. `documentation`, `enhancement`, `bug`), same label set as
+  issues.
+- **Assignees = JackKelly**.
+
+`gh pr create` can't set either: use `gh pr edit --add-label` and `gh pr edit --add-assignee
+JackKelly` right after creating the PR.
+
+## Merging pull requests
+
+Never squash-merge. Jack wants the full commit history preserved in `main`, so use a merge commit
+(`gh pr merge --merge`) or rebase (`gh pr merge --rebase`), not `gh pr merge --squash`. Under the
+`implement-issue` routine you stop and wait for Jack's review rather than merging at all.
+
+## GraphQL calls
+
+Attaching and reordering sub-issues, setting an issue's Type, and setting a project field all need
+`gh api graphql`. The `github-graphql` skill has the exact invocations and how to obtain the node
+IDs they need.
+
+## Ship-time triage
+
+When a PR lands a roadmap item, that PR (or an immediate follow-up) must also:
+
+1. Promote surviving design decisions to their permanent home (`docs/architecture/`,
+   `docs/ml_experimentation/`, …).
+2. Delete the item's "Implementation details" section (and any `plans/` file), pasting it (or
+   a summary) into the PR body. When a roadmap page's last 🚧 item ships, delete the page
+   (nav entry, inbound doc links).
+3. Close the GitHub issue; update the status banner on the roadmap page (and the milestone
+   section in `docs/roadmap/index.md` if the arc changed).

--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: implement-issue
+description: >-
+  The routine for implementing an approved plan for a GitHub issue in
+  openclimatefix/nged-substation-forecast: isolated worktree, implement, the green-before-push
+  verification set, PR with labels and the JackKelly assignee, a fresh sub-agent adversarially
+  reviews the diff, triage, stop for Jack — never merge. Load before writing any code for an
+  issue, and when dispatching a sub-agent or a fresh session to solve one. To decide *what* to
+  build, use `plan-issue` first.
+---
+
+# Implement a GitHub issue
+
+This routine starts from an **approved plan**. The `plan-issue` skill (invoked as
+`/plan-issue <N>`) is how you get one: it reads the issue, decides whether it is worth
+implementing at all, writes `plans/<branch-name>.md`, has a fresh sub-agent adversarially review
+the plan, and stops for Jack. It also does step 1 below, so when it hands over, the worktree and
+branch already exist and implementation resumes at step 2.
+
+When dispatching a sub-agent (or a fresh Claude Code/Desktop session), give it these steps up
+front — a report back after step 1 is not finished work.
+
+1. **Set up an isolated worktree** so concurrent sessions don't collide:
+
+    ```bash
+    git worktree add .claude/worktrees/<branch-name> -b <branch-name>
+    cd .claude/worktrees/<branch-name>
+    ln -s /home/jack/dev/python/nged-substation-forecast/.env .env   # if it exists and isn't already there
+    ```
+
+    If several sub-agents run concurrently, also give each its own scratchpad subdirectory —
+    a shared scratchpad root means two agents writing e.g. `pr_body.md` can collide and one
+    agent's output gets briefly published under another's PR.
+
+2. **Implement**, following every convention in CLAUDE.md — including leaving every doc page
+   that touches the change consistent with the code as it now stands, describing only how the
+   code works *now* (CLAUDE.md, "Write about the present, not the past"). For a docs change that
+   touches a link, run `uv run mkdocs build --strict` and read the rendered HTML under `site/`,
+   not just the linter — Python-Markdown has rendering gotchas that neither `pymarkdown scan`
+   nor a successful `mkdocs build` catches on their own (see the `mkdocs-authoring` skill).
+
+3. **Verify, all green before pushing**: `uv run ruff check .`, `uv run ruff format .`,
+   `uv run --all-packages ty check`, `uv run pytest`, plus (if docs were touched)
+   `uv run pymarkdown scan -r docs README.md CLAUDE.md packages/*/README.md` and
+   `uv run mkdocs build --strict`.
+
+4. **Push and open the PR** against `main`, with labels and `JackKelly` as assignee (`gh pr
+   create` can't set either — follow with `gh pr edit --add-label <label>` and `gh pr edit
+   --add-assignee JackKelly`), linking the issue so it closes on merge. Commit messages end
+   with `Co-Authored-By: Claude <noreply@anthropic.com>`. See the `github-issue-pr-workflow`
+   skill for the full PR checklist and the never-squash-merge rule.
+
+5. **Spawn a *new*, independent sub-agent to adversarially review the PR** — give it only the
+   PR number, not the implementer's reasoning, so it isn't anchored by it. Tailor the reviewer
+   brief to the issue: name the failure modes most worth attacking (the risky claim, a
+   behaviour change hiding inside a refactor, whether a new test would actually have failed on
+   `main`) rather than asking for a generic review.
+
+6. **Triage the review's findings** — verify each against the code rather than accepting it,
+   fix genuine defects, push, and record why any finding was rejected.
+
+7. **Stop and wait for Jack's review. Never merge.**
+
+Stay inside the issue's scope; report unrelated design mistakes rather than fixing them.
+
+**Why:** Jack reviews diffs in GitHub's UI and wants a PR to already have survived an
+adversarial pass by the time he looks at it, so his review is the last line of defence rather
+than the first. The fresh-reviewer requirement exists so the reviewer cannot be anchored by the
+implementer's rationale; the triage step exists because reviewer findings are often wrong and
+must not be applied uncritically.

--- a/.claude/skills/marimo-notebooks/SKILL.md
+++ b/.claude/skills/marimo-notebooks/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: marimo-notebooks
+description: >-
+  Three authoring rules for this repo's Marimo notebooks (`packages/dashboard/*.py`,
+  `packages/notebooks/*.py`), each reversing a normal Python habit: a leading underscore makes a
+  name cell-local, so cross-cell helpers must be public; every import belongs in `with app.setup:`
+  or ruff stops seeing it; and `ruff check --fix` must never be run over a notebook, because an
+  autofix can insert an import outside `app.setup` and break it while reporting success. Load
+  before creating or editing a Marimo notebook, or when one fails with a `NameError` on a helper
+  or an import that looks present.
+---
+
+# Authoring Marimo notebooks
+
+Marimo notebooks (`packages/dashboard/*.py`, `packages/notebooks/*.py`) are reactive: each
+`@app.cell` function is a separate cell, and the `with app.setup:` block holds names shared by
+every cell. The rules below follow from how Marimo scopes names and how ruff sees them.
+
+## Never give a leading underscore to anything you want to reuse across cells
+
+Marimo treats any name starting with `_` (a variable *or* a function) as *cell-local* — it is not
+exported to other cells, so a `_helper()` defined in one cell (or in `app.setup`) is invisible
+everywhere else and the call fails at runtime. A helper that multiple cells call must have a
+public name (no leading underscore). This is the opposite of the usual `_private` convention that
+CLAUDE.md's Code Style section asks for elsewhere in the repo, so it is easy to get wrong; the
+leading-underscore-means-private habit does not apply inside a Marimo notebook.
+
+## Put every import in the `with app.setup:` block
+
+Never at module top level, and never let Marimo thread them through cell signatures. When imports
+live in `app.setup`, they are real `import` statements that ruff analyses, so ruff flags a missing
+or unused import. If you instead scatter imports into individual cells, Marimo passes the imported
+names into the cells that use them as function parameters (`def _(pl, mo): ...`), and ruff treats
+a parameter as always defined — so a genuinely missing import is invisible to the linter and only
+blows up at runtime. Keeping all imports in `app.setup` keeps them statically checkable and
+available to every cell.
+
+## Never run `ruff check --fix` over a Marimo notebook
+
+When an autofix needs a name the file does not import yet, ruff inserts the import into the file's
+*top-level* import block — outside `app.setup`, where no cell can see it. The notebook then dies
+with a `NameError` the next time it is opened, while `ruff check` reports success, because what
+ruff produced is valid Python. This is a whole class, not one rule: any fix that adds an import
+does it, and ruff has no per-file fixability setting to prevent it (`unfixable` is global, and
+`per-file-ignores` would silence the check as well as the fix).
+
+The pre-commit hook is split so notebooks are checked but never auto-fixed; a bare `uv run ruff
+check . --fix` typed by hand is *not* covered, so after running one, check `git diff` for an
+import that landed above `import marimo` and move it into `app.setup`.

--- a/.claude/skills/marimo-notebooks/SKILL.md
+++ b/.claude/skills/marimo-notebooks/SKILL.md
@@ -22,7 +22,7 @@ Marimo treats any name starting with `_` (a variable *or* a function) as *cell-l
 exported to other cells, so a `_helper()` defined in one cell (or in `app.setup`) is invisible
 everywhere else and the call fails at runtime. A helper that multiple cells call must have a
 public name (no leading underscore). This is the opposite of the usual `_private` convention that
-CLAUDE.md's Code Style section asks for elsewhere in the repo, so it is easy to get wrong; the
+`docs/architecture/code-style.md` asks for elsewhere in the repo, so it is easy to get wrong; the
 leading-underscore-means-private habit does not apply inside a Marimo notebook.
 
 ## Put every import in the `with app.setup:` block

--- a/.claude/skills/mkdocs-authoring/SKILL.md
+++ b/.claude/skills/mkdocs-authoring/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: mkdocs-authoring
+description: >-
+  Ways Python-Markdown (MkDocs' renderer) renders a page visibly wrong while `pymarkdown scan`
+  and `mkdocs build --strict` both pass: nested sub-bullets need a full 4-space indent, a sibling
+  list item needs a blank line after an indented continuation, and a wrapped link whose
+  continuation line starts with `#` becomes a heading. Load before editing any page under `docs/`
+  — especially nested lists, list items containing code blocks, or wrapped links — and when a
+  rendered page looks wrong but the linters are clean.
+---
+
+# Authoring markdown that MkDocs renders correctly
+
+Python-Markdown is stricter and weirder than CommonMark in ways this repo's linters do not catch.
+The standing rule that follows: **any docs change that touches links or non-trivial lists should
+run `uv run mkdocs build --strict` and then actually read the generated HTML under `site/`**. A
+clean `pymarkdown scan` plus a successful build can both pass on rendering that is visibly wrong;
+only reading the HTML catches it.
+
+## Nested sub-bullets need a full 4-space indent
+
+Python-Markdown (without the `sane_lists` extension) only treats a sub-list as nested when it is
+indented a full 4 spaces. A 2-space indent — a bare list's natural default, and what most other
+renderers accept — silently renders as a flat, unnested list. This one *is* enforced, by the
+`pml101` rule configured in `pyproject.toml`, but write it correctly in the first place rather
+than waiting for the linter. `pml101` anchors every level at (depth − 1) × 4 spaces regardless
+of whether the parent marker is a bullet or a number.
+
+## A list item needs a blank line before it if it follows an indented continuation
+
+Python-Markdown doesn't let a list item interrupt a paragraph the way GitHub-flavored Markdown
+does. If a bullet's continuation content ends with an indented paragraph (e.g. a clarifying
+sentence after a fenced code block inside the item) and the next sibling bullet immediately
+follows with no blank line in between, Python-Markdown treats the new list-marker line as more
+paragraph text rather than a new list item — the marker renders as a literal hyphen, merged into
+the previous sentence's prose. `pymarkdown scan` does **not** catch this: a markdown source with
+the missing blank line lints clean.
+
+**How to apply:** always put a blank line between a list item's continuation content (paragraphs,
+fenced code blocks) and the next sibling item. For any non-trivial list item — one that embeds a
+code block or multiple paragraphs — spot-check with `uv run mkdocs build --strict` and inspect
+the rendered HTML rather than trusting the linter alone.
+
+## A wrapped link whose continuation line starts with `#` renders as a heading
+
+CommonMark requires a space after `#` for a line to start an ATX heading (`#5` is just text,
+`# 5` is a heading). Python-Markdown does not enforce that space, so any line that happens to
+start with `#` — for any reason — is parsed as a heading. A markdown link wrapped across the
+80-ish-character line length this repo's prose otherwise isn't held to can put the `#123](url)`
+half of `[issue #123](url)` at the start of a line, and Python-Markdown reads it as a heading
+rather than as the second half of a link. The rendered page gets a stray `<h1>`/`<h2>` containing
+the raw URL, the link text before the wrap point left dangling as plain text, and the paragraph
+split in two. Neither `pymarkdown scan` nor `mkdocs build --strict` catches this — both pass on a
+source file that renders visibly broken.
+
+**How to apply:** when a link's markdown source wraps across a line break, make sure the
+continuation line does not begin with `#`; keep `[text](url)` together on one line, or wrap
+before `[` rather than inside it.

--- a/.claude/skills/mkdocs-authoring/SKILL.md
+++ b/.claude/skills/mkdocs-authoring/SKILL.md
@@ -4,12 +4,17 @@ description: >-
   Ways Python-Markdown (MkDocs' renderer) renders a page visibly wrong while `pymarkdown scan`
   and `mkdocs build --strict` both pass: nested sub-bullets need a full 4-space indent, a sibling
   list item needs a blank line after an indented continuation, and a wrapped link whose
-  continuation line starts with `#` becomes a heading. Load before editing any page under `docs/`
-  — especially nested lists, list items containing code blocks, or wrapped links — and when a
-  rendered page looks wrong but the linters are clean.
+  continuation line starts with `#` becomes a heading. Load before editing any markdown MkDocs
+  renders — `docs/` pages, README files, `SKILL.md` files, and Python docstrings — especially ones
+  with nested lists, list items containing code blocks, or wrapped links, and when a rendered page
+  looks wrong but the linters are clean.
 ---
 
 # Authoring markdown that MkDocs renders correctly
+
+This applies to everything Python-Markdown renders, not just `docs/` pages: README files, the
+`SKILL.md` files, and Python docstrings (linted by `scripts/lint_docstring_markdown.py` and
+rendered by mkdocstrings) all go through the same renderer.
 
 Python-Markdown is stricter and weirder than CommonMark in ways this repo's linters do not catch.
 The standing rule that follows: **any docs change that touches links or non-trivial lists should

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -110,8 +110,8 @@ The plan covers:
   code works *now* (CLAUDE.md, "Write about the present, not the past"). Include ship-time
   triage if this issue completes a roadmap item: promote surviving design decisions to their
   permanent home, delete the "Implementation details" section, update the roadmap status banner.
-- **Verification commands** — the green-before-push set from CLAUDE.md, plus anything this
-  change specifically needs (for example `uv run pytest --run-network -m network` for
+- **Verification commands** — the green-before-push set from the `implement-issue` skill, plus
+  anything this change specifically needs (for example `uv run pytest --run-network -m network` for
   convention-sensitive NWP conversion code, or `uv run mkdocs build --strict` *and reading the
   rendered HTML* for any change that touches links).
 - **Risks and open questions** — the things Jack should decide, stated as questions with your

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -2,21 +2,19 @@
 name: plan-issue
 description: >-
   Turn a GitHub issue in openclimatefix/nged-substation-forecast into a reviewed implementation
-  plan, without writing any code. Reads the issue and its comments, decides whether the issue is
-  worth implementing at all, writes a plan that may overrule a stale issue body, has a fresh
-  sub-agent adversarially review that plan, triages the findings, and then stops for Jack's
-  review. Use this whenever Jack asks for a plan for an issue, says "plan issue N" or
-  "/plan-issue N", asks whether an issue is worth doing, or asks you to think through how to
-  implement an issue before touching code. Do not use it to implement an issue — that is the
-  `implement-issue` skill, which starts once a plan from this skill has been approved.
+  plan, writing no code: read the issue and its comments, decide whether it is worth implementing
+  at all, write a plan that may overrule a stale issue body, have a fresh sub-agent adversarially
+  review it, triage the findings, stop for Jack. Load whenever Jack asks for a plan for an issue,
+  says "plan issue N" or "/plan-issue N", asks whether an issue is worth doing, or asks you to
+  think through an implementation before touching code. To implement an approved plan, use
+  `implement-issue` instead.
 ---
 
 # Plan a GitHub issue
 
-The output of this skill is a **plan file and a recommendation**, never a code change. Planning
-and implementing are deliberately separate: Jack approves a plan before any code moves, so that
-his review of the eventual diff is checking execution rather than discovering the design for the
-first time.
+The output is a **plan file and a recommendation**, never a code change. Jack approves a plan
+before any code moves, so his review of the eventual diff checks execution rather than discovering
+the design for the first time.
 
 Take the issue number from the invocation (`/plan-issue 500`). If several are given, run the whole
 procedure once per issue, each on its own branch — do not merge them into one plan unless the
@@ -86,13 +84,11 @@ ln -s /home/jack/dev/python/nged-substation-forecast/.env .env   # if it exists 
 
 Then write the plan to **`plans/<branch-name>.md`** inside that worktree, and commit it.
 
-One worktree per issue means one checkout per branch, so `plans/` holds exactly one file on each
-branch and the "at most one plan" rule in `plans/README.md` holds without any coordination
-between parallel sessions. Committing it now rather than at implementation time is what makes the
-plan durable: it survives Claude Code shutting down, and it is already in the diff when the
-implementation PR opens, so the reviewer sees the plan next to the code that claims to follow it.
-It is deleted at ship time, with its content pasted into the PR body — the existing rule, not a
-new one.
+One worktree per issue means `plans/` holds exactly one file on each branch, so the "at most one
+plan" rule in `plans/README.md` holds with no coordination between parallel sessions. Committing
+now rather than at implementation time makes the plan durable: it survives Claude Code shutting
+down, and it is already in the diff when the PR opens, so the reviewer sees the plan next to the
+code that claims to follow it. It is deleted at ship time into the PR body, per the existing rule.
 
 The plan covers:
 

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   review. Use this whenever Jack asks for a plan for an issue, says "plan issue N" or
   "/plan-issue N", asks whether an issue is worth doing, or asks you to think through how to
   implement an issue before touching code. Do not use it to implement an issue — that is the
-  "Sub-agent routine" in CLAUDE.md, which starts once a plan from this skill has been approved.
+  `implement-issue` skill, which starts once a plan from this skill has been approved.
 ---
 
 # Plan a GitHub issue
@@ -76,7 +76,7 @@ departing from and why.
 ## 3. Write the plan
 
 The plan is a committed file on the issue's own branch, so set up the worktree now rather than
-leaving it to implementation — this is step 1 of CLAUDE.md's "Sub-agent routine", pulled forward:
+leaving it to implementation — this is step 1 of the `implement-issue` skill, pulled forward:
 
 ```bash
 git worktree add .claude/worktrees/<branch-name> -b <branch-name>
@@ -156,6 +156,6 @@ Report to Jack: the verdict from step 2, a short summary of the plan, what the r
 what it found that you rejected. Give the branch name and the path to the plan file.
 
 **Do not write any code, and do not open a PR.** Once Jack approves the plan, implementation runs
-under CLAUDE.md's "Sub-agent routine", resuming at its step 2 in the worktree this skill already
+under the `implement-issue` skill, resuming at its step 2 in the worktree this skill already
 created — implement, verify, PR, a second and independent adversarial review of the *diff*,
 triage, stop.

--- a/.claude/skills/polars-patito-gotchas/SKILL.md
+++ b/.claude/skills/polars-patito-gotchas/SKILL.md
@@ -1,0 +1,134 @@
+---
+name: polars-patito-gotchas
+description: >-
+  Five Patito/Polars/Delta traps that fail silently rather than raising: cross-model LazyFrame
+  joins, a `{column: dtype}` cast swallowed on a model-bearing frame, `ge`/`le` ignored on a
+  datetime field, `.filter()` dropping the Patito subclass, and dictionary-encoded columns
+  blocking Delta predicate pushdown. Load before writing Polars/Patito code that joins, casts,
+  filters a `pt.LazyFrame`, declares a Patito field, or reads/writes Delta — or when a
+  `validate()` dtype error, a `.join()` TypeError, or an over-reading Delta scan looks
+  inexplicable.
+---
+
+# Patito + Polars + Delta gotchas
+
+Every trap below produces **no error at the point of the mistake**. They surface later as a
+confusing `validate()` failure, a `ty` complaint several lines away, or a query that quietly
+reads the whole table. That is why they are written down.
+
+## Cross-model LazyFrame joins
+
+Patito creates a unique Python subclass for each model (e.g. `PowerTimeSeriesLazyFrame`,
+`PowerForecastLazyFrame`). Polars' `assert_same_type` check inside `.join()` rejects joining
+two differently-typed Patito LazyFrames with a `TypeError`.
+
+Workaround: strip the Patito subclass from the right-hand operand before joining:
+
+```python
+# Strip Patito model annotation so Polars' cross-subclass type check doesn't reject the join
+plain_lf = pl.LazyFrame._from_pyldf(patito_lf._ldf)
+left_patito_lf.join(plain_lf.select(...), on=..., how="inner")
+```
+
+`pl.LazyFrame._from_pyldf` constructs a plain `pl.LazyFrame` from the same underlying Rust
+object — zero-copy, no data movement. The check passes because `type(left_lf)` is a subclass
+of `pl.LazyFrame`, so `isinstance(left_lf, type(plain_lf))` is `True`.
+
+## `.cast({...})` on a model-bearing frame
+
+Patito **overrides** `.cast`: its signature is `cast(self, strict=False, columns=None)` and, on a
+frame that carries a model (set via `.set_model(...)` or a typed `pt.DataFrame[Schema]`), it casts
+every column to the *model's* declared dtypes. So `df.cast({"foo": pl.Int8})` on such a frame does
+**not** apply your mapping — Polars' `{column: dtype}` dict is swallowed as the `strict` argument
+and your `foo` cast is silently ignored while unrelated columns are reverted to model dtypes. The
+result usually only surfaces later as a confusing `validate()` dtype error.
+
+The trap fires only when the model is still attached. Many Polars ops **drop** the model
+(`group_by(...).agg(...)`, `.collect()`, `.unpivot()`, `.as_polars()`), so a dict-`.cast` after
+them is plain Polars and fine. But **iterating** `group_by` (`for k, g in df.group_by(...)`) yields
+sub-frames that **keep** the model, and `pl.concat` keeps it too — so a dict-`.cast` on the
+concatenated result hits the trap.
+
+Workaround: strip the Patito model before a `{column: dtype}` cast (mirrors the join gotcha above):
+
+```python
+# Strip the Patito model so the dict-cast uses plain Polars semantics (zero-copy)
+result = pl.DataFrame._from_pydf(patito_df._df).cast({"foo": pl.Categorical})
+```
+
+(No-arg `df.cast()` — casting a model-bearing frame to its declared dtypes — *is* the intended
+Patito use and is correct. Expression/Series casts like `pl.col("foo").cast(pl.Int8)` are always
+plain Polars and unaffected.)
+
+This is the caveat behind the Polars style rule in CLAUDE.md that prefers `df.cast({"foo":
+pl.Int8})` over `df.with_columns(pl.col("foo").cast(pl.Int8))`: the preference holds only on a
+plain Polars frame.
+
+## `ge`/`le` are silently ignored on a datetime field
+
+`pt.Field(ge=..., le=...)` enforces nothing on a `datetime` column. Patito builds its bounds checks
+by reading the `minimum`/`maximum` keywords out of the Pydantic JSON schema, and JSON Schema
+defines those keywords for numbers only — so a datetime field's `Ge`/`Le` metadata never reaches
+the JSON schema, Patito finds no keyword to turn into a filter, and `validate()` accepts every
+year. There is no warning and no error; the constraint simply does not exist. (`ge`/`le` on a
+numeric field works exactly as documented, which is what makes this so easy to miss.)
+
+**How to apply:** bound a datetime column from the model's `validate` override, not from the field.
+`contracts.common.check_datetime_bounds` is the shared helper, and `MIN_PLAUSIBLE_DATETIME` /
+`MAX_PLAUSIBLE_DATETIME` are the shared bounds; `PowerTimeSeries.validate` and `Nwp.validate` are
+the worked examples. A `constraints=` Polars expression on the field also works, but its failure
+message is the generic "1 row does not match custom constraints", so prefer the explicit check when
+you want the error to say which bound was broken.
+
+## `pt.LazyFrame.filter()` drops the Patito subclass
+
+Most Polars operations on a `pt.LazyFrame` return a plain `pl.LazyFrame`, including `.filter()`.
+Reassigning `scan = scan.filter(...)` where `scan: pt.LazyFrame[Schema]` therefore fails `ty`'s
+assignment check.
+
+Workaround: rebind to a plain `pl.LazyFrame` local for the filter accumulation, then re-wrap before
+returning:
+
+```python
+def apply(self, scan: pt.LazyFrame[MySchema]) -> pt.LazyFrame[MySchema]:
+    lf: pl.LazyFrame = scan  # .filter() drops the pt subclass; accumulate on a plain LazyFrame
+    if self.foo is not None:
+        lf = lf.filter(pl.col("foo") == self.foo)
+    return pt.LazyFrame.from_existing(lf).set_model(MySchema)  # zero-copy re-wrap
+```
+
+## Delta Lake dictionary-encoded columns: declare Delta filter/partition columns as `String`
+
+delta-rs stores all Arrow dictionary-encoded columns (`Categorical`, `Enum`) as plain `String` in
+Parquet (this is the write-path gotcha documented in `_write_metrics_to_delta`, which casts the
+remaining `Enum` columns to `String` before writing). Two consequences:
+
+1. **A contract column you filter or partition on in Delta should be `String`, not `Categorical`.**
+   If the schema declared it `Categorical`, every read would need a `String → Categorical` cast to
+   satisfy the model — and a cast placed between `pl.scan_delta(...)` and a `.filter()` on that
+   column **blocks predicate pushdown** (Polars can no longer prune Delta partitions or skip row
+   groups, so it reads the *whole* table even when the filter names one partition). Declaring the
+   column `String` matches what is on disk, so the scan is typed by `set_model` with no cast, the
+   filter pushes straight down, and there is no dtype tension at the write boundary either.
+   `PowerForecast.experiment_name` / `fold_id` (the `power_forecasts` partition columns) and
+   `power_fcst_model_name` are `String` for exactly this reason; `PopulationFilter.apply` therefore
+   takes and returns a typed `pt.LazyFrame[PowerForecast]`. Confirm pushdown with `.explain()` — it
+   should list only the matching `partition=value` paths.
+
+2. **For a genuinely low-cardinality column you only *read* (never filter on), cast `String →
+   Enum`/`Categorical` lazily** — in the `pl.scan_delta(...)` result, before `set_model` — so the
+   scan is typed from the start and the cast stays zero-cost until `.collect()`:
+
+    ```python
+    typed_scan = pt.LazyFrame.from_existing(
+        pl.scan_delta(str(path)).with_columns(
+            metric_name=pl.col("metric_name").cast(pl.Enum(METRIC_NAMES)),
+        )
+    ).set_model(MetricsSchema)
+    ```
+
+## The friction budget
+
+Five is the budget. If a sixth workaround becomes necessary, revisit the approach rather than
+adding it here — the alternatives are in `docs/architecture/code-style.md` under "Patito friction
+budget".

--- a/.claude/skills/polars-patito-gotchas/SKILL.md
+++ b/.claude/skills/polars-patito-gotchas/SKILL.md
@@ -60,9 +60,9 @@ result = pl.DataFrame._from_pydf(patito_df._df).cast({"foo": pl.Categorical})
 Patito use and is correct. Expression/Series casts like `pl.col("foo").cast(pl.Int8)` are always
 plain Polars and unaffected.)
 
-This is the caveat behind the Polars style rule in CLAUDE.md that prefers `df.cast({"foo":
-pl.Int8})` over `df.with_columns(pl.col("foo").cast(pl.Int8))`: the preference holds only on a
-plain Polars frame.
+This is the caveat behind the Polars style rule in `docs/architecture/code-style.md` that prefers
+`df.cast({"foo": pl.Int8})` over `df.with_columns(pl.col("foo").cast(pl.Int8))`: the preference
+holds only on a plain Polars frame.
 
 ## `ge`/`le` are silently ignored on a datetime field
 

--- a/.claude/skills/ty-workarounds/SKILL.md
+++ b/.claude/skills/ty-workarounds/SKILL.md
@@ -19,8 +19,9 @@ Altair decorates every `mark_*` method with `@use_signature`, whose return type 
 through a hand-written generic `TypeAliasType` over `Concatenate`. Since ty 0.0.64, ty resolves
 that alias but never solves its type variable, so `alt.Chart(df).mark_line()` infers as the bare
 `T@__call__` and the next call in the chain fails with
-`unresolved-attribute: Object of type 'T@__call__' has no attribute 'encode'`. This is upstream ty
-bug [astral-sh/ty#2520](https://github.com/astral-sh/ty/issues/2520).
+`unresolved-attribute: Object of type 'T@__call__' has no attribute 'encode'`. The code is
+correct — pyright infers `Chart` — and this is upstream ty bug
+[astral-sh/ty#2520](https://github.com/astral-sh/ty/issues/2520).
 
 **How to apply:** put `# ty: ignore[unresolved-attribute]` on the `.encode(` line of each chart
 chain. Restructuring does not help: annotating an intermediate variable as `alt.Chart` instead

--- a/.claude/skills/ty-workarounds/SKILL.md
+++ b/.claude/skills/ty-workarounds/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: ty-workarounds
+description: >-
+  Known upstream `ty` bugs where the code is correct and the checker is wrong, with the exact
+  workaround for each: Altair losing the chart type after a `mark_*()` call
+  (`unresolved-attribute: ... has no attribute 'encode'`), and numpy's `.view(np.uint32)`
+  inferring `type[...]` instead of `dtype[...]` (`unsupported-operator`). Load when `ty check`
+  flags Altair or numpy `.view()` code, or before adding any `# ty: ignore`.
+---
+
+# `ty` workarounds for known upstream bugs
+
+In both cases **the code is correct** — pyright infers the right type — so the fix is a narrow
+workaround, not a rewrite. Each entry records the signal that says it can be deleted.
+
+## Altair: `ty` loses the chart type after a `mark_*()` call
+
+Altair decorates every `mark_*` method with `@use_signature`, whose return type is expressed
+through a hand-written generic `TypeAliasType` over `Concatenate`. Since ty 0.0.64, ty resolves
+that alias but never solves its type variable, so `alt.Chart(df).mark_line()` infers as the bare
+`T@__call__` and the next call in the chain fails with
+`unresolved-attribute: Object of type 'T@__call__' has no attribute 'encode'`. This is upstream ty
+bug [astral-sh/ty#2520](https://github.com/astral-sh/ty/issues/2520).
+
+**How to apply:** put `# ty: ignore[unresolved-attribute]` on the `.encode(` line of each chart
+chain. Restructuring does not help: annotating an intermediate variable as `alt.Chart` instead
+raises `invalid-assignment`, and calling `.encode()` before `.mark_*()` just moves the unsolved
+type variable to the function's return. When ty fixes the bug, every suppression turns into an
+`unused-ignore-comment` warning, which is the signal to delete them all.
+
+## numpy: `ty` mis-types `.view(np.uint32)` — pass `np.dtype(np.uint32)` instead
+
+Since ty 0.0.67, `arr.view(np.uint32)` infers as
+`ndarray[_AnyShape, type[unsignedinteger[_32Bit]]]` instead of
+`ndarray[_AnyShape, dtype[unsignedinteger[_32Bit]]]`, so every subsequent operation on that array
+fails — a bit-mask check reports `unsupported-operator: Unsupported & operation`. `ndarray.view`
+is overloaded, and the inferred type looks like the overload taking
+`DTypeT | _HasDType[DTypeT]` (with `DTypeT` bound to `np.dtype`) matched with `DTypeT` solved as
+`type[np.uint32]`, in violation of that bound. The code is correct at runtime — pyright infers
+`dtype[unsignedinteger[_32Bit]]` — and this is upstream ty bug
+[astral-sh/ty#4208](https://github.com/astral-sh/ty/issues/4208).
+
+**How to apply:** pass a real dtype object — `arr.view(np.dtype(np.uint32))` — which is the same
+call at runtime and which ty resolves to the correct `ndarray[..., dtype[uint32]]`. Prefer this
+over a `# ty: ignore` comment: the suppression would have to sit on the line that *uses* the
+array, which can be several lines away from the `.view()` call that actually causes it.
+Annotating the intermediate as `npt.NDArray[np.uint32]` does not work — it raises
+`invalid-assignment` instead. The significand-rounding tests in `packages/delta_store/tests/`
+are the worked examples. Nothing warns when the upstream bug is fixed, so the signal to delete
+this section is astral-sh/ty#4208 closing; the `np.dtype(...)` calls themselves can stay, because
+they are correct either way.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,7 +92,8 @@ about how it used to work, what a change replaced, or which issue changed it —
 in git, in the PR and in the issue tracker, and repeating it here turns every page into a running
 changelog and makes the docs unreadable. When a change invalidates a passage, rewrite the passage
 to describe the new behaviour rather than appending a note about what changed. This is the
-"comments and docs must reflect current state only" rule under Code Style, applied to prose.
+"comments and docs must reflect current state only" rule in
+[`docs/architecture/code-style.md`](docs/architecture/code-style.md), applied to prose.
 
 ## How planning works
 
@@ -222,114 +223,11 @@ Each `BaseForecaster` also carries a `feature_engineer: ClassVar[FeatureEngineer
 
 ## Code Style
 
-The rules that come up in almost every edit are below. The fuller write-up — the ruff rule
-selection and its `per-file-ignores` traps, error handling, the Patito friction budget — is
-[`docs/architecture/code-style.md`](docs/architecture/code-style.md); keep the two consistent when
-you change either.
-
-- **Python 3.14+** required.
-- **Polars only** — pandas is strictly forbidden. Use `pl.LazyFrame` throughout the pipeline and
-  **do not call `.collect()` before the model boundary**; the full contract is
-  [Lazy evaluation strategy](docs/architecture/performance.md#lazy-evaluation-strategy).
-- **Patito** for all DataFrame schema definitions and validation. Use Patito type annotations (`pt.DataFrame[Schema]`, `pt.LazyFrame[Schema]`) whenever a function consumes or returns data that conforms to an existing schema — whether the function is public or private. Don't invent a new schema just to annotate a private helper; if no existing schema fits, use plain `pl.DataFrame` / `pl.LazyFrame`.
-- **Prefer small functions.** Extract private helpers (`_name`) rather than letting a function body grow long, even if that means more parameters. A well-named helper with a clear docstring beats a long inline block. Eight parameters is acceptable when each is distinct and the division of labour is clear.
-- **Ruff**: 100-char line length, double quotes, Google-style docstrings.
-- **Comments and docs must reflect current state only** — never reference previous iterations of
-  the code or deleted files. See "Write about the present, not the past" under Docs.
-- **Code links only to durable docs** — `docs/design-philosophy/`, `docs/background/`, `docs/techniques/`,
-  `docs/architecture/`, `docs/ml_experimentation/`, `docs/live_service/`. Never link from code *or* docs to `plans/`
-  files, and never from code to `docs/roadmap/` pages or to any
-  "Implementation details (deleted when this ships)" section — all of those are deleted when
-  the work lands, so the reference rots. (Docs-to-docs links into `docs/roadmap/` are fine;
-  retargeting them is part of ship-time triage.) Linking from a docstring to a durable page —
-  e.g. `docs/architecture/` — is encouraged.
-- **MkDocs-compatible constant docs** — document module-level constants with a string literal
-  immediately after the assignment, not with Sphinx-style `#:` comments. This is correct:
-
-  ```python
-  MY_CONST: Final[str] = "value"
-  """One-line summary.
-
-  Optional further detail.
-  """
-  ```
-
-- `snake_case` for variables/functions, `PascalCase` for classes, `UPPER_SNAKE_CASE` for constants.
-- All function signatures must have complete type hints including return types.
-- **Prefer self-documenting type hints over bare containers — a signature is documentation.**
-  Jack strongly prefers expressive signatures and is happy to spend a few extra lines of code to
-  get them, as long as complexity stays low. Whenever you would write `dict[str, str]` (or a bare
-  `str` for a value from a fixed set, or a tuple of positional values), stop and ask whether a more
-  self-documenting type is practical. Reach for: a `Type`-suffixed `Literal` alias for a closed set
-  of string values (`StageType = Literal["register", "train", "predict", "metrics"]`); a named
-  alias for a recurring shape (`MlflowTags = dict[str, str]`) so the intent is stated once and
-  reused; a `TypedDict` for a structured mapping with known keys (e.g. `ObjectStoreOptions`) —
-  taking the `TypedDict` in the signature and widening to a plain dict at the call boundary.
-  Constraining `dict` *keys* to a `Literal` alias (`dict[TableNameType, str]`) is worthwhile for a
-  closed vocabulary and works with bidirectional inference when callers pass dict literals.
-  `packages/ml_core/src/ml_core/_repro.py` is the worked example. Don't force it where no honest
-  stricter type exists — a genuinely heterogeneous or open-ended dict stays `dict[str, str]`.
-- All consts must be marked with the maximally "constant" type.
-  e.g. `CONST_SEQ: Final[tuple[str, ...]] = ("a", "b")` or `FOO: Final[str] = "bar"`
-- Never relax an existing test to make it pass.
-
-### Polars Style
-
-These rules are all about making Polars code easy to read.
-
-- When casting, prefer using the `cast` method like this: `df.cast({"foo": pl.Int8})`, in favour of
-  using `df.with_columns(pl.col("foo").cast(pl.Int8))`. **Caveat:** this is only safe on a plain
-  Polars frame — passing a `{column: dtype}` mapping to a *model-bearing* Patito frame silently does
-  the wrong thing. See the `polars-patito-gotchas` skill.
-- When using `.with_columns`, prefer specifying the destination column name as a key word argument
-  like this: `df.with_columns(bar=pl.col("foo").expression())` instead of using `alias` like this:
-  `df.with_columns(pl.col("foo").expression().alias("bar"))`
-
-- **`Literal` type aliases — use a `Type` suffix** to distinguish them from the runtime tuples
-  that drive Polars `Enum` declarations. Example:
-
-  ```python
-  EVALUATION_SCOPES: Final[tuple[str, ...]] = ("leaderboard", "production_monitoring", "ad_hoc")
-  """Runtime tuple — used as pl.Enum(EVALUATION_SCOPES)."""
-
-  EvalScopeType = Literal["leaderboard", "ad_hoc"]
-  """Type annotation — currently-implemented subset; update when adding a new scope."""
-  ```
-
-  The `Type`-suffixed alias is what goes in function signatures; the `UPPER_SNAKE_CASE` tuple is
-  what goes into `pl.Enum(...)`. They serve different purposes and should both exist.
-
-### Gotchas that fail silently
-
-Patito's model machinery collides with Polars and with delta-rs in five ways, and **none of them
-raise at the point of the mistake**: a cross-model `.join()` that has to have its right-hand
-operand stripped, a `{column: dtype}` `.cast` that gets swallowed on a model-bearing frame,
-`ge`/`le` doing nothing at all on a datetime field, `.filter()` dropping the Patito subclass, and
-a dictionary-encoded column blocking Delta predicate pushdown so a partition-filtered query reads
-the whole table. They are written up, with the workaround for each, in the
-**`polars-patito-gotchas`** skill. Load it before writing the code, not after the confusing
-`validate()` error.
-
-Two more live in their own skills: **`marimo-notebooks`** (leading underscores are cell-local,
-imports belong in `app.setup`, never `ruff check --fix` a notebook) and **`ty-workarounds`**
-(known upstream `ty` bugs on Altair and numpy, where the code is correct and the checker is not).
-
-### Polars Gotcha: row counts silently wrap past 2³² rows (32-bit `IdxSize`)
-
-Default Polars builds use a 32-bit row index (`IdxSize`), capping any single materialised frame,
-row count, or row index at 2³² (~4.29 billion) rows. Past the cap there is **no error** — counts
-wrap modulo 2³², streaming engine included.
-
-- **Never row-count a table that can exceed 2³² rows with Polars.** Use the Delta log instead —
-  `DeltaTable(path).count()`, or sum `num_records` over `get_add_actions(flatten=True)` — both
-  metadata-only and exact.
-- Filtered/partition-pruned queries whose *result* stays under 2³² rows are correct even when the
-  underlying scan is bigger, and value aggregations (`sum`, `min`/`max`, quantiles) over >2³² rows
-  are unaffected — only row counts and row indices wrap.
-- Tables past the cap today: NWP (~5.9B rows). `power_forecasts` will pass it at V2 scale.
-
-The measurements behind all of that, and the reasoning:
-[Performance and Scale → The other hard ceiling](https://openclimatefix.github.io/nged-substation-forecast/architecture/performance/#the-other-hard-ceiling-polars-32-bit-row-index).
+**Read [`docs/architecture/code-style.md`](docs/architecture/code-style.md) before writing or
+editing any Python.** It is the single source of truth for code style in this repo — Python
+version, ruff configuration and its traps, naming, how expressive a signature has to be, comments
+and doc links, Polars and Patito conventions, data handling, error handling — and none of it is
+repeated here. Skipping it means guessing at rules that are written down.
 
 ## This is a young project
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ uv sync
 
 # Linting & formatting
 uv run ruff check .            # check
-uv run ruff check . --fix      # fix (never over a marimo notebook - see the Marimo section)
+uv run ruff check . --fix      # fix (never over a marimo notebook - see marimo-notebooks skill)
 uv run ruff format .           # format
 uv run ty check                # type checking
 uv run pymarkdown scan -r docs README.md CLAUDE.md packages/*/README.md  # markdown lint
@@ -45,7 +45,7 @@ needed one, the mistake is already written.
 | Skill | Load it before… |
 |---|---|
 | `polars-patito-gotchas` | writing Polars/Patito code that joins, casts, filters a `pt.LazyFrame`, declares a Patito field, or reads/writes Delta |
-| `mkdocs-authoring` | editing any page under `docs/` — especially nested lists, list items containing code blocks, or wrapped links |
+| `mkdocs-authoring` | editing markdown MkDocs renders — `docs/`, READMEs, `SKILL.md`, docstrings — especially nested lists, list items with code blocks, or wrapped links |
 | `marimo-notebooks` | creating or editing a Marimo notebook (`packages/dashboard/*.py`, `packages/notebooks/*.py`) |
 | `ty-workarounds` | acting on a `ty` error in Altair chart code or numpy `.view()` code, or adding any `# ty: ignore` |
 | `plan-issue` | deciding what to build for a GitHub issue (`/plan-issue <N>`) — writes a reviewed plan, no code |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ needed one, the mistake is already written.
 
 | Skill | Load it before… |
 |---|---|
+| `code-style` | writing or editing **any** Python in this repo |
 | `polars-patito-gotchas` | writing Polars/Patito code that joins, casts, filters a `pt.LazyFrame`, declares a Patito field, or reads/writes Delta |
 | `mkdocs-authoring` | editing markdown MkDocs renders — `docs/`, READMEs, `SKILL.md`, docstrings — especially nested lists, list items with code blocks, or wrapped links |
 | `marimo-notebooks` | creating or editing a Marimo notebook (`packages/dashboard/*.py`, `packages/notebooks/*.py`) |
@@ -223,11 +224,11 @@ Each `BaseForecaster` also carries a `feature_engineer: ClassVar[FeatureEngineer
 
 ## Code Style
 
-**Read [`docs/architecture/code-style.md`](docs/architecture/code-style.md) before writing or
-editing any Python.** It is the single source of truth for code style in this repo — Python
-version, ruff configuration and its traps, naming, how expressive a signature has to be, comments
-and doc links, Polars and Patito conventions, data handling, error handling — and none of it is
-repeated here. Skipping it means guessing at rules that are written down.
+**Load the `code-style` skill before writing or editing any Python.** It takes you to
+[`docs/architecture/code-style.md`](docs/architecture/code-style.md), the single source of truth —
+Python version, ruff configuration and its traps, naming, how expressive a signature has to be,
+comments and doc links, Polars and Patito conventions, data handling, error handling. None of it is
+repeated here, so skipping it means guessing at rules that are written down.
 
 ## This is a young project
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,9 +32,26 @@ command above yourself before committing, for faster feedback than waiting on th
 hook.
 
 **Testing conventions** — where test dependencies and fixtures live, how discovery works, mocking
-with `monkeypatch`, network-gated tests, and the Patito assertion house style — are documented on the
-**[Testing](docs/architecture/testing.md)** page. (The moto and Polars row-count testing *gotchas*
-live further down this file, with the other gotchas.)
+with `monkeypatch`, network-gated tests, the moto S3 reset-per-test rule, and the Patito assertion
+house style — are documented on the **[Testing](docs/architecture/testing.md)** page.
+
+## Skills
+
+Detail that only matters while you are touching one specific thing lives in
+`.claude/skills/<name>/SKILL.md` and is loaded on demand. **Load the relevant skill *before* you
+start** — most of what they hold are traps that fail silently, so by the time you notice you
+needed one, the mistake is already written.
+
+| Skill | Load it before… |
+|---|---|
+| `polars-patito-gotchas` | writing Polars/Patito code that joins, casts, filters a `pt.LazyFrame`, declares a Patito field, or reads/writes Delta |
+| `mkdocs-authoring` | editing any page under `docs/` — especially nested lists, list items containing code blocks, or wrapped links |
+| `marimo-notebooks` | creating or editing a Marimo notebook (`packages/dashboard/*.py`, `packages/notebooks/*.py`) |
+| `ty-workarounds` | acting on a `ty` error in Altair chart code or numpy `.view()` code, or adding any `# ty: ignore` |
+| `plan-issue` | deciding what to build for a GitHub issue (`/plan-issue <N>`) — writes a reviewed plan, no code |
+| `implement-issue` | writing code for an approved plan: worktree, verify set, PR, adversarial review, stop |
+| `github-issue-pr-workflow` | `gh issue create`, `gh pr create`, `gh pr merge`, or ship-time triage |
+| `github-graphql` | any `gh api graphql` call — sub-issue attach/reorder, issue Type, project fields |
 
 ## Docs
 
@@ -93,105 +110,22 @@ Full description and a "which place do I use?" table: `docs/documentation-guide.
   `plan-issue` skill before any code is touched and deleted on merge. One worktree per branch is
   what keeps it to one file, so parallel sessions never collide. Usually empty on `main`.
 
-**Creating GitHub issues** — whenever you create an issue, also set:
+**Creating an issue or a PR has a checklist** — labels, org issue Type, OCF project membership
+and its fields, sub-issue ordering, the `JackKelly` assignee — and none of it can be set by `gh
+issue create` / `gh pr create`. It lives in the `github-issue-pr-workflow` skill, along with the
+never-squash-merge rule and ship-time triage. Load it before you run either command.
 
-- **Labels** and **Type** (org issue type: Task / Bug / Feature / Spike / Epic / …) — pick
-  whatever fits the issue.
-- Add it to the **OCF project** (org project 33, `gh project item-add 33 --owner
-  openclimatefix --url <issue-url>`) and set the project fields **Status = Todo**,
-  **Project = NGED**, **Area = ML**.
-- If it is a sub-issue, attach it to its parent epic **and position it appropriately in the
-  parent's sub-issue order** (execution order, respecting `blocked by` chains) — the
-  `reprioritizeSubIssue` GraphQL mutation with `afterId`/`beforeId`.
-- **Body** — if (and only if) the docs already contain a plan for the issue (e.g. a
-  `docs/roadmap/` section), the body may be *just* a link to that rendered docs section and
-  nothing more; don't duplicate the plan. Otherwise, write a self-contained body.
-- When the body links to a docs page, link to the **rendered site**
-  (`https://openclimatefix.github.io/nged-substation-forecast/...`), never a `github.com`
-  blob path.
+## How work gets done
 
-`gh issue create` can't set any of these: use `gh issue edit --add-label` for labels, the
-`updateIssueIssueType` GraphQL mutation for Type, and `gh project item-edit` (or the
-`updateProjectV2ItemFieldValue` mutation) for the project fields.
+Two skills, in order, and they are deliberately separate so that Jack approves a design before
+any code moves:
 
-**Creating pull requests** — whenever you create a PR, also set:
-
-- **Labels** — pick whatever fits (e.g. `documentation`, `enhancement`, `bug`), same label set as
-  issues.
-- **Assignees = JackKelly**.
-
-`gh pr create` can't set either: use `gh pr edit --add-label` and `gh pr edit --add-assignee
-JackKelly` right after creating the PR.
-
-**Merging pull requests** — never squash-merge. Jack wants the full commit history preserved in
-`main`, so use a merge commit (`gh pr merge --merge`) or rebase (`gh pr merge --rebase`), not
-`gh pr merge --squash`.
-
-**GitHub GraphQL calls** (attaching/reordering sub-issues, setting an issue's Type, setting a
-project field) — see the `github-graphql` skill (`.claude/skills/github-graphql/`) for exact
-`gh api graphql` invocations and how to obtain the node IDs they need.
-
-**Ship-time triage** — when a PR lands a roadmap item, that PR (or an immediate follow-up)
-must also:
-
-1. Promote surviving design decisions to their permanent home (`docs/architecture/`,
-   `docs/ml_experimentation/`, …).
-2. Delete the item's "Implementation details" section (and any `plans/` file), pasting it (or
-   a summary) into the PR body. When a roadmap page's last 🚧 item ships, delete the page
-   (nav entry, inbound doc links).
-3. Close the GitHub issue; update the status banner on the roadmap page (and the milestone
-   section in `docs/roadmap/index.md` if the arc changed).
-
-## Sub-agent routine
-
-When dispatching a sub-agent (or a fresh Claude Code/Desktop session) to solve a GitHub issue in
-this repo, give it these steps up front — a report back after step 1 is not finished work:
-
-This routine starts from an **approved plan**. The `plan-issue` skill
-(`.claude/skills/plan-issue/`, invoked as `/plan-issue <N>`) is how you get one: it reads the
-issue, decides whether it is worth implementing at all, writes `plans/<branch-name>.md`, has a
-fresh sub-agent adversarially review the plan, and stops for Jack. It also does step 1 below, so
-when it hands over, the worktree and branch already exist and implementation resumes at step 2.
-
-1. **Set up an isolated worktree** so concurrent sessions don't collide:
-
-   ```bash
-   git worktree add .claude/worktrees/<branch-name> -b <branch-name>
-   cd .claude/worktrees/<branch-name>
-   ln -s /home/jack/dev/python/nged-substation-forecast/.env .env   # if it exists and isn't already there
-   ```
-
-   If several sub-agents run concurrently, also give each its own scratchpad subdirectory —
-   a shared scratchpad root means two agents writing e.g. `pr_body.md` can collide and one
-   agent's output gets briefly published under another's PR.
-
-2. **Implement**, following every convention in this file — including leaving every doc page
-   that touches the change consistent with the code as it now stands, describing only how the
-   code works *now* (see "Write about the present, not the past" above). For a docs change that
-   touches a link, run `uv run mkdocs build --strict` and read the rendered HTML under `site/`,
-   not just the linter — Python-Markdown has rendering gotchas that neither `pymarkdown scan`
-   nor a successful `mkdocs build` catches on their own.
-
-3. **Verify, all green before pushing**: `uv run ruff check .`, `uv run ruff format .`,
-   `uv run --all-packages ty check`, `uv run pytest`, plus (if docs were touched)
-   `uv run pymarkdown scan -r docs README.md CLAUDE.md packages/*/README.md` and
-   `uv run mkdocs build --strict`.
-
-4. **Push and open the PR** against `main`, with labels and `JackKelly` as assignee (`gh pr
-   create` can't set either — follow with `gh pr edit --add-label <label>` and `gh pr edit
-   --add-assignee JackKelly`), linking the issue so it closes on merge. Commit messages end
-   with `Co-Authored-By: Claude <noreply@anthropic.com>`.
-
-5. **Spawn a *new*, independent sub-agent to adversarially review the PR** — give it only the
-   PR number, not the implementer's reasoning, so it isn't anchored by it. Tailor the reviewer
-   brief to the issue: name the failure modes most worth attacking (the risky claim, a
-   behaviour change hiding inside a refactor, whether a new test would actually have failed on
-   `main`) rather than asking for a generic review.
-
-6. **Triage the review's findings** — verify each against the code rather than accepting it,
-   fix genuine defects, push, and record why any finding was rejected.
-
-7. **Stop and wait for Jack's review. Never merge.**
+1. **`plan-issue`** (`/plan-issue <N>`) reads the issue, decides whether it is worth implementing
+   at all, writes `plans/<branch-name>.md`, has a fresh sub-agent adversarially review that plan,
+   and stops for Jack. It writes no code.
+2. **`implement-issue`** picks up an approved plan: worktree, implement, the green-before-push
+   verification set, PR with labels and assignee, a *second and independent* adversarial review
+   of the diff, triage, stop. **Never merge.**
 
 Stay inside the issue's scope; report unrelated design mistakes rather than fixing them.
 
@@ -288,8 +222,15 @@ Each `BaseForecaster` also carries a `feature_engineer: ClassVar[FeatureEngineer
 
 ## Code Style
 
+The rules that come up in almost every edit are below. The fuller write-up — the ruff rule
+selection and its `per-file-ignores` traps, error handling, the Patito friction budget — is
+[`docs/architecture/code-style.md`](docs/architecture/code-style.md); keep the two consistent when
+you change either.
+
 - **Python 3.14+** required.
-- **Polars only** — pandas is strictly forbidden. Use `pl.LazyFrame` and only `.collect()` when necessary.
+- **Polars only** — pandas is strictly forbidden. Use `pl.LazyFrame` throughout the pipeline and
+  **do not call `.collect()` before the model boundary**; the full contract is
+  [Lazy evaluation strategy](docs/architecture/performance.md#lazy-evaluation-strategy).
 - **Patito** for all DataFrame schema definitions and validation. Use Patito type annotations (`pt.DataFrame[Schema]`, `pt.LazyFrame[Schema]`) whenever a function consumes or returns data that conforms to an existing schema — whether the function is public or private. Don't invent a new schema just to annotate a private helper; if no existing schema fits, use plain `pl.DataFrame` / `pl.LazyFrame`.
 - **Prefer small functions.** Extract private helpers (`_name`) rather than letting a function body grow long, even if that means more parameters. A well-named helper with a clear docstring beats a long inline block. Eight parameters is acceptable when each is distinct and the division of labour is clear.
 - **Ruff**: 100-char line length, double quotes, Google-style docstrings.
@@ -339,7 +280,7 @@ These rules are all about making Polars code easy to read.
 - When casting, prefer using the `cast` method like this: `df.cast({"foo": pl.Int8})`, in favour of
   using `df.with_columns(pl.col("foo").cast(pl.Int8))`. **Caveat:** this is only safe on a plain
   Polars frame — passing a `{column: dtype}` mapping to a *model-bearing* Patito frame silently does
-  the wrong thing. See "Patito + Polars Gotcha: `.cast({...})` on a model-bearing frame" below.
+  the wrong thing. See the `polars-patito-gotchas` skill.
 - When using `.with_columns`, prefer specifying the destination column name as a key word argument
   like this: `df.with_columns(bar=pl.col("foo").expression())` instead of using `alias` like this:
   `df.with_columns(pl.col("foo").expression().alias("bar"))`
@@ -358,266 +299,37 @@ These rules are all about making Polars code easy to read.
   The `Type`-suffixed alias is what goes in function signatures; the `UPPER_SNAKE_CASE` tuple is
   what goes into `pl.Enum(...)`. They serve different purposes and should both exist.
 
-### Patito + Polars Gotcha: cross-model LazyFrame joins
+### Gotchas that fail silently
 
-Patito creates a unique Python subclass for each model (e.g. `PowerTimeSeriesLazyFrame`,
-`PowerForecastLazyFrame`). Polars' `assert_same_type` check inside `.join()` rejects joining
-two differently-typed Patito LazyFrames with a `TypeError`.
+Patito's model machinery collides with Polars and with delta-rs in five ways, and **none of them
+raise at the point of the mistake**: a cross-model `.join()` that has to have its right-hand
+operand stripped, a `{column: dtype}` `.cast` that gets swallowed on a model-bearing frame,
+`ge`/`le` doing nothing at all on a datetime field, `.filter()` dropping the Patito subclass, and
+a dictionary-encoded column blocking Delta predicate pushdown so a partition-filtered query reads
+the whole table. They are written up, with the workaround for each, in the
+**`polars-patito-gotchas`** skill. Load it before writing the code, not after the confusing
+`validate()` error.
 
-Workaround: strip the Patito subclass from the right-hand operand before joining:
-
-```python
-# Strip Patito model annotation so Polars' cross-subclass type check doesn't reject the join
-plain_lf = pl.LazyFrame._from_pyldf(patito_lf._ldf)
-left_patito_lf.join(plain_lf.select(...), on=..., how="inner")
-```
-
-`pl.LazyFrame._from_pyldf` constructs a plain `pl.LazyFrame` from the same underlying Rust
-object — zero-copy, no data movement. The check passes because `type(left_lf)` is a subclass
-of `pl.LazyFrame`, so `isinstance(left_lf, type(plain_lf))` is `True`.
-
-### Patito + Polars Gotcha: `.cast({...})` on a model-bearing frame
-
-Patito **overrides** `.cast`: its signature is `cast(self, strict=False, columns=None)` and, on a
-frame that carries a model (set via `.set_model(...)` or a typed `pt.DataFrame[Schema]`), it casts
-every column to the *model's* declared dtypes. So `df.cast({"foo": pl.Int8})` on such a frame does
-**not** apply your mapping — Polars' `{column: dtype}` dict is swallowed as the `strict` argument
-and your `foo` cast is silently ignored while unrelated columns are reverted to model dtypes. The
-result usually only surfaces later as a confusing `validate()` dtype error.
-
-The trap fires only when the model is still attached. Many Polars ops **drop** the model
-(`group_by(...).agg(...)`, `.collect()`, `.unpivot()`, `.as_polars()`), so a dict-`.cast` after
-them is plain Polars and fine. But **iterating** `group_by` (`for k, g in df.group_by(...)`) yields
-sub-frames that **keep** the model, and `pl.concat` keeps it too — so a dict-`.cast` on the
-concatenated result hits the trap.
-
-Workaround: strip the Patito model before a `{column: dtype}` cast (mirrors the join gotcha above):
-
-```python
-# Strip the Patito model so the dict-cast uses plain Polars semantics (zero-copy)
-result = pl.DataFrame._from_pydf(patito_df._df).cast({"foo": pl.Categorical})
-```
-
-(No-arg `df.cast()` — casting a model-bearing frame to its declared dtypes — *is* the intended
-Patito use and is correct. Expression/Series casts like `pl.col("foo").cast(pl.Int8)` are always
-plain Polars and unaffected.)
-
-### Patito Gotcha: `ge`/`le` are silently ignored on a datetime field
-
-`pt.Field(ge=..., le=...)` enforces nothing on a `datetime` column. Patito builds its bounds checks
-by reading the `minimum`/`maximum` keywords out of the Pydantic JSON schema, and JSON Schema
-defines those keywords for numbers only — so a datetime field's `Ge`/`Le` metadata never reaches
-the JSON schema, Patito finds no keyword to turn into a filter, and `validate()` accepts every
-year. There is no warning and no error; the constraint simply does not exist. (`ge`/`le` on a
-numeric field works exactly as documented, which is what makes this so easy to miss.)
-
-**How to apply:** bound a datetime column from the model's `validate` override, not from the field.
-`contracts.common.check_datetime_bounds` is the shared helper, and `MIN_PLAUSIBLE_DATETIME` /
-`MAX_PLAUSIBLE_DATETIME` are the shared bounds; `PowerTimeSeries.validate` and `Nwp.validate` are
-the worked examples. A `constraints=` Polars expression on the field also works, but its failure
-message is the generic "1 row does not match custom constraints", so prefer the explicit check when
-you want the error to say which bound was broken.
-
-### Delta Lake dictionary-encoded columns: declare Delta filter/partition columns as `String`
-
-delta-rs stores all Arrow dictionary-encoded columns (`Categorical`, `Enum`) as plain `String` in
-Parquet (this is the write-path gotcha documented in `_write_metrics_to_delta`, which casts the
-remaining `Enum` columns to `String` before writing). Two consequences:
-
-1. **A contract column you filter or partition on in Delta should be `String`, not `Categorical`.**
-   If the schema declared it `Categorical`, every read would need a `String → Categorical` cast to
-   satisfy the model — and a cast placed between `pl.scan_delta(...)` and a `.filter()` on that
-   column **blocks predicate pushdown** (Polars can no longer prune Delta partitions or skip row
-   groups, so it reads the *whole* table even when the filter names one partition). Declaring the
-   column `String` matches what is on disk, so the scan is typed by `set_model` with no cast, the
-   filter pushes straight down, and there is no dtype tension at the write boundary either.
-   `PowerForecast.experiment_name` / `fold_id` (the `power_forecasts` partition columns) and
-   `power_fcst_model_name` are `String` for exactly this reason; `PopulationFilter.apply` therefore
-   takes and returns a typed `pt.LazyFrame[PowerForecast]`. Confirm pushdown with `.explain()` — it
-   should list only the matching `partition=value` paths.
-
-2. **For a genuinely low-cardinality column you only *read* (never filter on), cast `String →
-   Enum`/`Categorical` lazily** — in the `pl.scan_delta(...)` result, before `set_model` — so the
-   scan is typed from the start and the cast stays zero-cost until `.collect()`:
-
-   ```python
-   typed_scan = pt.LazyFrame.from_existing(
-       pl.scan_delta(str(path)).with_columns(
-           metric_name=pl.col("metric_name").cast(pl.Enum(METRIC_NAMES)),
-       )
-   ).set_model(MetricsSchema)
-   ```
-
-### Patito + Polars Gotcha: `pt.LazyFrame.filter()` drops the Patito subclass
-
-Most Polars operations on a `pt.LazyFrame` return a plain `pl.LazyFrame`, including `.filter()`.
-Reassigning `scan = scan.filter(...)` where `scan: pt.LazyFrame[Schema]` therefore fails `ty`'s
-assignment check.
-
-Workaround: rebind to a plain `pl.LazyFrame` local for the filter accumulation, then re-wrap before
-returning:
-
-```python
-def apply(self, scan: pt.LazyFrame[MySchema]) -> pt.LazyFrame[MySchema]:
-    lf: pl.LazyFrame = scan  # .filter() drops the pt subclass; accumulate on a plain LazyFrame
-    if self.foo is not None:
-        lf = lf.filter(pl.col("foo") == self.foo)
-    return pt.LazyFrame.from_existing(lf).set_model(MySchema)  # zero-copy re-wrap
-```
+Two more live in their own skills: **`marimo-notebooks`** (leading underscores are cell-local,
+imports belong in `app.setup`, never `ruff check --fix` a notebook) and **`ty-workarounds`**
+(known upstream `ty` bugs on Altair and numpy, where the code is correct and the checker is not).
 
 ### Polars Gotcha: row counts silently wrap past 2³² rows (32-bit `IdxSize`)
 
 Default Polars builds use a 32-bit row index (`IdxSize`), capping any single materialised frame,
 row count, or row index at 2³² (~4.29 billion) rows. Past the cap there is **no error** — counts
-wrap modulo 2³²: `pl.len()` over the 5.9-billion-row NWP dev table returns 1,652,180,189
-(= 5,947,147,485 mod 2³²), and `group_by(...).agg(pl.len())` wraps identically for any single
-group past the cap, streaming engine included. Full analysis:
-[Performance and Scale → The other hard ceiling](https://openclimatefix.github.io/nged-substation-forecast/architecture/performance/#the-other-hard-ceiling-polars-32-bit-row-index).
+wrap modulo 2³², streaming engine included.
 
 - **Never row-count a table that can exceed 2³² rows with Polars.** Use the Delta log instead —
   `DeltaTable(path).count()`, or sum `num_records` over `get_add_actions(flatten=True)` — both
   metadata-only and exact.
 - Filtered/partition-pruned queries whose *result* stays under 2³² rows are correct even when the
   underlying scan is bigger, and value aggregations (`sum`, `min`/`max`, quantiles) over >2³² rows
-  are unaffected — only row counts and row indices wrap. Both verified empirically.
+  are unaffected — only row counts and row indices wrap.
 - Tables past the cap today: NWP (~5.9B rows). `power_forecasts` will pass it at V2 scale.
 
-### Testing Gotcha: moto's S3 backend is process-global — reset it per test
-
-The in-process `moto` server used for the S3 tests keeps its bucket contents in a **process-global
-backend that outlives the `ThreadedMotoServer` object**, so a module-scoped server does not hand
-each test a clean slate. A test whose write path runs twice against that server — a re-run, or
-state left behind by an earlier test — reads stale data: an appended Delta table returns double the
-rows, and an `object_exists` precondition sees a leftover parquet. Keep the *server* module-scoped
-for speed, but give each test a **function-scoped** fixture that `POST`s to `/moto-api/reset` and
-recreates the bucket before the test body runs, so every test starts pristine and independent of
-execution order. `tests/test_s3_data_paths.py` is the canonical pattern.
-
-### Altair Gotcha: `ty` loses the chart type after a `mark_*()` call
-
-Altair decorates every `mark_*` method with `@use_signature`, whose return type is expressed
-through a hand-written generic `TypeAliasType` over `Concatenate`. Since ty 0.0.64, ty resolves
-that alias but never solves its type variable, so `alt.Chart(df).mark_line()` infers as the bare
-`T@__call__` and the next call in the chain fails with
-`unresolved-attribute: Object of type 'T@__call__' has no attribute 'encode'`. The code is
-correct — pyright infers `Chart` — and this is upstream ty bug
-[astral-sh/ty#2520](https://github.com/astral-sh/ty/issues/2520).
-
-**How to apply:** put `# ty: ignore[unresolved-attribute]` on the `.encode(` line of each chart
-chain. Restructuring does not help: annotating an intermediate variable as `alt.Chart` instead
-raises `invalid-assignment`, and calling `.encode()` before `.mark_*()` just moves the unsolved
-type variable to the function's return. When ty fixes the bug, every suppression turns into an
-`unused-ignore-comment` warning, which is the signal to delete them all.
-
-Ruff's lint rule *selection* is written out in `pyproject.toml` (`[tool.ruff.lint] select`) for
-the same class of reason: ruff's defaults are a curated menu with no stability promise, so an
-inherited selection lets a `uv lock` refresh change which rules the repo enforces. `select` names
-whole families; `ignore` names each family member we decline, with the reason on the line above
-it. **When a rule fires somewhere it should not, add an `ignore` entry (or a `per-file-ignores`
-entry) with its justification — do not drop the whole family.** Note that ruff's defaults are not
-a superset of the old `E4`/`E7`/`E9`/`F` gate: of pycodestyle-E they keep only `E722` and `E902`,
-which is why `E4`/`E7`/`E9` are listed explicitly.
-
-Two traps when editing `[tool.ruff.lint.per-file-ignores]`:
-
-- **`*` crosses `/`.** A key of `packages/dashboard/*.py` also silences
-  `packages/dashboard/src/dashboard/*.py`. Name individual files when you mean "just the ones in
-  this directory"; `**/tests/**` is the right way to say "every tests directory, root included".
-- **A `# noqa` cannot live inside a docstring**, because it would become part of the string. An
-  over-long docstring line has to be reworded or re-wrapped, never suppressed.
-
-### numpy Gotcha: `ty` mis-types `.view(np.uint32)` — pass `np.dtype(np.uint32)` instead
-
-Since ty 0.0.67, `arr.view(np.uint32)` infers as
-`ndarray[_AnyShape, type[unsignedinteger[_32Bit]]]` instead of
-`ndarray[_AnyShape, dtype[unsignedinteger[_32Bit]]]`, so every subsequent operation on that array
-fails — a bit-mask check reports `unsupported-operator: Unsupported & operation`. `ndarray.view`
-is overloaded, and the inferred type looks like the overload taking
-`DTypeT | _HasDType[DTypeT]` (with `DTypeT` bound to `np.dtype`) matched with `DTypeT` solved as
-`type[np.uint32]`, in violation of that bound. The code is correct at runtime — pyright infers
-`dtype[unsignedinteger[_32Bit]]` — and this is upstream ty bug
-[astral-sh/ty#4208](https://github.com/astral-sh/ty/issues/4208).
-
-**How to apply:** pass a real dtype object — `arr.view(np.dtype(np.uint32))` — which is the same
-call at runtime and which ty resolves to the correct `ndarray[..., dtype[uint32]]`. Prefer this
-over a `# ty: ignore` comment: the suppression would have to sit on the line that *uses* the
-array, which can be several lines away from the `.view()` call that actually causes it.
-Annotating the intermediate as `npt.NDArray[np.uint32]` does not work — it raises
-`invalid-assignment` instead. The significand-rounding tests in `packages/delta_store/tests/`
-are the worked examples. Nothing warns when the upstream bug is fixed, so the signal to delete
-this section is astral-sh/ty#4208 closing; the `np.dtype(...)` calls themselves can stay, because
-they are correct either way.
-
-### Marimo Notebooks
-
-Marimo notebooks (`packages/dashboard/*.py`, `packages/notebooks/*.py`) are reactive: each
-`@app.cell` function is a separate cell, and the `with app.setup:` block holds names shared by
-every cell. Two authoring rules follow from how Marimo scopes names and how ruff sees them.
-
-- **Never give a leading underscore to anything you want to reuse across cells.** Marimo treats
-  any name starting with `_` (a variable *or* a function) as *cell-local* — it is not exported to
-  other cells, so a `_helper()` defined in one cell (or in `app.setup`) is invisible everywhere
-  else and the call fails at runtime. A helper that multiple cells call must have a public name
-  (no leading underscore). This is the opposite of the usual `_private` convention, so it is easy
-  to get wrong; the leading-underscore-means-private habit does not apply inside a Marimo
-  notebook.
-
-- **Put every import in the `with app.setup:` block, never at module top level and never let
-  Marimo thread them through cell signatures.** When imports live in `app.setup`, they are real
-  `import` statements that ruff analyses, so ruff flags a missing or unused import. If you instead
-  scatter imports into individual cells, Marimo passes the imported names into the cells that use
-  them as function parameters (`def _(pl, mo): ...`), and ruff treats a parameter as always
-  defined — so a genuinely missing import is invisible to the linter and only blows up at runtime.
-  Keeping all imports in `app.setup` keeps them statically checkable and available to every cell.
-
-- **Never run `ruff check --fix` over a Marimo notebook.** When an autofix needs a name the file
-  does not import yet, ruff inserts the import into the file's *top-level* import block — outside
-  `app.setup`, where no cell can see it. The notebook then dies with a `NameError` the next time it
-  is opened, while `ruff check` reports success, because what ruff produced is valid Python. This
-  is a whole class, not one rule: any fix that adds an import does it, and ruff has no per-file
-  fixability setting to prevent it (`unfixable` is global, and `per-file-ignores` would silence the
-  check as well as the fix). The pre-commit hook is split so notebooks are checked but never
-  auto-fixed; a bare `uv run ruff check . --fix` typed by hand is *not* covered, so after running
-  one, check `git diff` for an import that landed above `import marimo` and move it into
-  `app.setup`.
-
-### MkDocs Gotcha: a list item needs a blank line before it if it follows an indented continuation
-
-Python-Markdown (MkDocs' renderer) doesn't let a list item interrupt a paragraph the way
-GitHub-flavored Markdown does. If a bullet's continuation content ends with an indented
-paragraph (e.g. a clarifying sentence after a fenced code block inside the item) and the next
-sibling bullet immediately follows with no blank line in between, Python-Markdown treats the new
-list-marker line as more paragraph text rather than a new list item — the marker renders as a
-literal hyphen, merged into the previous sentence's prose. `pymarkdown scan` does **not** catch
-this: a markdown source with the missing blank line lints clean.
-
-**How to apply:** always put a blank line between a list item's continuation content (paragraphs,
-fenced code blocks) and the next sibling item. For any non-trivial list item — one that embeds a
-code block or multiple paragraphs — spot-check with `uv run mkdocs build --strict` and inspect
-the rendered HTML rather than trusting the linter alone. See also the nested-sub-bullet indent
-gotcha (4 spaces, not 2) tracked in memory — same root cause class: Python-Markdown's list
-parsing is stricter than CommonMark and stricter than `pymarkdown`'s default checks.
-
-### MkDocs Gotcha: a wrapped link whose continuation line starts with `#` renders as a heading
-
-CommonMark requires a space after `#` for a line to start an ATX heading (`#5` is just text,
-`# 5` is a heading). Python-Markdown does not enforce that space, so any line that happens to
-start with `#` — for any reason — is parsed as a heading. A markdown link wrapped across the
-80-ish-character line length this repo's prose otherwise isn't held to can put the `#123](url)`
-half of `[issue #123](url)` at the start of a line, and Python-Markdown reads it as a heading
-rather than as the second half of a link. The rendered page gets a stray `<h1>`/`<h2>` containing
-the raw URL, the link text before the wrap point left dangling as plain text, and the paragraph
-split in two. Neither `pymarkdown scan` nor `mkdocs build --strict` catches this — both pass on a
-source file that renders visibly broken.
-
-**How to apply:** when a link's markdown source wraps across a line break, make sure the
-continuation line does not begin with `#`; keep `[text](url)` together on one line, or wrap
-before `[` rather than inside it. This is the same root cause as the list-continuation gotcha
-above — Python-Markdown is stricter/weirder than CommonMark in ways the linters don't catch — so
-it generalises to a standing rule, not just this one wrapping case: **any docs PR that touches
-links should run `uv run mkdocs build --strict` and then actually read the generated HTML under
-`site/`**, not just trust a clean `pymarkdown scan` plus a successful `mkdocs build`. Both of
-those can pass on rendering that is visibly wrong; only reading the HTML catches it.
+The measurements behind all of that, and the reasoning:
+[Performance and Scale → The other hard ceiling](https://openclimatefix.github.io/nged-substation-forecast/architecture/performance/#the-other-hard-ceiling-polars-32-bit-row-index).
 
 ## This is a young project
 

--- a/docs/architecture/code-style.md
+++ b/docs/architecture/code-style.md
@@ -2,15 +2,27 @@
 
 (This is mostly written for LLM coding agents!)
 
+This page is the **single source of truth for code style in this repo**. `CLAUDE.md` does not
+repeat any of it — it points here. Read this page before writing or editing Python.
+
 ## General Principles
 
 - **Python Version**: Use Python 3.14+.
-- **Type Hints**: All function signatures **must** use expressive type hints for all arguments and return types. Use `typing` and `collections.abc` as needed.
-- **Modularity**: Keep logic in small, focused packages under `packages/`. The main app in `src/` should primarily handle orchestration.
-- **Small functions**: Prefer small function bodies that do one, well-defined thing.
+- **Type Hints**: All function signatures **must** use expressive type hints for all arguments and
+  return types, including the return type. Use `typing` and `collections.abc` as needed. See
+  [Type hints and signatures](#type-hints-and-signatures) for how expressive.
+- **Modularity**: Keep logic in small, focused packages under `packages/`. The main app in `src/`
+  should primarily handle orchestration.
+- **Small functions**: Prefer small function bodies that do one, well-defined thing. Extract
+  private helpers (`_name`) rather than letting a function body grow long, even if that means more
+  parameters — a well-named helper with a clear docstring beats a long inline block. Eight
+  parameters is acceptable when each is distinct and the division of labour is clear.
 - **Minimalism**: Re-use existing tools (Polars, Xarray, Dagster) instead of reinventing logic.
-- **Comments**: Do not remove existing comments unless they are misleading or out of date. Only add new comments if you're doing something that isn't obvious from the code. Write self-documenting code, and assume the reader is fluent in Python.
-- **Tests**: Unit tests should each be a short, simple function. For each function in the main code, there should be at least one test function that tests the "happy path", and one test function for each of the main "unhappy" paths. Never relax an existing test just to get it to pass! See the [Testing](testing.md) page for where tests live, how they are wired, mocking, and the assertion house style.
+- **Tests**: Unit tests should each be a short, simple function. For each function in the main
+  code, there should be at least one test function that tests the "happy path", and one test
+  function for each of the main "unhappy" paths. Never relax an existing test just to get it to
+  pass! See the [Testing](testing.md) page for where tests live, how they are wired, mocking, and
+  the assertion house style.
 
 ## Formatting & Linting (Ruff)
 
@@ -46,26 +58,142 @@
     - Classes: `PascalCase`
     - Constants: `UPPER_SNAKE_CASE`
 
+## Type hints and signatures
+
+**Prefer self-documenting type hints over bare containers — a signature is documentation.** Jack
+strongly prefers expressive signatures and is happy to spend a few extra lines of code to get
+them, as long as complexity stays low. Whenever you would write `dict[str, str]` (or a bare `str`
+for a value from a fixed set, or a tuple of positional values), stop and ask whether a more
+self-documenting type is practical. Reach for:
+
+- a `Type`-suffixed `Literal` alias for a closed set of string values
+  (`StageType = Literal["register", "train", "predict", "metrics"]`);
+- a named alias for a recurring shape (`MlflowTags = dict[str, str]`) so the intent is stated once
+  and reused;
+- a `TypedDict` for a structured mapping with known keys (e.g. `ObjectStoreOptions`) — taking the
+  `TypedDict` in the signature and widening to a plain dict at the call boundary.
+
+Constraining `dict` *keys* to a `Literal` alias (`dict[TableNameType, str]`) is worthwhile for a
+closed vocabulary and works with bidirectional inference when callers pass dict literals.
+`packages/ml_core/src/ml_core/_repro.py` is the worked example. Don't force it where no honest
+stricter type exists — a genuinely heterogeneous or open-ended dict stays `dict[str, str]`.
+
+**All constants must be marked with the maximally "constant" type**, e.g.
+`CONST_SEQ: Final[tuple[str, ...]] = ("a", "b")` or `FOO: Final[str] = "bar"`.
+
+## Comments, docstrings and links
+
+- **Do not remove existing comments** unless they are misleading or out of date. Only add new
+  comments if you're doing something that isn't obvious from the code. Write self-documenting
+  code, and assume the reader is fluent in Python.
+- **Comments and docs must reflect current state only** — never reference previous iterations of
+  the code or deleted files. This is the same rule as "Write about the present, not the past" in
+  `CLAUDE.md`, applied to code.
+- **Code links only to durable docs** — `docs/design-philosophy/`, `docs/background/`,
+  `docs/techniques/`, `docs/architecture/`, `docs/ml_experimentation/`, `docs/live_service/`.
+  Never link from code *or* docs to `plans/` files, and never from code to `docs/roadmap/` pages
+  or to any "Implementation details (deleted when this ships)" section — all of those are deleted
+  when the work lands, so the reference rots. (Docs-to-docs links into `docs/roadmap/` are fine;
+  retargeting them is part of ship-time triage.) Linking from a docstring to a durable page — e.g.
+  `docs/architecture/` — is encouraged.
+- **MkDocs-compatible constant docs** — document module-level constants with a string literal
+  immediately after the assignment, not with Sphinx-style `#:` comments. This is correct:
+
+    ```python
+    MY_CONST: Final[str] = "value"
+    """One-line summary.
+
+    Optional further detail.
+    """
+    ```
+
 ## Data Handling
 
-- **Tabular Data**: Use **Polars** (`import polars as pl`) for dataframes. Pandas is strictly forbidden. Use Polars for all tabular data.
-- **Lazy evaluation**: Use `pl.LazyFrame` throughout the pipeline. **Do not call `.collect()` before the model boundary.** See [Lazy evaluation strategy](performance.md#lazy-evaluation-strategy) for the full contract.
+- **Tabular Data**: Use **Polars** (`import polars as pl`) for dataframes. Pandas is strictly
+  forbidden. Use Polars for all tabular data.
+- **Lazy evaluation**: Use `pl.LazyFrame` throughout the pipeline. **Do not call `.collect()`
+  before the model boundary.** See [Lazy evaluation strategy](performance.md#lazy-evaluation-strategy)
+  for the full contract.
 - **Gridded/NWP Data**: Use **Xarray** and **Zarr**.
-- **Data Contracts**: Use **Patito** for defining and validating data schemas. Use Patito type annotations (`pt.DataFrame[MySchema]`, `pt.LazyFrame[MySchema]`) whenever a function consumes or returns data that conforms to an existing schema — whether the function is public or private. Don't invent a new schema just to annotate a private helper; if no existing schema fits, use plain `pl.DataFrame` / `pl.LazyFrame`.
-- **Patito friction budget**: the `polars-patito-gotchas` skill documents five Patito gotchas (cross-model LazyFrame joins, dict-`.cast` on model-bearing frames, `ge`/`le` silently ignored on a datetime field, `.filter()` dropping the Patito subclass, and Delta dictionary-encoded columns). Five workarounds is an acceptable price for schema validation — but if a sixth becomes necessary, revisit the approach: either validate only at I/O boundaries (typed annotations everywhere, `.validate()` only at persistence edges) or evaluate an alternative such as `dataframely`.
+- **Data Contracts**: Use **Patito** for defining and validating data schemas. Use Patito type
+  annotations (`pt.DataFrame[MySchema]`, `pt.LazyFrame[MySchema]`) whenever a function consumes or
+  returns data that conforms to an existing schema — whether the function is public or private.
+  Don't invent a new schema just to annotate a private helper; if no existing schema fits, use
+  plain `pl.DataFrame` / `pl.LazyFrame`.
+- **Patito friction budget**: the `polars-patito-gotchas` skill documents five Patito gotchas
+  (cross-model LazyFrame joins, dict-`.cast` on model-bearing frames, `ge`/`le` silently ignored
+  on a datetime field, `.filter()` dropping the Patito subclass, and Delta dictionary-encoded
+  columns). Five workarounds is an acceptable price for schema validation — but if a sixth becomes
+  necessary, revisit the approach: either validate only at I/O boundaries (typed annotations
+  everywhere, `.validate()` only at persistence edges) or evaluate an alternative such as
+  `dataframely`.
+- **Never row-count a table that can exceed 2³² rows with Polars.** Default Polars builds use a
+  32-bit row index, so past ~4.29 billion rows `pl.len()` and `group_by(...).agg(pl.len())` wrap
+  modulo 2³² with **no error**. Use the Delta log instead — `DeltaTable(path).count()`, or sum
+  `num_records` over `get_add_actions(flatten=True)` — both metadata-only and exact. Value
+  aggregations (`sum`, `min`/`max`, quantiles) are unaffected, and so are filtered queries whose
+  *result* stays under the cap. NWP (~5.9B rows) is past it today; `power_forecasts` will be at V2
+  scale. Full analysis:
+  [The other hard ceiling](performance.md#the-other-hard-ceiling-polars-32-bit-row-index).
 - **Persistence**: Prefer partitioned Parquet files for tabular data.
+
+## Polars style
+
+These rules are all about making Polars code easy to read.
+
+- When casting, prefer using the `cast` method like this: `df.cast({"foo": pl.Int8})`, in favour of
+  using `df.with_columns(pl.col("foo").cast(pl.Int8))`. **Caveat:** this is only safe on a plain
+  Polars frame — passing a `{column: dtype}` mapping to a *model-bearing* Patito frame silently
+  does the wrong thing. See the `polars-patito-gotchas` skill.
+- When using `.with_columns`, prefer specifying the destination column name as a key word argument
+  like this: `df.with_columns(bar=pl.col("foo").expression())` instead of using `alias` like this:
+  `df.with_columns(pl.col("foo").expression().alias("bar"))`
+- **`Literal` type aliases — use a `Type` suffix** to distinguish them from the runtime tuples
+  that drive Polars `Enum` declarations. Example:
+
+    ```python
+    EVALUATION_SCOPES: Final[tuple[str, ...]] = ("leaderboard", "production_monitoring", "ad_hoc")
+    """Runtime tuple — used as pl.Enum(EVALUATION_SCOPES)."""
+
+    EvalScopeType = Literal["leaderboard", "ad_hoc"]
+    """Type annotation — currently-implemented subset; update when adding a new scope."""
+    ```
+
+    The `Type`-suffixed alias is what goes in function signatures; the `UPPER_SNAKE_CASE` tuple is
+    what goes into `pl.Enum(...)`. They serve different purposes and should both exist.
+
+## Gotchas that fail silently
+
+Three groups of trap in this codebase produce **no error at the point of the mistake**, so each
+lives in a skill you are expected to load *before* writing the code rather than after the
+confusing failure:
+
+- **`polars-patito-gotchas`** — Patito's model machinery colliding with Polars and delta-rs: a
+  cross-model `.join()` that has to have its right-hand operand stripped, a `{column: dtype}`
+  `.cast` swallowed on a model-bearing frame, `ge`/`le` doing nothing on a datetime field,
+  `.filter()` dropping the Patito subclass, and a dictionary-encoded column blocking Delta
+  predicate pushdown so a partition-filtered query reads the whole table.
+- **`marimo-notebooks`** — leading underscores are cell-local, imports belong in `app.setup`, and
+  `ruff check --fix` must never be run over a notebook.
+- **`ty-workarounds`** — known upstream `ty` bugs on Altair and numpy, where the code is correct
+  and the checker is not.
 
 ## Machine Learning (PyTorch)
 
 - Use **PyTorch** for differentiable physics models.
 - Use **MLFlow** for tracking experiments.
-- Follow the "test-harness" pattern: separate research logic from production orchestration but ensure they use the same data contracts.
+- Follow the "test-harness" pattern: separate research logic from production orchestration but
+  ensure they use the same data contracts.
 
 ## Error Handling
 
 - Use specific exceptions.
 - Leverage Sentry for observability in production-like code.
 - Validate data at boundaries using data contracts.
+
+In production code the rule is stronger and is set out in full on the
+[Inherent stability](../design-philosophy/inherent-stability.md) page: never raise because an input
+is absent or stale — degrade, widen the uncertainty bands, and record the degradation on the row.
 
 ## Testing
 

--- a/docs/architecture/code-style.md
+++ b/docs/architecture/code-style.md
@@ -2,8 +2,9 @@
 
 (This is mostly written for LLM coding agents!)
 
-This page is the **single source of truth for code style in this repo**. `CLAUDE.md` does not
-repeat any of it — it points here. Read this page before writing or editing Python.
+This page is the **single source of truth for code style in this repo**. Nothing repeats it:
+`CLAUDE.md` and the `code-style` skill both route here, and the skill exists to make sure this page
+gets read before any Python is written or edited. Change a rule here and nowhere else.
 
 ## General Principles
 

--- a/docs/architecture/code-style.md
+++ b/docs/architecture/code-style.md
@@ -132,8 +132,8 @@ stricter type exists — a genuinely heterogeneous or open-ended dict stays `dic
   modulo 2³² with **no error**. Use the Delta log instead — `DeltaTable(path).count()`, or sum
   `num_records` over `get_add_actions(flatten=True)` — both metadata-only and exact. Value
   aggregations (`sum`, `min`/`max`, quantiles) are unaffected, and so are filtered queries whose
-  *result* stays under the cap. NWP (~5.9B rows) is past it today; `power_forecasts` will be at V2
-  scale. Full analysis:
+  *result* stays under the cap. NWP (~5.9B rows) is past it today; `power_forecasts` will pass it
+  at V2 scale. Full analysis:
   [The other hard ceiling](performance.md#the-other-hard-ceiling-polars-32-bit-row-index).
 - **Persistence**: Prefer partitioned Parquet files for tabular data.
 
@@ -191,9 +191,9 @@ confusing failure:
 - Leverage Sentry for observability in production-like code.
 - Validate data at boundaries using data contracts.
 
-In production code the rule is stronger and is set out in full on the
-[Inherent stability](../design-philosophy/inherent-stability.md) page: never raise because an input
-is absent or stale — degrade, widen the uncertainty bands, and record the degradation on the row.
+Production code is bound by a stronger rule about *when* to raise at all, summarised in
+`CLAUDE.md` and set out in full on the
+[Inherent stability](../design-philosophy/inherent-stability.md) page.
 
 ## Testing
 

--- a/docs/architecture/code-style.md
+++ b/docs/architecture/code-style.md
@@ -38,8 +38,9 @@ gets read before any Python is written or edited. Change a rule here and nowhere
 - **Imports**: Sorted automatically by `ruff` (isort rules). `import pandas` is banned outright
   (`TID251`), not merely discouraged.
 - **Rule selection**: `[tool.ruff.lint] select` in `pyproject.toml` names the enabled families
-  explicitly rather than inheriting ruff's defaults, so a `uv lock` refresh cannot quietly change
-  which rules the repo enforces. `select` names whole families; `ignore` names each family member
+  explicitly rather than inheriting ruff's defaults. Ruff's defaults are a curated menu with no
+  stability promise, so an inherited selection would let a `uv lock` refresh change which rules the
+  repo enforces. `select` names whole families; `ignore` names each family member
   we decline, with the reason on the line above it. **When a rule fires somewhere it should not,
   add an `ignore` entry (or a `per-file-ignores` entry) with its justification — do not drop the
   whole family.** Ruff's defaults are not a superset of the old `E4`/`E7`/`E9`/`F` gate: of

--- a/docs/architecture/code-style.md
+++ b/docs/architecture/code-style.md
@@ -25,8 +25,22 @@
 - **Imports**: Sorted automatically by `ruff` (isort rules). `import pandas` is banned outright
   (`TID251`), not merely discouraged.
 - **Rule selection**: `[tool.ruff.lint] select` in `pyproject.toml` names the enabled families
-  explicitly rather than inheriting ruff's defaults, so a ruff upgrade cannot quietly change the
-  gate. Each declined rule is an `ignore` entry carrying its justification.
+  explicitly rather than inheriting ruff's defaults, so a `uv lock` refresh cannot quietly change
+  which rules the repo enforces. `select` names whole families; `ignore` names each family member
+  we decline, with the reason on the line above it. **When a rule fires somewhere it should not,
+  add an `ignore` entry (or a `per-file-ignores` entry) with its justification — do not drop the
+  whole family.** Ruff's defaults are not a superset of the old `E4`/`E7`/`E9`/`F` gate: of
+  pycodestyle-E they keep only `E722` and `E902`, which is why `E4`/`E7`/`E9` are listed
+  explicitly.
+- **Two traps when editing `[tool.ruff.lint.per-file-ignores]`**:
+
+    - **`*` crosses `/`.** A key of `packages/dashboard/*.py` also silences
+      `packages/dashboard/src/dashboard/*.py`. Name individual files when you mean "just the ones
+      in this directory"; `**/tests/**` is the right way to say "every tests directory, root
+      included".
+    - **A `# noqa` cannot live inside a docstring**, because it would become part of the string.
+      An over-long docstring line has to be reworded or re-wrapped, never suppressed.
+
 - **Naming**:
     - Variables/Functions: `snake_case`
     - Classes: `PascalCase`
@@ -38,7 +52,7 @@
 - **Lazy evaluation**: Use `pl.LazyFrame` throughout the pipeline. **Do not call `.collect()` before the model boundary.** See [Lazy evaluation strategy](performance.md#lazy-evaluation-strategy) for the full contract.
 - **Gridded/NWP Data**: Use **Xarray** and **Zarr**.
 - **Data Contracts**: Use **Patito** for defining and validating data schemas. Use Patito type annotations (`pt.DataFrame[MySchema]`, `pt.LazyFrame[MySchema]`) whenever a function consumes or returns data that conforms to an existing schema — whether the function is public or private. Don't invent a new schema just to annotate a private helper; if no existing schema fits, use plain `pl.DataFrame` / `pl.LazyFrame`.
-- **Patito friction budget**: CLAUDE.md documents four Patito-vs-Polars gotchas (cross-model LazyFrame joins, dict-`.cast` on model-bearing frames, `.filter()` dropping the Patito subclass, and Delta dictionary-encoded columns). Four workarounds is an acceptable price for schema validation — but if a fifth becomes necessary, revisit the approach: either validate only at I/O boundaries (typed annotations everywhere, `.validate()` only at persistence edges) or evaluate an alternative such as `dataframely`.
+- **Patito friction budget**: the `polars-patito-gotchas` skill documents five Patito gotchas (cross-model LazyFrame joins, dict-`.cast` on model-bearing frames, `ge`/`le` silently ignored on a datetime field, `.filter()` dropping the Patito subclass, and Delta dictionary-encoded columns). Five workarounds is an acceptable price for schema validation — but if a sixth becomes necessary, revisit the approach: either validate only at I/O boundaries (typed annotations everywhere, `.validate()` only at persistence edges) or evaluate an alternative such as `dataframely`.
 - **Persistence**: Prefer partitioned Parquet files for tabular data.
 
 ## Machine Learning (PyTorch)

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -1,9 +1,9 @@
 # Testing
 
 How the test suite is wired up, the house style for writing tests, and the notable test suites
-that guard tricky invariants. Two testing *gotchas* are documented alongside the other gotchas in
-CLAUDE.md rather than here: the moto S3 backend being process-global (reset it per test), and Polars
-row counts wrapping past 2³² rows.
+that guard tricky invariants. One testing gotcha lives elsewhere because it is not really about
+tests: Polars row counts wrapping past 2³² rows, in
+[Performance and Scale](performance.md#the-other-hard-ceiling-polars-32-bit-row-index).
 
 ## Where tests and their dependencies live
 
@@ -50,6 +50,14 @@ row counts wrapping past 2³² rows.
   (`monkeypatch.setattr(some_module, "open", fake_open)`) through the built-in fixture. For S3,
   drive the in-process `moto` server instead of mocking — `tests/test_s3_data_paths.py` is the
   canonical pattern.
+- **Reset the moto S3 backend per test.** The in-process `moto` server keeps its bucket contents
+  in a **process-global backend that outlives the `ThreadedMotoServer` object**, so a
+  module-scoped server does not hand each test a clean slate. A test whose write path runs twice
+  against that server — a re-run, or state left behind by an earlier test — reads stale data: an
+  appended Delta table returns double the rows, and an `object_exists` precondition sees a
+  leftover parquet. Keep the *server* module-scoped for speed, but give each test a
+  **function-scoped** fixture that `POST`s to `/moto-api/reset` and recreates the bucket before
+  the test body runs, so every test starts pristine and independent of execution order.
 - **Take the `dagster_instance` fixture; never call `DagsterInstance.ephemeral()` in a test.** The
   fixture (in `tests/conftest.py`) enters the instance as a context manager, so `dispose()` runs
   when the test ends.

--- a/docs/roadmap/engineering-health.md
+++ b/docs/roadmap/engineering-health.md
@@ -125,8 +125,8 @@ remains:
   extend `docs/ml_experimentation/dagster-workflow.md` with the live-forecast and monitoring
   flows, and update the "Known limitation" and MLflow-logging notes in
   `docs/architecture/ml-orchestration.md` if the implementations diverged from the plans.
-- Run the ship-time triage (per CLAUDE.md) on any roadmap content the live-service work
-  implemented — e.g. flip the relevant 🚧 statuses in
+- Run the ship-time triage (per the `github-issue-pr-workflow` skill) on any roadmap content
+  the live-service work implemented — e.g. flip the relevant 🚧 statuses in
   `docs/roadmap/metrics-and-leaderboard.md` once monitoring lands.
 
 **Verification.** Full `uv run pytest` green from the repo root, **including the full-stack

--- a/docs/roadmap/metrics-and-leaderboard.md
+++ b/docs/roadmap/metrics-and-leaderboard.md
@@ -346,8 +346,8 @@ only skill floor the NWP ensemble must clear at long horizons.
 
 **Cross-cutting.** (1) **Issue hygiene:** create one tracked sub-issue per PR under epic
 [#6](https://github.com/openclimatefix/nged-substation-forecast/issues/6) / #147 following the
-`github-issue-pr-workflow` issue-creation rules (labels, Type, OCF project fields, sub-issue
-ordering), *including* one for `nged_incumbent_holiday_aligned` so it survives #147 closing. (2) **Re-run recipe:** add a
+`github-issue-pr-workflow` skill's issue-creation rules (labels, Type, OCF project fields,
+sub-issue ordering), *including* one for `nged_incumbent_holiday_aligned` so it survives #147 closing. (2) **Re-run recipe:** add a
 short "Re-running CV for an experiment" subsection to `docs/ml_experimentation/dagster-workflow.md`
 describing the `trained_cv_model++` backfill, written only after the drill is verified end-to-end,
 and mentioning `PopulationFilter` for single-experiment scoring. (3) **MLflow re-logging** on a

--- a/docs/roadmap/metrics-and-leaderboard.md
+++ b/docs/roadmap/metrics-and-leaderboard.md
@@ -346,8 +346,8 @@ only skill floor the NWP ensemble must clear at long horizons.
 
 **Cross-cutting.** (1) **Issue hygiene:** create one tracked sub-issue per PR under epic
 [#6](https://github.com/openclimatefix/nged-substation-forecast/issues/6) / #147 following the
-CLAUDE.md issue-creation rules (labels, Type, OCF project fields, sub-issue ordering), *including*
-one for `nged_incumbent_holiday_aligned` so it survives #147 closing. (2) **Re-run recipe:** add a
+`github-issue-pr-workflow` issue-creation rules (labels, Type, OCF project fields, sub-issue
+ordering), *including* one for `nged_incumbent_holiday_aligned` so it survives #147 closing. (2) **Re-run recipe:** add a
 short "Re-running CV for an experiment" subsection to `docs/ml_experimentation/dagster-workflow.md`
 describing the `trained_cv_model++` backfill, written only after the drill is verified end-to-end,
 and mentioning `PopulationFilter` for single-experiment scoring. (3) **MLflow re-logging** on a

--- a/packages/contracts/src/contracts/ml_schemas.py
+++ b/packages/contracts/src/contracts/ml_schemas.py
@@ -327,8 +327,8 @@ class Metrics(pt.Model):
 
     # String (not Categorical): fold_id/experiment_name are Delta partition columns and delta-rs
     # stores dictionary-encoded columns as String anyway; String keeps them cast-free and lets
-    # predicate pushdown work. See CLAUDE.md, "Delta Lake dictionary-encoded columns: declare
-    # Delta filter/partition columns as `String`".
+    # predicate pushdown work. See the "Delta Lake dictionary-encoded columns" section of the
+    # `polars-patito-gotchas` skill.
     power_fcst_model_name: str = pt.Field(
         dtype=pl.String,
         description="Identifier for the ML-based power forecasting model family.",

--- a/packages/contracts/src/contracts/power_schemas.py
+++ b/packages/contracts/src/contracts/power_schemas.py
@@ -349,8 +349,8 @@ class PowerForecast(pt.Model):
 
     # String (not Categorical): experiment_name/fold_id are the Delta partition columns and delta-rs
     # stores dictionary-encoded columns as String anyway; String keeps them cast-free and lets
-    # predicate pushdown work. See CLAUDE.md, "Delta Lake dictionary-encoded columns: declare
-    # Delta filter/partition columns as `String`".
+    # predicate pushdown work. See the "Delta Lake dictionary-encoded columns" section of the
+    # `polars-patito-gotchas` skill.
     experiment_name: str = pt.Field(
         dtype=pl.String,
         description=(

--- a/packages/delta_store/src/delta_store/nwp.py
+++ b/packages/delta_store/src/delta_store/nwp.py
@@ -90,9 +90,9 @@ def write_nwp(
 
     # Strip the Patito model before the dict-cast: `nwp_model_id` is declared `Enum` for
     # in-memory type safety, but delta-rs can't store `Enum`/`Categorical` (see the "Delta Lake
-    # dictionary-encoded columns" gotcha in CLAUDE.md). A dict-cast on a *model-bearing* frame
-    # would silently swallow the mapping and revert other columns to the model's declared dtypes
-    # instead — strip first so this is a plain-Polars cast.
+    # dictionary-encoded columns" gotcha in the `polars-patito-gotchas` skill). A dict-cast on a
+    # *model-bearing* frame would silently swallow the mapping and revert other columns to the
+    # model's declared dtypes instead — strip first so this is a plain-Polars cast.
     prepared = pl.DataFrame._from_pydf(rounded._df).cast({"nwp_model_id": pl.String}).to_arrow()
 
     write_deltalake(

--- a/packages/delta_store/tests/test_nwp.py
+++ b/packages/delta_store/tests/test_nwp.py
@@ -92,7 +92,7 @@ def test_continuous_vars_rounded_to_significand_bits(tmp_path: Path) -> None:
         expected = np.sort(np.array([base * (1 + 0.003 * i) for i in range(n)], dtype=np.float32))
         rel_err = np.abs(stored - expected) / np.abs(expected)
         assert (rel_err <= 2.0**-NWP_SIGNIFICAND_BITS).all(), var
-        # np.dtype(np.uint32), not a bare np.uint32 — see CLAUDE.md ("numpy Gotcha").
+        # np.dtype(np.uint32), not a bare np.uint32 — see the `ty-workarounds` skill.
         assert (stored.view(np.dtype(np.uint32)) & discarded == 0).all(), var
 
 

--- a/packages/delta_store/tests/test_power_forecasts.py
+++ b/packages/delta_store/tests/test_power_forecasts.py
@@ -85,7 +85,7 @@ def test_power_fcst_rounded_to_significand_bits(tmp_path: Path) -> None:
     rel_err = np.abs(stored - expected) / np.abs(expected)
     assert (rel_err <= 2.0**-POWER_FCST_SIGNIFICAND_BITS).all()
     discarded = np.uint32((1 << (23 - (POWER_FCST_SIGNIFICAND_BITS - 1))) - 1)
-    # np.dtype(np.uint32), not a bare np.uint32 — see CLAUDE.md ("numpy Gotcha").
+    # np.dtype(np.uint32), not a bare np.uint32 — see the `ty-workarounds` skill.
     assert (stored.view(np.dtype(np.uint32)) & discarded == 0).all()
 
 

--- a/packages/delta_store/tests/test_precision.py
+++ b/packages/delta_store/tests/test_precision.py
@@ -31,7 +31,7 @@ def test_relative_error_bounded_by_unit_roundoff(keep_bits: int) -> None:
 def test_low_fraction_bits_are_zero(keep_bits: int) -> None:
     values = [math.pi, -math.e, 0.123456789, 3.0000002, 65503.9]
     # We pass np.dtype(np.uint32) rather than the bare np.uint32 because ty mis-solves
-    # ndarray.view's overloads for a bare scalar type. See CLAUDE.md ("numpy Gotcha").
+    # ndarray.view's overloads for a bare scalar type. See the `ty-workarounds` skill.
     bits = _round(values, keep_bits).to_numpy().view(np.dtype(np.uint32))
     # keep_bits significand bits = (keep_bits - 1) explicit fraction bits kept of 23.
     discarded = np.uint32((1 << (23 - (keep_bits - 1))) - 1)

--- a/packages/ml_core/src/ml_core/_production_helpers.py
+++ b/packages/ml_core/src/ml_core/_production_helpers.py
@@ -121,7 +121,7 @@ def build_live_power_frame(
     times_lf = pl.LazyFrame({"time": grid_times}, schema={"time": UTC_DATETIME_DTYPE})
     spine = ids_lf.join(times_lf, how="cross")
 
-    # Strip the Patito subclass before joining (see CLAUDE.md's cross-model-join gotcha).
+    # Strip the Patito subclass before joining (see the `polars-patito-gotchas` skill).
     power_plain = pl.LazyFrame._from_pyldf(observed_power._ldf)
     dense = spine.join(power_plain, on=["time_series_id", "time"], how="left").sort(
         ["time_series_id", "time"]

--- a/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py
+++ b/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py
@@ -54,7 +54,7 @@ def _attach_nearest_nwp_cell(
     ``time_series_id`` (not ``h3_index``), which is what ``_engineer_features`` expects.
     """
     # Strip the Patito subclasses so Polars' cross-subclass join type check doesn't reject the
-    # join (see CLAUDE.md). Zero-copy: same underlying Rust LazyFrames.
+    # join (see the `polars-patito-gotchas` skill). Zero-copy: same underlying Rust LazyFrames.
     nwp_plain = pl.LazyFrame._from_pyldf(nwp._ldf)
     cell_to_ts = pl.LazyFrame._from_pyldf(time_series_metadata.lazy()._ldf).select(
         "time_series_id", "h3_res_5"

--- a/packages/nged_data/src/nged_data/storage.py
+++ b/packages/nged_data/src/nged_data/storage.py
@@ -235,7 +235,8 @@ def time_series_coverage(
 
     Returns an empty (but correctly typed) frame if the Delta table does not exist yet.
     ``min``/``max`` grouped by ``time_series_id`` are value aggregations, so they are safe from
-    the Polars 32-bit row-count wraparound even on a very large table (see CLAUDE.md).
+    the Polars 32-bit row-count wraparound even on a very large table (see
+    ``docs/architecture/code-style.md``).
 
     Cost: a full two-column scan-and-aggregate, O(rows in the table). Projection pushdown drops
     the ``power`` column, but a group-wise ``min``/``max`` cannot be answered from Parquet

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,7 +120,7 @@ line-length = 100
 # E711, E712, E713, E714, E721, E731, E741, E742 and E743. E4/E7/E9 are therefore listed
 # explicitly.
 select = [
-    "ANN",   # flake8-annotations: complete signatures are a house rule (see CLAUDE.md)
+    "ANN",   # flake8-annotations: complete signatures are a house rule (see docs/architecture/code-style.md)
     "ASYNC", # flake8-async
     "B",     # flake8-bugbear
     "BLE",   # flake8-blind-except
@@ -141,7 +141,7 @@ select = [
     "INT",   # flake8-gettext
     "ISC",   # flake8-implicit-str-concat
     "LOG",   # flake8-logging
-    "N",     # pep8-naming: the naming conventions CLAUDE.md mandates
+    "N",     # pep8-naming: the naming conventions docs/architecture/code-style.md mandates
     "PERF",  # perflint
     "PGH",   # pygrep-hooks
     "PIE",   # flake8-pie
@@ -175,7 +175,7 @@ select = [
 # here (and its justification) over dropping a whole family from `select`.
 ignore = [
     # --- Rules that fight this repo's own conventions ---
-    # CLAUDE.md explicitly blesses long-but-clear parameter lists ("Eight parameters is acceptable
+    # docs/architecture/code-style.md explicitly blesses long-but-clear parameter lists ("Eight parameters is acceptable
     # when each is distinct"), and prefers extracting named helpers with more parameters over
     # letting a function body grow.
     "PLR0913", # too many arguments
@@ -188,7 +188,7 @@ ignore = [
     # f-strings in log calls are fine here: this is not a high-volume hot path, and the eager
     # formatting cost is worth the readability.
     "G004", # logging statement uses f-string
-    # CLAUDE.md asks for *complete* type hints, which is what the rest of flake8-annotations
+    # docs/architecture/code-style.md asks for *complete* type hints, which is what the rest of flake8-annotations
     # enforces. It does not ask for the elimination of `Any`, and the places that use it — a
     # `**kwargs: Any` forwarded verbatim, a test double that accepts and ignores every argument —
     # have no honest narrower type.
@@ -200,10 +200,12 @@ ignore = [
     # are quantile levels, longitude bounds and similar domain literals that read better inline
     # than as named constants. Tighten to a tests-only entry if that ever stops being true.
     "PLR2004", # magic value used in comparison
-    # CLAUDE.md asks for UPPER_SNAKE_CASE constants, and N806 rejects that spelling for a constant
+    # docs/architecture/code-style.md asks for UPPER_SNAKE_CASE constants, and N806 rejects that spelling for a
+    # constant
     # that happens to be function-local (`RAD_TO_DEG`, `COMPRESSION`), as well as domain-conventional
     # names such as `X` for a feature matrix. The rest of pep8-naming (N801 classes, N802 functions,
-    # N815/N816 mixedCase) is left on and does encode the conventions CLAUDE.md states. N803 is
+    # N815/N816 mixedCase) is left on and does encode the conventions docs/architecture/code-style.md
+    # states. N803 is
     # *not* ignored here — every site is a marimo-generated cell parameter, so it is declined in
     # `per-file-ignores` for the notebooks alone and stays live over `src/` and the tests.
     "N806", # variable in function should be lowercase
@@ -275,7 +277,7 @@ ignore = [
 "**/conftest.py" = ["ANN201", "D", "DTZ"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
-# pandas is strictly forbidden in this repo — Polars only. See CLAUDE.md, "Code Style".
+# pandas is strictly forbidden in this repo — Polars only. See docs/architecture/code-style.md.
 "pandas".msg = "pandas is forbidden in this repo: use Polars (`pl.LazyFrame`/`pl.DataFrame`)."
 
 [tool.ruff.lint.pydocstyle]

--- a/src/nged_substation_forecast/defs/checks.py
+++ b/src/nged_substation_forecast/defs/checks.py
@@ -593,8 +593,7 @@ def _read_live_forecast_rows(
     then to the one ``power_fcst_init_time``, and every column is reduced to a scalar inside
     Polars, so only the aggregates cross back into Python. The ``pl.len()`` is safe from the
     32-bit row-count wraparound documented in ``docs/architecture/code-style.md``: it counts one
-    slot's rows (~1M at V1
-    scale, ~86M at V2), not the whole table.
+    slot's rows (~1M at V1 scale, ~86M at V2), not the whole table.
     """
     if not delta_table_exists(power_forecasts_path, storage_options):
         return _EMPTY_LIVE_FORECAST_ROWS

--- a/src/nged_substation_forecast/defs/checks.py
+++ b/src/nged_substation_forecast/defs/checks.py
@@ -592,7 +592,8 @@ def _read_live_forecast_rows(
     The scan is pruned to the matching ``(experiment_name, fold_id="live")`` Delta partitions and
     then to the one ``power_fcst_init_time``, and every column is reduced to a scalar inside
     Polars, so only the aggregates cross back into Python. The ``pl.len()`` is safe from the
-    32-bit row-count wraparound documented in ``CLAUDE.md``: it counts one slot's rows (~1M at V1
+    32-bit row-count wraparound documented in ``docs/architecture/code-style.md``: it counts one
+    slot's rows (~1M at V1
     scale, ~86M at V2), not the whole table.
     """
     if not delta_table_exists(power_forecasts_path, storage_options):
@@ -673,7 +674,8 @@ def _read_promoted_model_facts(production_model_path: str) -> PromotedModelFacts
         if ids is not None and not isinstance(ids, list):
             # A JSON string, int, etc. here is malformed, not merely a different shape: iterating
             # a str with int() would silently mis-parse it (e.g. "12" -> (1, 2)) instead of
-            # degrading, which is the "strict about malformed input" rule from CLAUDE.md.
+            # degrading, which is the "strict about malformed input" rule from CLAUDE.md
+            # ("Inherent stability").
             raise TypeError(  # noqa: TRY301 — raised to reach this function's own degrade handler.
                 f"trained_time_series_ids must be a list, got {type(ids).__name__}: {ids!r}"
             )

--- a/tests/test_cv_power_forecasts.py
+++ b/tests/test_cv_power_forecasts.py
@@ -241,7 +241,7 @@ def test_cv_power_forecasts_storage_format(
     # ballpark.)
     stored = _read_forecasts(env)["power_fcst"].to_numpy()
     assert np.isfinite(stored).all()
-    # np.dtype(np.uint32), not a bare np.uint32 — see CLAUDE.md ("numpy Gotcha").
+    # np.dtype(np.uint32), not a bare np.uint32 — see the `ty-workarounds` skill.
     assert (stored.view(np.dtype(np.uint32)) & np.uint32((1 << 11) - 1) == 0).all()
     assert (np.abs(stored) > 50).all()
 


### PR DESCRIPTION
*This PR was written by Claude Code.*

## Why

`CLAUDE.md` was 636 lines / 42.5 KB — about 11k tokens loaded into **every** session. Most of it
was conditional: content that only matters while touching one specific thing (a Polars cast, a
Marimo notebook, a docs link, a `gh issue create`), or code style that already had a docs page.

`CLAUDE.md`: **636 → 246 lines**, 42.5 KB → 16.8 KB (**−61%**).

## 1. Seven new on-demand skills

| Skill | Extracted from | Load it before… |
|---|---|---|
| `code-style` | (trigger for `docs/architecture/code-style.md`) | writing or editing **any** Python |
| `polars-patito-gotchas` | 5 gotcha sections | Polars/Patito code that joins, casts, filters a `pt.LazyFrame`, declares a Patito field, or touches Delta |
| `mkdocs-authoring` | 2 MkDocs gotchas + the 4-space indent rule | editing markdown MkDocs renders — `docs/`, READMEs, `SKILL.md`, docstrings |
| `marimo-notebooks` | "Marimo Notebooks" | creating or editing a Marimo notebook |
| `ty-workarounds` | Altair + numpy `ty` gotchas | acting on a `ty` error in Altair or numpy `.view()` code |
| `implement-issue` | "Sub-agent routine" | writing code for an approved plan |
| `github-issue-pr-workflow` | issue/PR creation, merging, ship-time triage | `gh issue create` / `gh pr create` / `gh pr merge` |

`implement-issue` is the counterpart to the existing `plan-issue` skill — `plan-issue`'s
description already said "that is the 'Sub-agent routine' in CLAUDE.md", so this closes the loop.

**The index is load-bearing.** `CLAUDE.md` gains a **Skills** table saying what to load before
what. Most of the extracted content is traps that **fail silently**, so you don't know you needed
the skill until the mistake is written. A skill nobody knows to load is worse than no skill — which
is why the table stays in the always-loaded file.

## 2. Code style: one copy, reached by a skill

`CLAUDE.md`'s "Code Style" and "Polars Style" sections are gone; what remains is one instruction to
load the `code-style` skill before writing Python.

This was a **merge, not a delete**. Seven rules lived only in `CLAUDE.md` and would have been lost:
the extract-private-helpers detail behind "prefer small functions", "comments must reflect current
state only", "code links only to durable docs", the MkDocs constant-docstring convention, the
self-documenting-type-hints rule, `Final` on every constant, and the entire Polars style
subsection. All are now in `code-style.md`, which gains three sections to hold them (Type hints and
signatures; Comments, docstrings and links; Polars style) plus a Gotchas section pointing at the
skills.

A **`code-style` skill** now carries the trigger. `CLAUDE.md` is loaded automatically but a docs
page is not, and unlike a skill it has no `description` the model sees each session — so a pointer
alone relied on being noticed. The skill fires on its own, before any Python is written.

The skill deliberately **does not restate the rules**: two copies of a style guide drift apart and
then nobody knows which is binding, which is exactly what had already happened here (the
four-vs-five Patito count below). It carries the trigger, an index of what the page covers, and a
hard instruction to read it. The two rules there that no linter enforces and that fail silently —
the 2³² Polars row-count cap and comments-describe-the-present — are named in the skill body, since
those are worth being deliberate about even before opening the page.

## 3. Moved to docs rather than to a skill

- **The moto reset-per-test rule** → `docs/architecture/testing.md`, whose intro previously said
  this gotcha lives in CLAUDE.md "rather than here".
- **The ruff `per-file-ignores` traps and the `E4`/`E7`/`E9` note** → `code-style.md`. In
  `CLAUDE.md` this paragraph sat **orphaned under the `### Altair Gotcha` heading**, with no
  heading of its own and no connection to Altair.
- **The Polars 32-bit row-index gotcha** → one bullet in Data Handling plus the link, since
  `performance.md` already carried the full analysis `CLAUDE.md` was duplicating.

## Divergence check against `docs/architecture/code-style.md`

Fixed here:

1. **Stale count.** "CLAUDE.md documents four Patito-vs-Polars gotchas … if a **fifth** becomes
   necessary, revisit the approach" — there are **five**; it omitted `ge`/`le` being silently
   ignored on a datetime field. The friction budget had been spent without anyone noticing.
2. **Contradictory `.collect()` rule.** `CLAUDE.md` said "only `.collect()` when necessary"; the
   docs say "**do not call `.collect()` before the model boundary**" and link the full contract.
3. **Nothing linked the two files.** `docs/index.md` and `design-principles.md` both link to
   `code-style.md`, but `CLAUDE.md` — the other file claiming to own code style — never did. That
   is how they drifted.

Reported, **not** fixed (out of scope; flagging per `CLAUDE.md`'s "discuss out-of-scope design
mistakes first"):

- **`code-style.md` has a "Machine Learning (PyTorch)" section** — "use PyTorch for differentiable
  physics models". There is no `torch` dependency anywhere in the workspace and the only forecaster
  is XGBoost. The section looks stale.
- **`CLAUDE.md`'s Packages table is missing `weather_utils` and `plotting`**, both of which exist
  in `packages/`.

## Reference retargeting

Every pointer to moved content now names its new home: **11 comment sites across 10 files**
(`contracts`, `delta_store`, `ml_core`, `defs/checks.py`, `nged_data`, four test modules, and seven
`pyproject.toml` ruff-`ignore` justifications), two `docs/roadmap/` pages, and the `plan-issue` and
`github-graphql` skills.

## Context-cost accounting

A skill's always-on cost is its frontmatter `description` — that is what the model reads to decide
whether to load it. The seven new descriptions total ~3.7 KB (~920 tokens) against ~25.7 KB
(~6,400 tokens) removed from `CLAUDE.md`: **net ≈ 5,500 tokens saved per session.** Descriptions
were tightened ~25% after a first draft, deliberately keeping the trigger phrases and error strings
(`unresolved-attribute`, `NameError`, `validate()` dtype error) that make a skill fire at the right
moment. The two pre-existing skills were trimmed the same way.

## Adversarial review

A fresh sub-agent reviewed the diff with only the PR number. It found **eight real defects**, all
verified against the code before fixing, **none rejected** — fixed in the last commit:

- Three **rotted references** — the exact failure class this PR exists to prevent. `CLAUDE.md`'s
  ruff `--fix` command still said "see the Marimo section" (deleted by this PR, and guarding the
  highest-consequence trap in the set); `plan-issue` cited a "green-before-push set from CLAUDE.md"
  that had moved to `implement-issue`; and seven `pyproject.toml` comments attributed ruff
  justifications to `CLAUDE.md`, one of them quoting a string no longer in that file.
- Two cases of **content damaged in summarising** — the row-count bullet dropped the verb from
  "`power_forecasts` will **pass it** at V2 scale", losing the claim entirely; and `code-style.md`
  opened by saying `CLAUDE.md` repeats none of it, then restated the inherent-stability rule
  near-verbatim.
- Three cosmetic: a ragged docstring reflow, a dropped noun, and `mkdocs-authoring`'s trigger
  scoped to `docs/` when the same traps hit READMEs, `SKILL.md` files and docstrings.

It also independently confirmed the four-vs-five divergence above, and found **no content lost** in
the relocation after a rule-by-rule diff of everything removed from `CLAUDE.md`.

## Content-loss audit

A second independent agent was given one job: prove whether anything on `main` was lost. It ran a
heading census (all 33 `CLAUDE.md` headings mapped to a destination), sentence-level n-gram
coverage of all 636 lines against the new tree (the 31 low-scoring sentences read by hand), and an
identifier census of ~220 backticked symbols and every URL.

**Verdict: nothing important lost.** Three identifiers are genuinely absent, all deliberate — two
literal skill directory paths replaced by the `.claude/skills/<name>/SKILL.md` convention stated
once, and one rendered-site URL correctly demoted to a relative link (the repo reserves
rendered-site URLs for links from *outside* `docs/`).

It flagged five clauses as reworded-down. **Three carried rationale, and I restored those verbatim**
in the last commit: ruff's defaults being "a curated menu with no stability promise", "pyright
infers `Chart`" as the evidence the Altair code is correct, and the github-graphql fields having
been confirmed by live-schema introspection (GitHub *adds* fields as well as renaming them). The
other two were an explanatory intermediate step and a "two rules" count that `main` got wrong while
listing three.

The audit separately quoted `performance.md:91-125` line by line to confirm every fact cut from the
row-count summary is carried there — including the exact 1,652,180,189 measurement, "streaming
engine included", and "verified empirically" — and confirmed the moto rule, all five Patito
gotchas, the full 7-step routine with its `**Why:**` paragraph, and the entire issue/PR checklist
survive essentially verbatim. It also noted a **net gain**: the 4-space nested-list rule existed on
`main` only as a pointer to memory, and is now written out with its `pml101` mechanism.

## Verification

All green: `ruff check`, `ruff format`, `uv run --all-packages ty check`, `uv run pytest`
(529 passed, 1 skipped), `pymarkdown scan` over both the documented set **and** the `SKILL.md`
files, the docstring markdown linter, and `mkdocs build --strict`.

Per the repo's rule that a strict build is not enough, I read the generated HTML under `site/`:
both new nested lists in `code-style.md` render as real nested `<ul>`s with their code blocks
inside the list items, and every new anchor resolves to a real `id=` target.
