### PR TITLE
Review the diff twice: cut it down, then mutation-test it

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -3,10 +3,12 @@ name: implement-issue
 description: >-
   The routine for implementing an approved plan for a GitHub issue in
   openclimatefix/nged-substation-forecast: isolated worktree, implement, the green-before-push
-  verification set, PR with labels and the JackKelly assignee, a fresh sub-agent adversarially
-  reviews the diff, triage, stop for Jack — never merge. Load before writing any code for an
-  issue, and when dispatching a sub-agent or a fresh session to solve one. To decide *what* to
-  build, use `plan-issue` first.
+  verification set, PR with labels and the JackKelly assignee, then two fresh sub-agents
+  adversarially review the diff in turn — one for correctness and for keeping the code, tests and
+  prose as short as they can be, then one that mutation-tests the change — triaging and pushing
+  after each, stop for Jack, never merge. Load before writing any code for an issue, and when
+  dispatching a sub-agent or a fresh session to solve one. To decide *what* to build, use
+  `plan-issue` first.
 ---
 
 # Implement a GitHub issue
@@ -51,16 +53,65 @@ front — a report back after step 1 is not finished work.
    with `Co-Authored-By: Claude <noreply@anthropic.com>`. See the `github-issue-pr-workflow`
    skill for the full PR checklist and the never-squash-merge rule.
 
-5. **Spawn a *new*, independent sub-agent to adversarially review the PR** — give it only the
-   PR number, not the implementer's reasoning, so it isn't anchored by it. Tailor the reviewer
-   brief to the issue: name the failure modes most worth attacking (the risky claim, a
-   behaviour change hiding inside a refactor, whether a new test would actually have failed on
-   `main`) rather than asking for a generic review.
+5. **First adversarial review: correctness, and cutting the change down.** Spawn a *new*,
+   independent sub-agent and give it only the PR number, not the implementer's reasoning, so it
+   isn't anchored by it. It attacks four things:
 
-6. **Triage the review's findings** — verify each against the code rather than accepting it,
-   fix genuine defects, push, and record why any finding was rejected.
+    - **Correctness.** Tailor this part to the issue rather than asking for a generic review:
+      name the failure modes most worth attacking — the risky claim, a behaviour change hiding
+      inside a refactor, whether each new test would actually have failed on `main`.
+    - **Simplicity of the code.** Which added lines could go without a user of the system
+      telling the difference? Does an existing function, package or Patito model already do what
+      a new one does? Would a plain function do what a new class, config object or strategy
+      object was added for? Is the diff generalising for a second caller that does not exist?
+      For every guard, branch and error path the diff adds, can the condition it handles
+      actually arise — which caller, which input, which sequence of events? A branch nothing can
+      reach, because no caller passes that argument or the Patito schema already rejects that
+      row, is dead weight plus a test that proves nothing; say so and delete both. The exception
+      is the degradation paths `docs/design-philosophy/inherent-stability.md` requires in
+      production: an absent or stale input is always reachable, because the outside world is not
+      ours to constrain.
+    - **Simplicity of the tests.** Is a new test asserting what an existing test already
+      asserts? Would a parametrised case, a plain literal or an existing fixture replace a
+      bespoke builder?
+    - **Concision of the prose** — every added line of docs, docstring, comment and the PR body
+      itself. Which whole sentences carry no information: restating the heading, summarising
+      what the reader has just read, hedging, or narrating what the change replaced? Cut whole
+      sentences, not words (CLAUDE.md, "Prose style").
 
-7. **Stop and wait for Jack's review. Never merge.**
+    Ask for each finding as a concrete deletion or replacement. The standard is that the PR adds
+    no more lines of code, tests or prose than the change absolutely needs.
+
+6. **Triage and push** — verify each finding against the code rather than accepting it, fix the
+   genuine ones, re-run the step-3 verification set, push, and record each rejected finding with
+   its one-line reason.
+
+7. **Second adversarial review: mutation testing.** Spawn *another* new sub-agent — not the one
+   from step 5, and again with no account of your reasoning. Its job is to break the production
+   code the PR touches and find out whether the tests notice. There is no mutation-testing tool
+   in this repo, so it does this by hand, in its own detached worktree, which keeps a mutation
+   off the branch:
+
+    ```bash
+    git worktree add --detach .claude/worktrees/mutate-<branch-name> <branch-name>
+    ```
+
+    Brief it to take each behavioural claim the diff makes, introduce the smallest bug that
+    breaks that claim, run the tests covering it, then revert the bug before trying the next
+    one. Mutations worth naming: flip a comparison or a boolean, swap two join keys, drop a
+    `.filter()` or a `.round()`, return an argument unchanged, shift a lag by one period, make a
+    warning path raise. It reports every mutation the suite stays green on, with the file, the
+    mutation, and the test that should have caught it — then removes its worktree (`git worktree
+    remove`). It never commits or pushes. The table under "NWP grid → H3 orientation coverage"
+    in `docs/architecture/testing.md` is what a finished pass of this looks like.
+
+8. **Triage and push** — on the same terms as step 6. A surviving mutation is a gap only where
+   the behaviour it breaks is behaviour we rely on; where it is, tighten or add a test and
+   confirm that test goes red against the mutation and green without it. Re-run the step-3
+   verification set and push.
+
+9. **Stop and wait for Jack's review. Never merge.** Report what each of the two reviews changed
+   and what each found that you rejected.
 
 Stay inside the issue's scope; report unrelated design mistakes rather than fixing them.
 
@@ -68,4 +119,7 @@ Stay inside the issue's scope; report unrelated design mistakes rather than fixi
 adversarial pass by the time he looks at it, so his review is the last line of defence rather
 than the first. The fresh-reviewer requirement exists so the reviewer cannot be anchored by the
 implementer's rationale; the triage step exists because reviewer findings are often wrong and
-must not be applied uncritically.
+must not be applied uncritically. Mutation testing goes second because it should be aimed at the
+tests that survive the first round, not at ones the first round deletes — and it gets its own
+reviewer because a green suite proves nothing on its own: the only way to learn whether a test
+would catch the bug it exists for is to write that bug and watch.

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -157,6 +157,13 @@ is that one exists.
 
 Name the attacks that apply to this issue:
 
+- **Can the problem actually happen?** For each failure the plan defends against, ask the reviewer
+  to name the caller, the input and the sequence of events that produces it. A bug nobody can
+  reach — because no caller passes that argument, or the Patito schema already rejects that row,
+  or the data source cannot emit that value — is theoretical, and the plan should drop it rather
+  than carry code and tests for it. The degradation paths
+  `docs/design-philosophy/inherent-stability.md` requires in production are the exception: an
+  absent or stale input is always reachable, because the outside world is not ours to constrain.
 - Which parts of the plan solve a problem the issue did not ask about? Cut them and say what
   breaks.
 - Is there an existing function, package or Patito model that already does what a proposed new
@@ -221,5 +228,5 @@ file.
 
 **Do not write any code, and do not open a PR.** Once Jack approves the plan, implementation runs
 under the `implement-issue` skill, resuming at its step 2 in the worktree this skill already
-created — implement, verify, PR, a further independent adversarial review of the *diff*, triage,
-stop.
+created — implement, verify, PR, then two further independent adversarial reviews of the *diff*,
+triaging and pushing after each, stop.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ needed one, the mistake is already written.
 | `marimo-notebooks` | creating or editing a Marimo notebook (`packages/dashboard/*.py`, `packages/notebooks/*.py`) |
 | `ty-workarounds` | acting on a `ty` error in Altair chart code or numpy `.view()` code, or adding any `# ty: ignore` |
 | `plan-issue` | deciding what to build for a GitHub issue (`/plan-issue <N>`) — writes a reviewed plan, no code |
-| `implement-issue` | writing code for an approved plan: worktree, verify set, PR, adversarial review, stop |
+| `implement-issue` | writing code for an approved plan: worktree, verify set, PR, two adversarial reviews, stop |
 | `github-issue-pr-workflow` | `gh issue create`, `gh pr create`, `gh pr merge`, or ship-time triage |
 | `github-graphql` | any `gh api graphql` call — sub-issue attach/reorder, issue Type, project fields |
 
@@ -152,8 +152,10 @@ any code moves:
    plan in turn — the first hunting for a simpler approach, the second checking correctness and
    testability — and stops for Jack. It writes no code.
 2. **`implement-issue`** picks up an approved plan: worktree, implement, the green-before-push
-   verification set, PR with labels and assignee, a *further independent* adversarial review
-   of the diff, triage, stop. **Never merge.**
+   verification set, PR with labels and assignee, then two *further independent* adversarial
+   reviews of the diff — the first for correctness and for cutting the code, tests and prose
+   down to what the change needs, the second mutation-testing the change — triaging and pushing
+   after each, stop. **Never merge.**
 
 Stay inside the issue's scope; report unrelated design mistakes rather than fixing them.
 
@@ -163,7 +165,9 @@ than the first. The fresh-reviewer requirement exists so the reviewer cannot be 
 implementer's rationale; the triage step exists because reviewer findings are often wrong and
 must not be applied uncritically. Simplicity gets its own reviewer, and gets it first, because a
 plan that is more complicated than the issue requires is the failure mode that survives a
-correctness review intact.
+correctness review intact. Mutation testing gets the last reviewer because a green suite proves
+nothing on its own: whether a test would catch the bug it exists for is only settled by writing
+that bug and watching.
 
 ## Architecture
 


### PR DESCRIPTION
🤖 This PR was written by Claude Code.

Two changes to the review stages in the `implement-issue` and `plan-issue` skills, both requested by Jack.

**The diff now gets two adversarial reviews instead of one.** After the PR opens, a fresh sub-agent reviews it for correctness *and* for anything the change does not need — simplicity of the code, simplicity of the tests, and concision of every added line of prose (docs, docstrings, comments and the PR body itself), with the standard stated as "no more lines than the change absolutely needs" and each finding asked for as a concrete deletion. That round is triaged and pushed. Then a second, different sub-agent mutation-tests the change: there is no mutation-testing tool in this repo, so it works by hand in a detached worktree (`git worktree add --detach`, so a mutation can never reach the branch), introducing the smallest bug that breaks each behavioural claim, running the covering tests, reverting, and reporting every mutation the suite stayed green on. Its triage requires any new test to be confirmed red against the mutation and green without it. The routine still stops for Jack and never merges.

**Both simplicity passes now check that the problem is real.** The plan reviewer (`plan-issue` step 4) and the diff reviewer (`implement-issue` step 5) are each asked, for every failure the change defends against, to name the caller, the input and the sequence of events that produces it. A bug nothing can reach — no caller passes that argument, the Patito schema already rejects that row, the data source cannot emit that value — is theoretical, and the code plus its test should go. The degradation paths `docs/design-philosophy/inherent-stability.md` requires in production are called out as the exception, so a reviewer cannot use this rule to strip them: an absent or stale input is always reachable, because the outside world is not ours to constrain.

`CLAUDE.md` is updated to match in the two places that describe the routine.

Docs-only change: `uv run pymarkdown scan` is clean on all three files, and the pre-commit hooks passed.
