### PR TITLE
Split the plan review into simplicity and correctness passes

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -13,9 +13,10 @@ description: >-
 
 This routine starts from an **approved plan**. The `plan-issue` skill (invoked as
 `/plan-issue <N>`) is how you get one: it reads the issue, decides whether it is worth
-implementing at all, writes `plans/<branch-name>.md`, has a fresh sub-agent adversarially review
-the plan, and stops for Jack. It also does step 1 below, so when it hands over, the worktree and
-branch already exist and implementation resumes at step 2.
+implementing at all, writes `plans/<branch-name>.md`, has two fresh sub-agents adversarially
+review the plan — one for simplicity, one for correctness and testability — and stops for Jack. It
+also does step 1 below, so when it hands over, the worktree and branch already exist and
+implementation resumes at step 2.
 
 When dispatching a sub-agent (or a fresh Claude Code/Desktop session), give it these steps up
 front — a report back after step 1 is not finished work.

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -3,8 +3,9 @@ name: plan-issue
 description: >-
   Turn a GitHub issue in openclimatefix/nged-substation-forecast into a reviewed implementation
   plan, writing no code: read the issue and its comments, decide whether it is worth implementing
-  at all, write a plan that may overrule a stale issue body, have a fresh sub-agent adversarially
-  review it, triage the findings, stop for Jack. Load whenever Jack asks for a plan for an issue,
+  at all, write a plan that may overrule a stale issue body, put it through two fresh adversarial
+  sub-agent reviews — one hunting for a simpler approach, then one checking correctness and
+  testability — triage the findings, stop for Jack. Load whenever Jack asks for a plan for an issue,
   says "plan issue N" or "/plan-issue N", asks whether an issue is worth doing, or asks you to
   think through an implementation before touching code. To implement an approved plan, use
   `implement-issue` instead.
@@ -143,16 +144,60 @@ The plan covers:
 
 Do not paste large code blocks into the plan. Name the change; the implementer writes the code.
 
-## 4. Adversarial review by a fresh sub-agent
+## 4. First adversarial review: is there a simpler way?
 
-Launch a **new** sub-agent. Give it the issue number and the path to the plan file, and **nothing
-about your reasoning** — it must not be anchored by the argument that produced the plan.
+The plan now goes through **two** reviews, by two separate fresh sub-agents, in this order:
+simplicity first, then correctness. Simplifying a plan can break it, so the correctness reviewer
+has to see the plan that simplification left behind, not the one that went in.
+
+Launch a **new** sub-agent for this first pass. Give it the issue number and the path to the plan
+file, and **nothing about your reasoning** — it must not be anchored by the argument that produced
+the plan. Its single job is to find a simpler way to satisfy the issue, and its default assumption
+is that one exists.
+
+Name the attacks that apply to this issue:
+
+- Which parts of the plan solve a problem the issue did not ask about? Cut them and say what
+  breaks.
+- Is there an existing function, package or Patito model that already does what a proposed new
+  one would? (`packages/` is small enough to check.)
+- Would a plain function do what a new class, abstract base class, config object or strategy
+  object is proposed for?
+- Is a new column, table, asset or config field earning its place, or is the value already
+  derivable from what is stored?
+- Is the plan generalising for a second caller that does not exist? This project is young; a
+  breaking change later is cheap.
+- What is the smallest change to the existing code that a user of the system could not tell apart
+  from the plan's version?
+
+Ask for each simplification as a concrete alternative — what to do instead, which files it
+touches, and what capability is given up by taking it.
+
+## 5. Triage and revise
+
+Verify each proposed simplification against the code rather than accepting it — **reviewer
+findings are often wrong, and applying them uncritically makes the plan worse**. Take the genuine
+ones into the plan file. Reject a simplification when it drops something the issue actually asked
+for, or trades away a rule in `docs/design-philosophy/` — and say which, in one line.
+
+For each finding you reject, record the finding and the one-line reason in the plan file, so Jack
+can see what was considered and dismissed. Commit the revised plan.
+
+## 6. Second adversarial review: correctness and testability
+
+Launch **another** new sub-agent — not the one from step 4, and again with no account of your
+reasoning or of what the first review changed. Give it the issue number and the path to the
+revised plan file. Its job is to establish whether the plan, as now written, is correct and whether
+its tests would actually catch it being wrong.
 
 Tailor the brief to this issue's specific failure modes rather than asking for a generic review.
 The attacks worth naming, when they apply:
 
 - Does the plan's description of *current* behaviour actually match the code on `main`?
-- Would each proposed test really have failed before the change?
+- Would each proposed test really have failed before the change? A test that passes on `main`
+  today tests nothing about this change.
+- Is any part of the plan untestable as written — needing network, wall-clock time, or a whole
+  trained model to exercise one branch? Say what would have to change to make it testable.
 - Does the change fail closed anywhere production is supposed to degrade — in particular, can any
   warning path now raise?
 - Is a refactor hiding a behaviour change inside it?
@@ -162,20 +207,19 @@ The attacks worth naming, when they apply:
 Ask the reviewer for findings with file/line evidence, and for an explicit verdict on each: real
 defect, or not.
 
-## 5. Triage the findings
+## 7. Triage the findings
 
-Verify each finding against the code rather than accepting it — **reviewer findings are often
-wrong, and applying them uncritically makes the plan worse**. Fix the genuine ones in the plan
-file. For each finding you reject, record the finding and the one-line reason it was rejected, in
-the plan file, so Jack can see what was considered and dismissed. Commit the updated plan, so the
-branch carries both the original plan and what the review did to it.
+Verify each finding against the code, on the same terms as step 5: fix the genuine ones in the
+plan file, and record each rejected finding with its one-line reason. Commit the updated plan, so
+the branch carries the original plan and what both reviews did to it.
 
-## 6. Stop
+## 8. Stop
 
-Report to Jack: the verdict from step 2, a short summary of the plan, what the review changed, and
-what it found that you rejected. Give the branch name and the path to the plan file.
+Report to Jack: the verdict from step 2, a short summary of the plan, what each of the two reviews
+changed, and what each found that you rejected. Give the branch name and the path to the plan
+file.
 
 **Do not write any code, and do not open a PR.** Once Jack approves the plan, implementation runs
 under the `implement-issue` skill, resuming at its step 2 in the worktree this skill already
-created — implement, verify, PR, a second and independent adversarial review of the *diff*,
-triage, stop.
+created — implement, verify, PR, a further independent adversarial review of the *diff*, triage,
+stop.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,10 +148,11 @@ Two skills, in order, and they are deliberately separate so that Jack approves a
 any code moves:
 
 1. **`plan-issue`** (`/plan-issue <N>`) reads the issue, decides whether it is worth implementing
-   at all, writes `plans/<branch-name>.md`, has a fresh sub-agent adversarially review that plan,
-   and stops for Jack. It writes no code.
+   at all, writes `plans/<branch-name>.md`, has two fresh sub-agents adversarially review that
+   plan in turn — the first hunting for a simpler approach, the second checking correctness and
+   testability — and stops for Jack. It writes no code.
 2. **`implement-issue`** picks up an approved plan: worktree, implement, the green-before-push
-   verification set, PR with labels and assignee, a *second and independent* adversarial review
+   verification set, PR with labels and assignee, a *further independent* adversarial review
    of the diff, triage, stop. **Never merge.**
 
 Stay inside the issue's scope; report unrelated design mistakes rather than fixing them.
@@ -160,7 +161,9 @@ Stay inside the issue's scope; report unrelated design mistakes rather than fixi
 adversarial pass by the time he looks at it, so his review is the last line of defence rather
 than the first. The fresh-reviewer requirement exists so the reviewer cannot be anchored by the
 implementer's rationale; the triage step exists because reviewer findings are often wrong and
-must not be applied uncritically.
+must not be applied uncritically. Simplicity gets its own reviewer, and gets it first, because a
+plan that is more complicated than the issue requires is the failure mode that survives a
+correctness review intact.
 
 ## Architecture
 


### PR DESCRIPTION
*This PR was written by Claude Code.*

`plan-issue` had one adversarial review stage. It now has two, run by two separate fresh sub-agents in a fixed order.

**Step 4 — simplicity.** The first reviewer's only job is to find a simpler way to satisfy the issue, and its default assumption is that one exists. The named attacks: parts of the plan that solve a problem the issue did not ask about, an existing function or Patito model that already does the job, a plain function where a class or strategy object is proposed, a new column/table/asset/config field whose value is already derivable, generalising for a second caller that does not exist, and "what is the smallest change a user could not tell apart from the plan's version?". Each simplification has to come back as a concrete alternative: what to do instead, which files it touches, and what capability is given up.

**Step 5 — triage and revise**, on the existing terms (verify each finding, record rejections with a one-line reason, commit). A simplification is rejected when it drops something the issue asked for or trades away a rule in `docs/design-philosophy/`.

**Step 6 — correctness and testability.** This is the old review, plus an explicit testability attack: is any part of the plan untestable as written — needing network, wall-clock time, or a whole trained model to exercise one branch — and what would have to change to fix that? The reviewer is a different sub-agent, given the revised plan and no account of what the first review changed.

Steps 7 and 8 are the old triage and stop, renumbered.

The ordering is the point: simplifying a plan can break it, so the correctness reviewer has to see the plan that simplification left behind rather than the one that went in.

Also updated the pointers to this routine in `CLAUDE.md` and in the `implement-issue` skill, which both described a single plan review. `implement-issue`'s own review of the diff was "a *second and independent* adversarial review"; it is now "a *further independent*" one, since there are three reviews in the sequence.

## Verification

`pymarkdown scan` over the three changed files, via the pre-commit hook — clean. No code changed.
