### PR TITLE
Note the sticky closing-issue links in the PR-workflow skill

### DIFF
--- a/.claude/skills/github-issue-pr-workflow/SKILL.md
+++ b/.claude/skills/github-issue-pr-workflow/SKILL.md
@@ -50,6 +50,23 @@ Never squash-merge. Jack wants the full commit history preserved in `main`, so u
 (`gh pr merge --merge`) or rebase (`gh pr merge --rebase`), not `gh pr merge --squash`. Under the
 `implement-issue` routine you stop and wait for Jack's review rather than merging at all.
 
+**Check what the merge will close, before you merge:**
+
+```bash
+gh pr view <N> --json closingIssuesReferences --jq '.closingIssuesReferences[].number'
+```
+
+Every number listed is closed the moment the PR merges. The list is *sticky*: a closing keyword
+in an early draft of the PR body, or in any commit message on the branch, registers the link
+permanently, and later editing that text away does not remove it. So a PR whose body now says
+"filed rather than fixed, see #512" can still be holding a closing link to #512 from a draft —
+reading the current body is not enough, and neither is grepping the commits.
+
+If the list contains an issue you did not mean to close, either sort it out before merging or
+watch for it afterwards: `gh issue reopen <N>`, then put its project Status back (the board
+automation moves a closed issue to Done, and reopening it lands on In Progress, not Todo — see
+the `github-graphql` skill for `gh project item-edit`).
+
 ## GraphQL calls
 
 Attaching and reordering sub-issues, setting an issue's Type, and setting a project field all need


### PR DESCRIPTION
> 🤖 **This PR description was written by [Claude Code](https://claude.com/claude-code)**, acting on Jack's behalf.

Adds a "check what the merge will close" step to the `github-issue-pr-workflow` skill.

## Why

Issue [#512](https://github.com/openclimatefix/nged-substation-forecast/issues/512) was closed by
the merge of [#514](https://github.com/openclimatefix/nged-substation-forecast/pull/514) — a PR
that had deliberately left it alone, and whose body said so ("Two things noticed in passing, filed
rather than fixed"). It has since been reopened, with its project Status put back to Todo.

The cause is that a closing reference is sticky. GitHub registers the link when the text
containing the keyword is first saved, and does **not** remove it when the text is edited away.
An early draft of #514's body must have said "closes #512"; by merge time no trace of that
remained in either the body or the branch's five commit messages, but the link was still live:

```console
$ gh pr view 514 --json closingIssuesReferences --jq '.closingIssuesReferences[].number'
228
512
```

So the check has to be that field. Reading the body is not evidence, and neither is grepping the
commits.

## What the note says

The command to run before `gh pr merge`, why the current body cannot be trusted, and how to
recover — because reopening is not the whole of it. The board automation moves a closed issue to
Done, and a reopen lands it on **In Progress**, not back on Todo, so the project field needs
setting explicitly.
