### PR TITLE
Correct the closing-issue check: commit messages are a second route

### DIFF
--- a/.claude/skills/github-issue-pr-workflow/SKILL.md
+++ b/.claude/skills/github-issue-pr-workflow/SKILL.md
@@ -50,22 +50,29 @@ Never squash-merge. Jack wants the full commit history preserved in `main`, so u
 (`gh pr merge --merge`) or rebase (`gh pr merge --rebase`), not `gh pr merge --squash`. Under the
 `implement-issue` routine you stop and wait for Jack's review rather than merging at all.
 
-**Check what the merge will close, before you merge:**
+**Check what the merge will close, before you merge.** Issues are closed by two independent
+routes, and you have to check both — neither one shows you the other's:
 
 ```bash
 gh pr view <N> --json closingIssuesReferences --jq '.closingIssuesReferences[].number'
+git log origin/main..HEAD --format='%B' | grep -inE '(close[sd]?|fix(e[sd])?|resolve[sd]?) +#[0-9]+'
 ```
 
-Every number listed is closed the moment the PR merges. The list is *sticky*: a closing keyword
-in an early draft of the PR body, or in any commit message on the branch, registers the link
-permanently, and later editing that text away does not remove it. So a PR whose body now says
-"filed rather than fixed, see #512" can still be holding a closing link to #512 from a draft —
-reading the current body is not enough, and neither is grepping the commits.
+The first lists the links registered from the **PR body** (and the Development sidebar). That list
+is *sticky*: GitHub registers a link when the text containing the keyword is first saved and does
+not drop it when the text is edited away. A PR whose body now reads "filed rather than fixed, see
+\#512" can still hold a closing link to 512 from an early draft, so reading the current body proves
+nothing. A link you did not intend cannot be edited out either — close the PR and open it again
+from the same branch with a clean body.
 
-If the list contains an issue you did not mean to close, either sort it out before merging or
-watch for it afterwards: `gh issue reopen <N>`, then put its project Status back (the board
-automation moves a closed issue to Done, and reopening it lands on In Progress, not Todo — see
-the `github-graphql` skill for `gh project item-edit`).
+The second catches keywords in **commit messages**, which close their issue when the commit lands
+on `main` and are invisible to `closingIssuesReferences` beforehand — that field stays `[]` right
+up to the merge. Prose *about* a closure counts: "Merging #514 closed #512" in a commit message
+closes 512. Keep those words away from any issue reference when writing about one.
+
+When something is closed that should not have been: `gh issue reopen <N>`, then put its project
+Status back explicitly. The board automation moves a closed issue to Done, and reopening lands it
+on In Progress rather than Todo — see the `github-graphql` skill for `gh project item-edit`.
 
 ## GraphQL calls
 


### PR DESCRIPTION
> 🤖 **This PR description was written by [Claude Code](https://claude.com/claude-code)**, acting on Jack's behalf.

Corrects the check added in [#518](https://github.com/openclimatefix/nged-substation-forecast/pull/518).

## Why

That PR named `gh pr view <N> --json closingIssuesReferences` as the reliable way to see what a
merge will shut. It is not sufficient. There are two independent routes, and neither is visible in
the other:

| Route | Shows up in `closingIssuesReferences`? |
|---|---|
| Keyword in the **PR body** / Development sidebar | Yes — and stickily, surviving a body edit |
| Keyword in a **commit message** | No — takes effect only when the commit lands on `main` |

\#518 demonstrated this on itself. Its commit message opened by describing the earlier incident in
prose — "Merging PR 514 …" — which GitHub read as an instruction rather than a description. The PR
reported no closing references right up to the merge, and merging it shut issue 512 a second time,
attributed to the commit:

```console
$ gh api repos/.../issues/512/events --jq '.[] | select(.event=="closed") | {created_at, commit_id}'
{"created_at":"2026-08-10T19:06:32Z","commit_id":null}                                     # via #514's body
{"created_at":"2026-08-10T19:24:27Z","commit_id":"ade9dd84..."}                            # via #518's commit
```

Issue 512 has been reopened and its project Status put back to Todo, again.

## What changed

The section now gives both commands, says which route each one covers, and adds the part that
caught me twice: prose *about* a closure is indistinguishable from an instruction to close, so
those words have to be kept away from any issue reference — in commit messages as much as in
bodies. The recovery note stays, including that reopening lands the board on In Progress rather
than Todo.

This PR's own body and commit message were both checked against the grep before it was opened.
