### PR TITLE
Name the run and the remedy when a promoted run has no meta.json

### DIFF
--- a/packages/ml_core/src/ml_core/_production_helpers.py
+++ b/packages/ml_core/src/ml_core/_production_helpers.py
@@ -263,13 +263,20 @@ def fetch_model_artifacts(run_id: str, dest: Path) -> None:
         dest: Directory to populate — typically ``Settings.production_model_path``.
 
     Raises:
-        ValueError: The model's ``selected_features`` are absent, malformed, or name a feature
-            this code cannot parse — re-train against the current feature vocabulary and promote
-            that run instead.
+        ValueError: The run holds no ``meta.json``, or the model's ``selected_features`` are
+            absent, malformed, or name a feature this code cannot parse — re-train against the
+            current feature vocabulary and promote that run instead.
     """
     with tempfile.TemporaryDirectory() as tmp_dir:
         downloaded_dir = _download_and_unpack_model(run_id, Path(tmp_dir))
-        meta = json.loads((downloaded_dir / "meta.json").read_text())
+        meta_path = downloaded_dir / "meta.json"
+        if not meta_path.exists():
+            raise ValueError(
+                f"The model saved under run {run_id} has no meta.json, so no forecaster here can "
+                "load it. Re-train against the current feature vocabulary and promote that run "
+                "instead."
+            )
+        meta = json.loads(meta_path.read_text())
         _check_meta_features_are_parseable(meta=meta, source=f"run {run_id}")
 
         promotion = {

--- a/packages/ml_core/src/ml_core/_production_helpers.py
+++ b/packages/ml_core/src/ml_core/_production_helpers.py
@@ -264,8 +264,8 @@ def fetch_model_artifacts(run_id: str, dest: Path) -> None:
 
     Raises:
         ValueError: The run holds no ``meta.json``, or the model's ``selected_features`` are
-            absent, malformed, or name a feature this code cannot parse — re-train against the
-            current feature vocabulary and promote that run instead.
+            absent, malformed, or name a feature this code cannot parse — re-train and promote a
+            run this code version can read instead.
     """
     with tempfile.TemporaryDirectory() as tmp_dir:
         downloaded_dir = _download_and_unpack_model(run_id, Path(tmp_dir))
@@ -273,8 +273,8 @@ def fetch_model_artifacts(run_id: str, dest: Path) -> None:
         if not meta_path.exists():
             raise ValueError(
                 f"The model saved under run {run_id} has no meta.json, so no forecaster here can "
-                "load it. Re-train against the current feature vocabulary and promote that run "
-                "instead."
+                "load it. Re-train and promote a run saved by a code version that writes "
+                "meta.json (see BaseForecaster.save)."
             )
         meta = json.loads(meta_path.read_text())
         _check_meta_features_are_parseable(meta=meta, source=f"run {run_id}")

--- a/packages/ml_core/tests/test_base_forecaster.py
+++ b/packages/ml_core/tests/test_base_forecaster.py
@@ -93,6 +93,14 @@ class _MetaWithoutModelParams(_FakeForecaster):
         (path / "meta.json").write_text(json.dumps(meta))
 
 
+class _MetaJsonMissing(_FakeForecaster):
+    """A forecaster whose saved record omits ``meta.json`` altogether."""
+
+    def save(self, path: Path) -> None:
+        super().save(path)
+        (path / "meta.json").unlink()
+
+
 def test_trained_time_series_ids_is_abstract() -> None:
     """A subclass that omits ``trained_time_series_ids`` cannot be instantiated."""
 
@@ -270,11 +278,21 @@ def _save_without_model_params(run_id: str) -> None:
     ).save_to_mlflow(run_id)
 
 
+def _save_without_meta_json(run_id: str) -> None:
+    """Save a run whose archive holds the model files but no record describing them."""
+    _MetaJsonMissing(
+        model_params=BaseForecasterConfig(selected_features=set()),
+        payload="recordless",
+        series=[10],
+    ).save_to_mlflow(run_id)
+
+
 @pytest.mark.parametrize(
     ("save_unservable", "expected"),
     [
         (_save_stale_vocabulary, "local_utc_offset"),
         (_save_without_model_params, "model_params"),
+        (_save_without_meta_json, "no meta.json"),
     ],
 )
 def test_fetch_model_artifacts_keeps_the_previous_model_when_the_new_one_is_unservable(


### PR DESCRIPTION
🤖 Written by [Claude Code](https://claude.com/claude-code).

## The bug

`fetch_model_artifacts` reads the staged `meta.json` unguarded:

```python
meta = json.loads((downloaded_dir / "meta.json").read_text())
```

A promoted run whose downloaded archive holds model files but no `meta.json` therefore raises `FileNotFoundError`, which the function's `Raises:` block does not list — it names only `ValueError`. The message an operator gets is `[Errno 2] No such file or directory: '/tmp/tmpXXXX/unpacked_model/meta.json'`: a path inside a temporary directory that no longer exists by the time they read it, naming neither the run nor anything to do about it.

## Why `ValueError` rather than documenting the `FileNotFoundError`

`load_forecaster_from_dir` raises `FileNotFoundError` when `Settings.production_model_path` has no `meta.json`, and its remedy is "materialise the `promoted_model` asset first". That is a *precondition not yet met*: nobody claims a model is there, the operator simply has not put one there, and the fix is an action on this machine. It raises `ValueError` instead when a `meta.json` is present but unusable, and the remedy is to promote a different run.

A downloaded run with no `meta.json` is the second situation, not the first. The download succeeded and the artifacts arrived; the run just is not a saved model any forecaster here can load, and no amount of re-downloading will change that. The remedy is to go and promote a run that is a proper saved model. `FileNotFoundError` would tell an operator the opposite, that something went wrong locally and a retry might work.

## The change

The refusal happens before anything is written, so the previous champion stays in place at `Settings.production_model_path` and keeps serving — unchanged from before, since the old `FileNotFoundError` was raised at the same point.

The message does not reuse the "re-train against the current feature vocabulary" remedy that `_check_meta_features_are_parseable`'s two messages carry, because a missing `meta.json` has nothing to do with feature names and an operator who went and checked theirs would learn nothing. `BaseForecaster.save` requires every implementation to write a `meta.json`, so the remedy is the one the sibling `model_class is None` refusal already gives: promote a run saved by a code version that writes it.

The message names the run and never the experiment tracker, the same rule the two refusals in `_check_meta_features_are_parseable` are bound by (`scripts/build_and_verify_image.sh` greps the smoke-test container log for that word, and `test_the_rejection_message_never_mentions_the_experiment_tracker` pins it).

## Test

A third case on the existing `test_fetch_model_artifacts_keeps_the_previous_model_when_the_new_one_is_unservable` parametrisation. Verified it fails on `main` with `FileNotFoundError` and passes here.

## Notes for review

Another PR in flight rewrites `_check_meta_features_are_parseable` in this same file and is likely to touch this `Raises:` block too, so expect a trivial docstring conflict between the two.

Out of scope but worth flagging: `MlflowException` also escapes `fetch_model_artifacts` undocumented, from `_download_and_unpack_model`, and a run holding no archive at all is a more likely fault than one holding an archive without a `meta.json`. Left alone here to keep the conflict above small.
