### PR TITLE
Require keyword arguments at call sites

### DIFF
--- a/.claude/skills/code-style/SKILL.md
+++ b/.claude/skills/code-style/SKILL.md
@@ -3,8 +3,8 @@ name: code-style
 description: >-
   This repo's code conventions, which Jack cares about and expects to be followed: Python 3.14+,
   Polars only (pandas banned), Patito schemas, ruff configuration and its traps, naming, how
-  expressive a type hint has to be, `Final` on constants, comment and doc-link rules, and Polars
-  style. Load before writing or editing any Python in this repo — a new module, a new function, a
+  expressive a type hint has to be, `Final` on constants, calling functions with keyword arguments,
+  comment and doc-link rules, and Polars style. Load before writing or editing any Python in this repo — a new module, a new function, a
   refactor, a test — and before reviewing Python for style, or answering a question about what the
   house style is.
 ---
@@ -23,6 +23,7 @@ What is in there, so you know what you are getting:
 | General Principles | Python 3.14+, modularity, small functions (and when extra parameters are fine), re-using existing tools, tests |
 | Formatting & Linting (Ruff) | line length, quotes, docstring convention, import rules, how `select`/`ignore` are maintained, two `per-file-ignores` traps |
 | Type hints and signatures | how expressive a signature must be — `Literal` aliases, `TypedDict`, named aliases — and `Final` on every constant |
+| Calling functions | keyword arguments at every call site the callee allows, and the three positional exceptions |
 | Comments, docstrings and links | current-state-only rule, which docs code may link to, MkDocs-compatible constant docstrings |
 | Data Handling | Polars/Patito/Xarray choices, lazy-evaluation contract, Patito friction budget, the 2³² row-count rule |
 | Polars style | `.cast` vs `.with_columns`, keyword-argument column naming, `Type`-suffixed `Literal` aliases |

--- a/docs/architecture/code-style.md
+++ b/docs/architecture/code-style.md
@@ -83,6 +83,27 @@ stricter type exists — a genuinely heterogeneous or open-ended dict stays `dic
 **All constants must be marked with the maximally "constant" type**, e.g.
 `CONST_SEQ: Final[tuple[str, ...]] = ("a", "b")` or `FOO: Final[str] = "bar"`.
 
+## Calling functions
+
+**Pass arguments by keyword wherever the callee allows it.** Write
+`write_nwp(nwp=nwp, table_uri=uri, storage_options=options)`, not
+`write_nwp(nwp, uri, options)`. The keyword names what each value is for, so the reader learns it
+from the call site instead of opening the callee; and if a parameter is later reordered, renamed or
+removed, the call fails loudly rather than binding the wrong value in silence. The payoff is
+biggest for bare strings, numbers and booleans, whose meaning is invisible without the keyword.
+
+Three places where a positional argument is right:
+
+- **Positional-only parameters** — those before a `/` in the signature, and most of what C
+  implements: `len(df)`, `isinstance(value, str)`, `Path("data")`. A keyword is a `TypeError`
+  there.
+- **A variadic `*args` position** — `pl.col("power_mw", "power_mva")`, and the expressions in
+  `df.select(...)` and `df.with_columns(...)`.
+  Every keyword parameter that follows one still takes its name, as the
+  [Polars style](#polars-style) rules below assume.
+- **One argument whose role the function name already states** — `forecaster.save(path)`,
+  `json.loads(text)`. There is nothing for it to be confused with.
+
 ## Comments, docstrings and links
 
 - **Do not remove existing comments** unless they are misleading or out of date. Only add new


### PR DESCRIPTION
🤖 Written by Claude Code.

Adds a **Calling functions** section to `docs/architecture/code-style.md`, at Jack's request: pass arguments by keyword wherever the callee allows it, so a call site says what each value is for and a later parameter reorder fails loudly instead of silently binding the wrong value.

Three positional exceptions are spelled out, so "where possible" isn't left to interpretation: positional-only parameters (`len(df)`, `Path("data")`), a variadic `*args` position (`pl.col(...)`, the expressions in `df.select(...)`), and a lone argument whose role the function name already states (`forecaster.save(path)`).

The `code-style` skill gets a row in its section table and a mention in its description, so the rule is discoverable from the skill listing. The rule itself stays in the docs page only — the skill routes there rather than restating it.

No code changes; this is the style guide, and existing call sites are not retrofitted.
