### PR TITLE
Give each duplicated argument one home

### DIFF
--- a/docs/architecture/ecmwf-ens-known-issues.md
+++ b/docs/architecture/ecmwf-ens-known-issues.md
@@ -1,12 +1,9 @@
 # Known ECMWF ENS data-quality issues
 
 **Scope: this page is about *upstream* — the ways the data arrives damaged, and which of those we
-reject and which we tolerate.** Its subject is data we did not create and cannot fix, so a defect
-described here is a reason to talk to Dynamical.org. How to *interpret* the data that arrives
-undamaged — which variables are instantaneous and which are averages over the preceding step, which
-one is an angle that wraps, and what our own feature pipeline does to each on the way to the model —
-is the separate subject of [NWP variable conventions](nwp-variable-conventions.md). A defect
-described on that page is a reason to change our code.
+reject and which we tolerate.** How to *interpret* the data that arrives undamaged is the separate
+subject of [NWP variable conventions](nwp-variable-conventions.md), which sets out how the two pages
+divide the subject between them.
 
 We ingest ECMWF IFS ENS from [Dynamical.org](https://dynamical.org). Its data carries a few
 known, recurring quality quirks. This page records what they are, how we tell them apart, and the

--- a/docs/architecture/ecmwf-ens-known-issues.md
+++ b/docs/architecture/ecmwf-ens-known-issues.md
@@ -1,9 +1,16 @@
 # Known ECMWF ENS data-quality issues
 
-**Scope: this page is about *upstream* — the ways the data arrives damaged, and which of those we
-reject and which we tolerate.** How to *interpret* the data that arrives undamaged is the separate
-subject of [NWP variable conventions](nwp-variable-conventions.md), which sets out how the two pages
-divide the subject between them.
+This page and [NWP variable conventions](nwp-variable-conventions.md) split the subject between
+them:
+
+- **This page is about *upstream*.** It covers the ways Dynamical.org's data arrives damaged —
+  corrupt source accumulations, null grid points, incomplete runs — and the ingest policy that
+  decides which of those we reject and which we tolerate. Its subject is data we did not create and
+  cannot fix, so a defect described here is a reason to talk to Dynamical.
+
+- **That page is about *us*.** It covers how the data that arrives intact is meant to be
+  interpreted, and what our own code does with it. Everything there is a choice this project made,
+  or failed to make deliberately, so a defect described there is a reason to change our code.
 
 We ingest ECMWF IFS ENS from [Dynamical.org](https://dynamical.org). Its data carries a few
 known, recurring quality quirks. This page records what they are, how we tell them apart, and the

--- a/docs/architecture/nwp-variable-conventions.md
+++ b/docs/architecture/nwp-variable-conventions.md
@@ -5,17 +5,10 @@ to it on the way to the model. Every ECMWF ENS variable we store is listed with 
 governs it: some values describe an instant, some describe the three or six hours before that
 instant, and two are angles that wrap.
 
-This page and [Known ECMWF ENS data-quality issues](ecmwf-ens-known-issues.md) split the subject
-between them:
-
-- **That page is about *upstream*.** It covers the ways Dynamical.org's data arrives damaged —
-  corrupt source accumulations, null grid points, incomplete runs — and the ingest policy that
-  decides which of those we reject and which we tolerate. Its subject is data we did not create and
-  cannot fix, so a defect described there is a reason to talk to Dynamical.
-
-- **This page is about *us*.** It covers how the data that arrives intact is meant to be
-  interpreted, and what our own code does with it. Everything here is a choice this project made, or
-  failed to make deliberately, so a defect described here is a reason to change our code.
+Everything here is a choice this project made, so a defect described on this page is a reason to
+change our code. Damage the data arrives with is the separate subject of [Known ECMWF ENS
+data-quality issues](ecmwf-ens-known-issues.md), which sets out how the two pages divide the subject
+between them.
 
 ## The forecast step grid
 

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -81,9 +81,7 @@ series) an uncapped table serialises to about 355 KB per hourly evaluation, agai
 rows. The cap matches the Sentry event context below, so the same leading series appear in both and
 there is one less thing to reconcile. The counts beside it are uncapped, and an `n_late_listed`
 field records how many rows the table actually holds, so a truncated table can never make a large
-stall look small. Rows are ordered never-reported first, then most-stale first, so a roster with
-more than 50 never-reported series fills the table with those alone — `n_stale` and
-`n_never_reported` stay exact regardless. Dagster's
+stall look small. Dagster's
 Checks view becomes the operator's at-a-glance "is the power data healthy?" status surface, showing
 a green tick when every series is current and a yellow warning naming the late count when the feed
 has stalled.

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -74,11 +74,16 @@ The check is attached to `power_time_series_and_metadata`, so the existing hourl
 runs it every hour with no extra wiring. It reports two kinds of lateness: a series that once
 reported but has now gone **stale**, and a roster series (present in the `TimeSeriesMetadata`
 parquet) that has **never** sent data. The count of each, plus a table of the offending
-`time_series_id`s, lands in the check's Dagster metadata. That table is **capped** at 50 rows, for
-the same reason the Sentry payloads below are — an uncapped listing writes thousands of rows into
-the event log every hour a whole-feed stall lasts, and the event log is durable storage that gets
-backed up. The counts beside it are uncapped, and an `n_late_listed` field records how many rows
-the table actually holds, so a truncated table can never make a large stall look small. Dagster's
+`time_series_id`s, lands in the check's Dagster metadata. That table is **capped** at 50 rows,
+because an uncapped listing writes thousands of rows into Dagster's event log every hour a
+whole-feed stall lasts, and that log is durable storage that gets backed up: at V2 scale (~2,500
+series) an uncapped table serialises to about 355 KB per hourly evaluation, against about 8 KB at 50
+rows. The cap matches the Sentry event context below, so the same leading series appear in both and
+there is one less thing to reconcile. The counts beside it are uncapped, and an `n_late_listed`
+field records how many rows the table actually holds, so a truncated table can never make a large
+stall look small. Rows are ordered never-reported first, then most-stale first, so a roster with
+more than 50 never-reported series fills the table with those alone — `n_stale` and
+`n_never_reported` stay exact regardless. Dagster's
 Checks view becomes the operator's at-a-glance "is the power data healthy?" status surface, showing
 a green tick when every series is current and a yellow warning naming the late count when the feed
 has stalled.
@@ -208,7 +213,7 @@ is configured — so laptops and CI stay silent by default.
   reported`), and the full per-series detail is attached as structured event context. Both are
   capped — the message to a short leading slice with an `…and N more` line, the context to a larger
   slice — so a whole-feed stall at V2 scale can't attach thousands of rows; the true late count is
-  always carried by the `n_late` tag, so a capped list never makes a large stall look small. Sending
+  always carried by the `n_late` tag. Sending
   is best-effort: `report_power_freshness` never raises, so a Sentry hiccup costs no more than its
   own event. Were it to raise, the check's catch-all would swallow it and discard the whole
   freshness evaluation with it — every late series, in the very hour they went late.

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -76,10 +76,11 @@ reported but has now gone **stale**, and a roster series (present in the `TimeSe
 parquet) that has **never** sent data. The count of each, plus a table of the offending
 `time_series_id`s, lands in the check's Dagster metadata. That table is **capped** at 50 rows,
 because an uncapped listing writes thousands of rows into Dagster's event log every hour a
-whole-feed stall lasts, and that log is durable storage that gets backed up: at V2 scale (~2,500
-series) an uncapped table serialises to about 355 KB per hourly evaluation, against about 8 KB at 50
-rows. The cap matches the Sentry event context below, so the same leading series appear in both and
-there is one less thing to reconcile. The counts beside it are uncapped, and an `n_late_listed`
+whole-feed stall lasts, and that log is durable storage — Postgres in the AWS deployment,
+`pg_dump`ed to S3 nightly. At V2 scale (~2,500 series) an uncapped table serialises to about 355 KB
+per hourly evaluation, against about 8 KB at 50 rows. The cap matches the Sentry event *context*
+below (both 50) rather than the tighter 20 on the Sentry message body, so the same leading series
+appear in both and there is one less thing to reconcile. The counts beside it are uncapped, and an `n_late_listed`
 field records how many rows the table actually holds, so a truncated table can never make a large
 stall look small. Dagster's
 Checks view becomes the operator's at-a-glance "is the power data healthy?" status surface, showing

--- a/docs/live_service/operations.md
+++ b/docs/live_service/operations.md
@@ -178,7 +178,8 @@ series with `last_seen` and `hours_late`. A warning therefore never stops foreca
 produced; it tells you which feed to chase. A handful of persistently-late series is usually a
 decommissioned or renamed substation rather than an outage — check the roster before escalating.
 
-That table is capped at 50 rows, because it is written to the event log every hour a stall lasts.
+That table is capped at 50 rows
+([why](../architecture/production-deployment.md#warn-on-stale-power-data-with-a-dagster-asset-check)).
 **Read `n_late`, not the table's length**, to see how big the stall is: `n_late` is the true count,
 and `n_late_listed` tells you how many rows the table holds, so the two agreeing means you are
 looking at every late series and the two differing means the list is truncated. The same pair

--- a/docs/roadmap/xgboost-improvements.md
+++ b/docs/roadmap/xgboost-improvements.md
@@ -114,9 +114,11 @@ effect.
 **(b) Radiation and precipitation are interpolated as though they were instantaneous.** They are
 period-ending means over the preceding step, so interpolating between `valid_time` stamps treats a
 backward-looking average as a reading at the end of its window. That shifts the modelled solar day
-late by half the step width — three hours beyond day 6 — and cuts its peak by a quarter
+late by half the step width — three hours beyond day 6 — and cuts its peak by a quarter, from
+816 W m⁻² to 590
 ([measurements](../architecture/nwp-variable-conventions.md#period-ending-variables-are-interpolated-as-though-they-were-instantaneous)).
-Shortwave radiation is the worst-affected numeric variable, at half again the next-worst.
+Shortwave radiation is the worst-affected numeric variable, at half again the next-worst
+(MAE/SD 0.44 against 0.30).
 
 The fix is the clear-sky-index resample, and it has **four requirements**. Getting the first wrong
 makes the result worse than doing nothing: normalising by the instantaneous clear-sky value at
@@ -142,8 +144,8 @@ convention but needs no clear-sky treatment: its accumulator features integrate 
 anyway, so only sub-window timing is lost.
 
 **(c) Instantaneous variables lose diurnal amplitude beyond day 6**, because the ~15:00 temperature
-maximum falls between the 12:00 and 18:00 samples: the mean daily temperature range is compressed by
-**11.9%**
+maximum falls between the 12:00 and 18:00 samples: the mean daily temperature range falls from
+6.09 °C to 5.37 °C, an **11.9% compression**
 ([measurements](../architecture/nwp-variable-conventions.md#instantaneous-variables-lose-diurnal-amplitude)).
 This one has no exact fix, since the asymmetric
 afternoon peak needs the second harmonic and four samples a day is at the Nyquist limit for it. A
@@ -152,7 +154,7 @@ not been measured. It feeds the effective-temperature, degree-day and `windchill
 as a bounded experiment rather than a correctness fix, and expect a smaller win than (a) or (b).
 
 The synoptic variables need no fix: `pressure_surface`, `pressure_reduced_to_mean_sea_level` and
-`geopotential_height_500hpa` lose almost nothing at 6-hourly spacing.
+`geopotential_height_500hpa` lose almost nothing at 6-hourly spacing (MAE/SD 0.02–0.09).
 
 ### Store wind as u/v components rather than speed and direction
 

--- a/docs/roadmap/xgboost-improvements.md
+++ b/docs/roadmap/xgboost-improvements.md
@@ -114,9 +114,9 @@ effect.
 **(b) Radiation and precipitation are interpolated as though they were instantaneous.** They are
 period-ending means over the preceding step, so interpolating between `valid_time` stamps treats a
 backward-looking average as a reading at the end of its window. That shifts the modelled solar day
-late by half the step width — three hours beyond day 6 — and cuts its peak by a quarter, from
-816 W m⁻² to 590. Shortwave radiation is the worst-affected numeric variable, at half again the
-next-worst (MAE/SD 0.44 against 0.30).
+late by half the step width — three hours beyond day 6 — and cuts its peak by a quarter
+([measurements](../architecture/nwp-variable-conventions.md#period-ending-variables-are-interpolated-as-though-they-were-instantaneous)).
+Shortwave radiation is the worst-affected numeric variable, at half again the next-worst.
 
 The fix is the clear-sky-index resample, and it has **four requirements**. Getting the first wrong
 makes the result worse than doing nothing: normalising by the instantaneous clear-sky value at
@@ -142,15 +142,17 @@ convention but needs no clear-sky treatment: its accumulator features integrate 
 anyway, so only sub-window timing is lost.
 
 **(c) Instantaneous variables lose diurnal amplitude beyond day 6**, because the ~15:00 temperature
-maximum falls between the 12:00 and 18:00 samples: the mean daily temperature range falls from
-6.09 °C to 5.37 °C, an **11.9% compression**. This one has no exact fix, since the asymmetric
+maximum falls between the 12:00 and 18:00 samples: the mean daily temperature range is compressed by
+**11.9%**
+([measurements](../architecture/nwp-variable-conventions.md#instantaneous-variables-lose-diurnal-amplitude)).
+This one has no exact fix, since the asymmetric
 afternoon peak needs the second harmonic and four samples a day is at the Nyquist limit for it. A
 shape-preserving cubic or a diurnal-harmonic fit should recover part of the amplitude; how much has
 not been measured. It feeds the effective-temperature, degree-day and `windchill` features. Treat it
 as a bounded experiment rather than a correctness fix, and expect a smaller win than (a) or (b).
 
 The synoptic variables need no fix: `pressure_surface`, `pressure_reduced_to_mean_sea_level` and
-`geopotential_height_500hpa` lose almost nothing at 6-hourly spacing (MAE/SD 0.02–0.09).
+`geopotential_height_500hpa` lose almost nothing at 6-hourly spacing.
 
 ### Store wind as u/v components rather than speed and direction
 
@@ -181,14 +183,12 @@ speed, because interpolating the components and taking the magnitude is not the 
 interpolating the magnitude — so this is a behaviour change to a live feature, and it needs a
 leaderboard arm rather than a silent swap.
 
-**The open question this item must answer: does a scalar-mean speed column earn its storage?**
-Today's stored speed is the magnitude of each cell's *vector* mean, not the mean of its grid points'
-scalar speeds, and the two differ (|E[**v**]| ≤ E[|**v**|]). The scalar mean is what a turbine power
-curve wants, because power responds to the speed at each point and the curve is strongly non-linear.
-It cannot be recovered from the archive — it is a different spatial reduction — so obtaining it
-requires re-ingesting, and it costs a third wind column per height. The preference is to store `u`
-and `v` only and derive speed on the fly, so this needs the gap measured before it is accepted or
-rejected rather than assumed small.
+**The open question this item must answer: does a scalar-mean speed column earn its storage?** The
+stored speed is a vector mean, and the scalar mean a turbine power curve wants is [a different
+spatial reduction](../architecture/nwp-variable-conventions.md#wind-is-stored-as-speed-and-direction-and-why),
+so it cannot be recovered from the archive: obtaining it means re-ingesting, and it costs a third
+wind column per height. The preference is to store `u` and `v` only and derive speed on the fly, so
+this needs the gap measured before it is accepted or rejected rather than assumed small.
 
 **If this item is rejected, the resample item grows back its wind arm.** The sequencing below
 assumes the components land, which removes the wrapped angle from the table entirely. Should the

--- a/docs/roadmap/xgboost-improvements.md
+++ b/docs/roadmap/xgboost-improvements.md
@@ -118,7 +118,7 @@ late by half the step width — three hours beyond day 6 — and cuts its peak b
 816 W m⁻² to 590
 ([measurements](../architecture/nwp-variable-conventions.md#period-ending-variables-are-interpolated-as-though-they-were-instantaneous)).
 Shortwave radiation is the worst-affected numeric variable, at half again the next-worst
-(MAE/SD 0.44 against 0.30).
+([MAE/SD 0.44 against 0.30](../architecture/nwp-variable-conventions.md#every-variable-and-how-to-read-it)).
 
 The fix is the clear-sky-index resample, and it has **four requirements**. Getting the first wrong
 makes the result worse than doing nothing: normalising by the instantaneous clear-sky value at
@@ -154,7 +154,8 @@ not been measured. It feeds the effective-temperature, degree-day and `windchill
 as a bounded experiment rather than a correctness fix, and expect a smaller win than (a) or (b).
 
 The synoptic variables need no fix: `pressure_surface`, `pressure_reduced_to_mean_sea_level` and
-`geopotential_height_500hpa` lose almost nothing at 6-hourly spacing (MAE/SD 0.02–0.09).
+`geopotential_height_500hpa` lose almost nothing at 6-hourly spacing
+([MAE/SD 0.02–0.09](../architecture/nwp-variable-conventions.md#every-variable-and-how-to-read-it)).
 
 ### Store wind as u/v components rather than speed and direction
 

--- a/packages/contracts/src/contracts/weather_schemas.py
+++ b/packages/contracts/src/contracts/weather_schemas.py
@@ -172,11 +172,8 @@ class Nwp(pt.Model):
         dtype=pl.Float32,
         description=(
             "Wind speed at 10 m. Unit: meters per second. This is the magnitude of the cell's"
-            " *vector* mean wind, not the mean of its grid points' scalar speeds — the H3"
-            " aggregation averages the u/v components and speed is derived afterwards. The two"
-            " differ wherever direction varies across a cell, and a turbine power curve wants the"
-            " scalar mean. See"
-            " <https://openclimatefix.github.io/nged-substation-forecast/architecture/nwp-variable-conventions/>"
+            " *vector* mean wind, not the mean of its grid points' scalar speeds. See"
+            " <https://openclimatefix.github.io/nged-substation-forecast/architecture/nwp-variable-conventions/#wind-is-stored-as-speed-and-direction-and-why>"
         ),
         ge=0,
         le=200,  # Gemini says the highest non-tornadic surface wind speed recorded was 113 m/s
@@ -200,8 +197,7 @@ class Nwp(pt.Model):
         dtype=pl.Float32,
         description=(
             "Wind speed at 100 m. Unit: meters per second. This is a vector mean, with the same"
-            " caveat as `wind_speed_10m`. It is the one that matters most for wind generation,"
-            " because a turbine power curve responds to the scalar speed at each grid point."
+            " caveat as `wind_speed_10m`. It is the height that matters most for wind generation."
         ),
         ge=0,
         le=200,  # Gemini says the highest non-tornadic surface wind speed recorded was 113 m/s

--- a/packages/contracts/src/contracts/weather_schemas.py
+++ b/packages/contracts/src/contracts/weather_schemas.py
@@ -197,7 +197,9 @@ class Nwp(pt.Model):
         dtype=pl.Float32,
         description=(
             "Wind speed at 100 m. Unit: meters per second. This is a vector mean, with the same"
-            " caveat as `wind_speed_10m`. It is the height that matters most for wind generation."
+            " caveat as `wind_speed_10m`. It is the height that matters most for wind generation,"
+            " because a turbine power curve responds to the scalar speed at each grid point. See"
+            " <https://openclimatefix.github.io/nged-substation-forecast/architecture/nwp-variable-conventions/#wind-is-stored-as-speed-and-direction-and-why>"
         ),
         ge=0,
         le=200,  # Gemini says the highest non-tornadic surface wind speed recorded was 113 m/s

--- a/src/nged_substation_forecast/defs/checks.py
+++ b/src/nged_substation_forecast/defs/checks.py
@@ -98,24 +98,12 @@ _LATE_TABLE_SCHEMA: Final[TableSchema] = TableSchema(
 _MAX_LATE_SERIES_IN_TABLE: Final[int] = 50
 """Cap on how many late series the check's metadata table lists.
 
-Unlike the other capped listings this one lands in Dagster's event log — Postgres in the AWS
-deployment, `pg_dump`ed to S3 nightly — so it is written to durable storage every hour for as long
-as a stall lasts. Uncapped, a whole-feed stall at V2 scale (~2,500 series) would serialise to about
-355 KB per hourly evaluation; at 50 rows it is about 8 KB.
-
-The rows follow ``_LATE_STATUS_ORDER``: every never-reported series outranks every stale one, and
-the stale ones are most-stale first. So the listing is "the head of that order", not "the 50 series
-in most trouble" — when never-reported series outnumber the cap, no stale series is listed at all,
-however stale it is. That is a real limit of the drill-down at V2 cutover, when the roster is
-populated before data flows; ``n_stale`` and ``n_never_reported`` stay exact throughout, which is
-what the operator should read first.
-
-Matches ``_sentry.MAX_LATE_SERIES_IN_CONTEXT`` rather than the tighter caps on the one-line
-description and the Sentry message body, because a browsable table and the Sentry event context
-serve the same drill-down purpose and showing the same leading series in both is one less thing to
-reconcile. The true count is always carried by the uncapped ``n_late`` metadata field, and
-``n_late_listed`` records how many rows the table actually holds, so a truncated table never makes a
-large stall look small."""
+The rows follow ``_LATE_STATUS_ORDER``, so the listing is the head of that order rather than the 50
+series in most trouble: when never-reported series outnumber the cap, no stale series is listed at
+all, however stale it is. ``n_stale`` and ``n_never_reported`` stay exact regardless. Why the table
+is capped, and why at this number:
+<https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/#warn-on-stale-power-data-with-a-dagster-asset-check>
+"""
 
 _LATE_STATUS_ORDER: Final[tuple[str, ...]] = ("never", "stale")
 """Runtime tuple — declared order for the ``status`` column's ``pl.Enum``, which is also the
@@ -411,9 +399,7 @@ _MAX_MISSING_SERIES_LISTED: Final[int] = 20
 """Cap on how many missing ``time_series_id``s the description and the metadata spell out.
 
 Keeps the one-line description readable at V2 scale (~2,500 series) when a whole population is
-missing; the true count is always carried by the ``n_time_series_missing`` metadata field and
-``n_time_series_missing_listed`` records how many the list holds, so a truncated list never makes a
-large gap look small."""
+missing. ``n_time_series_missing`` carries the uncapped count."""
 
 _UNIX_EPOCH: Final[datetime] = datetime(1970, 1, 1, tzinfo=UTC)
 """Origin for ``_floor_to_interval``'s arithmetic. Both cadences we floor to (daily NWP runs at

--- a/src/nged_substation_forecast/defs/checks.py
+++ b/src/nged_substation_forecast/defs/checks.py
@@ -98,13 +98,18 @@ _LATE_TABLE_SCHEMA: Final[TableSchema] = TableSchema(
 _MAX_LATE_SERIES_IN_TABLE: Final[int] = 50
 """Cap on how many late series the check's metadata table lists.
 
-Uncapped, a whole-feed stall at V2 scale (~2,500 series) would serialise to about 355 KB per hourly
-evaluation; at 50 rows it is about 8 KB.
+Unlike the other capped listings this one lands in Dagster's event log, so it is written to durable
+storage every hour a stall lasts. Uncapped, a whole-feed stall at V2 scale (~2,500 series) would
+serialise to about 355 KB per hourly evaluation; at 50 rows it is about 8 KB.
+
+Matches ``_sentry.MAX_LATE_SERIES_IN_CONTEXT`` (50) rather than the tighter
+``_sentry.MAX_LATE_SERIES_IN_MESSAGE`` (20) that bounds the Sentry message body, because a browsable
+table and the Sentry event context serve the same drill-down purpose.
 
 The rows follow ``_LATE_STATUS_ORDER``, so the listing is the head of that order rather than the 50
 series in most trouble: when never-reported series outnumber the cap, no stale series is listed at
-all, however stale it is. ``n_stale`` and ``n_never_reported`` stay exact regardless. Why the table
-is capped, and why at this number:
+all, however stale it is. ``n_stale`` and ``n_never_reported`` stay exact throughout, and are what
+the operator should read first. Why the table is capped, and why at this number:
 <https://openclimatefix.github.io/nged-substation-forecast/architecture/production-deployment/#warn-on-stale-power-data-with-a-dagster-asset-check>
 """
 

--- a/src/nged_substation_forecast/defs/checks.py
+++ b/src/nged_substation_forecast/defs/checks.py
@@ -98,6 +98,9 @@ _LATE_TABLE_SCHEMA: Final[TableSchema] = TableSchema(
 _MAX_LATE_SERIES_IN_TABLE: Final[int] = 50
 """Cap on how many late series the check's metadata table lists.
 
+Uncapped, a whole-feed stall at V2 scale (~2,500 series) would serialise to about 355 KB per hourly
+evaluation; at 50 rows it is about 8 KB.
+
 The rows follow ``_LATE_STATUS_ORDER``, so the listing is the head of that order rather than the 50
 series in most trouble: when never-reported series outnumber the cap, no stale series is listed at
 all, however stale it is. ``n_stale`` and ``n_never_reported`` stay exact regardless. Why the table

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -170,7 +170,9 @@ def test_late_series_table_is_capped_but_the_counts_are_not() -> None:
 def test_the_table_never_holds_more_detail_than_the_sentry_event_context() -> None:
     """The durable listing may not be more detailed than the transient one.
 
-    Pinning the relationship rather than the number leaves the cap free to be retuned downwards.
+    Both cap the same worst-first ordering, and the table is the one written to the event log every
+    hour a stall lasts, so it is the table that must not outgrow the Sentry context. Pinning the
+    relationship rather than the number leaves the cap free to be retuned downwards.
     """
     assert checks._MAX_LATE_SERIES_IN_TABLE <= _sentry.MAX_LATE_SERIES_IN_CONTEXT
 

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -147,12 +147,8 @@ def test_result_threshold_hours_reflects_threshold() -> None:
 
 
 def test_late_series_table_is_capped_but_the_counts_are_not() -> None:
-    """A whole-feed stall lists only ``_MAX_LATE_SERIES_IN_TABLE`` series, most-stale first.
-
-    The table is written to Dagster's event log every hour for as long as a stall lasts, so it is
-    capped; the counts beside it are not, which is what stops a truncated table making a large
-    stall look small.
-    """
+    """A whole-feed stall lists only ``_MAX_LATE_SERIES_IN_TABLE`` series, most-stale first, while
+    the counts beside the table stay uncapped."""
     cap = checks._MAX_LATE_SERIES_IN_TABLE
     n_late = cap + 10
     # Series `i` is `i` hours staler than series `i - 1`, so worst-first order is descending id.
@@ -174,17 +170,14 @@ def test_late_series_table_is_capped_but_the_counts_are_not() -> None:
 def test_the_table_never_holds_more_detail_than_the_sentry_event_context() -> None:
     """The durable listing may not be more detailed than the transient one.
 
-    Both cap the same worst-first ordering, and the table is the one written to the event log every
-    hour a stall lasts, so it is the one that must not grow without a reason. Pinning the
-    relationship rather than the number leaves the cap free to be retuned downwards.
+    Pinning the relationship rather than the number leaves the cap free to be retuned downwards.
     """
     assert checks._MAX_LATE_SERIES_IN_TABLE <= _sentry.MAX_LATE_SERIES_IN_CONTEXT
 
 
 def test_never_reported_series_crowd_stale_ones_out_of_a_truncated_table() -> None:
     """Every never-reported series outranks every stale one, so at V2 cutover — a populated roster
-    before data flows — the table can hold no stale series at all. The counts stay exact, which is
-    why the operator is told to read those first."""
+    before data flows — the table can hold no stale series at all, while the counts stay exact."""
     cap = checks._MAX_LATE_SERIES_IN_TABLE
     coverage = _coverage({i: _NOW - timedelta(hours=1000) for i in range(1, 11)})  # 10 very stale
     roster = _roster(list(range(1, 11)) + list(range(100, 100 + cap + 5)))  # + cap+5 never-reported
@@ -737,11 +730,8 @@ def test_missed_nwp_runs_make_an_otherwise_good_slot_unhealthy() -> None:
 
 
 def test_missing_series_metadata_reports_how_many_ids_it_listed() -> None:
-    """A whole missing population spells out only the first ``_MAX_MISSING_SERIES_LISTED`` ids.
-
-    Same rule as the freshness check's late-series table: the list is capped, the count beside it
-    is not, and a third field says how many the list holds so the two can't be confused.
-    """
+    """A whole missing population spells out only the first ``_MAX_MISSING_SERIES_LISTED`` ids,
+    while ``n_time_series_missing`` stays uncapped and a third field says how many were listed."""
     cap = checks._MAX_MISSING_SERIES_LISTED
     n_missing = cap + 5
     result = checks._to_live_forecast_check_result(


### PR DESCRIPTION
*Written by Claude Code (Opus 5).*

Four arguments that landed on 2026-08-11 were written out in more than one place, breaking the [One home per argument](https://openclimatefix.github.io/nged-substation-forecast/architecture/code-style/#comments-docstrings-and-links) rule and, in one case, "Be concise by cutting whole sentences, not words". Each argument now has one home; the other copies are cut to what the reader of *that* file needs plus a link. Prose and docstrings only — no behaviour change, and `pytest` is green.

## 1. The late-series cap — five copies down to two homes

The cap deliberately has two homes, because this repo separates design rationale from operator how-to:

- **Why there is a cap, and why 50** → `docs/architecture/production-deployment.md`. It absorbs the two facts that were only in the docstring: the 355 KB-vs-8 KB serialisation figure at V2 scale, and that the cap matches the Sentry event context so the same leading series appear in both. It does *not* gain the row-ordering caveat, which belongs to the two homes below.
- **How to read the check when it is truncated** → `docs/live_service/operations.md`. It keeps "read `n_late`, not the table's length" and the ordering warning — never-reported series crowd stale ones out of a full table — and drops its own version of "because it is written to the event log every hour" in favour of a link.

`_MAX_LATE_SERIES_IN_TABLE`'s docstring goes from eighteen lines to five. What survives is the number, the one caveat a reader of the constant cannot do without — rows follow `_LATE_STATUS_ORDER`, so the listing is the head of that order rather than the 50 series in most trouble, which changes what the listing *means* — and a link. `_MAX_MISSING_SERIES_LISTED` keeps the readability reason for 20 and the fact that `n_time_series_missing` is uncapped. Four test docstrings lose their restatement of the argument and keep the claim each test pins. `production-deployment.md` also loses its own second copy of "so a capped list never makes a large stall look small", in the Sentry bullet.

## 2. The wind vector-mean caveat — three copies down to one

`nwp-variable-conventions.md` is the home. The `wind_speed_10m` Patito description keeps the one sentence a caller must not get wrong — the stored value is the magnitude of the cell's vector mean, not the mean of its grid points' scalar speeds — and drops the |E[**v**]| ≤ E[|**v**|] gap and the power-curve explanation, with its link now pointing at the section anchor rather than the page. `wind_speed_100m` keeps "vector mean, same caveat as `wind_speed_10m`". The roadmap's "Store wind as u/v components" item keeps the open question it has to answer and links out for why the two means differ.

## 3. The two-page scope split — `ecmwf-ens-known-issues.md` carries it

Both pages opened with a ~7-line, near-identical statement of how they divide the subject. The known-issues page keeps the full symmetric statement and the conventions page keeps its own scope line plus a pointer. The choice is by inbound traffic: `ecmwf-ens-known-issues` is linked from code eleven times — from `assets.py`, `convert_to_polars.py` and eight `weather_schemas.py` field descriptions — against three for `nwp-variable-conventions`, so the full statement now sits on the page whose readers arrive from a docstring and are least likely to know the other page exists.

## 4. The roadmap section — measurements kept, argument trimmed

The rule being applied here is narrower than "one home per argument": **a measurement is not the same kind of duplication as a paragraph of rationale.** A number is short, checkable against the world, and is what lets a reader weigh a decision without navigating away; a "because" restated in three docstrings drifts silently and no linter can tell. So every measurement in the "Before anything else" section stays where it is — `816 W m⁻² to 590`, `MAE/SD 0.44 against 0.30`, `6.09 °C to 5.37 °C`, the synoptic `MAE/SD 0.02–0.09`, the 6.57% / ~100° pair and the 1221 W m⁻² clear-sky trap — and each now carries a `[measurements]` link to the exact section or table it comes from, so the number and its provenance travel together rather than being alternatives.

The same distinction restored the 355 KB-versus-8 KB sizing figure to `_MAX_LATE_SERIES_IN_TABLE`'s docstring as well as `production-deployment.md`: a reader judging whether 50 is the right cap needs the size of the problem in front of them. What stays cut is prose — the wind vector-mean argument, the late-series cap rationale, and the duplicated scope-split paragraph.

## Verification

`ruff check` / `ruff format` / `ty check` / `pytest` (606 passed, 1 skipped) / `pymarkdown scan` / `mkdocs build --strict` all clean. All four new anchors were checked against the built `site/` directory rather than trusted to the linter, and the edited paragraphs were read as rendered HTML.

## Review

**Adversarial review.** Two findings applied: the scope split moved to the page with the inbound code links (item 3, whose original justification the reviewer disproved by counting them), and a row-ordering sentence deleted from `production-deployment.md` as a third copy of an argument that already had two homes.

**Information-loss audit** — an independent pass that enumerated every claim, number and caveat in `main`'s version of each touched file and asked only "is this still reachable?". It found five facts that had gone or become vaguer, all now restored: the contrast between this listing and the other capped ones; the constants the cap is pinned against, by name and value (`MAX_LATE_SERIES_IN_CONTEXT` at 50, `MAX_LATE_SERIES_IN_MESSAGE` at 20); the storage mechanism behind "durable" (Postgres, `pg_dump`ed to S3 nightly); the "read the exact counts first" instruction; and the invariant `test_the_table_never_holds_more_detail_than_the_sentry_event_context` exists to pin — both listings cap the same worst-first ordering, which `_sentry.report_power_freshness` relies on and no prose stated. It also caught `wind_speed_100m` having no link to the caveat it defers to, and two MAE/SD figures whose link pointed at a section that does not contain them.

## Verification

`ruff check` / `ruff format` / `ty check` / `pytest` (607 passed, 1 skipped) / `pymarkdown scan` / `mkdocs build --strict` all clean on the final commit, with `origin/main` at `c89d9df4` merged in. Every anchor was checked against the built `site/` directory rather than trusted to the linter, and the edited paragraphs were read as rendered HTML.
