### PR TITLE
Require prose to be concrete and skim-readable

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,7 +85,7 @@ by rendering both to PNG at 2× and comparing pixel by pixel). Unoptimised expor
 
 ### Prose style
 
-These three rules apply to everything we write in prose: `docs/` pages, READMEs, docstrings, code
+These four rules apply to everything we write in prose: `docs/` pages, READMEs, docstrings, code
 comments, and GitHub issue and PR bodies.
 
 **Be concrete and plain; write for a skim-reader.** Assume the reader is skimming and wants the
@@ -99,6 +99,14 @@ Economist*'s house style — short words, active voice, concrete nouns, British 
 acronym expanded on first use — but without the two journalistic habits that would hurt a reference
 doc, so no punning or whimsical headings, and no scene-setting opening: state the conclusion first,
 then explain it.
+
+**Be concise by cutting whole sentences, not words.** Prose should be as short as it can be
+without losing readability, but the compressible material is rarely inside a sentence. It is whole
+sentences and paragraphs that carry no information: restating the heading, summarising what the
+reader has just read, hedging ("it is worth noting that"), listing what we are *not* doing, or a
+closing paragraph that repeats the opening. Delete those outright, and leave the surviving
+sentences intact — buying brevity by clipping words out of a sentence that needs them is the
+mistake the next rule forbids.
 
 **Write full sentences; don't drop the subject.** Don't clip words for terseness
 if it leaves a sentence without a clear subject/verb. Prefer "We split storage across two

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,20 +83,24 @@ which took `docs/example_power_forecast.svg` from 571 KB to 296 KB with no visib
 by rendering both to PNG at 2× and comparing pixel by pixel). Unoptimised exports tend to trip
 `check-added-large-files`' 500 KB limit, which is the signal that this step was skipped.
 
-**Prose style — write for a skim-reader: concrete, plain, never poetic.** Assume the reader is
-skimming and wants the meaning to jump off the page, not to spend effort decoding a clever,
-abstract or metaphorical phrase. Name the actual thing — the asset, the column, the number, the
-failure — rather than gesturing at it. Prefer "if the ECMWF download fails, the forecast reuses
-yesterday's NWP run and widens the uncertainty bands" over "the pipeline weathers upstream
-turbulence"; prefer "one Delta table per data source" over "a constellation of storage
-primitives". Short everyday words beat long Latinate ones, and a plain sentence beats an elegant
-one. A useful shorthand for the target: *The Economist*'s house style — short words, active voice,
-concrete nouns, British spelling, every acronym expanded on first use — but without the two
-journalistic habits that would hurt a reference doc, so no punning or whimsical headings, and no
-scene-setting opening: state the conclusion first, then explain it. This applies to everything we
-write in prose: `docs/` pages, READMEs, docstrings, code comments, and GitHub issue and PR bodies.
+### Prose style
 
-**Prose style — write full sentences, don't drop the subject.** Don't clip words for terseness
+These three rules apply to everything we write in prose: `docs/` pages, READMEs, docstrings, code
+comments, and GitHub issue and PR bodies.
+
+**Be concrete and plain; write for a skim-reader.** Assume the reader is skimming and wants the
+meaning to jump off the page, not to spend effort decoding a clever, abstract or metaphorical
+phrase. Name the actual thing — the asset, the column, the number, the failure — rather than
+gesturing at it. Prefer "if the ECMWF download fails, the forecast reuses yesterday's NWP run and
+widens the uncertainty bands" over "the pipeline weathers upstream turbulence"; prefer "one Delta
+table per data source" over "a constellation of storage primitives". Short everyday words beat long
+Latinate ones, and a plain sentence beats an elegant one. A useful shorthand for the target: *The
+Economist*'s house style — short words, active voice, concrete nouns, British spelling, every
+acronym expanded on first use — but without the two journalistic habits that would hurt a reference
+doc, so no punning or whimsical headings, and no scene-setting opening: state the conclusion first,
+then explain it.
+
+**Write full sentences; don't drop the subject.** Don't clip words for terseness
 if it leaves a sentence without a clear subject/verb. Prefer "We split storage across two
 buckets so that..." over "Two buckets, not one — split so that...". The full form is more
 readable and no less concise in practice.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,19 @@ which took `docs/example_power_forecast.svg` from 571 KB to 296 KB with no visib
 by rendering both to PNG at 2× and comparing pixel by pixel). Unoptimised exports tend to trip
 `check-added-large-files`' 500 KB limit, which is the signal that this step was skipped.
 
+**Prose style — write for a skim-reader: concrete, plain, never poetic.** Assume the reader is
+skimming and wants the meaning to jump off the page, not to spend effort decoding a clever,
+abstract or metaphorical phrase. Name the actual thing — the asset, the column, the number, the
+failure — rather than gesturing at it. Prefer "if the ECMWF download fails, the forecast reuses
+yesterday's NWP run and widens the uncertainty bands" over "the pipeline weathers upstream
+turbulence"; prefer "one Delta table per data source" over "a constellation of storage
+primitives". Short everyday words beat long Latinate ones, and a plain sentence beats an elegant
+one. A useful shorthand for the target: *The Economist*'s house style — short words, active voice,
+concrete nouns, British spelling, every acronym expanded on first use — but without the two
+journalistic habits that would hurt a reference doc, so no punning or whimsical headings, and no
+scene-setting opening: state the conclusion first, then explain it. This applies to everything we
+write in prose: `docs/` pages, READMEs, docstrings, code comments, and GitHub issue and PR bodies.
+
 **Prose style — write full sentences, don't drop the subject.** Don't clip words for terseness
 if it leaves a sentence without a clear subject/verb. Prefer "We split storage across two
 buckets so that..." over "Two buckets, not one — split so that...". The full form is more


### PR DESCRIPTION
> 🤖 **This PR description was written by [Claude Code](https://claude.com/claude-code)**, acting on Jack's behalf.

Adds two rules to `CLAUDE.md` — prose must be concrete and skim-readable, and it must be concise — and groups them with the two prose rules that were already there under a new `### Prose style` heading in the **Docs** section.

## The concreteness rule

> **Be concrete and plain; write for a skim-reader.** Assume the reader is skimming and wants the meaning to jump off the page, not to spend effort decoding a clever, abstract or metaphorical phrase. Name the actual thing — the asset, the column, the number, the failure — rather than gesturing at it. Prefer "if the ECMWF download fails, the forecast reuses yesterday's NWP run and widens the uncertainty bands" over "the pipeline weathers upstream turbulence"; prefer "one Delta table per data source" over "a constellation of storage primitives". Short everyday words beat long Latinate ones, and a plain sentence beats an elegant one. A useful shorthand for the target: *The Economist*'s house style — short words, active voice, concrete nouns, British spelling, every acronym expanded on first use — but without the two journalistic habits that would hurt a reference doc, so no punning or whimsical headings, and no scene-setting opening: state the conclusion first, then explain it.

## Why

Jack's observation is that the docs Claude Code generates drift towards abstract and poetic phrasing, which costs a skim-reader effort they should not have to spend.

Two choices in the wording are worth flagging for review:

- **Scope is wider than `docs/`.** The same habit shows up in docstrings, code comments and GitHub bodies, so the section's opening sentence names all of them. Easy to narrow to `docs/` if that is too broad.
- **The Economist reference is qualified rather than bare.** It is a compressed signal a language model has a strong model of, and it pulls the right way — that style guide opens by endorsing Orwell's rules against stale metaphors and long words. It also matches the British spelling already used across the repo. Unqualified, though, it imports the exact failure mode the rule exists to kill: The Economist is known for punning headlines and for opening a piece with an anecdote before reaching the point. Both are good journalism and bad reference documentation.

It lives in `CLAUDE.md` rather than in a skill because `CLAUDE.md` is loaded into every session, so the rule binds unconditionally. The `code-style` skill only loads when Python is being touched, and `mkdocs-authoring` only when markdown is; prose quality should not depend on a skill firing.

## The conciseness rule

> **Be concise by cutting whole sentences, not words.** Prose should be as short as it can be without losing readability, but the compressible material is rarely inside a sentence. It is whole sentences and paragraphs that carry no information: restating the heading, summarising what the reader has just read, hedging ("it is worth noting that"), listing what we are *not* doing, or a closing paragraph that repeats the opening. Delete those outright, and leave the surviving sentences intact — buying brevity by clipping words out of a sentence that needs them is the mistake the next rule forbids.

The framing is deliberate. A bare "be as concise as possible" would pull directly against the rule immediately below it, "write full sentences; don't drop the subject" — a rule that exists precisely because clipping words for terseness cost readability. Naming the compressible material as whole sentences and paragraphs resolves that tension instead of creating it, and it targets what actually bloats generated prose: restatement, hedging and summary, not verbose sentences. The two rules are adjacent so the tension and its resolution are read together.

## The restructure (second commit)

Adding the rule left two adjacent paragraphs both opening with `**Prose style`, which broke the bold lead-in as a scanning handle — a reader had to read both to work out which one applied, in a rule about not making readers work. So the second commit:

- adds a `### Prose style` heading covering all four prose rules;
- gives each rule a distinct lead-in, so the handles now read "Be concrete and plain", "Be concise", "Write full sentences" and "Write about the present";
- hoists the scope sentence ("these rules apply to `docs/` pages, READMEs, docstrings, code comments, and GitHub issue and PR bodies") to the top of the section, where it covers every rule rather than only the new one.

No wording changed in the two pre-existing rules apart from their lead-ins.

## Verification

`uv run pymarkdown scan CLAUDE.md` is clean, and the pre-commit hooks passed on all three commits. Documentation only — no code changed.
