### PR TITLE
Describe what upsert_metadata does to a series the snapshot omits

### DIFF
--- a/packages/nged_data/src/nged_data/storage.py
+++ b/packages/nged_data/src/nged_data/storage.py
@@ -370,13 +370,12 @@ def upsert_metadata(
     explicit locking is required.
 
     If the Parquet file does not exist, it saves the new_metadata. If it exists, it merges the
-    new_metadata into it and rewrites the file only if something changed. The snapshot and the
-    stored roster need not share a schema, and rows are matched on ``time_series_id``. The two
-    kinds of series then fare differently. A series that ``new_metadata`` covers is replaced
-    wholesale, so a field the snapshot has stopped carrying is **cleared** for that series. A
-    series that ``new_metadata`` omits is left untouched, and keeps its last stored values
-    indefinitely. The roster therefore holds every time series we have ever seen, not only the
-    ones in the latest snapshot.
+    new_metadata into it and rewrites the file only if something changed. The snapshot need not
+    carry the same columns, or the same column order, as the stored roster, and rows are matched
+    on ``time_series_id``. A series that ``new_metadata`` covers is replaced wholesale, so a field
+    the snapshot has stopped carrying is **cleared** for that series. A series that
+    ``new_metadata`` omits keeps its last stored values indefinitely. The roster therefore holds
+    every time series we have ever seen, not only the ones in the latest snapshot.
 
     Args:
         new_metadata: The new metadata DataFrame.

--- a/packages/nged_data/src/nged_data/storage.py
+++ b/packages/nged_data/src/nged_data/storage.py
@@ -371,8 +371,12 @@ def upsert_metadata(
 
     If the Parquet file does not exist, it saves the new_metadata. If it exists, it merges the
     new_metadata into it and rewrites the file only if something changed. The snapshot and the
-    stored roster need not share a schema, and a field that ``new_metadata`` no longer carries is
-    **cleared**, so the roster always means "the latest snapshot of what NGED published".
+    stored roster need not share a schema, and rows are matched on ``time_series_id``. The two
+    kinds of series then fare differently. A series that ``new_metadata`` covers is replaced
+    wholesale, so a field the snapshot has stopped carrying is **cleared** for that series. A
+    series that ``new_metadata`` omits is left untouched, and keeps its last stored values
+    indefinitely. The roster therefore holds every time series we have ever seen, not only the
+    ones in the latest snapshot.
 
     Args:
         new_metadata: The new metadata DataFrame.

--- a/packages/nged_data/tests/test_storage.py
+++ b/packages/nged_data/tests/test_storage.py
@@ -282,9 +282,9 @@ def test_upsert_metadata_adds_a_new_id_when_the_stored_roster_is_thinner(tmp_pat
 
 def test_upsert_metadata_merges_a_snapshot_missing_the_optional_columns(tmp_path: Path):
     """`TimeSeriesMetadata` has four `allow_missing` fields, so a snapshot can be narrower than the
-    stored roster and still validate. Merging the two must not raise, and the two kinds of series
-    must fare differently: a field the snapshot no longer carries is *cleared* for the series the
-    snapshot covers, while a series the snapshot omits keeps every value it already had."""
+    stored roster and still validate. Merging the two must not raise: a field the snapshot no
+    longer carries is *cleared* for the series the snapshot covers, while a series the snapshot
+    omits keeps every value it already had."""
     metadata_path = tmp_path / "metadata.parquet"
     _roster([1, 2], information="note").write_parquet(metadata_path)
 

--- a/packages/nged_data/tests/test_storage.py
+++ b/packages/nged_data/tests/test_storage.py
@@ -282,9 +282,9 @@ def test_upsert_metadata_adds_a_new_id_when_the_stored_roster_is_thinner(tmp_pat
 
 def test_upsert_metadata_merges_a_snapshot_missing_the_optional_columns(tmp_path: Path):
     """`TimeSeriesMetadata` has four `allow_missing` fields, so a snapshot can be narrower than the
-    stored roster and still validate. Merging the two must not raise, and a field the snapshot no
-    longer carries must be *cleared*, so the roster keeps meaning "the latest snapshot of what NGED
-    published"."""
+    stored roster and still validate. Merging the two must not raise, and the two kinds of series
+    must fare differently: a field the snapshot no longer carries is *cleared* for the series the
+    snapshot covers, while a series the snapshot omits keeps every value it already had."""
     metadata_path = tmp_path / "metadata.parquet"
     _roster([1, 2], information="note").write_parquet(metadata_path)
 

--- a/src/nged_substation_forecast/defs/checks.py
+++ b/src/nged_substation_forecast/defs/checks.py
@@ -188,11 +188,11 @@ def evaluate_power_freshness(
     # Stale: has data on disk, but the newest observation predates the cutoff.
     #
     # NOTE: this is deliberately not restricted to `roster_ids`. A series that NGED has
-    # decommissioned (dropped from the metadata roster) but that still has old rows on disk will
-    # keep being flagged stale — which is what we want for now: we would rather be told about a
-    # series that has gone quiet than silently stop watching it. If a permanently-yellow check
-    # for a genuinely retired series becomes a nuisance, intersect the stale ids with
-    # `roster_ids` here (when a roster is available) so only currently-expected series count.
+    # decommissioned but that still has old rows on disk will keep being flagged stale — which is
+    # what we want for now: we would rather be told about a series that has gone quiet than
+    # silently stop watching it. Restricting to `roster_ids` would not silence one anyway:
+    # `upsert_metadata` never drops a series, so a retired series stays in the roster for good.
+    # Silencing one needs an explicit record of which ids we have retired.
     stale = coverage.filter(pl.col("last_time") < cutoff).select(
         "time_series_id",
         last_seen=pl.col("last_time"),


### PR DESCRIPTION
*This PR was written by Claude Code.*

## The bug

`upsert_metadata`'s docstring claimed that a field `new_metadata` no longer carries is cleared, "so the roster always means 'the latest snapshot of what NGED published'". The final clause is false, and `test_upsert_metadata_merges_a_snapshot_missing_the_optional_columns` — added alongside the docstring — proves it: it stores a roster covering series 1 and 2 with `information="note"`, upserts a snapshot covering series 2 only and carrying no `information` column, and asserts that series 1 keeps `information="note"`.

The clearing applies only to the series the snapshot covers. `combined.unique(subset="time_series_id", keep="first")` keeps the snapshot's row where the snapshot has one and the stored row otherwise, so a series that drops out of the snapshot is retained untouched — including for fields the snapshot has stopped publishing entirely.

## The change

Docs only, no behaviour change.

Both docstrings now describe the two fates separately. The comment in `defs/checks.py` about the freshness check's stale set is fixed too: it proposed intersecting the stale ids with `roster_ids` to silence a retired series, which cannot work, because `upsert_metadata` never drops a series and `_read_roster_ids` filters nothing — the retired series is still in `roster_ids`. Following that suggestion would ship a no-op.

I grepped the repo for other copies of the claim. `docs/live_service/operations.md:179` and `docs/architecture/production-deployment.md:75` are both accurate as written.

## One thing for you to decide, not changed here

**Should a series that drops out of the snapshot be dropped from the roster?** Retaining it forever is what the code does today and I have left it alone. It has a real consequence: `power_data_is_fresh` counts a roster series with no rows on disk as "never reported", so a series NGED decommissions and stops publishing stays in the roster and can keep the check yellow indefinitely — with, as above, no way to silence it short of an explicit retirement record. The argument for retaining is that a series missing from one snapshot is usually a gap in that delivery rather than a decommissioning, and dropping it would lose the metadata we need to interpret power rows already on disk. If you want stale series expired, that wants its own issue — a `last_seen_in_snapshot` column and an age threshold, rather than dropping on first absence.
