### PR TITLE
Give every argument one home, and stop hard-wrapping GitHub bodies

### DIFF
--- a/.claude/skills/github-issue-pr-workflow/SKILL.md
+++ b/.claude/skills/github-issue-pr-workflow/SKILL.md
@@ -4,8 +4,10 @@ description: >-
   The checklist for creating a GitHub issue or PR in openclimatefix/nged-substation-forecast —
   the fields `gh issue create` / `gh pr create` cannot set (labels, org issue Type, OCF project 33
   and its Status/Project/Area fields, sub-issue attachment and ordering, the JackKelly assignee) —
-  plus the never-squash-merge rule and ship-time triage. Load before running `gh issue create`,
-  `gh pr create` or `gh pr merge`, or when a PR completes a roadmap item.
+  plus the never-hard-wrap rule for anything posted to GitHub, the never-squash-merge rule and
+  ship-time triage. Load before running `gh issue create`, `gh pr create`, `gh pr comment`,
+  `gh issue comment` or `gh pr merge`, before writing any issue/PR body or comment, or when a PR
+  completes a roadmap item.
 ---
 
 # Creating issues and PRs, and shipping them
@@ -43,6 +45,33 @@ Whenever you create a PR, also set:
 
 `gh pr create` can't set either: use `gh pr edit --add-label` and `gh pr edit --add-assignee
 JackKelly` right after creating the PR.
+
+## Never hard-wrap a GitHub body or comment
+
+**Write one line per paragraph. No hard wraps, at any width.** This applies to every issue body,
+PR body, issue comment, PR comment and review comment — everything posted to GitHub rather than
+committed to the repo. Blank lines still separate paragraphs, and list items still get their own
+line; it is only wrapping *within* a paragraph that is forbidden.
+
+GitHub renders comment-shaped content with hard line breaks turned on, so a single newline inside
+a paragraph becomes a literal `<br>`. Repo `.md` files are rendered without that setting, which is
+why the same wrapping is correct there and wrong here. GitHub's own API shows the two renderers
+disagreeing on identical input:
+
+```bash
+printf '{"text":"line one\nline two","mode":"gfm"}' | gh api /markdown --input -
+```
+
+`mode=gfm` (the issue/PR/comment renderer) returns `<p>line one<br>\nline two</p>`;
+`mode=markdown` (the repo-file renderer) returns `<p>line one\nline two</p>` with no `<br>`. A body
+wrapped at this repo's 100-character prose width therefore reaches a reviewer as a ragged block of
+forced breaks, one per source line.
+
+**The trap is the draft file, not the typing.** A long body wants to be written to a file and
+passed with `gh pr create --body-file`, and a draft written *inside the repo* gets reflowed to the
+house line length by the markdown linter or by habit — at which point the wrapping is baked in
+before the body is ever posted. Write the draft to the session scratchpad directory instead, where
+no linter touches it, and pass that path to `--body-file`. Never commit a body draft.
 
 ## Merging pull requests
 

--- a/.claude/skills/github-issue-pr-workflow/SKILL.md
+++ b/.claude/skills/github-issue-pr-workflow/SKILL.md
@@ -59,7 +59,7 @@ why the same wrapping is correct there and wrong here. GitHub's own API shows th
 disagreeing on identical input:
 
 ```bash
-printf '{"text":"line one\nline two","mode":"gfm"}' | gh api /markdown --input -
+printf '{"text":"line one\\nline two","mode":"gfm"}' | gh api /markdown --input -
 ```
 
 `mode=gfm` (the issue/PR/comment renderer) returns `<p>line one<br>\nline two</p>`;

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -48,6 +48,30 @@ gh issue view <N> --comments
   work, `docs/architecture/` for why the current design is what it is, `docs/techniques/` for
   method write-ups, `docs/design-philosophy/` for the rules the plan has to obey.
 
+## 1a. Name the session
+
+As soon as you have the issue title, **open your very next reply with a session-title line and
+nothing above it**:
+
+```text
+Planning: Cap late-series metadata table (#510)
+```
+
+An imperative phrase naming what the issue *changes*, about 50 characters, then the issue number
+in parentheses. Not the issue's own title verbatim — those run long and bury the point (#512's is
+"Reject unknown keys in config_overrides (extra=\"forbid\" on BaseForecasterConfig)", which wants
+to become "Reject unknown config_overrides keys (#512)").
+
+Jack picks sessions out of the desktop app's session list, where the default title is derived from
+the `/plan-issue <N>` invocation and reads "Plan issue 510" — which does not say what the session
+is about once several are open at once.
+
+**Do not reach for a tool to do this.** Every session-management tool refuses the session it is
+running in, by contract, so there is nothing to call. The line above is a hint to whatever titles
+the session, and failing that a title Jack can copy in one gesture. If you find the session list
+still showing "Plan issue \<N\>" after a run, say so rather than working around it — that is the
+signal that this needs solving at the harness level instead.
+
 ## 2. Decide whether it is worth implementing
 
 This is a real gate, not a formality. State a clear verdict before writing any plan, and be

--- a/conftest.py
+++ b/conftest.py
@@ -8,7 +8,8 @@ Why a collection hook rather than ``-m "not network"`` in ``addopts``: pytest ke
 replaces an ``addopts`` ``-m "not network"`` and re-includes the network tests. A skip applied
 during collection cannot be defeated that way — the gate holds regardless of what ``-m`` the caller
 passes. Run the network tests with ``uv run pytest --run-network`` (add ``-m network`` to run *only*
-them). See docs/architecture/testing.md.
+them). See
+<https://openclimatefix.github.io/nged-substation-forecast/architecture/testing/>.
 """
 
 import os

--- a/docs/architecture/code-style.md
+++ b/docs/architecture/code-style.md
@@ -98,14 +98,15 @@ stricter type exists — a genuinely heterogeneous or open-ended dict stays `dic
   when the work lands, so the reference rots. (Docs-to-docs links into `docs/roadmap/` are fine;
   retargeting them is part of ship-time triage.) Linking from a docstring to a durable page — e.g.
   `docs/architecture/` — is encouraged.
-- **Spell a docs link as its rendered URL**, never as a repo path. mkdocstrings renders docstrings
-  onto the API reference pages, where a relative `docs/architecture/overview.md` resolves against
-  the *rendered* site tree and 404s. Write
-  `<https://openclimatefix.github.io/nged-substation-forecast/architecture/overview/>` instead —
-  the same URL `CLAUDE.md` already mandates for issue and PR bodies. Use it in `#` comments too:
-  comments are never rendered, so a repo path would work there, but one spelling everywhere is one
-  fewer thing to get right, and the URL is the more useful of the two to a reader who has the docs
-  open rather than the repo checked out.
+- **Spell a docs link as its rendered URL**, never as a repo path. Write
+  `<https://openclimatefix.github.io/nged-substation-forecast/architecture/overview/>`, not
+  `docs/architecture/overview.md` — the same URL `CLAUDE.md` already mandates for issue and PR
+  bodies. Two reasons, neither of which is that a bare path is currently broken. A public docstring
+  is rendered by mkdocstrings onto an API page, where a repo path is dead text to a reader who has
+  the site open and not the repo checked out, and where writing it as a markdown link *would* 404,
+  because the path resolves against the rendered site tree. And a URL survives the file being moved
+  or renamed, which a path does not. Use it in `#` comments too: those are never rendered, so a
+  path would do, but one spelling everywhere is one fewer thing to get right.
 - **One home per argument** — a design decision's *rationale* lives on one docs page, and the
   docstring links to it. The docstring's own job is to say what the function guarantees and what a
   caller must not assume. A sentence of "because" is fine; a paragraph of it means the paragraph

--- a/docs/architecture/code-style.md
+++ b/docs/architecture/code-style.md
@@ -98,6 +98,23 @@ stricter type exists — a genuinely heterogeneous or open-ended dict stays `dic
   when the work lands, so the reference rots. (Docs-to-docs links into `docs/roadmap/` are fine;
   retargeting them is part of ship-time triage.) Linking from a docstring to a durable page — e.g.
   `docs/architecture/` — is encouraged.
+- **Spell a docs link as its rendered URL**, never as a repo path. mkdocstrings renders docstrings
+  onto the API reference pages, where a relative `docs/architecture/overview.md` resolves against
+  the *rendered* site tree and 404s. Write
+  `<https://openclimatefix.github.io/nged-substation-forecast/architecture/overview/>` instead —
+  the same URL `CLAUDE.md` already mandates for issue and PR bodies. Use it in `#` comments too:
+  comments are never rendered, so a repo path would work there, but one spelling everywhere is one
+  fewer thing to get right, and the URL is the more useful of the two to a reader who has the docs
+  open rather than the repo checked out.
+- **One home per argument** — a design decision's *rationale* lives on one docs page, and the
+  docstring links to it. The docstring's own job is to say what the function guarantees and what a
+  caller must not assume. A sentence of "because" is fine; a paragraph of it means the paragraph
+  belongs on the page. Two copies of an argument drift, and the drift is silent — a later change
+  updates the page, the docstring goes on asserting the superseded reasoning, and no linter, type
+  checker or test can tell. This is the same trade the durable-docs rule above makes: a link that
+  might rot is cheaper than a copy that rots invisibly. It cuts the other way too — rationale
+  worth a paragraph does not belong *only* in a docstring, where no reader browsing the docs will
+  find it.
 - **MkDocs-compatible constant docs** — document module-level constants with a string literal
   immediately after the assignment, not with Sphinx-style `#:` comments. This is correct:
 

--- a/docs/architecture/ecmwf-ens-known-issues.md
+++ b/docs/architecture/ecmwf-ens-known-issues.md
@@ -58,6 +58,14 @@ of clean data, so it leaves the provenance guarantees of
 [principle 9](../design-philosophy/design-principles.md#9-provenance-travels-with-the-forecast-data)
 intact. Nothing is fabricated from another time step, another run or another cell.
 
+Each variable gets its *own* denominator, rather than one shared across the cell. A shared
+denominator would be simpler and is wrong: it would let a single corrupt variable null every other
+variable in the same cell, which is the amplification described below, applied across variables
+instead of across cells. What per-variable denominators cost is that two variables in one cell can
+end up averaged over different sub-areas of the hexagon. That matters only where a pair is later
+recombined — `wind_u_*` with `wind_v_*`, in `_calc_wind_speed` and `_calc_wind_direction` — and
+upstream corruption has so far always been co-located across variables, so it is theoretical today.
+
 `categorical_precipitation_type_surface` cannot be averaged, so the `proportion` weights are summed
 per category and the category covering most of the cell's area wins. Points that supplied no
 category are excluded from that ranking rather than competing in it — the distinction matters,

--- a/packages/contracts/src/contracts/power_schemas.py
+++ b/packages/contracts/src/contracts/power_schemas.py
@@ -421,8 +421,10 @@ class EffectiveCapacity(pt.Model):
     the full observed history. This is a static scalar per series.
 
     **Planned upgrade (v0.7):** replace the P99 scalar with a time-varying capacity estimate
-    (see ``docs/techniques/convex-optimisation.md`` and
-    ``docs/techniques/differentiable-physics.md`` for the candidate estimation methods),
+    (see
+    <https://openclimatefix.github.io/nged-substation-forecast/techniques/convex-optimisation/> and
+    <https://openclimatefix.github.io/nged-substation-forecast/techniques/differentiable-physics/>
+    for the candidate estimation methods),
     giving one row per ``(time_series_id, time)`` half-hourly timestep. This schema is unchanged;
     the ``effective_capacity`` asset body changes and the ``metrics`` pipeline swaps its
     ``time_series_id``-only NMAE-denominator join for a temporal as-of join. Do **not** pre-densify

--- a/packages/contracts/src/contracts/settings.py
+++ b/packages/contracts/src/contracts/settings.py
@@ -378,9 +378,10 @@ class Settings(BaseSettings):
         self.h3_grid_weights_path = self.h3_grid_weights_path or uri_join(
             self.data_path_internal, "h3_grid_weights.parquet"
         )
-        # NGED-facing delivery tables (see docs/roadmap/delivery-tables.md) derive from
-        # data_path_delivery instead, so a new delivery table can't silently land in the
-        # internal bucket by inheriting the default derivation.
+        # NGED-facing delivery tables derive from data_path_delivery instead, so a new delivery
+        # table can't silently land in the internal bucket by inheriting the default derivation.
+        # Which tables those are:
+        # <https://openclimatefix.github.io/nged-substation-forecast/roadmap/delivery-tables/>.
         self.power_forecasts_data_path = self.power_forecasts_data_path or uri_join(
             self.data_path_delivery, "power_forecasts"
         )

--- a/packages/contracts/src/contracts/weather_schemas.py
+++ b/packages/contracts/src/contracts/weather_schemas.py
@@ -103,8 +103,9 @@ class Nwp(pt.Model):
     (nwp_model_id, init_time, valid_time, ensemble_member, h3_index).
 
     Stored on disk as plain Float32, rounded to a significand-bit budget by
-    `delta_store.nwp.write_nwp` — see `docs/architecture/overview.md` for the physical format
-    and measured numbers.
+    `delta_store.nwp.write_nwp` — see
+    <https://openclimatefix.github.io/nged-substation-forecast/architecture/overview/> for the
+    physical format and measured numbers.
 
     `validate` is the fatal ingest gate; `assess_nwp_quality` reports the tolerated nulls in the
     de-accumulated variables (the known upstream ECMWF ENS corruption) and
@@ -280,15 +281,12 @@ class Nwp(pt.Model):
     )
     """The variables Dynamical.org de-accumulates from ECMWF's cumulative source fields to rates.
 
-    They share a de-accumulation step whose known upstream corruption leaves nulls beyond lead-0 —
-    usually scattered per-pixel, occasionally a whole (ensemble_member, valid_time) slice (and all
-    three are legitimately null at lead-0). The scattered case mostly does not survive the H3
-    spatial aggregation as a null, because a cell is renormalised over the grid points that did
-    arrive; what reaches a frame validated here is therefore the blocky remainder plus whatever
-    scatter took out every point of a cell. Both are tolerated at ingest and reported by
-    :func:`assess_nwp_quality`; only a variable that is null in *every* slice beyond lead-0 is
-    fatal. See
-    <https://openclimatefix.github.io/nged-substation-forecast/architecture/ecmwf-ens-known-issues/>.
+    All three are legitimately null at lead-0, and they share a de-accumulation step whose known
+    upstream corruption leaves further nulls beyond it. Those are tolerated at ingest and reported
+    by :func:`assess_nwp_quality`; only a variable null in *every* slice beyond lead-0 is fatal.
+    Which corruption patterns arrive, what the H3 aggregation absorbs before they reach a validated
+    frame, and why the survivors are tolerated:
+    <https://openclimatefix.github.io/nged-substation-forecast/architecture/ecmwf-ens-known-issues/#nulls-in-the-de-accumulated-variables-tolerated>.
     """
 
     # Columns that aren't NWP variables:
@@ -343,43 +341,23 @@ class Nwp(pt.Model):
         That is, one that is null in *every* (ensemble_member, valid_time) slice beyond lead-0 of
         a run.
 
-        An all-null weather column is an absent input rather than a degraded one: it would train
-        and serve silently for the whole 15-day horizon, so a run 24 hours old but *complete* is
-        the better degradation. It is also one shape a half-published upstream run takes, which is
-        why :class:`NwpVariableWhollyMissing` is retried rather than failed outright.
-
         Every smaller null pattern is *tolerated* and reported by :func:`assess_nwp_quality`
-        instead, because the run it would otherwise discard is overwhelmingly good. That covers
-        both the occasional whole slice that arrives empty and the cells where the upstream
-        per-pixel corruption took out every contributing grid point — a run can carry 2 wholly-null
-        slices out of one variable's 4284 (51 members
-        × 84 steps beyond lead-0) and still be worth the other 4282, plus the twelve variables that
-        arrived complete.
+        instead, so this is a cliff rather than a slope: a run one slice short of empty lands with
+        a warning. There is no tunable fraction — the test is that *nothing* survives. Why an
+        absent column is the one case worth discarding a run over, and why every smaller pattern
+        is not:
+        <https://openclimatefix.github.io/nged-substation-forecast/architecture/ecmwf-ens-known-issues/#a-wholly-missing-variable-and-instantaneous-nulls-fatal>.
 
-        Be precise about *why* that is survivable, because the obvious argument is wrong. It is
-        true that all three variables are legitimately null at lead-0 in every run, so every model
-        handles nulls in them — but those lead-0 nulls reach the model *as nulls* only because they
-        are leading, and `_upsample_nwp_to_half_hourly` leaves leading nulls alone. An
-        *interior* wholly-null slice does not survive that way: `interpolate()` fills it from the
-        neighbouring steps, so the model sees a fabricated value rather than a null. The real
-        argument is narrower — a tolerated slice is a small, isolated part of one member's
-        trajectory, and bridging it (6 hours in the 3-hourly part of the horizon, 12 in the
-        6-hourly part, since the fill spans the steps *either side* of the missing one) is a
-        tolerable approximation. Note that it is a poorer one than the *spatial* fill the H3
-        aggregation applies to the scattered corruption, which stays inside one hexagon at one
-        step.
+        Two things a caller must not assume:
 
-        The judgement is made per `init_time`, so a run whose column is empty is caught even inside
-        a frame holding other, healthy runs. There is no tunable fraction here — the test is that
-        *nothing* survives — though it is still a cliff rather than a slope: a run one slice short
-        of empty lands with a warning.
-
-        The one place this is sharper than it looks: a frame filtered down to nothing *but* a
-        wholly-null slice is indistinguishable from an empty column and does raise, even though
-        the same slice was deliberately landed when the whole run was validated. That is latent
-        rather than live — the only production caller validates one whole run, and reads go
-        through `scan_delta`/`set_model`, which do not validate. See
-        <https://openclimatefix.github.io/nged-substation-forecast/architecture/ecmwf-ens-known-issues/>.
+        - The judgement is made per `init_time`, so a run whose column is empty is caught even
+          inside a frame holding other, healthy runs — but by the same token, a frame filtered down
+          to nothing *but* a wholly-null slice is indistinguishable from an empty column and does
+          raise, even though that same slice was deliberately landed when the whole run was
+          validated. Latent rather than live today: the only production caller validates one whole
+          run, and reads go through `scan_delta`/`set_model`, which do not validate.
+        - Raising is not the end of the partition. :class:`NwpVariableWhollyMissing` is a distinct
+          type because the `ecmwf_ens` asset retries it rather than failing outright.
         """
         slices_per_run = (
             dataframe.filter(pl.col("valid_time") > pl.col("init_time"))

--- a/packages/contracts/src/contracts/weather_schemas.py
+++ b/packages/contracts/src/contracts/weather_schemas.py
@@ -343,10 +343,13 @@ class Nwp(pt.Model):
 
         Every smaller null pattern is *tolerated* and reported by :func:`assess_nwp_quality`
         instead, so this is a cliff rather than a slope: a run one slice short of empty lands with
-        a warning. There is no tunable fraction — the test is that *nothing* survives. Why an
-        absent column is the one case worth discarding a run over, and why every smaller pattern
-        is not:
+        a warning. There is no tunable fraction — the test is that *nothing* survives.
+
+        Why an absent column is the one case worth discarding a run over:
         <https://openclimatefix.github.io/nged-substation-forecast/architecture/ecmwf-ens-known-issues/#a-wholly-missing-variable-and-instantaneous-nulls-fatal>.
+        Why every smaller pattern is not — the slice arithmetic, and the interpolation argument
+        that makes a tolerated slice survivable:
+        <https://openclimatefix.github.io/nged-substation-forecast/architecture/ecmwf-ens-known-issues/#nulls-in-the-de-accumulated-variables-tolerated>.
 
         Two things a caller must not assume:
 

--- a/packages/contracts/tests/test_settings.py
+++ b/packages/contracts/tests/test_settings.py
@@ -13,8 +13,9 @@ def _isolate_settings_from_ambient_config(monkeypatch: pytest.MonkeyPatch) -> No
 
     ``Settings`` reads ``PROJECT_ROOT/.env`` and process environment variables by default, so a
     developer's real local configuration — e.g. the ``DATA_STORE_*`` credentials that
-    ``docs/live_service/setup.md`` has them put in ``.env`` — would otherwise leak into tests
-    that assert on unset-field defaults (``storage_options == {}``, path derivation, …).
+    <https://openclimatefix.github.io/nged-substation-forecast/live_service/setup/> has them put
+    in ``.env`` — would otherwise leak into tests that assert on unset-field defaults
+    (``storage_options == {}``, path derivation, …).
     """
     # cast: SettingsConfigDict is a TypedDict, whose per-key value types don't unify with
     # monkeypatch.setitem's Mapping[K, V] signature.
@@ -64,8 +65,9 @@ def test_delivery_fields_are_exactly_the_known_delivery_tables():
     """Guards against a new delivery table being added but never wired into _derive_unset_paths.
 
     If this test fails after adding a new *_data_path field, decide whether it belongs in the
-    NGED-facing delivery bucket (see docs/roadmap/delivery-tables.md) and update either this set
-    or Settings._derive_unset_paths accordingly.
+    NGED-facing delivery bucket
+    (<https://openclimatefix.github.io/nged-substation-forecast/roadmap/delivery-tables/>) and
+    update either this set or Settings._derive_unset_paths accordingly.
     """
     known_delivery_fields = {"power_forecasts_data_path", "effective_capacity_data_path"}
     # Always-local artifacts derive from local_artifacts_path, not either data-table root, so

--- a/packages/delta_store/src/delta_store/nwp.py
+++ b/packages/delta_store/src/delta_store/nwp.py
@@ -14,7 +14,8 @@ H3 cells / ensemble members round to the same value), which Parquet's *default* 
 encoding captures directly; ``BYTE_STREAM_SPLIT`` scatters that repetition across four separate
 byte planes and loses more than it gains. ``power_forecasts``'s target values have no such
 repetition (near-continuous ML output), so ``BYTE_STREAM_SPLIT`` wins there instead — the two
-tables need different writer properties. See ``docs/architecture/overview.md`` for the measured
+tables need different writer properties. See
+<https://openclimatefix.github.io/nged-substation-forecast/architecture/overview/> for the measured
 GB/yr and read-latency numbers.
 """
 

--- a/packages/dynamical_data/src/dynamical_data/ecmwf_ens/convert_to_polars.py
+++ b/packages/dynamical_data/src/dynamical_data/ecmwf_ens/convert_to_polars.py
@@ -38,7 +38,8 @@ def convert_nwp_xarray_dataset_to_polars_dataframe(
     # and the physical units feed Nwp.validate. The offline tests share those assumptions, so after
     # changing this function run the network-gated test manually:
     #     uv run pytest --run-network -m network
-    # See docs/architecture/testing.md ("Network-gated tests").
+    # See
+    # <https://openclimatefix.github.io/nged-substation-forecast/architecture/testing/#network-gated-tests>.
     # Precompute latitude and longitude grids
     lat_grid, lon_grid = np.meshgrid(
         ds.latitude.values.astype(np.float32),
@@ -138,39 +139,25 @@ def _aggregate_grid_points_to_h3_cells(
 ) -> pl.DataFrame:
     """Reduce one H3 cell's overlapping NWP grid points to a single row per cell.
 
-    An H3 cell's value is the area-weighted mean of the grid points that overlap it: `sum(v * p)`
-    over the cell, where the `proportion` weights `p` sum to 1 by construction (see
-    `geo.h3.compute_h3_grid_weights`). Each variable is renormalised over the points that actually
-    supplied a value — dividing by the *contributing* weight rather than by 1.0 — so a cell keeps a
-    usable value when only some of its points arrived, instead of losing every point because one
-    was corrupt. Without that division, a missing point is silently treated as contributing zero,
-    which biases the cell low; the production grid averages ~2.9 grid points per cell, so that is
-    not a corner case.
+    Guarantees, per cell:
 
-    A cell where *no* point contributed has a contributing weight of zero and yields null, never
-    `0.0`. Getting that wrong is subtle and consequential: Polars sums an all-null group to `0.0`,
-    which for weather is a physically plausible, in-bounds lie (0 degC, 0 Pa, 0 m s-1) that passes
-    every downstream check. Nulling it is what makes the failure visible — see
-    <https://openclimatefix.github.io/nged-substation-forecast/architecture/ecmwf-ens-known-issues/>.
+    - A **numeric** variable is the area-weighted mean of the points that supplied a value —
+      `sum(v * p)` divided by the *contributing* weight rather than by 1.0, so a missing point
+      costs only its own share instead of biasing the cell low.
+    - A **categorical** variable is the category covering most of the cell's area, with an exact
+      tie resolved to the lowest category code. Points that supplied no category are excluded from
+      the ranking rather than competing in it.
+    - Either kind yields **null**, never `0.0` or a spurious category, when *no* point contributed.
 
-    A categorical variable cannot be averaged, so its cell takes the category covering the most of
-    the cell's area: the `proportion` weights are summed per category and the heaviest wins, with
-    the lowest category code breaking an exact tie. That tie-break is arbitrary but deterministic,
-    which matters because ties are reachable — two grid points in one cell can carry identical
-    `proportion` weights, which happens for 185 of the V1 grid's 1671 cells — and an
-    order-dependent answer would vary with Polars' internals. Note the direction of the bias it
-    introduces: **ties resolve to the lowest category code, and code 0 is "no precipitation", so an
-    evenly-split cell leans dry.** Points that supplied no category are excluded from the ranking
-    rather than competing in it, so the cell is null only when *no* point supplied one, matching
-    the numeric rule above.
+    Each variable is renormalised over its own denominator, which is what keeps one variable's
+    corruption from nulling the others. The cost a caller must know about: two variables in one
+    cell can end up averaged over different sub-areas of the hexagon, so if `wind_u_*` and
+    `wind_v_*` ever have different null footprints, the vector `_calc_wind_speed` and
+    `_calc_wind_direction` derive from them mixes two sub-areas.
 
-    Renormalising each variable over *its own* contributing weight is what makes a variable's
-    corruption cost only that variable, but it does mean two variables in one cell can end up
-    averaged over different sub-areas of the hexagon. That matters only for `wind_u_*`/`wind_v_*`,
-    where `_calc_wind_speed` and `_calc_wind_direction` later combine the pair: if `u` and `v` have
-    different null footprints, the derived vector mixes two sub-areas. Upstream corruption has
-    always been co-located across variables, so this is theoretical today, and a shared denominator
-    would be worse — it would let one variable's corruption null every other variable in the cell.
+    Why it is done this way, with the measurements, the tie-break's dry bias and the shared-
+    denominator alternative that was rejected:
+    <https://openclimatefix.github.io/nged-substation-forecast/architecture/ecmwf-ens-known-issues/#spatial-aggregation-is-where-a-grid-points-null-is-resolved>.
 
     Args:
         joined: The H3 grid weights left-joined onto one chunk's NWP grid values. NaN must already
@@ -216,6 +203,9 @@ def _aggregate_grid_points_to_h3_cells(
             *contributing_weights,
             *weighted_modes,
         )
+        # The `> 0` guard is load-bearing, not defensive: Polars sums an all-null group to `0.0`,
+        # so without it a cell that lost every point would divide 0.0 by 0.0. Keeping the null is
+        # what stops that cell reading as an in-bounds 0 degC / 0 Pa.
         .with_columns(
             **{
                 var: pl.when(pl.col(var + _CONTRIBUTING_WEIGHT_SUFFIX) > 0)

--- a/packages/dynamical_data/src/dynamical_data/ecmwf_ens/convert_to_polars.py
+++ b/packages/dynamical_data/src/dynamical_data/ecmwf_ens/convert_to_polars.py
@@ -141,22 +141,23 @@ def _aggregate_grid_points_to_h3_cells(
 
     Guarantees, per cell:
 
-    - A **numeric** variable is the area-weighted mean of the points that supplied a value —
-      `sum(v * p)` divided by the *contributing* weight rather than by 1.0, so a missing point
-      costs only its own share instead of biasing the cell low.
+    - A **numeric** variable is the area-weighted mean of the points that supplied a value:
+      `sum(v * p)`, where the `proportion` weights `p` sum to 1 over the whole cell by construction
+      (see `geo.h3.compute_h3_grid_weights`), divided by the *contributing* weight rather than by
+      that 1.0, so a missing point costs only its own share instead of biasing the cell low.
     - A **categorical** variable is the category covering most of the cell's area, with an exact
       tie resolved to the lowest category code. Points that supplied no category are excluded from
       the ranking rather than competing in it.
     - Either kind yields **null**, never `0.0` or a spurious category, when *no* point contributed.
 
-    Each variable is renormalised over its own denominator, which is what keeps one variable's
+    Each variable is renormalised over its *own* denominator, which is what keeps one variable's
     corruption from nulling the others. The cost a caller must know about: two variables in one
-    cell can end up averaged over different sub-areas of the hexagon, so if `wind_u_*` and
+    cell can then be averaged over different sub-areas of the hexagon, so if `wind_u_*` and
     `wind_v_*` ever have different null footprints, the vector `_calc_wind_speed` and
-    `_calc_wind_direction` derive from them mixes two sub-areas.
+    `_calc_wind_direction` derive from them mixes two sub-areas. Upstream corruption has always
+    been co-located across variables, so that is theoretical today.
 
-    Why it is done this way, with the measurements, the tie-break's dry bias and the shared-
-    denominator alternative that was rejected:
+    Why it is done this way, with the measurements and the tie-break's dry bias:
     <https://openclimatefix.github.io/nged-substation-forecast/architecture/ecmwf-ens-known-issues/#spatial-aggregation-is-where-a-grid-points-null-is-resolved>.
 
     Args:
@@ -204,8 +205,7 @@ def _aggregate_grid_points_to_h3_cells(
             *weighted_modes,
         )
         # The `> 0` guard is load-bearing, not defensive: Polars sums an all-null group to `0.0`,
-        # so without it a cell that lost every point would divide 0.0 by 0.0. Keeping the null is
-        # what stops that cell reading as an in-bounds 0 degC / 0 Pa.
+        # so without it a cell that lost every point would divide 0.0 by 0.0.
         .with_columns(
             **{
                 var: pl.when(pl.col(var + _CONTRIBUTING_WEIGHT_SUFFIX) > 0)

--- a/packages/dynamical_data/src/dynamical_data/ecmwf_ens/download.py
+++ b/packages/dynamical_data/src/dynamical_data/ecmwf_ens/download.py
@@ -51,7 +51,8 @@ def open_ecmwf_ens_run(
     # The offline tests share those assumptions and cannot catch a mismatch with the live
     # catalog, so after changing this function run the network-gated test manually:
     #     uv run pytest --run-network -m network
-    # See docs/architecture/testing.md ("Network-gated tests").
+    # See
+    # <https://openclimatefix.github.io/nged-substation-forecast/architecture/testing/#network-gated-tests>.
     if h3_grid.is_empty():
         raise ValueError("h3_grid is empty. Cannot download ECMWF data for an empty grid.")
 

--- a/packages/ml_core/src/ml_core/base_forecaster.py
+++ b/packages/ml_core/src/ml_core/base_forecaster.py
@@ -169,7 +169,8 @@ class BaseForecaster(ABC):
     responsibility: it prunes the inputs (NWP control member, the relevant H3 cells, the window's
     `init_time` partitions) and, where the full ensemble is needed, processes one `init_time` chunk
     at a time — filtering the engineered output cannot prune the upstream join/upsample. See the NWP
-    scan-pruning notes in `docs/architecture/overview.md`.
+    scan-pruning notes in
+    <https://openclimatefix.github.io/nged-substation-forecast/architecture/overview/>.
 
     Persistence has two layers. Subclasses implement ``save``/``load`` for their own on-disk
     format and need know nothing about MLflow. The concrete ``save_to_mlflow``/``load_from_mlflow``

--- a/packages/nged_data/src/nged_data/storage.py
+++ b/packages/nged_data/src/nged_data/storage.py
@@ -236,7 +236,7 @@ def time_series_coverage(
     Returns an empty (but correctly typed) frame if the Delta table does not exist yet.
     ``min``/``max`` grouped by ``time_series_id`` are value aggregations, so they are safe from
     the Polars 32-bit row-count wraparound even on a very large table (see
-    ``docs/architecture/code-style.md``).
+    <https://openclimatefix.github.io/nged-substation-forecast/architecture/code-style/#data-handling>).
 
     Cost: a full two-column scan-and-aggregate, O(rows in the table). Projection pushdown drops
     the ``power`` column, but a group-wise ``min``/``max`` cannot be answered from Parquet

--- a/packages/xgboost_forecaster/src/xgboost_forecaster/forecaster.py
+++ b/packages/xgboost_forecaster/src/xgboost_forecaster/forecaster.py
@@ -111,7 +111,7 @@ class XGBoostForecaster(BaseForecaster):
         the inputs (control member, the relevant H3 cells, the window's ``init_time`` partitions),
         because filtering the engineered output cannot prune the upstream join/upsample. See
         ``_load_engineering_inputs`` and the "NWP scan pruning" notes in
-        ``docs/architecture/overview.md``.
+        <https://openclimatefix.github.io/nged-substation-forecast/architecture/overview/>.
 
         Only the requested ``time_series_ids`` are trained; a requested series with no non-null
         ``power`` rows (e.g. none in the training window) simply does not appear and gets no
@@ -124,7 +124,8 @@ class XGBoostForecaster(BaseForecaster):
         # control-member read — but h3_index is not a sort-early column, so cell filtering is still
         # decode-then-filter within the surviving row groups. The streaming engine applies those
         # predicates per morsel, holding peak memory to a few GB where the in-memory engine would
-        # materialise every surviving row first. See docs/architecture/overview.md.
+        # materialise every surviving row first. See
+        # <https://openclimatefix.github.io/nged-substation-forecast/architecture/overview/>.
         df = data.drop_nulls(subset=["power"]).collect(engine="streaming")
         for group_key, group in df.group_by(["time_series_id"]):
             ts_id = int(group_key[0])
@@ -150,7 +151,8 @@ class XGBoostForecaster(BaseForecaster):
         ``time_series_id`` this model was not trained on are ignored (the model only scores its own
         trained population — see ``trained_time_series_ids``). Keeping the collect bounded is the
         caller's job: at validation every NWP ensemble member is present, so the caller engineers
-        one H3 cell at a time (see ``cv_power_forecasts`` and ``docs/architecture/overview.md``).
+        one H3 cell at a time (see ``cv_power_forecasts`` and
+        <https://openclimatefix.github.io/nged-substation-forecast/architecture/overview/>).
 
         ``fold_id`` is stamped onto every output row (the model has no inherent fold; the caller
         supplies it). Defaults to the ``"live"`` production sentinel.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -204,10 +204,9 @@ ignore = [
     # formatting cost is worth the readability.
     "G004", # logging statement uses f-string
     # The code-style page asks for *complete* type hints, which is what the rest of
-    # flake8-annotations enforces. It does not ask for the elimination of `Any`, and the sites
-    # that use it — a
-    # `**kwargs: Any` forwarded verbatim, a test double that accepts and ignores every argument —
-    # have no honest narrower type.
+    # flake8-annotations enforces. It does not ask for the elimination of `Any`, and the places
+    # that use it — a `**kwargs: Any` forwarded verbatim, a test double that accepts and ignores
+    # every argument — have no honest narrower type.
     "ANN401", # dynamically typed expressions (`typing.Any`) are disallowed
     # Asserting against a literal is the whole point of a unit test, and `magic-value-comparison`
     # cannot tell a test's expected value from a hard-coded constant in production code. That
@@ -310,16 +309,19 @@ docstring-code-line-length = 100
 # importlib mode lets test modules in different directories share a basename (e.g.
 # tests/test_metrics.py and packages/ml_core/tests/test_metrics.py); the default prepend
 # mode aborts collection with an "import file mismatch" error on the duplicate name.
-# The network-gated tests are skipped by default by the root conftest.py's collection hook (a plain
-# `uv run pytest` — local dev and per-PR CI — never touches the real Dynamical.org catalog). Run them
-# with `uv run pytest --run-network` — see docs/architecture/testing.md. The gate lives in a hook,
-# not in an `addopts` `-m "not network"`, because any caller-supplied `-m` would silently override it.
+# The network-gated tests are skipped by default by the root conftest.py's collection hook (a
+# plain `uv run pytest` — local dev and per-PR CI — never touches the real Dynamical.org catalog).
+# Run them with `uv run pytest --run-network` — see
+# <https://openclimatefix.github.io/nged-substation-forecast/architecture/testing/>. The gate lives
+# in a hook, not in an `addopts` `-m "not network"`, because any caller-supplied `-m` would
+# silently override it.
 addopts = "--import-mode=importlib"
 # The first two patterns are pytest's default, restated because naming any pattern replaces the
 # default list. The notebook is named as well because a marimo notebook is an ordinary Python file
 # that pytest can collect, and this one holds a `test_*` function exercising its chart-building
-# helper. See docs/architecture/testing.md. Patterns containing a `/` match against the path
-# rather than the basename, so this reaches exactly one file.
+# helper. See <https://openclimatefix.github.io/nged-substation-forecast/architecture/testing/>.
+# Patterns containing a `/` match against the path rather than the basename, so this reaches
+# exactly one file.
 python_files = ["test_*.py", "*_test.py", "packages/notebooks/plot_missing_NWP_data.py"]
 # Put the root `tests/` dir on sys.path so its integration tests can import shared, non-fixture
 # test data (e.g. `_nwp_test_data`) by bare name — importlib mode does not add each test file's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,8 +131,11 @@ line-length = 100
 # adopting the defaults verbatim would stop enforcing all fourteen of E401, E402, E701, E702, E703,
 # E711, E712, E713, E714, E721, E731, E741, E742 and E743. E4/E7/E9 are therefore listed
 # explicitly.
+#
+# "The code-style page", below and in `ignore`, means
+# <https://openclimatefix.github.io/nged-substation-forecast/architecture/code-style/>.
 select = [
-    "ANN",   # flake8-annotations: complete signatures are a house rule (see docs/architecture/code-style.md)
+    "ANN",   # flake8-annotations: complete signatures are a house rule (the code-style page)
     "ASYNC", # flake8-async
     "B",     # flake8-bugbear
     "BLE",   # flake8-blind-except
@@ -153,7 +156,7 @@ select = [
     "INT",   # flake8-gettext
     "ISC",   # flake8-implicit-str-concat
     "LOG",   # flake8-logging
-    "N",     # pep8-naming: the naming conventions docs/architecture/code-style.md mandates
+    "N",     # pep8-naming: the naming conventions the code-style page mandates
     "PERF",  # perflint
     "PGH",   # pygrep-hooks
     "PIE",   # flake8-pie
@@ -187,9 +190,9 @@ select = [
 # here (and its justification) over dropping a whole family from `select`.
 ignore = [
     # --- Rules that fight this repo's own conventions ---
-    # docs/architecture/code-style.md explicitly blesses long-but-clear parameter lists ("Eight parameters is acceptable
-    # when each is distinct"), and prefers extracting named helpers with more parameters over
-    # letting a function body grow.
+    # The code-style page explicitly blesses long-but-clear parameter lists ("Eight parameters is
+    # acceptable when each is distinct"), and prefers extracting named helpers with more parameters
+    # over letting a function body grow.
     "PLR0913", # too many arguments
     "PLR0917", # too many positional arguments
     # Our prose — docstrings and error messages alike — uses en-dashes and typographic quotes on
@@ -200,8 +203,9 @@ ignore = [
     # f-strings in log calls are fine here: this is not a high-volume hot path, and the eager
     # formatting cost is worth the readability.
     "G004", # logging statement uses f-string
-    # docs/architecture/code-style.md asks for *complete* type hints, which is what the rest of flake8-annotations
-    # enforces. It does not ask for the elimination of `Any`, and the places that use it — a
+    # The code-style page asks for *complete* type hints, which is what the rest of
+    # flake8-annotations enforces. It does not ask for the elimination of `Any`, and the sites
+    # that use it — a
     # `**kwargs: Any` forwarded verbatim, a test double that accepts and ignores every argument —
     # have no honest narrower type.
     "ANN401", # dynamically typed expressions (`typing.Any`) are disallowed
@@ -212,14 +216,13 @@ ignore = [
     # are quantile levels, longitude bounds and similar domain literals that read better inline
     # than as named constants. Tighten to a tests-only entry if that ever stops being true.
     "PLR2004", # magic value used in comparison
-    # docs/architecture/code-style.md asks for UPPER_SNAKE_CASE constants, and N806 rejects that spelling for a
-    # constant
-    # that happens to be function-local (`RAD_TO_DEG`, `COMPRESSION`), as well as domain-conventional
-    # names such as `X` for a feature matrix. The rest of pep8-naming (N801 classes, N802 functions,
-    # N815/N816 mixedCase) is left on and does encode the conventions docs/architecture/code-style.md
-    # states. N803 is
-    # *not* ignored here — every site is a marimo-generated cell parameter, so it is declined in
-    # `per-file-ignores` for the notebooks alone and stays live over `src/` and the tests.
+    # The code-style page asks for UPPER_SNAKE_CASE constants, and N806 rejects that spelling for a
+    # constant that happens to be function-local (`RAD_TO_DEG`, `COMPRESSION`), as well as
+    # domain-conventional names such as `X` for a feature matrix. The rest of pep8-naming (N801
+    # classes, N802 functions, N815/N816 mixedCase) is left on and does encode the conventions that
+    # page states. N803 is *not* ignored here — every site is a marimo-generated cell parameter, so
+    # it is declined in `per-file-ignores` for the notebooks alone and stays live over `src/` and
+    # the tests.
     "N806", # variable in function should be lowercase
     # The three sites are `NoNewData`, `NwpRunNotYetAvailable` and `NwpVariableWhollyMissing`;
     # renaming any of them is a public-API change across several packages, not a lint fix. Revisit
@@ -289,7 +292,8 @@ ignore = [
 "**/conftest.py" = ["ANN201", "D", "DTZ"]
 
 [tool.ruff.lint.flake8-tidy-imports.banned-api]
-# pandas is strictly forbidden in this repo — Polars only. See docs/architecture/code-style.md.
+# pandas is strictly forbidden in this repo — Polars only. See
+# <https://openclimatefix.github.io/nged-substation-forecast/architecture/code-style/>.
 "pandas".msg = "pandas is forbidden in this repo: use Polars (`pl.LazyFrame`/`pl.DataFrame`)."
 
 [tool.ruff.lint.pydocstyle]

--- a/scripts/run_baseline_experiment.py
+++ b/scripts/run_baseline_experiment.py
@@ -162,7 +162,8 @@ def main() -> None:
     # Context manager, not a bare ``DagsterInstance.ephemeral()``: ``__exit__`` calls ``dispose()``,
     # closing the two SQLite connections the in-memory run and event-log storages hold open. Letting
     # the local fall out of scope does not do this — Dagster caches retain a used instance until the
-    # interpreter exits. Rationale and measurements: docs/architecture/testing.md.
+    # interpreter exits. Rationale and measurements:
+    # <https://openclimatefix.github.io/nged-substation-forecast/architecture/testing/>.
     with DagsterInstance.ephemeral() as instance:
         _run_pipeline(instance)
 

--- a/src/nged_substation_forecast/defs/assets.py
+++ b/src/nged_substation_forecast/defs/assets.py
@@ -379,11 +379,13 @@ def _nwp_quality_check_result(report: NwpQualityReport) -> AssetCheckResult:
         metadata={
             "n_null_cells": report.n_null_cells,
             "n_affected_slices": report.n_affected_slices,
-            # Broken out because the two mean different things, and because this is the one the
-            # report measures well: a wholly-null slice reaches the cells intact however they are
-            # aggregated, whereas the scattered remainder is whatever upstream corruption happened
-            # to take out every grid point of a cell.
+            # The split of `n_affected_slices`, broken out because the two halves mean different
+            # things and only one of them is measured well: a wholly-null slice reaches the cells
+            # intact however they are aggregated, whereas the scattered remainder is only whatever
+            # upstream corruption happened to take out every grid point of a cell. Both are
+            # emitted so the operations runbook can name either as a number to read off this check.
             "n_whole_null_slices": report.n_whole_null_slices,
+            "n_scattered_slices": report.n_scattered_slices,
             "affected_variables": list(report.affected_variables),
             "affected_slices": _nwp_null_slices_metadata(report.affected),
         },

--- a/src/nged_substation_forecast/defs/checks.py
+++ b/src/nged_substation_forecast/defs/checks.py
@@ -358,7 +358,9 @@ _NWP_RUN_EXPECTED_ON_DISK_BY: Final[timedelta] = timedelta(hours=14)
 minutes, up to 8 times. The delays alone put the last healthy landing at about 12:30 UTC, but one
 of the two retryable failures (``NwpVariableWhollyMissing``) is raised *after* the download, so
 the worst case pays a download and convert on every attempt too — about 12:40 UTC at the ~1
-min/run measured in ``docs/architecture/performance.md``. That leaves 81 minutes of margin to
+min/run measured in
+<https://openclimatefix.github.io/nged-substation-forecast/architecture/performance/>. That leaves
+81 minutes of margin to
 14:00 UTC, spread over 9 attempts: the deadline is breached only if download-and-convert
 *averages* about 10 minutes across all of them, not if one attempt is slow. So the 645 s download
 recorded in ``dynamical_data.ecmwf_ens.download`` would cost only ~10 of those 81 minutes on its
@@ -639,8 +641,9 @@ def _read_live_forecast_rows(
     The scan is pruned to the matching ``(experiment_name, fold_id="live")`` Delta partitions and
     then to the one ``power_fcst_init_time``, and every column is reduced to a scalar inside
     Polars, so only the aggregates cross back into Python. The ``pl.len()`` is safe from the
-    32-bit row-count wraparound documented in ``docs/architecture/code-style.md``: it counts one
-    slot's rows (~1M at V1 scale, ~86M at V2), not the whole table.
+    32-bit row-count wraparound documented in
+    <https://openclimatefix.github.io/nged-substation-forecast/architecture/code-style/#data-handling>:
+    it counts one slot's rows (~1M at V1 scale, ~86M at V2), not the whole table.
     """
     if not delta_table_exists(power_forecasts_path, storage_options):
         return _EMPTY_LIVE_FORECAST_ROWS

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -264,7 +264,9 @@ def _load_engineering_inputs(
     ``init_time`` × every H3 cell × ~51 ensemble members × the 30-min forecast horizon). Every
     filter below is applied directly to the ``Nwp.scan_delta`` scan, so only the surviving rows
     are ever decoded into memory. This is the difference between a few GB and an OOM. See the
-    "NWP scan pruning" notes in ``docs/architecture/overview.md``. The three levers:
+    "NWP scan pruning" notes in
+    <https://openclimatefix.github.io/nged-substation-forecast/architecture/overview/>. The three
+    levers:
 
     - ``init_time``: the table is partitioned by ``init_time``, so bounding it to the runs that can
       cover the window (``[window_start - _MAX_NWP_LEAD, window_end]``) is a true *partition* prune
@@ -273,7 +275,7 @@ def _load_engineering_inputs(
     - ``ensemble_member``: applied at the scan so we never decode the ~50 discarded members; the
       member-early sort (``delta_store.nwp.NWP_SORT_COLS``) additionally lets Parquet row-group
       stats skip most of each partition outright for this predicate — see
-      ``docs/architecture/overview.md``.
+      <https://openclimatefix.github.io/nged-substation-forecast/architecture/overview/>.
     - ``h3_index``: restricted to the cells the requested series sit in. There is a *many-to-one*
       relationship between ``time_series_id`` and ``h3_index`` (one NWP cell covers several series),
       so this is a small set of cells; the per-cell weather is later replicated across the series in
@@ -490,7 +492,7 @@ def cv_power_forecasts(context: AssetExecutionContext) -> None:
     ensemble members and all trained series — tens of GB. ``init_time`` is the NWP partition key
     *and* the axis that inflates the output, so chunking by it bounds the per-iteration forecast
     frame (~2-3 GB) while each partition is still read exactly once. See the "NWP scan pruning"
-    notes in ``docs/architecture/overview.md``.
+    notes in <https://openclimatefix.github.io/nged-substation-forecast/architecture/overview/>.
 
     Forecasts are written to the ``power_forecasts`` Delta table keyed by
     ``(experiment_name, fold_id)``: the **first** chunk overwrites the partition (clearing any prior

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -350,6 +350,9 @@ def test_ecmwf_ens_warns_on_scattered_nulls_but_still_materialises(
     assert not evaluation.passed  # WARN: the scatter is surfaced
     assert evaluation.metadata["n_null_cells"].value == 1
     assert evaluation.metadata["n_whole_null_slices"].value == 0
+    # Both halves of the split are emitted, not just the whole-null one: the operations runbook
+    # names `n_scattered_slices` as a number to read off this check.
+    assert evaluation.metadata["n_scattered_slices"].value == 1
 
 
 def test_ecmwf_ens_reports_whole_null_slices_in_its_quality_check(
@@ -393,6 +396,9 @@ def test_ecmwf_ens_reports_whole_null_slices_in_its_quality_check(
     assert not evaluation.passed  # WARN: the missing slice is surfaced
     assert evaluation.metadata["n_whole_null_slices"].value == 1
     assert evaluation.metadata["n_null_cells"].value == 1
+    # The mirror of the scattered test above: the same slice must be counted once, on one side of
+    # the split, so the two metadata fields cannot both claim it.
+    assert evaluation.metadata["n_scattered_slices"].value == 0
 
 
 def test_ecmwf_ens_retries_when_a_variable_is_wholly_missing(
@@ -500,8 +506,9 @@ def test_ecmwf_ens_retries_when_run_not_yet_available(
 
     monkeypatch.setattr(assets, "open_ecmwf_ens_run", _raise_not_available)
 
-    # `build_asset_context()` defaults to its own `DagsterInstance.ephemeral()` (see
-    # `docs/architecture/testing.md`) and is used as a context manager here for the same reason
+    # `build_asset_context()` defaults to its own `DagsterInstance.ephemeral()`
+    # (<https://openclimatefix.github.io/nged-substation-forecast/architecture/testing/>) and is
+    # used as a context manager here for the same reason
     # `dagster_instance` is a fixture: entering it makes disposal happen deterministically at
     # `__exit__`, rather than depending on `__del__` running via garbage collection, which the
     # traceback captured by `pytest.raises` delays past this test — see the fixture's docstring.


### PR DESCRIPTION
> 🤖 **This PR was written by [Claude Code](https://claude.com/claude-code)**, acting on Jack's behalf, from a review of the sixteen PRs merged on 2026-08-10.

Follow-ups from that review. Two defects it found, one new code-style rule Jack asked for plus the violations of it, and one skill note. The third defect it found — `config_overrides` silently dropping a misspelled key — is already filed as #512 and is deliberately **not** touched here.

This PR body is itself the first written under the new no-hard-wrap rule below, so its paragraphs are single lines. Compare it with any PR merged yesterday to see what the rule is for.

## The new rule: one home per argument

Added to [the code-style page](https://openclimatefix.github.io/nged-substation-forecast/architecture/code-style/#comments-docstrings-and-links), so human collaborators see it too, not only the `code-style` skill:

> **One home per argument** — a design decision's *rationale* lives on one docs page, and the docstring links to it. The docstring's own job is to say what the function guarantees and what a caller must not assume. A sentence of "because" is fine; a paragraph of it means the paragraph belongs on the page.

The failure mode it guards against is silent: a later change updates the page, the docstring goes on asserting the superseded reasoning, and no linter, type checker or test can tell. It cuts both ways, and the page says so — rationale worth a paragraph does not belong *only* in a docstring, where nobody browsing the docs will find it.

A second bullet went in alongside it: **spell a docs link as its rendered URL, never as a repo path.** Two reasons, and the rule states both rather than the one I first reached for: a public docstring is rendered onto an API page, where a repo path is dead text to a reader who has the site open and not the repo checked out (and where writing it as a markdown link *would* 404, since it resolves against the rendered tree); and a URL survives the file being moved or renamed, which a path does not.

## Fixing the violations

**Bare repo paths → rendered URLs, 24 sites.** To be precise about what this fixes, because the first draft of this PR overstated it and the adversarial review caught that: none of them were broken, because none were written as markdown links. What they were is dead text on the rendered API pages — a path pointing at a file the reader may not have checked out — and a reference that a file move would silently invalidate. Every anchor I link to is verified present in the built HTML, not assumed.

**Rationale moved off three docstrings and onto its page.** All three are in the ECMWF null-handling cluster that #493 and #516 wrote yesterday, and all three restated arguments that `ecmwf-ens-known-issues.md` already makes in full: the renormalisation and its measurements, the categorical tie-break's dry bias, and why an interior wholly-null slice is bridged rather than seen as a null. `_aggregate_grid_points_to_h3_cells` goes from 42 docstring lines to 29, and now leads with three bullets stating what a cell is guaranteed to be. My first pass claimed nothing was deleted without checking the page already carried it; that was not true of three clauses, and the adversarial review below is what caught them.

Two things deliberately **stayed** at the code site, because they are facts about the code rather than rationale — this is the rule working, not an exception to it:

- the caller-facing note that per-variable denominators can average `wind_u_*` and `wind_v_*` over different sub-areas of a hexagon, which matters because `_calc_wind_speed` combines the pair;
- the hazard that validating a frame filtered down to nothing *but* a wholly-null slice does raise, even though that slice was deliberately landed when the whole run was validated.

I also added a comment that was missing: the `> 0` guard on the contributing weight is load-bearing, because Polars sums an all-null group to `0.0`. A future editor deleting that guard needs to see why it is there in the file, not on a page.

## Adversarial review

A fresh sub-agent reviewed the diff with one instruction weighted above the rest: for every clause removed from a docstring, find where that information now lives or report it lost. It found three genuine losses and seven smaller defects, all fixed in `2c780172`. The three that mattered:

- The **rejected shared-denominator alternative** existed nowhere afterwards — I had asserted the page carried it, and it did not. It is rationale, so it now lives on the page, next to the amplification argument it is a variant of.
- **"Upstream corruption has always been co-located, so this is theoretical today"** was dropped while the hazard it qualifies was kept. That is strictly worse than either keeping both or cutting both: a reader was left with an unqualified warning and no way to size it.
- The docstring still wrote `sum(v * p)` after the sentence defining `p` had been cut, and lost both the `geo.h3.compute_h3_grid_weights` cross-reference and the fact that the weights sum to 1 — without which "divided by the contributing weight rather than by 1.0" is meaningless.

It also caught that **the new rule's own justification was false**: I wrote that a repo path in a docstring 404s, but none of the converted references were markdown links, so nothing was 404ing. The rule now states the two reasons that are actually true. And the skill's `gh api /markdown` proof **did not run** — `printf` expanded `\n` inside the JSON string and GitHub returned a 400. Fixed to `\\n` and re-run; the underlying claim was correct, only the copy-pasteable command was broken.

Two of its findings I noted but did not act on, and they are worth your eye. First: the two most-heavily-trimmed docstrings are on *private* functions that mkdocstrings does not render, so at exactly those two sites there is no clickable link and the reader is in an editor either way — which weakens the rendering half of the argument for trimming them, though the drift half stands on its own. Second: it flagged that the Polars-sums-to-`0.0` fact is now in three places (page, docstring-adjacent comment, and the page again). I trimmed the inline comment to the mechanical fact alone, which the rule's "a sentence of because is fine" allows, but you may think that is still one copy too many.

## Defect: `n_scattered_slices` was documented but never emitted

[`operations.md`](https://openclimatefix.github.io/nged-substation-forecast/live_service/operations/) tells an operator to read `n_null_cells` and `n_scattered_slices` off the `nwp_has_no_unexpected_nulls` check. Only the first was in the metadata dict. The scattered count reached the operator solely inside the check's free-text description, so anyone following the runbook into Dagster's metadata table would not have found it.

Both halves of the `n_affected_slices` split are now emitted. The two asset tests assert them from opposite sides — 1 scattered / 0 whole in one, 0 scattered / 1 whole in the other — so neither half can claim a slice the other one counted.

## Defect: ragged comment blocks in `pyproject.toml`

#503's mechanical `CLAUDE.md` → `docs/architecture/code-style.md` rename substituted a longer string in place, pushing four comment blocks past the line length and splitting two of them mid-phrase, onto continuation lines reading just `# constant` and `# states. N803 is`. Nothing lints TOML comments, so it passed. Reflowed, and the page is now named once at the top of the block instead of four times, so the prose reads as prose.

## The skill note: never hard-wrap a GitHub body

Jack's diagnosis was exactly right, and it is now a section in the `github-issue-pr-workflow` skill, which is already the mandatory load before `gh issue create` / `gh pr create` / `gh pr merge`. GitHub renders comment-shaped content with hard line breaks turned on, so a single newline inside a paragraph becomes a literal `<br>`; repo `.md` files are rendered without that setting, which is why the same wrapping is correct there and wrong here. GitHub's own API shows the two renderers disagreeing on identical input, and the skill records the command so the claim is checkable rather than folklore:

```bash
printf '{"text":"line one\nline two","mode":"gfm"}' | gh api /markdown --input -
```

`mode=gfm` returns `<p>line one<br>\nline two</p>`. `mode=markdown` returns the same two lines with no `<br>`.

The skill also names the actual trap, which is the draft file rather than the typing: a long body wants `--body-file`, and a draft written *inside* the repo gets reflowed to the house width by the markdown linter or by habit, baking the wrapping in before the body is ever posted. Drafts belong in the scratchpad. The skill's `description` was widened so it also triggers on `gh pr comment` / `gh issue comment` and on writing any body, not only on creating things.

## `plan-issue` now states a session title

The desktop session list derives its title from the `/plan-issue <N>` invocation, so every planning session reads "Plan issue 510" and says nothing about itself once several are open at once. The skill now opens its first reply with an imperative title line naming what the issue *changes*, plus the number — `Planning: Cap late-series metadata table (#510)`.

This is recorded in the skill as a **hint, explicitly not a tool call**, because every session-management tool refuses the session it is running in, by contract. That matters for the next reader: without it, someone will "fix" this by reaching for `set_session_title` and get nowhere. The skill says to report the problem upward instead if the list still shows the default after a run, since that would mean it needs solving at the harness level rather than in a skill.

## Out of scope, deliberately

- **#512** (`config_overrides` silently dropping unknown keys) is the one defect from the review that is not fixed here. It is already filed with a proposed change, and it wants its own PR because `extra="forbid"` has a blast radius — it would also reject stale saved configs on load — that this PR should not be carrying.
- Two of the converted links point into `docs/roadmap/delivery-tables.md`, which code is not supposed to link to at all, since roadmap pages are deleted when they ship. I converted the spelling and left the target alone: retargeting them is ship-time triage for that page, not this PR's job.
- The `one home per argument` sweep is scoped to the ECMWF cluster the review actually examined. I did not go looking for every long docstring in the repo, because length alone is not the violation and a blanket trim would be a much larger, riskier diff than what was asked for.

## Verification

`pytest` (579 passed, 1 skipped, re-run after the review fixes), `ruff check`, `ruff format --check`, `ty check`, `pymarkdown scan` over both the repo command's targets and `.claude/skills/`, and `mkdocs build --strict` — all green.

Because this PR touches docs links and a list, I followed the `mkdocs-authoring` standing rule and read the generated HTML rather than trusting the linters: the six new/edited bullets in the code-style section render as six separate list items, and all six anchors I link to (`#spatial-aggregation-is-where-a-grid-points-null-is-resolved`, `#nulls-in-the-de-accumulated-variables-tolerated`, `#a-wholly-missing-variable-and-instantaneous-nulls-fatal`, `#data-handling`, `#comments-docstrings-and-links`, `#network-gated-tests`) are present as real `id=` attributes in the built site.
