### PR TITLE
Correct the ML tooling section and complete the Packages table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,7 +181,9 @@ in [`docs/design-philosophy/engineering-hypotheses.md`](docs/design-philosophy/e
 | `nged_data` | Reading NGED JSON files from S3 and writing to Delta Lake |
 | `dynamical_data` | Downloading ECMWF ensemble NWP from Dynamical.org |
 | `geo` | H3 spatial indexing utilities |
+| `weather_utils` | Shared NWP query helpers used by both the dashboard and the feature pipeline (the analysis-proxy selection, `NWP_PUBLICATION_DELAY_HOURS`) |
 | `xgboost_forecaster` | Concrete `BaseForecaster` implementation using XGBoost |
+| `plotting` | The OCF-brand Altair theme and shared plotting helpers |
 | `dashboard` | Marimo web apps for visualisation (`view_forecasts.py`, `map_and_timeseries.py`) plus their shared helpers in `src/dashboard/` |
 | `notebooks` | Marimo exploration notebooks |
 

--- a/docs/architecture/code-style.md
+++ b/docs/architecture/code-style.md
@@ -180,12 +180,27 @@ confusing failure:
 - **`ty-workarounds`** — known upstream `ty` bugs on Altair and numpy, where the code is correct
   and the checker is not.
 
-## Machine Learning (PyTorch)
+## Machine Learning
 
-- Use **PyTorch** for differentiable physics models.
-- Use **MLFlow** for tracking experiments.
-- Follow the "test-harness" pattern: separate research logic from production orchestration but
-  ensure they use the same data contracts.
+- **Every forecasting model subclasses `BaseForecaster`** (`packages/ml_core`), which fixes
+  `train` / `predict` / `save` / `load` and carries a `feature_engineer` strategy object. A model
+  that needs a different view of the data supplies a different `FeatureEngineer` rather than
+  changing the shared feature pipeline. `XGBoostForecaster` is the only implementation so far.
+- **Use MLflow for experiment tracking.**
+- **Choosing an optimisation tool: convex estimation subproblems → CVXPY; learning shapes, or
+  anything needing posteriors → PyTorch.** "Non-convex" comes in grades, and the grade decides the
+  tool — the full rule is
+  [Where PyTorch is the right tool](../techniques/convex-optimisation.md#where-pytorch-is-the-right-tool),
+  and the physics side is [Differentiable physics](../techniques/differentiable-physics.md).
+  PyTorch is not yet a dependency of the workspace; the first model to need it is the variational
+  capacity estimator in the
+  [v0.7 capacity head-to-head](../roadmap/capacity-estimation.md).
+- **Research and production share one execution path.** There is no research-only implementation of
+  a pipeline step — see
+  [design principle 3](../design-philosophy/design-principles.md#3-one-execution-path-from-research-to-production).
+  What legitimately differs between them is failure policy, not code: the CV, training and metrics
+  assets fail fast, while the production service degrades (see
+  [Inherent stability](../design-philosophy/inherent-stability.md)).
 
 ## Error Handling
 


### PR DESCRIPTION
*This PR was written by Claude Code.*

Two documentation defects found while reviewing #503 and deliberately left out of it as out of
scope. Docs-only; no code changes.

## 1. `code-style.md`'s "Machine Learning (PyTorch)" section

The section had three bullets. All three were wrong or misleading.

**"Use PyTorch for differentiable physics models"** was the entire tooling guidance. But the repo's
actual rule is a *choice between two tools*, worked out at length in
[`techniques/convex-optimisation.md`](https://openclimatefix.github.io/nged-substation-forecast/techniques/convex-optimisation/#where-pytorch-is-the-right-tool):
convex estimation subproblems → **CVXPY**; learning shapes, or anything needing posteriors →
**PyTorch**; a low-dimensional non-convex remainder around a convex core → enumerate the remainder.
Naming only PyTorch on the code-style page pointed a reader away from CVXPY for precisely the
problems CVXPY exists to solve — and CVXPY is the tool that wins the v0.7 head-to-head for
per-site work.

**PyTorch is not yet a workspace dependency** (`grep -rn torch` over the workspace returns
nothing). Since you plan to start using it, the section keeps the guidance rather than deleting it,
but is now honest about status and names where it lands first — the variational capacity estimator
in the v0.7 capacity head-to-head. `inherent-stability.md:440` already said conformal prediction
"can ship before any PyTorch work exists", so the docs were internally inconsistent on this.

**"Follow the 'test-harness' pattern: separate research logic from production orchestration"**
contradicted
[design principle 3](https://openclimatefix.github.io/nged-substation-forecast/design-philosophy/design-principles/#3-one-execution-path-from-research-to-production),
which forbids a second implementation for research versus production, and `mlops-approach.md`'s
"nothing gets rewritten on the way to production". It also misread "test-harness" — in
`overview.md` that term means building a production-like service so ML research runs in a
production-like environment *from day one*, which is close to the opposite of separating the two.
What legitimately differs between research and production is **failure policy**, not code: the CV,
training and metrics assets fail fast, while the production service degrades. That is what it now
says.

I also added what a new model must actually subclass (`BaseForecaster`, and supplying a different
`FeatureEngineer` rather than editing the shared pipeline), since that is the code-style question
someone arrives at this section with, and it was answered nowhere on the page.

⚠️ **The third bullet is a judgment call worth your eye.** Rewriting it goes slightly beyond
"the PyTorch section is stale" — but it sits inside that section and asserts something the design
principles forbid, so leaving it would have meant knowingly shipping a contradiction. Say the word
and I'll restore it.

## 2. CLAUDE.md's Packages table

Missing `weather_utils` and `plotting`. Both exist and are real dependencies — `weather_utils` of
`ml_core`, `dashboard` and `notebooks`; `plotting` of `dashboard` and `notebooks`. Descriptions
taken from each package's own `pyproject.toml` description and module docstring. The other nine
rows were checked and are accurate (both `dashboard` marimo apps named in the table still exist).

## Verification

All green: `ruff check`, `ruff format`, `uv run --all-packages ty check`, `uv run pytest`
(529 passed, 1 skipped), `pymarkdown scan`, `mkdocs build --strict`.

Per the repo rule that a strict build isn't enough, I read the rendered HTML under `site/` and
checked every outbound link in the rewritten section — all five resolve, including both `#anchor`
fragments (`#where-pytorch-is-the-right-tool` and
`#3-one-execution-path-from-research-to-production`).
