### PR TITLE
Catch marimo notebooks whose cells reference unbound names

### DIFF
--- a/.claude/skills/marimo-notebooks/SKILL.md
+++ b/.claude/skills/marimo-notebooks/SKILL.md
@@ -7,8 +7,9 @@ description: >-
   app.setup:` or ruff stops seeing it; `ruff check --fix` must never be run over a notebook,
   because an autofix can insert an import outside `app.setup` and break it while reporting
   success; and a helper belongs in the `@app.function` form marimo itself writes. Load before
-  creating or editing a Marimo notebook, or when one fails with a `NameError` on a helper or an
-  import that looks present.
+  creating or editing a Marimo notebook, when one fails with a `NameError` on a helper or an
+  import that looks present, or when the `check-marimo-notebooks` hook reports a cell referencing
+  a name no cell defines.
 ---
 
 # Authoring Marimo notebooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,17 @@ repos:
         language: system
         types: [python]
         files: *marimo_notebooks
+      # The hooks above never auto-fix a notebook, but a hand-typed `uv run ruff check . --fix`
+      # still can, and `marimo check --fix` leaves the same shape behind by a different route. So
+      # every commit that touches a notebook also checks that each name its cells reference is
+      # bound by some cell — the breakage those fixes cause, and the one thing ruff, ty and
+      # pytest all miss. `tests/test_marimo_notebooks.py` runs the same check over every notebook.
+      - id: check-marimo-notebooks
+        name: marimo notebooks (no unbound names)
+        entry: uv run python scripts/check_marimo_notebooks.py
+        language: system
+        types: [python]
+        files: *marimo_notebooks
       - id: ruff-format
         name: ruff format
         entry: uv run ruff format --force-exclude

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,10 +45,9 @@ repos:
         types: [python]
         files: *marimo_notebooks
       # The hooks above never auto-fix a notebook, but a hand-typed `uv run ruff check . --fix`
-      # still can, and `marimo check --fix` leaves the same shape behind by a different route. So
-      # every commit that touches a notebook also checks that each name its cells reference is
-      # bound by some cell — the breakage those fixes cause, and the one thing ruff, ty and
-      # pytest all miss. `tests/test_marimo_notebooks.py` runs the same check over every notebook.
+      # still can, and `marimo check --fix` leaves the same breakage behind by another route. So
+      # every commit that touches a notebook also checks its cells bind every name they reference
+      # — see the script's docstring. `tests/test_marimo_notebooks.py` runs the same check in CI.
       - id: check-marimo-notebooks
         name: marimo notebooks (no unbound names)
         entry: uv run python scripts/check_marimo_notebooks.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -572,7 +572,11 @@ every cell. Two authoring rules follow from how Marimo scopes names and how ruff
   check as well as the fix). The pre-commit hook is split so notebooks are checked but never
   auto-fixed; a bare `uv run ruff check . --fix` typed by hand is *not* covered, so after running
   one, check `git diff` for an import that landed above `import marimo` and move it into
-  `app.setup`.
+  `app.setup`. `marimo check --fix` does not rescue it: that deletes the module-level import and
+  rewrites the cell that used the name as `def _(name)`, leaving the name as a cell input nothing
+  defines. Both shapes are caught by `scripts/check_marimo_notebooks.py` — a pre-commit hook, and
+  run over every notebook by `tests/test_marimo_notebooks.py` — so a broken notebook fails the
+  commit or CI rather than surviving to whoever next opens it.
 
 ### MkDocs Gotcha: a list item needs a blank line before it if it follows an indented continuation
 

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -270,15 +270,11 @@ references that no cell binds. It runs as a pre-commit hook over changed noteboo
 
 Testing what a notebook's cells actually *do* is a separate job, and
 `packages/notebooks/plot_missing_NWP_data.py` is the worked example. Its chart-building helper is
-an `@app.function` — marimo's form for a function that closes over nothing but the setup cell — so
-it is an ordinary function that a `test_*` function in the same notebook exercises on a synthetic
-frame. Naming the notebook in `python_files` is what makes a plain `uv run pytest` collect it.
-
-Write the helper and its test in that `@app.function` form, and let `marimo check --fix` settle
-the file's shape before committing: a helper hand-written inside an `@app.cell` gets rewritten to
-the same thing the next time marimo saves the notebook, which is a large diff for no change. This
-test tells you the chart still computes what it should; it is not a second line of defence for
-name binding, which is the checker's job.
+an `@app.function` — marimo's form for a top-level reusable function — so an ordinary `test_*`
+function in the same notebook can exercise it on a synthetic frame. Naming the notebook in
+`python_files` is what makes a plain `uv run pytest` collect it. Such a test tells you the chart
+still computes what it should; it is not a second line of defence for name binding, which is the
+checker's job. The authoring rules for writing one are in the `marimo-notebooks` skill.
 
 ## Assertion style for Patito frames
 

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -231,6 +231,42 @@ present):
 the only layer that can catch *future upstream drift* — a change in Dynamical.org's own conventions
 that the committed slice, frozen at capture time, cannot.
 
+## Marimo notebooks bind every name their cells reference
+
+Marimo rebuilds a notebook from its `with app.setup:` block plus its `@app.cell` functions, and
+never runs the module-level statements in between. A name bound at module level is therefore
+invisible to every cell: the notebook raises `NameError` the next time it is opened, while ruff, ty
+and pytest all pass, because the file they were handed is valid Python. Two tools produce exactly
+that shape from a working notebook — `ruff check --fix`, which writes an import an autofix needs
+into the top-level import block, and `marimo check --fix`, which deletes such an import and
+rewrites the cell that used the name as `def _(name)`, leaving a cell input nothing defines.
+
+`scripts/check_marimo_notebooks.py` reads each cell's `refs` and `defs` and reports any name a cell
+references that no cell binds. It runs as a pre-commit hook over changed notebooks, and
+`tests/test_marimo_notebooks.py` runs it over every notebook in `packages/notebooks/` and
+`packages/dashboard/`. Three properties are worth knowing:
+
+- **It is static.** Nothing executes, so the check needs none of the notebooks' runtime
+  dependencies — only marimo itself, which the root environment has via the `dashboard` dev
+  dependency. It cannot catch a notebook that binds every name and still fails inside a Polars or
+  Altair call; executing the notebooks is not an option, because they read real Delta tables and
+  S3.
+- **It rides on private marimo API.** `Cell.refs` and `Cell.defs` are documented, but loading a
+  notebook without running it is not. So the checker raises rather than reporting "no findings"
+  whenever a file does not parse into at least one cell, and the tests keep a positive control —
+  a deliberately broken notebook, held as a string so ruff never sees it — that fails if a marimo
+  release stops the check detecting a real breakage.
+- **Every `.py` file directly inside those two directories must be a notebook**, and a file that
+  is not one is a finding. The ruff pre-commit hooks share that assumption: they use it to decide
+  which files must never be auto-fixed.
+
+Testing what a notebook's cells actually *do* is a separate job, and
+`packages/notebooks/plot_missing_NWP_data.py` is the worked example: it keeps its chart-building
+helper in its own cell and a cell of `test_*` functions that exercises it on a synthetic frame.
+marimo runs those in cell scope — the same scope the notebook really runs in, and the reason they
+would catch a misplaced import that an ordinary `import` of the notebook module would not. Naming
+the notebook in `python_files` is what makes a plain `uv run pytest` collect it.
+
 ## Assertion style for Patito frames
 
 Build a frame, attach the model, cast, and validate for the happy path:

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -261,11 +261,16 @@ references that no cell binds. It runs as a pre-commit hook over changed noteboo
   which files must never be auto-fixed.
 
 Testing what a notebook's cells actually *do* is a separate job, and
-`packages/notebooks/plot_missing_NWP_data.py` is the worked example: it keeps its chart-building
-helper in its own cell and a cell of `test_*` functions that exercises it on a synthetic frame.
-marimo runs those in cell scope — the same scope the notebook really runs in, and the reason they
-would catch a misplaced import that an ordinary `import` of the notebook module would not. Naming
-the notebook in `python_files` is what makes a plain `uv run pytest` collect it.
+`packages/notebooks/plot_missing_NWP_data.py` is the worked example. Its chart-building helper is
+an `@app.function` — marimo's form for a function that closes over nothing but the setup cell — so
+it is an ordinary function that a `test_*` function in the same notebook exercises on a synthetic
+frame. Naming the notebook in `python_files` is what makes a plain `uv run pytest` collect it.
+
+Write the helper and its test in that `@app.function` form, and let `marimo check --fix` settle
+the file's shape before committing: a helper hand-written inside an `@app.cell` gets rewritten to
+the same thing the next time marimo saves the notebook, which is a large diff for no change. This
+test tells you the chart still computes what it should; it is not a second line of defence for
+name binding, which is the checker's job.
 
 ## Assertion style for Patito frames
 

--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -272,9 +272,8 @@ Testing what a notebook's cells actually *do* is a separate job, and
 `packages/notebooks/plot_missing_NWP_data.py` is the worked example. Its chart-building helper is
 an `@app.function` — marimo's form for a top-level reusable function — so an ordinary `test_*`
 function in the same notebook can exercise it on a synthetic frame. Naming the notebook in
-`python_files` is what makes a plain `uv run pytest` collect it. Such a test tells you the chart
-still computes what it should; it is not a second line of defence for name binding, which is the
-checker's job. The authoring rules for writing one are in the `marimo-notebooks` skill.
+`python_files` is what makes a plain `uv run pytest` collect it. The authoring rules for writing
+one are in the `marimo-notebooks` skill.
 
 ## Assertion style for Patito frames
 

--- a/packages/notebooks/plot_missing_NWP_data.py
+++ b/packages/notebooks/plot_missing_NWP_data.py
@@ -1,6 +1,6 @@
 import marimo
 
-__generated_with = "0.23.6"
+__generated_with = "0.23.16"
 app = marimo.App()
 
 with app.setup:
@@ -39,86 +39,83 @@ def _():
     return (nwp_vars,)
 
 
-@app.cell
-def _():
-    def plot_null_distribution(df, target_init_time, target_h3_index, nwp_vars):
-        """Chart where `nwp_vars` is missing, one row per ensemble member.
+@app.function
+def plot_null_distribution(df, target_init_time, target_h3_index, nwp_vars):
+    """Chart where `nwp_vars` is missing, one row per ensemble member.
 
-        Args:
-            df: Lazy scan of the NWP Delta table.
-            target_init_time: The single NWP run to plot.
-            target_h3_index: The single H3 cell to plot.
-            nwp_vars: The NWP variable name (or list of names) to plot.
-        """
-        # 1. Filter down to the specific init_time and h3_index
-        filtered = df.filter(
-            (pl.col("init_time") == target_init_time) & (pl.col("h3_index") == target_h3_index)
+    Args:
+        df: Lazy scan of the NWP Delta table.
+        target_init_time: The single NWP run to plot.
+        target_h3_index: The single H3 cell to plot.
+        nwp_vars: The NWP variable name (or list of names) to plot.
+    """
+    # 1. Filter down to the specific init_time and h3_index
+    filtered = df.filter(
+        (pl.col("init_time") == target_init_time) & (pl.col("h3_index") == target_h3_index)
+    )
+
+    # 2. Unpivot (melt) the data so we can plot all variables on a single Y-axis
+    melted = filtered.unpivot(
+        on=nwp_vars,
+        index=["valid_time", "ensemble_member"],
+        variable_name="variable",
+        value_name="value",
+    )
+
+    # 3. Create a boolean flag for missing data and a combined label for the Y-axis. Altair
+    # only accepts materialised data, so collect once the filter has cut the scan down to a
+    # single NWP run and a single H3 cell.
+    plot_df = melted.with_columns(
+        # Check for both database Nulls and float NaNs
+        is_missing=pl.col("value").is_null() | pl.col("value").is_nan(),
+        # Create a string like "temperature_2m (Member 0)":
+        # row_label=(
+        #     pl.col("variable") + " (Member " + pl.col("ensemble_member").cast(pl.Utf8) + ")"
+        # ),
+        row_label=pl.col("ensemble_member"),
+    ).collect()
+
+    # 5. Build the Altair Chart
+    base = alt.Chart(plot_df).encode(
+        y=alt.Y("row_label:N", title="Ensemble Member", sort="ascending")
+    )
+
+    # Layer 1: A light gray background line showing the full time series extent
+    background_line = base.mark_line(color=GRID, strokeWidth=1)
+    background_lines = background_line.encode(  # ty: ignore[unresolved-attribute]
+        x=alt.X("valid_time:T", title="Valid Time"),
+        detail="row_label:N",  # Ensures lines don't connect across different rows
+    )
+
+    # Layer 2: Red ticks superimposed exactly where the data is missing
+    missing_marks = (
+        base.transform_filter(alt.datum.is_missing)
+        .mark_tick(
+            color=ORANGE_RED,
+            thickness=3,  # Make the red mark stand out
+            size=12,  # Height of the tick mark
         )
+        .encode(x="valid_time:T")  # ty: ignore[unresolved-attribute]  # astral-sh/ty#2520
+    )
 
-        # 2. Unpivot (melt) the data so we can plot all variables on a single Y-axis
-        melted = filtered.unpivot(
-            on=nwp_vars,
-            index=["valid_time", "ensemble_member"],
-            variable_name="variable",
-            value_name="value",
+    # Combine the layers and configure the chart size
+    return (
+        (background_lines + missing_marks)
+        .properties(
+            title=(
+                f"Missing NWP Data | init_time: {target_init_time.strftime('%Y-%m-%d')}"
+                f" | {nwp_vars} | H3: {target_h3_index}"
+            ),
+            width=800,
+            # Dynamically scales chart height based on the number of rows
+            height=alt.Step(10),
         )
-
-        # 3. Create a boolean flag for missing data and a combined label for the Y-axis. Altair
-        # only accepts materialised data, so collect once the filter has cut the scan down to a
-        # single NWP run and a single H3 cell.
-        plot_df = melted.with_columns(
-            # Check for both database Nulls and float NaNs
-            is_missing=pl.col("value").is_null() | pl.col("value").is_nan(),
-            # Create a string like "temperature_2m (Member 0)":
-            # row_label=(
-            #     pl.col("variable") + " (Member " + pl.col("ensemble_member").cast(pl.Utf8) + ")"
-            # ),
-            row_label=pl.col("ensemble_member"),
-        ).collect()
-
-        # 5. Build the Altair Chart
-        base = alt.Chart(plot_df).encode(
-            y=alt.Y("row_label:N", title="Ensemble Member", sort="ascending")
-        )
-
-        # Layer 1: A light gray background line showing the full time series extent
-        background_line = base.mark_line(color=GRID, strokeWidth=1)
-        background_lines = background_line.encode(  # ty: ignore[unresolved-attribute]
-            x=alt.X("valid_time:T", title="Valid Time"),
-            detail="row_label:N",  # Ensures lines don't connect across different rows
-        )
-
-        # Layer 2: Red ticks superimposed exactly where the data is missing
-        missing_marks = (
-            base.transform_filter(alt.datum.is_missing)
-            .mark_tick(
-                color=ORANGE_RED,
-                thickness=3,  # Make the red mark stand out
-                size=12,  # Height of the tick mark
-            )
-            .encode(x="valid_time:T")  # ty: ignore[unresolved-attribute]  # astral-sh/ty#2520
-        )
-
-        # Combine the layers and configure the chart size
-        return (
-            (background_lines + missing_marks)
-            .properties(
-                title=(
-                    f"Missing NWP Data | init_time: {target_init_time.strftime('%Y-%m-%d')}"
-                    f" | {nwp_vars} | H3: {target_h3_index}"
-                ),
-                width=800,
-                # Dynamically scales chart height based on the number of rows
-                height=alt.Step(10),
-            )
-            .configure_axis(labelFontSize=11, titleFontSize=13)
-        )
-
-    return (plot_null_distribution,)
+        .configure_axis(labelFontSize=11, titleFontSize=13)
+    )
 
 
 @app.cell
-def _(df, nwp_vars, plot_null_distribution):
+def _(df, nwp_vars):
     chart = plot_null_distribution(
         df,
         target_init_time=datetime(2026, 5, 1, tzinfo=UTC),
@@ -129,33 +126,36 @@ def _(df, nwp_vars, plot_null_distribution):
     return
 
 
-@app.cell
-def _(plot_null_distribution):
-    def test_plot_null_distribution_flags_nulls_and_nans():
-        init_time = datetime(2026, 5, 1, tzinfo=UTC)
-        h3_index = 599148110664433663
-        readings = pl.LazyFrame(
-            {
-                "init_time": [init_time] * 4,
-                "valid_time": [datetime(2026, 5, 1, hour=h, tzinfo=UTC) for h in range(4)],
-                "ensemble_member": [0, 0, 0, 0],
-                "h3_index": [h3_index] * 4,
-                "temperature_2m": pl.Series([1.0, None, float("nan"), 4.0], dtype=pl.Float32),
-            }
-        )
+@app.function
+def test_plot_null_distribution_flags_nulls_and_nans():
+    init_time = datetime(2026, 5, 1, tzinfo=UTC)
+    other_init_time = datetime(2026, 5, 2, tzinfo=UTC)
+    h3_index = 599148110664433663
+    other_h3_index = 599148110664433662
+    # The last two readings are missing too, but belong to another NWP run and another H3 cell, so
+    # the filter must drop them rather than plot them.
+    readings = pl.LazyFrame(
+        {
+            "init_time": [init_time] * 4 + [other_init_time, init_time],
+            "valid_time": [datetime(2026, 5, 1, hour=h, tzinfo=UTC) for h in range(6)],
+            "ensemble_member": [0, 0, 0, 0, 0, 0],
+            "h3_index": [h3_index] * 5 + [other_h3_index],
+            "temperature_2m": pl.Series(
+                [1.0, None, float("nan"), 4.0, None, None], dtype=pl.Float32
+            ),
+        }
+    )
 
-        chart = plot_null_distribution(
-            readings,
-            target_init_time=init_time,
-            target_h3_index=h3_index,
-            nwp_vars="temperature_2m",
-        )
+    chart = plot_null_distribution(
+        readings,
+        target_init_time=init_time,
+        target_h3_index=h3_index,
+        nwp_vars="temperature_2m",
+    )
 
-        # Altair inlines the chart's data as its single named dataset.
-        (rows,) = chart.to_dict()["datasets"].values()
-        assert [row["is_missing"] for row in rows] == [False, True, True, False]
-
-    return
+    # Altair inlines the chart's data as its single named dataset.
+    (rows,) = chart.to_dict()["datasets"].values()
+    assert [row["is_missing"] for row in rows] == [False, True, True, False]
 
 
 if __name__ == "__main__":

--- a/packages/notebooks/plot_missing_NWP_data.py
+++ b/packages/notebooks/plot_missing_NWP_data.py
@@ -9,13 +9,14 @@ with app.setup:
     import altair as alt
     import plotting.ocf_theme  # noqa: F401 — registers OCF Altair theme as side effect
     import polars as pl
+    from contracts.weather_schemas import Nwp
     from plotting.ocf_theme import GRID, ORANGE_RED
 
 
 @app.cell
 def _():
-    # TODO: Load polars DataFrame from local Delta Table of NWP data.
-    return
+    df = Nwp.scan_delta().drop("nwp_model_id")
+    return (df,)
 
 
 @app.cell
@@ -39,8 +40,16 @@ def _():
 
 
 @app.cell
-def _(df, nwp_vars):
+def _():
     def plot_null_distribution(df, target_init_time, target_h3_index, nwp_vars):
+        """Chart where `nwp_vars` is missing, one row per ensemble member.
+
+        Args:
+            df: Lazy scan of the NWP Delta table.
+            target_init_time: The single NWP run to plot.
+            target_h3_index: The single H3 cell to plot.
+            nwp_vars: The NWP variable name (or list of names) to plot.
+        """
         # 1. Filter down to the specific init_time and h3_index
         filtered = df.filter(
             (pl.col("init_time") == target_init_time) & (pl.col("h3_index") == target_h3_index)
@@ -54,7 +63,9 @@ def _(df, nwp_vars):
             value_name="value",
         )
 
-        # 3. Create a boolean flag for missing data and a combined label for the Y-axis
+        # 3. Create a boolean flag for missing data and a combined label for the Y-axis. Altair
+        # only accepts materialised data, so collect once the filter has cut the scan down to a
+        # single NWP run and a single H3 cell.
         plot_df = melted.with_columns(
             # Check for both database Nulls and float NaNs
             is_missing=pl.col("value").is_null() | pl.col("value").is_nan(),
@@ -63,7 +74,7 @@ def _(df, nwp_vars):
             #     pl.col("variable") + " (Member " + pl.col("ensemble_member").cast(pl.Utf8) + ")"
             # ),
             row_label=pl.col("ensemble_member"),
-        )
+        ).collect()
 
         # 5. Build the Altair Chart
         base = alt.Chart(plot_df).encode(
@@ -103,6 +114,11 @@ def _(df, nwp_vars):
             .configure_axis(labelFontSize=11, titleFontSize=13)
         )
 
+    return (plot_null_distribution,)
+
+
+@app.cell
+def _(df, nwp_vars, plot_null_distribution):
     chart = plot_null_distribution(
         df,
         target_init_time=datetime(2026, 5, 1, tzinfo=UTC),
@@ -110,6 +126,35 @@ def _(df, nwp_vars):
         nwp_vars=nwp_vars[0],  # ["downward_short_wave_radiation_flux_surface"], #
     )
     chart.show()
+    return
+
+
+@app.cell
+def _(plot_null_distribution):
+    def test_plot_null_distribution_flags_nulls_and_nans():
+        init_time = datetime(2026, 5, 1, tzinfo=UTC)
+        h3_index = 599148110664433663
+        readings = pl.LazyFrame(
+            {
+                "init_time": [init_time] * 4,
+                "valid_time": [datetime(2026, 5, 1, hour=h, tzinfo=UTC) for h in range(4)],
+                "ensemble_member": [0, 0, 0, 0],
+                "h3_index": [h3_index] * 4,
+                "temperature_2m": pl.Series([1.0, None, float("nan"), 4.0], dtype=pl.Float32),
+            }
+        )
+
+        chart = plot_null_distribution(
+            readings,
+            target_init_time=init_time,
+            target_h3_index=h3_index,
+            nwp_vars="temperature_2m",
+        )
+
+        # Altair inlines the chart's data as its single named dataset.
+        (rows,) = chart.to_dict()["datasets"].values()
+        assert [row["is_missing"] for row in rows] == [False, True, True, False]
+
     return
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -297,6 +297,13 @@ docstring-code-line-length = 100
 # with `uv run pytest --run-network` — see docs/architecture/testing.md. The gate lives in a hook,
 # not in an `addopts` `-m "not network"`, because any caller-supplied `-m` would silently override it.
 addopts = "--import-mode=importlib"
+# `test_*.py` is pytest's default; the notebook is named as well because marimo notebooks are
+# ordinary Python files that pytest can collect, and it holds a cell of `test_*` functions
+# exercising a helper defined in another cell. marimo runs those in *cell* scope, which is the
+# only scope that matches how the notebook really runs — a plain `import` of the notebook module
+# would resolve names against module globals instead and so could not see a name bound in the
+# wrong place. Patterns containing a `/` are matched against the whole path, not the basename.
+python_files = ["test_*.py", "packages/notebooks/plot_missing_NWP_data.py"]
 # Put the root `tests/` dir on sys.path so its integration tests can import shared, non-fixture
 # test data (e.g. `_nwp_test_data`) by bare name — importlib mode does not add each test file's
 # own directory to sys.path the way prepend mode does.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -299,11 +299,12 @@ docstring-code-line-length = 100
 # with `uv run pytest --run-network` — see docs/architecture/testing.md. The gate lives in a hook,
 # not in an `addopts` `-m "not network"`, because any caller-supplied `-m` would silently override it.
 addopts = "--import-mode=importlib"
-# `test_*.py` is pytest's default; the notebook is named as well because a marimo notebook is an
-# ordinary Python file that pytest can collect, and this one holds a `test_*` function exercising
-# its chart-building helper. See docs/architecture/testing.md. Patterns containing a `/` match
-# against the path rather than the basename, so this reaches exactly one file.
-python_files = ["test_*.py", "packages/notebooks/plot_missing_NWP_data.py"]
+# The first two patterns are pytest's default, restated because naming any pattern replaces the
+# default list. The notebook is named as well because a marimo notebook is an ordinary Python file
+# that pytest can collect, and this one holds a `test_*` function exercising its chart-building
+# helper. See docs/architecture/testing.md. Patterns containing a `/` match against the path
+# rather than the basename, so this reaches exactly one file.
+python_files = ["test_*.py", "*_test.py", "packages/notebooks/plot_missing_NWP_data.py"]
 # Put the root `tests/` dir on sys.path so its integration tests can import shared, non-fixture
 # test data (e.g. `_nwp_test_data`) by bare name — importlib mode does not add each test file's
 # own directory to sys.path the way prepend mode does.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -297,12 +297,10 @@ docstring-code-line-length = 100
 # with `uv run pytest --run-network` — see docs/architecture/testing.md. The gate lives in a hook,
 # not in an `addopts` `-m "not network"`, because any caller-supplied `-m` would silently override it.
 addopts = "--import-mode=importlib"
-# `test_*.py` is pytest's default; the notebook is named as well because marimo notebooks are
-# ordinary Python files that pytest can collect, and it holds a cell of `test_*` functions
-# exercising a helper defined in another cell. marimo runs those in *cell* scope, which is the
-# only scope that matches how the notebook really runs — a plain `import` of the notebook module
-# would resolve names against module globals instead and so could not see a name bound in the
-# wrong place. Patterns containing a `/` are matched against the whole path, not the basename.
+# `test_*.py` is pytest's default; the notebook is named as well because a marimo notebook is an
+# ordinary Python file that pytest can collect, and this one holds a `test_*` function exercising
+# its chart-building helper. See docs/architecture/testing.md. Patterns containing a `/` match
+# against the path rather than the basename, so this reaches exactly one file.
 python_files = ["test_*.py", "packages/notebooks/plot_missing_NWP_data.py"]
 # Put the root `tests/` dir on sys.path so its integration tests can import shared, non-fixture
 # test data (e.g. `_nwp_test_data`) by bare name — importlib mode does not add each test file's

--- a/scripts/check_marimo_notebooks.py
+++ b/scripts/check_marimo_notebooks.py
@@ -1,0 +1,125 @@
+"""Check that every name a marimo notebook's cells reference is bound inside the notebook.
+
+Marimo never executes a notebook's module-level statements: it rebuilds the notebook from the
+`with app.setup:` block plus the `@app.cell` functions. A name bound at module level is therefore
+invisible to every cell, and the notebook dies with a `NameError` the next time it is opened —
+while `ruff`, `ty` and `pytest` all report success, because the file they were handed is perfectly
+valid Python.
+
+Two tools turn a working notebook into exactly that shape:
+
+- `ruff check --fix` writes an import that an autofix needs into the file's *top-level* import
+  block (`UP017` and `UP035` today, and any future fix that reaches for `itertools`). The
+  pre-commit hooks are split so notebooks are never auto-fixed, but a hand-typed
+  `uv run ruff check . --fix` is not covered by that split.
+- `marimo check --fix` deletes such an import and rewrites the cell that used the name as
+  `def _(name)`, which leaves the name as a cell input that nothing defines.
+
+This script catches both, and a cell input left dangling by hand. It is a *static* name-binding
+check: it reads `Cell.refs` and `Cell.defs` — marimo's documented public API for the names a cell
+reads and the names it binds — without executing a single cell, so it needs none of the notebooks'
+runtime dependencies. It cannot catch a notebook that binds every name and still fails inside a
+Polars or Altair call.
+
+Loading a notebook *without* executing it needs `marimo._ast`, which is private API. So that a
+marimo release cannot quietly downgrade this check to a no-op, `unbound_cells` raises whenever a
+file does not parse into at least one cell, and `tests/test_marimo_notebooks.py` keeps a positive
+control that fails if the check ever stops detecting a real breakage.
+"""
+
+import builtins
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Final
+
+from marimo._ast.app import InternalApp
+from marimo._ast.load import get_notebook_status, load_app
+from marimo._ast.parse import MarimoFileError, NonMarimoPythonScriptError
+
+BUILTIN_NAMES: Final[frozenset[str]] = frozenset(dir(builtins))
+"""Names a cell may reference without any cell defining them."""
+
+
+@dataclass(frozen=True, slots=True)
+class UnboundCell:
+    """One notebook cell, and the names it references that its notebook never binds."""
+
+    lineno: int
+    """1-indexed line of the cell's `@app.cell` decorator, or of its `with app.setup:` statement."""
+
+    names: tuple[str, ...]
+    """The unbound names, sorted."""
+
+
+def unbound_cells(path: Path) -> list[UnboundCell]:
+    """Return the cells of the marimo notebook at `path` that reference names it never binds.
+
+    A name counts as bound if any cell defines it — cell order is irrelevant, because marimo
+    derives execution order from the dependency graph rather than from position in the file — or
+    if it is a Python builtin.
+
+    Args:
+        path: Path to a marimo notebook.
+
+    Raises:
+        MarimoFileError: if `path` is not a marimo notebook.
+        NonMarimoPythonScriptError: if `path` is an ordinary Python script.
+        ValueError: if `path` parses into no cells at all, or if marimo's two views of the
+            notebook disagree about how many cells it has. Either means the private API this
+            check rides on has moved, and is raised rather than reported as "no findings" so that
+            the check fails loudly instead of silently passing everything.
+    """
+    app = load_app(str(path))
+    load_result = get_notebook_status(str(path))
+    if app is None or load_result.notebook is None:
+        raise ValueError(f"{path}: holds no marimo app — expected a notebook.")
+    cell_data = list(InternalApp(app).cell_manager.cell_data())
+    serialized = load_result.notebook.cells
+    if not cell_data:
+        raise ValueError(f"{path}: parsed into zero marimo cells.")
+    if len(cell_data) != len(serialized):
+        raise ValueError(
+            f"{path}: marimo reports {len(cell_data)} compiled cells but {len(serialized)} "
+            "serialized ones, so cells can no longer be matched to line numbers."
+        )
+    # `cell` is None for a cell marimo could not compile; those carry no refs or defs to check.
+    cells = [(source.lineno, data.cell) for data, source in zip(cell_data, serialized, strict=True)]
+    defined = BUILTIN_NAMES.union(*(cell.defs for _, cell in cells if cell is not None))
+    return [
+        UnboundCell(lineno, tuple(sorted(cell.refs - defined)))
+        for lineno, cell in cells
+        if cell is not None and cell.refs - defined
+    ]
+
+
+def _check_file(path: Path) -> list[str]:
+    """Return one human-readable finding per unbound-name cell in the notebook at `path`."""
+    try:
+        unbound = unbound_cells(path)
+    except (MarimoFileError, NonMarimoPythonScriptError) as error:
+        return [
+            (
+                f"{path}: not a marimo notebook ({error}). Every `.py` file directly inside "
+                "`packages/notebooks/` or `packages/dashboard/` is taken to be one, both here and "
+                "by the `ruff check --fix` exclusion in .pre-commit-config.yaml — so an ordinary "
+                "module put there would silently stop being auto-fixed."
+            )
+        ]
+    return [
+        f"{path}:{cell.lineno}: cell references name(s) that no cell defines: "
+        f"{', '.join(cell.names)}"
+        for cell in unbound
+    ]
+
+
+def main(argv: list[str]) -> int:
+    """Check each marimo notebook path in `argv`; return the process exit code."""
+    findings = [finding for arg in argv for finding in _check_file(Path(arg))]
+    for finding in findings:
+        print(finding)
+    return 1 if findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/check_marimo_notebooks.py
+++ b/scripts/check_marimo_notebooks.py
@@ -1,30 +1,18 @@
 """Check that every name a marimo notebook's cells reference is bound inside the notebook.
 
-Marimo never executes a notebook's module-level statements: it rebuilds the notebook from the
-`with app.setup:` block plus the `@app.cell` functions. A name bound at module level is therefore
-invisible to every cell, and the notebook dies with a `NameError` the next time it is opened —
-while `ruff`, `ty` and `pytest` all report success, because the file they were handed is perfectly
-valid Python.
+Marimo never executes a notebook's module-level statements, so a name bound there is invisible to
+every cell and the notebook dies with a `NameError` the next time it is opened — while ruff, ty and
+pytest all pass, because the file they were handed is valid Python. `ruff check --fix` and
+`marimo check --fix` each produce that shape from a working notebook. Full rationale, and what this
+check can and cannot catch:
+<https://openclimatefix.github.io/nged-substation-forecast/architecture/testing/#marimo-notebooks-bind-every-name-their-cells-reference>
 
-Two tools turn a working notebook into exactly that shape:
-
-- `ruff check --fix` writes an import that an autofix needs into the file's *top-level* import
-  block (`UP017` and `UP035` today, and any future fix that reaches for `itertools`). The
-  pre-commit hooks are split so notebooks are never auto-fixed, but a hand-typed
-  `uv run ruff check . --fix` is not covered by that split.
-- `marimo check --fix` deletes such an import and rewrites the cell that used the name as
-  `def _(name)`, which leaves the name as a cell input that nothing defines.
-
-This script catches both, and a cell input left dangling by hand. It is a *static* name-binding
-check: it reads `Cell.refs` and `Cell.defs` — marimo's documented public API for the names a cell
-reads and the names it binds — without executing a single cell, so it needs none of the notebooks'
-runtime dependencies. It cannot catch a notebook that binds every name and still fails inside a
-Polars or Altair call.
-
-Loading a notebook *without* executing it needs `marimo._ast`, which is private API. So that a
-marimo release cannot quietly downgrade this check to a no-op, `unbound_cells` raises whenever a
-file does not parse into at least one cell, and `tests/test_marimo_notebooks.py` keeps a positive
-control that fails if the check ever stops detecting a real breakage.
+`Cell.refs` and `Cell.defs` are public marimo API; loading a notebook without running it is not, so
+this reads `marimo._ast`. Attaching line numbers costs a second private entry point
+(`get_notebook_status`) on top of `load_app` — worth it for a hook whose output should be
+clickable, but it is the first thing to drop if keeping up with marimo gets expensive. Nothing here
+may fail quietly: every way of not reaching an answer raises, and `tests/test_marimo_notebooks.py`
+keeps a positive control that fails if this stops detecting a real breakage.
 """
 
 import builtins
@@ -37,8 +25,13 @@ from marimo._ast.app import InternalApp
 from marimo._ast.load import get_notebook_status, load_app
 from marimo._ast.parse import MarimoFileError, NonMarimoPythonScriptError
 
-BUILTIN_NAMES: Final[frozenset[str]] = frozenset(dir(builtins))
-"""Names a cell may reference without any cell defining them."""
+ALWAYS_BOUND: Final[frozenset[str]] = frozenset(dir(builtins)) | {"__file__"}
+"""Names a cell may reference without any cell defining them.
+
+`__file__` is not a builtin: marimo injects it into the cell globals itself (`_runtime.runtime`
+sets it from the notebook's filename), so a cell locating a data file relative to the notebook is
+correct code and must not be flagged.
+"""
 
 
 @dataclass(frozen=True, slots=True)
@@ -57,7 +50,7 @@ def unbound_cells(path: Path) -> list[UnboundCell]:
 
     A name counts as bound if any cell defines it — cell order is irrelevant, because marimo
     derives execution order from the dependency graph rather than from position in the file — or
-    if it is a Python builtin.
+    if it is in `ALWAYS_BOUND`.
 
     Args:
         path: Path to a marimo notebook.
@@ -65,27 +58,27 @@ def unbound_cells(path: Path) -> list[UnboundCell]:
     Raises:
         MarimoFileError: if `path` is not a marimo notebook.
         NonMarimoPythonScriptError: if `path` is an ordinary Python script.
-        ValueError: if `path` parses into no cells at all, or if marimo's two views of the
-            notebook disagree about how many cells it has. Either means the private API this
-            check rides on has moved, and is raised rather than reported as "no findings" so that
-            the check fails loudly instead of silently passing everything.
+        ValueError: if the notebook cannot be checked in full — it holds no marimo app, it holds a
+            cell marimo cannot compile, or marimo's two views of it disagree about how many cells
+            it has (which would mean the private API this rides on has moved). Raised rather than
+            reported as "no findings", so that the check cannot degrade into passing everything.
     """
     app = load_app(str(path))
     load_result = get_notebook_status(str(path))
     if app is None or load_result.notebook is None:
-        raise ValueError(f"{path}: holds no marimo app — expected a notebook.")
-    cell_data = list(InternalApp(app).cell_manager.cell_data())
+        raise ValueError(f"not a usable marimo notebook (marimo status: {load_result.status})")
+    compiled = list(InternalApp(app).cell_manager.cell_data())
     serialized = load_result.notebook.cells
-    if not cell_data:
-        raise ValueError(f"{path}: parsed into zero marimo cells.")
-    if len(cell_data) != len(serialized):
+    if len(compiled) != len(serialized):
         raise ValueError(
-            f"{path}: marimo reports {len(cell_data)} compiled cells but {len(serialized)} "
-            "serialized ones, so cells can no longer be matched to line numbers."
+            f"marimo reports {len(compiled)} compiled cells but {len(serialized)} serialized "
+            "ones, so cells can no longer be matched to line numbers"
         )
-    # `cell` is None for a cell marimo could not compile; those carry no refs or defs to check.
-    cells = [(source.lineno, data.cell) for data, source in zip(cell_data, serialized, strict=True)]
-    defined = BUILTIN_NAMES.union(*(cell.defs for _, cell in cells if cell is not None))
+    cells = [(source.lineno, data.cell) for data, source in zip(compiled, serialized, strict=True)]
+    for lineno, cell in cells:
+        if cell is None:
+            raise ValueError(f"marimo cannot compile the cell at line {lineno}")
+    defined = ALWAYS_BOUND.union(*(cell.defs for _, cell in cells if cell is not None))
     return [
         UnboundCell(lineno, tuple(sorted(cell.refs - defined)))
         for lineno, cell in cells
@@ -94,18 +87,17 @@ def unbound_cells(path: Path) -> list[UnboundCell]:
 
 
 def _check_file(path: Path) -> list[str]:
-    """Return one human-readable finding per unbound-name cell in the notebook at `path`."""
+    """Return one human-readable finding per unbound-name cell in the notebook at `path`.
+
+    A file that cannot be checked at all is itself a finding, rather than a raised exception, so
+    that one bad path cannot hide the findings for the others the hook was given.
+    """
     try:
         unbound = unbound_cells(path)
     except (MarimoFileError, NonMarimoPythonScriptError) as error:
-        return [
-            (
-                f"{path}: not a marimo notebook ({error}). Every `.py` file directly inside "
-                "`packages/notebooks/` or `packages/dashboard/` is taken to be one, both here and "
-                "by the `ruff check --fix` exclusion in .pre-commit-config.yaml — so an ordinary "
-                "module put there would silently stop being auto-fixed."
-            )
-        ]
+        return [f"{path}: not a marimo notebook: {error}"]
+    except (OSError, SyntaxError, ValueError) as error:
+        return [f"{path}: cannot be checked: {error}"]
     return [
         f"{path}:{cell.lineno}: cell references name(s) that no cell defines: "
         f"{', '.join(cell.names)}"
@@ -115,10 +107,12 @@ def _check_file(path: Path) -> list[str]:
 
 def main(argv: list[str]) -> int:
     """Check each marimo notebook path in `argv`; return the process exit code."""
-    findings = [finding for arg in argv for finding in _check_file(Path(arg))]
-    for finding in findings:
-        print(finding)
-    return 1 if findings else 0
+    found = False
+    for arg in argv:
+        for finding in _check_file(Path(arg)):
+            print(finding)
+            found = True
+    return 1 if found else 0
 
 
 if __name__ == "__main__":

--- a/scripts/check_marimo_notebooks.py
+++ b/scripts/check_marimo_notebooks.py
@@ -7,12 +7,9 @@ pytest all pass, because the file they were handed is valid Python. `ruff check 
 check can and cannot catch:
 <https://openclimatefix.github.io/nged-substation-forecast/architecture/testing/#marimo-notebooks-bind-every-name-their-cells-reference>
 
-`Cell.refs` and `Cell.defs` are public marimo API; loading a notebook without running it is not, so
-this reads `marimo._ast`. Attaching line numbers costs a second private entry point
-(`get_notebook_status`) on top of `load_app` — worth it for a hook whose output should be
-clickable, but it is the first thing to drop if keeping up with marimo gets expensive. Nothing here
-may fail quietly: every way of not reaching an answer raises, and `tests/test_marimo_notebooks.py`
-keeps a positive control that fails if this stops detecting a real breakage.
+`Cell.refs` and `Cell.defs` are public marimo API; parsing a notebook without running it is not, so
+this reads `marimo._ast`. The serialized form carries the line numbers and the compiled form
+carries the names, so both are needed.
 """
 
 import builtins
@@ -22,8 +19,9 @@ from pathlib import Path
 from typing import Final
 
 from marimo._ast.app import InternalApp
-from marimo._ast.load import get_notebook_status, load_app
-from marimo._ast.parse import MarimoFileError, NonMarimoPythonScriptError
+from marimo._ast.cell import Cell
+from marimo._ast.load import get_notebook_status, load_notebook_ir
+from marimo._ast.parse import MarimoFileError
 
 ALWAYS_BOUND: Final[frozenset[str]] = frozenset(dir(builtins)) | {
     "__builtin__",
@@ -62,41 +60,32 @@ def unbound_cells(path: Path) -> list[UnboundCell]:
         path: Path to a marimo notebook.
 
     Raises:
-        MarimoFileError: if `path` is not a marimo notebook.
-        NonMarimoPythonScriptError: if `path` is an ordinary Python script.
-        ValueError: if the notebook cannot be checked in full — it holds no marimo app, it holds a
-            cell marimo cannot compile, or marimo's two views of it disagree about how many cells
-            it has (which would mean the private API this rides on has moved). Raised rather than
-            reported as "no findings", so that the check cannot degrade into passing everything.
+        MarimoFileError: if marimo cannot parse `path` at all.
+        ValueError: if the notebook cannot be checked in full — it parses into no cells, or it
+            holds a cell marimo cannot compile. Raised rather than reported as "no findings", so
+            that the check cannot degrade into passing everything.
     """
-    app = load_app(str(path))
-    load_result = get_notebook_status(str(path))
-    if app is None or load_result.notebook is None:
-        # marimo reports an unparsable file as `empty` too, so only trust that status for a file
-        # that really is empty; anything else with no app is a file we could not read as one.
-        if load_result.status == "empty" and not path.read_text().strip():
-            raise ValueError("file is empty")
+    notebook = get_notebook_status(str(path)).notebook
+    if notebook is None or not notebook.cells:
         raise ValueError(
-            f"could not be read as a marimo notebook (marimo status: {load_result.status})"
+            "did not parse into any marimo cells. Every `.py` file directly inside "
+            "`packages/notebooks/` or `packages/dashboard/` is taken to be a notebook — an "
+            "ordinary module put there silently stops being auto-fixed by the ruff pre-commit hook."
         )
-    compiled = list(InternalApp(app).cell_manager.cell_data())
-    serialized = load_result.notebook.cells
-    if not serialized:
-        raise ValueError("parsed into zero marimo cells")
-    if len(compiled) != len(serialized):
-        raise ValueError(
-            f"marimo reports {len(compiled)} compiled cells but {len(serialized)} serialized "
-            "ones, so cells can no longer be matched to line numbers"
-        )
-    cells = [(source.lineno, data.cell) for data, source in zip(compiled, serialized, strict=True)]
-    for lineno, cell in cells:
-        if cell is None:
-            raise ValueError(f"marimo cannot compile the cell at line {lineno}")
-    defined = ALWAYS_BOUND.union(*(cell.defs for _, cell in cells if cell is not None))
+    compiled = InternalApp(load_notebook_ir(notebook)).cell_manager.cell_data()
+    cells: list[tuple[int, Cell]] = []
+    # `load_notebook_ir` registers one compiled cell per serialized cell, so `strict` never fires
+    # unless that stops being true — in which case the line numbers below would be attached to the
+    # wrong cells, and a loud failure beats a misleading report.
+    for data, source in zip(compiled, notebook.cells, strict=True):
+        if data.cell is None:
+            raise ValueError(f"marimo cannot compile the cell at line {source.lineno}")
+        cells.append((source.lineno, data.cell))
+    defined = ALWAYS_BOUND.union(*(cell.defs for _, cell in cells))
     return [
         UnboundCell(lineno, tuple(sorted(cell.refs - defined)))
         for lineno, cell in cells
-        if cell is not None and cell.refs - defined
+        if cell.refs - defined
     ]
 
 
@@ -108,15 +97,7 @@ def _check_file(path: Path) -> list[str]:
     """
     try:
         unbound = unbound_cells(path)
-    except (MarimoFileError, NonMarimoPythonScriptError) as error:
-        return [
-            (
-                f"{path}: not a marimo notebook: {error} Every `.py` file directly inside "
-                "`packages/notebooks/` or `packages/dashboard/` is taken to be one — an ordinary "
-                "module put there silently stops being auto-fixed by the ruff pre-commit hook."
-            )
-        ]
-    except (OSError, SyntaxError, ValueError) as error:
+    except (MarimoFileError, OSError, SyntaxError, ValueError) as error:
         return [f"{path}: cannot be checked: {error}"]
     return [
         f"{path}:{cell.lineno}: cell references name(s) that no cell defines: "

--- a/scripts/check_marimo_notebooks.py
+++ b/scripts/check_marimo_notebooks.py
@@ -25,12 +25,18 @@ from marimo._ast.app import InternalApp
 from marimo._ast.load import get_notebook_status, load_app
 from marimo._ast.parse import MarimoFileError, NonMarimoPythonScriptError
 
-ALWAYS_BOUND: Final[frozenset[str]] = frozenset(dir(builtins)) | {"__file__"}
+ALWAYS_BOUND: Final[frozenset[str]] = frozenset(dir(builtins)) | {
+    "__builtin__",
+    "__builtins__",
+    "__file__",
+}
 """Names a cell may reference without any cell defining them.
 
-`__file__` is not a builtin: marimo injects it into the cell globals itself (`_runtime.runtime`
-sets it from the notebook's filename), so a cell locating a data file relative to the notebook is
-correct code and must not be flagged.
+The three dunders are not builtins — they are the names marimo seeds the cell globals with, in
+`marimo._runtime.patches.create_main_module`. A cell locating a data file relative to the notebook
+(`__file__`) or sandboxing an `eval` (`__builtins__`) is correct code and must not be flagged. Take
+any addition here from that function, not from what looks plausible: `__marimo__`, for instance, is
+bound in the editor kernel but *not* when the notebook runs as a script, so it stays flagged.
 """
 
 
@@ -66,9 +72,17 @@ def unbound_cells(path: Path) -> list[UnboundCell]:
     app = load_app(str(path))
     load_result = get_notebook_status(str(path))
     if app is None or load_result.notebook is None:
-        raise ValueError(f"not a usable marimo notebook (marimo status: {load_result.status})")
+        # marimo reports an unparsable file as `empty` too, so only trust that status for a file
+        # that really is empty; anything else with no app is a file we could not read as one.
+        if load_result.status == "empty" and not path.read_text().strip():
+            raise ValueError("file is empty")
+        raise ValueError(
+            f"could not be read as a marimo notebook (marimo status: {load_result.status})"
+        )
     compiled = list(InternalApp(app).cell_manager.cell_data())
     serialized = load_result.notebook.cells
+    if not serialized:
+        raise ValueError("parsed into zero marimo cells")
     if len(compiled) != len(serialized):
         raise ValueError(
             f"marimo reports {len(compiled)} compiled cells but {len(serialized)} serialized "
@@ -95,7 +109,13 @@ def _check_file(path: Path) -> list[str]:
     try:
         unbound = unbound_cells(path)
     except (MarimoFileError, NonMarimoPythonScriptError) as error:
-        return [f"{path}: not a marimo notebook: {error}"]
+        return [
+            (
+                f"{path}: not a marimo notebook: {error} Every `.py` file directly inside "
+                "`packages/notebooks/` or `packages/dashboard/` is taken to be one — an ordinary "
+                "module put there silently stops being auto-fixed by the ruff pre-commit hook."
+            )
+        ]
     except (OSError, SyntaxError, ValueError) as error:
         return [f"{path}: cannot be checked: {error}"]
     return [

--- a/tests/test_marimo_notebooks.py
+++ b/tests/test_marimo_notebooks.py
@@ -2,8 +2,9 @@
 
 The check itself lives in `scripts/check_marimo_notebooks.py`, which is also a pre-commit hook;
 its module docstring explains what the failure looks like and which tools produce it. These tests
-run it over every notebook in the repo, and — because it rides on private marimo API — keep two
-positive controls that fail if a marimo release ever stops it detecting a real breakage.
+run it over every notebook in the repo, and — because it rides on private marimo API — keep hand-
+written notebooks either side of the line: two that it must flag, so a marimo release cannot
+quietly turn it into a no-op, and one correct notebook that it must not.
 """
 
 import importlib.util
@@ -51,6 +52,27 @@ if __name__ == "__main__":
 """
 """A notebook broken exactly as `ruff check --fix` breaks one, held as a string rather than as a
 file under `tests/data/` so that ruff never sees a deliberately-broken notebook to "fix"."""
+
+DUNDER_FILE_NOTEBOOK: Final[str] = """import marimo
+
+__generated_with = "0.23.16"
+app = marimo.App()
+
+with app.setup:
+    import pathlib
+
+
+@app.cell
+def _():
+    print(pathlib.Path(__file__).name)
+    return
+
+
+if __name__ == "__main__":
+    app.run()
+"""
+"""A correct notebook that locates itself. `__file__` is not a builtin — marimo injects it into
+the cell globals — so it is the one name that would otherwise look unbound in working code."""
 
 
 def _load_checker() -> ModuleType:
@@ -122,9 +144,8 @@ def test_checker_rejects_a_file_that_is_not_a_notebook(tmp_path: Path):
     assert "not a marimo notebook" in result.stdout
 
 
-def test_checker_passes_over_every_notebook_at_once():
-    # Covers the hook's own invocation: exit code 0 and nothing printed when all is well.
-    result = _run_checker(*_notebooks())
+def test_checker_allows_a_cell_to_reference_dunder_file(tmp_path: Path):
+    notebook = tmp_path / "locates_itself.py"
+    notebook.write_text(DUNDER_FILE_NOTEBOOK)
 
-    assert result.returncode == 0, result.stdout
-    assert not result.stdout
+    assert not CHECKER.unbound_cells(notebook)

--- a/tests/test_marimo_notebooks.py
+++ b/tests/test_marimo_notebooks.py
@@ -1,0 +1,130 @@
+"""Every marimo notebook binds every name its cells reference.
+
+The check itself lives in `scripts/check_marimo_notebooks.py`, which is also a pre-commit hook;
+its module docstring explains what the failure looks like and which tools produce it. These tests
+run it over every notebook in the repo, and — because it rides on private marimo API — keep two
+positive controls that fail if a marimo release ever stops it detecting a real breakage.
+"""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+from types import ModuleType
+from typing import Final
+
+import pytest
+
+REPO_ROOT: Final[Path] = Path(__file__).parent.parent
+"""The repo root, one level above this `tests/` directory."""
+
+CHECKER_PATH: Final[Path] = REPO_ROOT / "scripts" / "check_marimo_notebooks.py"
+"""The checker, imported by path below because `scripts/` is not an importable package."""
+
+NOTEBOOK_DIRS: Final[tuple[str, ...]] = ("packages/notebooks", "packages/dashboard")
+"""Directories whose top-level `.py` files are marimo notebooks.
+
+The same set as the `exclude`/`files` regex shared by the two ruff pre-commit hooks. Only the
+files sitting *directly* in each directory are notebooks: `packages/dashboard/src/` is ordinary
+library code and `packages/*/tests/` is ordinary test code.
+"""
+
+BROKEN_NOTEBOOK: Final[str] = """import marimo
+
+from datetime import UTC
+
+__generated_with = "0.23.16"
+app = marimo.App()
+
+with app.setup:
+    from datetime import datetime
+
+
+@app.cell
+def _():
+    print(datetime(2026, 1, 1, tzinfo=UTC))
+    return
+
+
+if __name__ == "__main__":
+    app.run()
+"""
+"""A notebook broken exactly as `ruff check --fix` breaks one, held as a string rather than as a
+file under `tests/data/` so that ruff never sees a deliberately-broken notebook to "fix"."""
+
+
+def _load_checker() -> ModuleType:
+    """Import `scripts/check_marimo_notebooks.py` by path."""
+    spec = importlib.util.spec_from_file_location("check_marimo_notebooks", CHECKER_PATH)
+    assert spec is not None, f"cannot import {CHECKER_PATH}"
+    assert spec.loader is not None, f"no loader for {CHECKER_PATH}"
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _notebooks() -> list[Path]:
+    """Every marimo notebook in the repo."""
+    return sorted(path for d in NOTEBOOK_DIRS for path in (REPO_ROOT / d).glob("*.py"))
+
+
+def _run_checker(*paths: Path) -> subprocess.CompletedProcess[str]:
+    """Run the checker as the pre-commit hook runs it, over `paths`."""
+    return subprocess.run(
+        [sys.executable, str(CHECKER_PATH), *(str(path) for path in paths)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+CHECKER: Final[ModuleType] = _load_checker()
+"""The checker module, loaded once for every test in this file."""
+
+
+def test_every_directory_of_notebooks_holds_at_least_one():
+    # Guards the parametrised test below: a glob that silently matched nothing would collect zero
+    # cases and pass.
+    for directory in NOTEBOOK_DIRS:
+        assert list((REPO_ROOT / directory).glob("*.py")), f"no notebooks found in {directory}"
+
+
+@pytest.mark.parametrize("notebook", _notebooks(), ids=lambda path: path.name)
+def test_notebook_binds_every_name_its_cells_reference(notebook: Path):
+    unbound = CHECKER.unbound_cells(notebook)
+    assert not unbound, (
+        f"{notebook.name} references names no cell defines: {unbound}. A name bound at module "
+        "level does not count — marimo never runs module-level statements."
+    )
+
+
+def test_checker_flags_an_import_hoisted_to_module_level(tmp_path: Path):
+    # The positive control. `unbound_cells` reads private marimo API, so this is what fails if a
+    # marimo release moves it and the check degrades to reporting nothing.
+    notebook = tmp_path / "hoisted_import.py"
+    notebook.write_text(BROKEN_NOTEBOOK)
+
+    result = _run_checker(notebook)
+
+    assert result.returncode == 1, result.stdout
+    assert "UTC" in result.stdout
+
+
+def test_checker_rejects_a_file_that_is_not_a_notebook(tmp_path: Path):
+    # The second control: an ordinary module in a notebook directory is a finding, not a silent
+    # pass, because the ruff pre-commit hooks would stop auto-fixing it.
+    script = tmp_path / "ordinary_module.py"
+    script.write_text("x = 1\n")
+
+    result = _run_checker(script)
+
+    assert result.returncode == 1, result.stdout
+    assert "not a marimo notebook" in result.stdout
+
+
+def test_checker_passes_over_every_notebook_at_once():
+    # Covers the hook's own invocation: exit code 0 and nothing printed when all is well.
+    result = _run_checker(*_notebooks())
+
+    assert result.returncode == 0, result.stdout
+    assert not result.stdout

--- a/tests/test_marimo_notebooks.py
+++ b/tests/test_marimo_notebooks.py
@@ -7,9 +7,11 @@ written notebooks either side of the line: two that it must flag, so a marimo re
 quietly turn it into a no-op, and one correct notebook that it must not.
 """
 
+import ast
 import importlib.util
 import subprocess
 import sys
+import tomllib
 from pathlib import Path
 from types import ModuleType
 from typing import Final
@@ -52,6 +54,31 @@ if __name__ == "__main__":
 """
 """A notebook broken exactly as `ruff check --fix` breaks one, held as a string rather than as a
 file under `tests/data/` so that ruff never sees a deliberately-broken notebook to "fix"."""
+
+UNPARSABLE_NOTEBOOK: Final[str] = '''import marimo
+
+__generated_with = "0.23.16"
+app = marimo.App()
+
+with app.setup:
+    from datetime import datetime
+
+
+app._unparsable_cell(
+    r"""
+    print(datetime(2026, 1, 1)
+    """,
+    name="_",
+)
+
+if __name__ == "__main__":
+    app.run()
+'''
+"""What marimo writes when a cell is saved with a syntax error.
+
+Its names cannot be analysed, so a checker that quietly skipped it would report a notebook holding
+one as clean.
+"""
 
 DUNDER_FILE_NOTEBOOK: Final[str] = """import marimo
 
@@ -144,8 +171,44 @@ def test_checker_rejects_a_file_that_is_not_a_notebook(tmp_path: Path):
     assert "not a marimo notebook" in result.stdout
 
 
+def test_checker_flags_a_cell_marimo_cannot_compile(tmp_path: Path):
+    # Such a cell has no names to analyse, so skipping it would pass a notebook marimo itself
+    # reports as broken.
+    notebook = tmp_path / "unparsable_cell.py"
+    notebook.write_text(UNPARSABLE_NOTEBOOK)
+
+    result = _run_checker(notebook)
+
+    assert result.returncode == 1, result.stdout
+    assert "cannot compile" in result.stdout
+
+
 def test_checker_allows_a_cell_to_reference_dunder_file(tmp_path: Path):
     notebook = tmp_path / "locates_itself.py"
     notebook.write_text(DUNDER_FILE_NOTEBOOK)
 
     assert not CHECKER.unbound_cells(notebook)
+
+
+def test_checker_passes_over_every_notebook_at_once():
+    # The only test of the exit-0 path: without it, a checker that rejected every notebook it was
+    # given would still pass this whole file.
+    result = _run_checker(*_notebooks())
+
+    assert result.returncode == 0, result.stdout
+    assert not result.stdout
+
+
+def test_every_notebook_named_in_python_files_exists_and_holds_tests():
+    # `python_files` reaches the notebook's own `test_*` functions by naming one exact path, so a
+    # rename would silently stop collecting them — the same silent-drop failure this file exists
+    # to prevent, one layer up.
+    config = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+    patterns = config["tool"]["pytest"]["ini_options"]["python_files"]
+    named = [REPO_ROOT / pattern for pattern in patterns if "/" in pattern and "*" not in pattern]
+    assert named, "expected python_files to name the notebook holding test cells"
+    for path in named:
+        assert path.is_file(), f"{path} is named in python_files but does not exist"
+        tree = ast.parse(path.read_text())
+        tests = [n for n in ast.walk(tree) if isinstance(n, ast.FunctionDef)]
+        assert any(n.name.startswith("test_") for n in tests), f"{path} defines no test_ function"

--- a/tests/test_marimo_notebooks.py
+++ b/tests/test_marimo_notebooks.py
@@ -3,26 +3,25 @@
 The check itself lives in `scripts/check_marimo_notebooks.py`, which is also a pre-commit hook;
 its module docstring explains what the failure looks like and which tools produce it. These tests
 run it over every notebook in the repo, and — because it rides on private marimo API — keep hand-
-written notebooks either side of the line: two that it must flag, so a marimo release cannot
+written notebooks either side of the line: three that it must flag, so a marimo release cannot
 quietly turn it into a no-op, and one correct notebook that it must not.
+
+Every test drives the checker as a subprocess, which is how pre-commit drives it, so its exit code
+is covered as well as its findings.
 """
 
 import ast
-import importlib.util
 import subprocess
 import sys
 import tomllib
 from pathlib import Path
-from types import ModuleType
 from typing import Final
-
-import pytest
 
 REPO_ROOT: Final[Path] = Path(__file__).parent.parent
 """The repo root, one level above this `tests/` directory."""
 
 CHECKER_PATH: Final[Path] = REPO_ROOT / "scripts" / "check_marimo_notebooks.py"
-"""The checker, imported by path below because `scripts/` is not an importable package."""
+"""The checker, run as a subprocess below because `scripts/` is not an importable package."""
 
 NOTEBOOK_DIRS: Final[tuple[str, ...]] = ("packages/notebooks", "packages/dashboard")
 """Directories whose top-level `.py` files are marimo notebooks.
@@ -80,7 +79,7 @@ Its names cannot be analysed, so a checker that quietly skipped it would report 
 one as clean.
 """
 
-DUNDER_FILE_NOTEBOOK: Final[str] = """import marimo
+DUNDERS_NOTEBOOK: Final[str] = """import marimo
 
 __generated_with = "0.23.16"
 app = marimo.App()
@@ -92,24 +91,18 @@ with app.setup:
 @app.cell
 def _():
     print(pathlib.Path(__file__).name)
+    print(eval("1 + 1", {"__builtins__": __builtins__}))
     return
 
 
 if __name__ == "__main__":
     app.run()
 """
-"""A correct notebook that locates itself. `__file__` is not a builtin — marimo injects it into
-the cell globals — so it is the one name that would otherwise look unbound in working code."""
+"""A correct notebook that locates itself and sandboxes an `eval`.
 
-
-def _load_checker() -> ModuleType:
-    """Import `scripts/check_marimo_notebooks.py` by path."""
-    spec = importlib.util.spec_from_file_location("check_marimo_notebooks", CHECKER_PATH)
-    assert spec is not None, f"cannot import {CHECKER_PATH}"
-    assert spec.loader is not None, f"no loader for {CHECKER_PATH}"
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-    return module
+Neither `__file__` nor `__builtins__` is a builtin — marimo injects both into the cell globals — so
+they are the names that would otherwise look unbound in working code.
+"""
 
 
 def _notebooks() -> list[Path]:
@@ -127,24 +120,22 @@ def _run_checker(*paths: Path) -> subprocess.CompletedProcess[str]:
     )
 
 
-CHECKER: Final[ModuleType] = _load_checker()
-"""The checker module, loaded once for every test in this file."""
-
-
 def test_every_directory_of_notebooks_holds_at_least_one():
-    # Guards the parametrised test below: a glob that silently matched nothing would collect zero
-    # cases and pass.
+    # Guards the test below: a glob that silently matched nothing would check nothing and pass.
     for directory in NOTEBOOK_DIRS:
         assert list((REPO_ROOT / directory).glob("*.py")), f"no notebooks found in {directory}"
 
 
-@pytest.mark.parametrize("notebook", _notebooks(), ids=lambda path: path.name)
-def test_notebook_binds_every_name_its_cells_reference(notebook: Path):
-    unbound = CHECKER.unbound_cells(notebook)
-    assert not unbound, (
-        f"{notebook.name} references names no cell defines: {unbound}. A name bound at module "
-        "level does not count — marimo never runs module-level statements."
+def test_every_notebook_binds_every_name_its_cells_reference():
+    # Also the only test of the exit-0 path: without it, a checker that rejected every notebook it
+    # was given would still pass this whole file.
+    result = _run_checker(*_notebooks())
+
+    assert result.returncode == 0, (
+        f"{result.stdout}A name bound at module level does not count — marimo never runs "
+        "module-level statements."
     )
+    assert not result.stdout
 
 
 def test_checker_flags_an_import_hoisted_to_module_level(tmp_path: Path):
@@ -168,7 +159,7 @@ def test_checker_rejects_a_file_that_is_not_a_notebook(tmp_path: Path):
     result = _run_checker(script)
 
     assert result.returncode == 1, result.stdout
-    assert "not a marimo notebook" in result.stdout
+    assert "did not parse into any marimo cells" in result.stdout
 
 
 def test_checker_flags_a_cell_marimo_cannot_compile(tmp_path: Path):
@@ -183,20 +174,13 @@ def test_checker_flags_a_cell_marimo_cannot_compile(tmp_path: Path):
     assert "cannot compile" in result.stdout
 
 
-def test_checker_allows_a_cell_to_reference_dunder_file(tmp_path: Path):
+def test_checker_allows_a_cell_to_reference_the_dunders_marimo_injects(tmp_path: Path):
     notebook = tmp_path / "locates_itself.py"
-    notebook.write_text(DUNDER_FILE_NOTEBOOK)
+    notebook.write_text(DUNDERS_NOTEBOOK)
 
-    assert not CHECKER.unbound_cells(notebook)
-
-
-def test_checker_passes_over_every_notebook_at_once():
-    # The only test of the exit-0 path: without it, a checker that rejected every notebook it was
-    # given would still pass this whole file.
-    result = _run_checker(*_notebooks())
+    result = _run_checker(notebook)
 
     assert result.returncode == 0, result.stdout
-    assert not result.stdout
 
 
 def test_every_notebook_named_in_python_files_exists_and_holds_tests():


### PR DESCRIPTION
> Written by Claude Code, reviewed by Jack.

Closes #500.

## What this adds

`scripts/check_marimo_notebooks.py` reads each cell's `refs`/`defs` and reports any name a cell
references that no cell binds. It runs as a pre-commit hook over changed notebooks, and
`tests/test_marimo_notebooks.py` runs it over every notebook in `packages/notebooks/` and
`packages/dashboard/`, plus two positive controls (a deliberately broken notebook held as a
string, and an ordinary module). The check is static — nothing executes — so it needs none of the
notebooks' runtime dependencies, and it takes under 100 ms for all six notebooks.

It goes red immediately on `packages/notebooks/plot_missing_NWP_data.py`, whose plotting cell took
a `df` that no cell defined. That cell now scans the NWP Delta table (as its sibling
`plot_nwp_map.py` does), and `plot_null_distribution` collects before handing its frame to Altair,
which cannot take a `LazyFrame`. The helper moves into its own cell, and a new cell of `test_*`
functions exercises it on a synthetic frame.

## Two things the issue said that turned out to be wrong

- **The pre-commit hook no longer re-introduces this bug.** The issue's comment quotes "the hook's
  exact command" as `ruff check --fix --force-exclude <notebook>`, but 67c54a4 (inside #494 itself)
  split the ruff hook so notebooks are never auto-fixed. The justification survives in a different
  form: nothing in `[tool.ruff]` excludes notebooks, so the command CLAUDE.md's own Commands
  section tells every agent to run — `uv run ruff check . --fix` — still hoists the import.
  Reproduced with ruff 0.16.2 on a reverted copy of `plot_nwp_map.py`.
- **Fixing the notebook needed more than binding `df`.** `alt.Chart(lazyframe)` warns and then
  raises `SchemaValidationError`, so the `.collect()` had to go in too — after the filter, since
  the NWP table is ~5.9 B rows.

## Alternatives considered and rejected

Searched for prior art before writing anything. Nothing upstream covers this: marimo-team/marimo#2051
asked for exactly this static check and closed with no lint rule shipped.

| Approach | Catches a hoisted import | Catches a dangling `df` |
| --- | --- | --- |
| `marimo check` | No — only an `MF001` *warning*, exit 0 without `--strict` | No |
| `marimo check --fix` | **Makes it worse** — see below | — |
| `pytest notebook.py` with `test_*` cells | Yes — marimo runs them in *cell* scope | Only if a test exercises it |
| `pytest notebook.py` with no test cells | No (but does execute `app.setup`) | No |
| `@app.function` imported into an ordinary test | No — verified to pass | No |
| this check | Yes | Yes |

`marimo check --fix` deletes the module-level import and rewrites the cell that used the name as
`def _(name)` — converting the breakage into a dangling cell input, at exit code 0. So the obvious
"use marimo's own tooling" answer would have replaced one silent breakage with another; this check
catches that shape too.

An in-notebook `test_*` function *is* the right tool for testing what a notebook computes, which
is why `plot_missing_NWP_data.py` gains one — but it is not a substitute for the checker: it only
covers code a test exercises, and the other five notebooks read real Delta tables and S3. It is
also not a second net for name binding. That property holds only while the helper sits inside an
`@app.cell`, and `marimo check --fix` rewrites it to an `@app.function`, whose test runs in module
scope; the notebook is committed in that canonical form so the editor cannot produce the rewrite
as a surprise diff.

## Verification

All gates green: `ruff check`, `ruff format --check`, `--all-packages ty check`, `pytest`
(540 passed), `pymarkdown scan`, `mkdocs build --strict` (rendered HTML read, not just linted).

Beyond the gates:

- The new test **fails on `main`** — that is how the `df` bug was found.
- The hook was confirmed to fail on a deliberately broken notebook dropped into
  `packages/notebooks/`, not just to pass on the clean ones.
- The fixed notebook was **run end to end against the real 5.9 B-row NWP Delta table**
  (`NWP_DATA_PATH=… uv run python packages/notebooks/plot_missing_NWP_data.py`), which builds the
  chart. Its hard-coded `init_time`/`h3_index` select 4,335 real rows across 51 ensemble members.

## Adversarial review

An independent reviewer went over this before Jack, and found four real defects, all now fixed in
`9b31763`:

- **`__file__` was a false positive.** It is not in `dir(builtins)`, but marimo injects it into the
  cell globals, so a notebook locating a data file relative to itself was correct code that the
  hook would have blocked. Allowed now, with a regression test.
- **A cell marimo cannot compile was skipped silently**, so a notebook holding an unparsable cell
  that referenced a module-level name passed clean. It is a finding now.
- **One unreadable path aborted the whole run** with a traceback before any other file's findings
  were printed, which could hide a genuine finding when several notebooks were staged.
- **The notebook was not in marimo's canonical form**, so `marimo check --fix` (and the editor on
  the next save) rewrote both new cells into `@app.function`, and the docs claim about the test
  catching a hoisted import held only for the pre-rewrite shape. The notebook is now committed in
  the canonical form and the claim is gone.

Two more from the same review: the test gained rows from another NWP run and another H3 cell,
which kills a filter mutant (`&` → `|`) that previously survived; and a redundant test plus some
prose that repeated the docs page were cut.

The reviewer independently reproduced the `ruff check --fix` hoist, confirmed the check goes red
on `main`, confirmed `marimo check --strict` exits 1 on all six of the repo's current clean
notebooks (so it is unusable as a gate), and ran all six repo gates.

## Second adversarial review

A second, independent reviewer checked the fixes above and the `main` merge. It confirmed all four
earlier fixes by reproducing each failing case on the old revision and the repair on the new one,
and found three more defects plus several smaller ones, all fixed in `69239e7e`:

- **The exit-0 path had no test.** Cutting `test_checker_passes_over_every_notebook_at_once` as
  "redundant" in the first round was wrong: with it gone, a `main()` mutated to `return 1` — a
  checker that rejects every commit touching a notebook — passed the entire suite. Restored, with
  a comment recording why it is not redundant. Verified: the mutant now fails.
- **`python_files` was silently unguarded.** Renaming the notebook would have stopped collecting
  its tests with everything still green — the same silent-drop failure this PR exists to prevent,
  one layer up. A test now asserts every path named in `python_files` exists and defines a `test_`
  function. Verified against a mutated `python_files` entry.
- **`__builtins__` and `__builtin__` were false positives.** `marimo._runtime.patches.create_main_module`
  seeds all three dunders, not just `__file__`, so a cell sandboxing an `eval` would have been
  blocked. The docstring now names that function as the source for any future addition, and
  records why `__marimo__` stays flagged (bound in the editor kernel, not in script mode).

Also: a notebook with no cells was caught only incidentally and reported as marimo API drift; a
file marimo cannot parse was reported as "empty"; the uncompilable-cell finding gained a
regression test; and the hook message regained its explanation. On the docs, `@app.function` does
not "close over nothing but the setup cell" (it can reference a plain cell's names) — that claim is
gone, as is a rule `testing.md` and the marimo skill both stated in full.

**Rejected, with reasons:** an unparsable cell aborts before naming other unbound names in the same
file (exit code is 1 either way, and collecting both would add a second finding channel for a
notebook that is already visibly broken); and three cosmetic notes inside the notebook's helper
(dead commented-out code, a `3 → 5` step numbering jump) that pre-date this PR and are out of its
scope.

## Third adversarial review — simplicity

A third reviewer was asked to attack the code and prose for simplicity and conciseness, on the
grounds that two rounds of fixes accrete defensiveness. It found one defect and two structural
simplifications, all applied in `2502d868`:

- **`python_files` had quietly dropped pytest's `*_test.py` default.** Naming any pattern replaces
  the whole default list rather than extending it, so a future `foo_test.py` would never have been
  collected — the same silent-drop failure this PR exists to prevent, one layer up. Reproduced with
  a probe file (collected 0 times before, 1 after). Restored, and the comment no longer claims the
  default is a single pattern.
- **The checker parsed each notebook twice** — once through `load_app`, once through
  `get_notebook_status` — and then reconciled marimo's two views of it. Parsing once and building
  the app from that IR deletes the empty-file branch, the zero-cell check, the cell-count mismatch,
  two now-dead `is not None` guards and one of the two exception arms; `zip(..., strict=True)` is
  now the pairing guard. 139 → 121 lines, and the zero-cell guard went from untested to killed by
  mutation, because an ordinary module now reaches it directly. One amendment to the reviewer's
  sketch: dropping `load_app` makes `NonMarimoPythonScriptError` unreachable, but `MarimoFileError`
  can still escape `get_notebook_status`, so that catch stays.
- **The tests reached the checker two ways**, in-process through an importlib dance and as a
  subprocess. Only the subprocess is how pre-commit runs it, so the import machinery, the
  module-level `CHECKER` and the parametrised per-notebook test are gone; one test now runs the
  checker over every notebook at once and covers the exit-0 path as well. Verified two ways: the
  same seven-mutant sweep kills the same mutants, and a real notebook broken on purpose (a cell
  referencing an undefined name, inserted inside the parsed region) still fails the suite with the
  file, line and name in the message.
- The dunder fixture now also sandboxes an `eval`, which turns the surviving `__builtins__` mutant
  into a killed one. Prose: dropped the module docstring's speculation about future maintenance and
  its third statement of the never-fail-quietly rule, plus a pre-emptive disclaimer in
  `testing.md`.

**Rejected:** trimming the `.pre-commit-config.yaml` comment above the new hook — it looks like a
fourth restatement, but each sentence explains why a third hook exists given the two above it.

One limitation found while testing and worth recording: a cell appended *after*
`if __name__ == "__main__": app.run()` is outside marimo's own parse boundary, so the checker does
not see it. Marimo would drop such a cell on the next save, so this is not a gap in practice.

Suite is now 537 passed, 1 skipped — six fewer than before, which is exactly the six parametrised
per-notebook cases folded into one.

