### PR TITLE
Note the sticky closing-issue links in the PR-workflow skill

### DIFF
--- a/.claude/skills/github-issue-pr-workflow/SKILL.md
+++ b/.claude/skills/github-issue-pr-workflow/SKILL.md
@@ -50,6 +50,23 @@ Never squash-merge. Jack wants the full commit history preserved in `main`, so u
 (`gh pr merge --merge`) or rebase (`gh pr merge --rebase`), not `gh pr merge --squash`. Under the
 `implement-issue` routine you stop and wait for Jack's review rather than merging at all.
 
+**Check what the merge will close, before you merge:**
+
+```bash
+gh pr view <N> --json closingIssuesReferences --jq '.closingIssuesReferences[].number'
+```
+
+Every number listed is closed the moment the PR merges. The list is *sticky*: a closing keyword
+in an early draft of the PR body, or in any commit message on the branch, registers the link
+permanently, and later editing that text away does not remove it. So a PR whose body now says
+"filed rather than fixed, see #512" can still be holding a closing link to #512 from a draft —
+reading the current body is not enough, and neither is grepping the commits.
+
+If the list contains an issue you did not mean to close, either sort it out before merging or
+watch for it afterwards: `gh issue reopen <N>`, then put its project Status back (the board
+automation moves a closed issue to Done, and reopening it lands on In Progress, not Todo — see
+the `github-graphql` skill for `gh project item-edit`).
+
 ## GraphQL calls
 
 Attaching and reordering sub-issues, setting an issue's Type, and setting a project field all need


### PR DESCRIPTION
> 🤖 **This PR description was written by [Claude Code](https://claude.com/claude-code)**, acting on Jack's behalf.

Adds a "check what the merge will close" step to the `github-issue-pr-workflow` skill.

## Why

When [#514](https://github.com/openclimatefix/nged-substation-forecast/pull/514) merged, it took
issue 512 down with it — an issue that PR had deliberately left alone, and whose body said as much
("Two things noticed in passing, filed rather than fixed"). Issue 512 has since been reopened, with
its project Status put back to Todo.

A closing reference turns out to be sticky. GitHub registers the link when text containing the
keyword is first saved, and does **not** drop it when that text is edited away. An early draft of
#514's body must have carried one; by merge time no trace remained in either the body or the
branch's five commit messages, yet the link was still live:

```console
$ gh pr view 514 --json closingIssuesReferences --jq '.closingIssuesReferences[].number'
228
512
```

So that field is the only reliable check. Reading the body is not evidence, and neither is grepping
the commits.

I confirmed the stickiness on this PR's own first attempt, which used the word "closed" directly
before a link to the issue and so registered the same link. Editing the phrase out left the
reference in place ninety seconds later, which is why this PR was opened afresh rather than edited.

## What the note says

The command to run before `gh pr merge`, why the current body cannot be trusted, and how to
recover — because reopening is not the whole of it. The board automation moves a closed issue to
Done, and a reopen lands it on **In Progress**, not back on Todo, so the project field has to be
set explicitly.
