### PR TITLE
Refuse a promotion whose saved config this code cannot rebuild

### DIFF
--- a/docs/design-philosophy/inherent-stability.md
+++ b/docs/design-philosophy/inherent-stability.md
@@ -144,7 +144,7 @@ code as it stands; "intended" describes where this principle takes it.
 | A whole ECMWF slice corrupt | Landed; `nwp_has_no_unexpected_nulls` warns, naming the slice | Unchanged | No |
 | A whole ECMWF weather variable absent | `Nwp.validate` rejects it; `ecmwf_ens` turns each rejection into a retry for up to 4h, and once those are exhausted it manifests downstream as a missed run | Unchanged | No |
 | The promoted model is empty or unloadable | **Hard failure** — the asset raises | Unchanged: this is a promotion bug, not a data outage | Yes, next business day |
-| A model is promoted whose features this code no longer recognises | `promoted_model` refuses it before replacing the model on disk, so the outgoing champion stays and keeps forecasting | Unchanged | Yes, at promotion time |
+| A model is promoted whose saved config this code can no longer rebuild — a feature name it does not recognise, or a `model_params` key it no longer declares | `promoted_model` refuses it before replacing the model on disk, so the outgoing champion stays and keeps forecasting | Unchanged | Yes, at promotion time |
 | The service is not running at all | Sentry missed-check-in alarm fires from outside the deployment | Unchanged | Yes, next business day |
 | Any of the above during model R&D | Fails fast | Unchanged — see [R&D fails the other way](#rd-fails-the-other-way) | n/a |
 

--- a/docs/live_service/operations.md
+++ b/docs/live_service/operations.md
@@ -61,12 +61,13 @@ deployment bakes into its container image at build time.
 
 1. Downloads that run's saved model artifacts from MLflow
    (`ml_core._production_helpers.fetch_model_artifacts`) into a temporary directory.
-2. Checks the downloaded model's `selected_features` against the running code, and **fails the
-   materialisation if any feature name no longer parses** — naming the offending feature. The check
-   runs before anything is written, so a refused promotion leaves the previous champion in place and
-   still serving. Re-train the model against the current feature vocabulary and promote that run;
-   never hand-edit `meta.json` to rename a feature, because the trained boosters carry the old
-   names too.
+2. Checks the downloaded model's saved config against the running code, and **fails the
+   materialisation if this code could not load that model** — because a feature name no longer
+   parses (the offending feature is named), or because `model_params` carry a hyper-parameter this
+   code no longer declares. The check runs before anything is written, so a refused promotion
+   leaves the previous champion in place and still serving. Re-train the model against the current
+   code and promote that run; never hand-edit `meta.json`, because the trained boosters carry the
+   old names too.
 3. Stamps a `promotion.json` (`mlflow_run_id`, `promoted_at`) and atomically replaces the directory
    at `Settings.production_model_path` (`data/production_model/` by default) with the new artifacts.
 4. Reads back the new `meta.json` and reports `model_class`, `experiment_name`, and
@@ -117,10 +118,11 @@ partition's `power_fcst_init_time` is 2026-07-04 06:00 UTC — not at the midnig
 
 1. Loads the production model from `Settings.production_model_path` via a plain disk `load` —
    the concrete forecaster class is reconstructed from `meta.json`'s `model_class` field. Raises
-   if the model has no trained time series, if its `selected_features` name a feature this code
-   cannot parse, or if its saved `model_params` carry a key this code no longer declares. The last
-   two both mean the promoted model predates the code now serving it: re-promote from a run
-   trained against the current vocabulary, rather than hand-editing what is on disk.
+   if the model has no trained time series, or if the running code cannot rebuild its saved config
+   — a `selected_features` name it cannot parse, or a `model_params` key it no longer declares.
+   Promotion (step 2 above) applies that same check, so it fires here only when the code changed
+   after the champion was promoted; either way, re-promote from a run trained against the current
+   code rather than hand-editing what is on disk.
 2. Resolves which NWP `init_time` to join against via `select_nwp_init_time` and
    `availability_mode` (table above).
 3. Builds the power spine (`build_live_power_frame`), covering 15 days of history (long enough

--- a/docs/live_service/operations.md
+++ b/docs/live_service/operations.md
@@ -66,8 +66,8 @@ deployment bakes into its container image at build time.
    parses (the offending feature is named), or because `model_params` carry a hyper-parameter this
    code no longer declares. The check runs before anything is written, so a refused promotion
    leaves the previous champion in place and still serving. Re-train the model against the current
-   code and promote that run; never hand-edit `meta.json`, because the trained boosters carry the
-   old names too.
+   code and promote that run; never hand-edit `meta.json`, because the boosters on disk were
+   trained under the config it records.
 3. Stamps a `promotion.json` (`mlflow_run_id`, `promoted_at`) and atomically replaces the directory
    at `Settings.production_model_path` (`data/production_model/` by default) with the new artifacts.
 4. Reads back the new `meta.json` and reports `model_class`, `experiment_name`, and

--- a/packages/ml_core/src/ml_core/_production_helpers.py
+++ b/packages/ml_core/src/ml_core/_production_helpers.py
@@ -200,9 +200,9 @@ def load_forecaster_from_dir(path: Path) -> BaseForecaster:
     (the same mechanism ``ml_core._mlflow_runs.load_experiment_forecaster`` uses), then calls the
     concrete subclass's ``load(path)``.
 
-    The forecaster returned is one this code can engineer features for, not merely one it could
-    deserialise: an unparseable feature vocabulary is rejected here, so it surfaces at model load
-    rather than partway through a live tick's feature engineering.
+    The forecaster returned is one this code can actually serve, not merely one it could
+    deserialise: a config it cannot rebuild, or a feature vocabulary it cannot parse, is rejected
+    here rather than partway through a live tick's feature engineering.
 
     Args:
         path: Directory previously populated by ``fetch_model_artifacts`` (the

--- a/packages/ml_core/src/ml_core/_production_helpers.py
+++ b/packages/ml_core/src/ml_core/_production_helpers.py
@@ -5,7 +5,8 @@ Every function here is unit-testable in isolation: the two data-shaping helpers
 explicit parameter rather than calling ``datetime.now()`` internally, so a test can pass any
 fixed time and get a deterministic result; the two disk/MLflow helpers
 (``load_forecaster_from_dir``, ``fetch_model_artifacts``) do the IO and check that the saved
-model's feature names still parse. The ``live_forecasts`` and ``promoted_model`` Dagster assets
+model is one this code can still build a config for and parse the features of. The
+``live_forecasts`` and ``promoted_model`` Dagster assets
 (``src/nged_substation_forecast/defs/production_assets.py``) stay thin shells over these.
 """
 
@@ -24,11 +25,7 @@ from contracts.config_schemas import import_class
 from contracts.power_schemas import PowerTimeSeries
 from pydantic import ValidationError
 
-from ml_core.base_forecaster import (
-    BaseForecaster,
-    BaseForecasterConfig,
-    _download_and_unpack_model,
-)
+from ml_core.base_forecaster import BaseForecaster, _download_and_unpack_model
 from ml_core.features._nwp import NWP_PUBLICATION_DELAY_HOURS
 from ml_core.features._parsed_features import ParsedFeatures
 
@@ -135,11 +132,14 @@ def build_live_power_frame(
     return pt.LazyFrame.from_existing(dense).set_model(PowerTimeSeries)
 
 
-def _check_meta_features_are_parseable(meta: dict[str, Any], source: str) -> None:
-    """Raise if this code cannot serve the model that ``meta.json`` describes.
+def _check_meta_is_servable(meta: dict[str, Any], source: str) -> type[BaseForecaster]:
+    """Raise if this code cannot serve the model that ``meta.json`` describes; return its class.
 
-    A saved model names its features as strings, so renaming or removing a feature in code leaves
-    every model trained before the change unservable. See
+    A saved model names its class, its hyper-parameters and its features as strings, so renaming or
+    removing any of them in code leaves every model saved before the change unservable. The whole
+    of ``model_params`` is validated against the concrete ``CONFIG_CLASS`` reached from
+    ``model_class``, which is the same object the subclass's ``load`` builds its config from — so a
+    model that passes here is one ``load`` will accept. See
     <https://openclimatefix.github.io/nged-substation-forecast/design-philosophy/inherent-stability/#the-rules>
     for why this raises rather than degrading.
 
@@ -148,32 +148,36 @@ def _check_meta_features_are_parseable(meta: dict[str, Any], source: str) -> Non
         source: What is being validated — a directory or a run id — quoted back in the message so
             an operator knows which model to re-train.
 
+    Returns:
+        The concrete ``BaseForecaster`` subclass named by ``meta["model_class"]``.
+
     Raises:
-        ValueError: ``model_params`` carries no usable ``selected_features``, or one of those
-            features is a name this code cannot parse.
+        ValueError: ``meta`` names no importable ``model_class``; its ``model_params`` do not build
+            that class's ``CONFIG_CLASS``, because a key it declared has since been removed or
+            renamed; or one of its features is a name this code cannot parse.
     """
-    # Both messages can reach the container log that scripts/build_and_verify_image.sh greps
-    # case-insensitively for "mlflow" to prove the runtime is hermetic, so neither may contain that
+    # Every message here can reach the container log that scripts/build_and_verify_image.sh greps
+    # case-insensitively for "mlflow" to prove the runtime is hermetic, so none may contain that
     # word.
     remedy = (
-        "Re-train against the current feature vocabulary and promote that run; never hand-edit "
-        "meta.json, which leaves the trained model carrying the old names."
+        "Re-train against the current code and promote that run. Never hand-edit meta.json: that "
+        "changes what the model claims, not what it was trained with."
     )
-    # Validate only the field this function reads. A saved config is always a *subclass* instance,
-    # so handing the whole mapping to the base class would reject every real model on the subclass's
-    # own hyper-parameters — ``BaseForecasterConfig`` forbids unknown keys. Whether the full config
-    # still builds is the concrete subclass's ``load`` to decide, and it does.
-    model_params = meta.get("model_params")
-    try:
-        config = BaseForecasterConfig.model_validate(
-            {"selected_features": model_params.get("selected_features")}
-            if isinstance(model_params, dict)
-            else model_params
-        )
-    except (ValidationError, AttributeError) as error:
+    model_class = meta.get("model_class")
+    if model_class is None:
         raise ValueError(
-            f"The model at {source} has model_params with no usable selected_features, so no "
-            f"forecaster here can load it. {remedy}"
+            f"The model at {source} has no 'model_class' field, so the concrete forecaster class "
+            f"cannot be reconstructed (see BaseForecaster.save). {remedy}"
+        )
+    forecaster_cls = cast(type[BaseForecaster], import_class(model_class))
+
+    config_cls = forecaster_cls.CONFIG_CLASS
+    try:
+        config = config_cls.model_validate(meta.get("model_params"))
+    except ValidationError as error:
+        raise ValueError(
+            f"The model at {source} has model_params that {config_cls.__name__} cannot build, so "
+            f"{forecaster_cls.__name__} cannot load it. {remedy}"
         ) from error
 
     # One at a time and sorted, so the feature named is the same in every process: they live in a
@@ -186,6 +190,7 @@ def _check_meta_features_are_parseable(meta: dict[str, Any], source: str) -> Non
                 f"The model at {source} requests a feature this code cannot parse: {feature}. "
                 f"{remedy}"
             ) from error
+    return forecaster_cls
 
 
 def load_forecaster_from_dir(path: Path) -> BaseForecaster:
@@ -209,10 +214,9 @@ def load_forecaster_from_dir(path: Path) -> BaseForecaster:
     Raises:
         FileNotFoundError: ``path`` or its ``meta.json`` does not exist — materialise the
             ``promoted_model`` asset first.
-        ValueError: ``meta.json`` has no ``model_class`` field — it was saved by a code version
-            predating this contract; re-promote with a version that stamps ``model_class``. Or
-            the model's ``selected_features`` name a feature this code cannot parse, in which case
-            re-train and promote the new run.
+        ValueError: This code cannot serve the saved model — see ``_check_meta_is_servable``.
+            Promotion applies the same check, so this fires only when the code changed after the
+            champion was promoted.
     """
     meta_path = path / "meta.json"
     if not meta_path.exists():
@@ -221,17 +225,9 @@ def load_forecaster_from_dir(path: Path) -> BaseForecaster:
             "`promoted_model` asset first."
         )
     meta = json.loads(meta_path.read_text())
-    model_class = meta.get("model_class")
-    if model_class is None:
-        raise ValueError(
-            f"{meta_path} has no 'model_class' field, so the concrete forecaster class cannot "
-            "be reconstructed. Re-promote the model with a code version that stamps "
-            "model_class (see BaseForecaster.save)."
-        )
-    forecaster_cls = cast(type[BaseForecaster], import_class(model_class))
     # Before `load`, not after: `load` reads every serialised sub-model off disk, which is a lot of
-    # IO to do on the way to rejecting the directory over one field already parsed above.
-    _check_meta_features_are_parseable(meta=meta, source=str(path))
+    # IO to do on the way to rejecting the directory over fields already parsed here.
+    forecaster_cls = _check_meta_is_servable(meta=meta, source=str(path))
     return forecaster_cls.load(path)
 
 
@@ -244,11 +240,11 @@ def fetch_model_artifacts(run_id: str, dest: Path) -> None:
     (``ml_core.base_forecaster._MLFLOW_MODEL_ARTIFACT``), so ``dest`` gets exactly the files the
     last ``save_to_mlflow`` wrote and can never inherit a stale file from an earlier, larger model.
 
-    The downloaded model's ``selected_features`` are checked against the running code *before* the
-    swap, reading the staged ``meta.json`` rather than loading the model, so a model this code
-    cannot serve is refused while the previous champion stays in ``dest`` and keeps serving.
-    Reading the one field is deliberate: loading would additionally pull every booster into memory
-    to answer a question one JSON field already answers.
+    The downloaded model's saved config is checked against the running code *before* the swap,
+    reading the staged ``meta.json`` rather than loading the model, so a model this code cannot
+    serve is refused while the previous champion stays in ``dest`` and keeps serving. Reading the
+    JSON is deliberate: it applies the same validation the subclass's ``load`` would, without
+    pulling every booster into memory to do it.
 
     Also writes a ``promotion.json`` (``{"mlflow_run_id", "promoted_at"}``) into ``dest`` for
     provenance; a ``BaseForecaster.load`` implementation reads its own population from its saved
@@ -263,14 +259,13 @@ def fetch_model_artifacts(run_id: str, dest: Path) -> None:
         dest: Directory to populate — typically ``Settings.production_model_path``.
 
     Raises:
-        ValueError: The model's ``selected_features`` are absent, malformed, or name a feature
-            this code cannot parse — re-train against the current feature vocabulary and promote
-            that run instead.
+        ValueError: This code cannot serve the downloaded model — see ``_check_meta_is_servable``.
+            Re-train against the current code and promote that run instead.
     """
     with tempfile.TemporaryDirectory() as tmp_dir:
         downloaded_dir = _download_and_unpack_model(run_id, Path(tmp_dir))
         meta = json.loads((downloaded_dir / "meta.json").read_text())
-        _check_meta_features_are_parseable(meta=meta, source=f"run {run_id}")
+        _check_meta_is_servable(meta=meta, source=f"run {run_id}")
 
         promotion = {
             "mlflow_run_id": run_id,

--- a/packages/ml_core/src/ml_core/base_forecaster.py
+++ b/packages/ml_core/src/ml_core/base_forecaster.py
@@ -166,10 +166,10 @@ class BaseForecaster(ABC):
     Every forecasting model subclasses this abstract base to allow shared Dagster assets and
     evaluation code to remain completely agnostic to the underlying model implementation.
 
-    Subclasses must define ``MODEL_NAME`` and ``MODEL_VERSION`` as class-level constants.
-    These are stamped onto every ``PowerForecast`` row at predict time and used as the MLflow
-    experiment name. Bumping ``MODEL_VERSION`` requires a code change (intentional), not a
-    config edit.
+    Subclasses must define ``MODEL_NAME``, ``MODEL_VERSION`` and ``CONFIG_CLASS`` as class-level
+    constants. ``MODEL_NAME`` and ``MODEL_VERSION`` are stamped onto every ``PowerForecast`` row at
+    predict time and used as the MLflow experiment name. Bumping ``MODEL_VERSION`` requires a code
+    change (intentional), not a config edit.
 
     Lazy evaluation contract: `train` and `predict` both accept a `pt.LazyFrame[AllFeatures]`.
     Callers must not collect before passing data in; doing so wastes memory and prevents Polars
@@ -189,6 +189,16 @@ class BaseForecaster(ABC):
 
     MODEL_NAME: ClassVar[str]
     MODEL_VERSION: ClassVar[int]
+
+    CONFIG_CLASS: ClassVar[type[BaseForecasterConfig]]
+    """The config class ``load`` rebuilds from a saved ``model_params`` mapping.
+
+    Declared on the class so that a saved ``meta.json``, which names only ``model_class``, is
+    enough to reach it. That is what lets promotion validate a stored config *before* it replaces
+    the champion on disk (``ml_core._production_helpers.fetch_model_artifacts``). A subclass's
+    ``load`` must build its config through this attribute rather than naming its config class
+    again, so the class promotion checks against is always the class ``load`` uses.
+    """
 
     feature_engineer: ClassVar[FeatureEngineer] = TabularFeatureEngineer()
     """The feature pipeline this forecaster's data is engineered through.

--- a/packages/ml_core/src/ml_core/base_forecaster.py
+++ b/packages/ml_core/src/ml_core/base_forecaster.py
@@ -193,11 +193,9 @@ class BaseForecaster(ABC):
     CONFIG_CLASS: ClassVar[type[BaseForecasterConfig]]
     """The config class ``load`` rebuilds from a saved ``model_params`` mapping.
 
-    Declared on the class so that a saved ``meta.json``, which names only ``model_class``, is
-    enough to reach it. That is what lets promotion validate a stored config *before* it replaces
-    the champion on disk (``ml_core._production_helpers.fetch_model_artifacts``). A subclass's
-    ``load`` must build its config through this attribute rather than naming its config class
-    again, so the class promotion checks against is always the class ``load`` uses.
+    A subclass's ``load`` must build its config through this attribute rather than naming its
+    config class again, so the class ``ml_core._production_helpers._check_meta_is_servable``
+    validates a saved config against is always the class ``load`` uses.
     """
 
     feature_engineer: ClassVar[FeatureEngineer] = TabularFeatureEngineer()

--- a/packages/ml_core/tests/test_base_forecaster.py
+++ b/packages/ml_core/tests/test_base_forecaster.py
@@ -18,6 +18,7 @@ from typing import Self
 import mlflow
 import patito as pt
 import pytest
+from contracts.config_schemas import class_target
 from contracts.ml_schemas import AllFeatures
 from contracts.power_schemas import PowerForecast
 from ml_core._production_helpers import fetch_model_artifacts
@@ -33,6 +34,7 @@ class _FakeForecaster(BaseForecaster):
 
     MODEL_NAME = "fake"
     MODEL_VERSION = 1
+    CONFIG_CLASS = BaseForecasterConfig
 
     def __init__(
         self,
@@ -56,7 +58,7 @@ class _FakeForecaster(BaseForecaster):
                 {
                     "model_params": self.model_params.model_dump(mode="json"),
                     "trained_time_series_ids": self._series,
-                    "model_class": "fake",
+                    "model_class": class_target(self),
                 }
             )
         )
@@ -67,7 +69,7 @@ class _FakeForecaster(BaseForecaster):
     def load(cls, path: Path) -> Self:
         meta = json.loads((path / "meta.json").read_text())
         return cls(
-            BaseForecasterConfig.model_validate(meta["model_params"]),
+            cls.CONFIG_CLASS.model_validate(meta["model_params"]),
             payload=(path / "payload.txt").read_text(),
             series=meta["trained_time_series_ids"],
         )
@@ -90,6 +92,16 @@ class _MetaWithoutModelParams(_FakeForecaster):
         super().save(path)
         meta = json.loads((path / "meta.json").read_text())
         del meta["model_params"]
+        (path / "meta.json").write_text(json.dumps(meta))
+
+
+class _MetaWithUndeclaredHyperparameter(_FakeForecaster):
+    """A forecaster saved while the code still declared a hyper-parameter that has since gone."""
+
+    def save(self, path: Path) -> None:
+        super().save(path)
+        meta = json.loads((path / "meta.json").read_text())
+        meta["model_params"]["dropout_rate"] = 0.1
         (path / "meta.json").write_text(json.dumps(meta))
 
 
@@ -270,11 +282,21 @@ def _save_without_model_params(run_id: str) -> None:
     ).save_to_mlflow(run_id)
 
 
+def _save_with_an_undeclared_hyperparameter(run_id: str) -> None:
+    """Save a model whose stored config carries a key the config class no longer declares."""
+    _MetaWithUndeclaredHyperparameter(
+        model_params=BaseForecasterConfig(selected_features=set()),
+        payload="undeclared",
+        series=[10],
+    ).save_to_mlflow(run_id)
+
+
 @pytest.mark.parametrize(
     ("save_unservable", "expected"),
     [
         (_save_stale_vocabulary, "local_utc_offset"),
         (_save_without_model_params, "model_params"),
+        (_save_with_an_undeclared_hyperparameter, "model_params"),
     ],
 )
 def test_fetch_model_artifacts_keeps_the_previous_model_when_the_new_one_is_unservable(
@@ -286,12 +308,15 @@ def test_fetch_model_artifacts_keeps_the_previous_model_when_the_new_one_is_unse
     """A promotion this code could not serve must not displace the champion already in place.
 
     The check runs before the atomic swap, so ``dest`` is untouched and the outgoing champion keeps
-    serving instead of the service breaking at its next tick.
+    serving instead of the service breaking at its next tick. The unservable cases are the three
+    ways a saved record outlives the code that wrote it: a retired feature name, no config at all,
+    and a hyper-parameter this code no longer declares.
     """
     dest = tmp_path / "production_model"
     fetch_model_artifacts(run_id=saved_run, dest=dest)
 
-    with mlflow.start_run(experiment_id=mlflow.create_experiment(f"unservable_{expected}")) as run:
+    # Each parametrised case gets its own tmp_path, so its own tracking store: one name is enough.
+    with mlflow.start_run(experiment_id=mlflow.create_experiment("unservable")) as run:
         unservable_run_id = run.info.run_id
     save_unservable(unservable_run_id)
 

--- a/packages/ml_core/tests/test_production_helpers.py
+++ b/packages/ml_core/tests/test_production_helpers.py
@@ -10,7 +10,7 @@ import json
 from collections.abc import Callable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import patito as pt
 import polars as pl
@@ -262,6 +262,32 @@ def test_load_forecaster_from_dir_accepts_the_current_vocabulary(tmp_path: Path)
     assert load_forecaster_from_dir(tmp_path).model_params.selected_features == (
         config.selected_features
     )
+
+
+class _NarrowerConfig(XGBoostConfig):
+    """Stands in for the config class a second forecaster would bring with it."""
+
+
+class _NarrowerConfigForecaster(XGBoostForecaster):
+    """Overrides ``CONFIG_CLASS`` and nothing else, so ``load`` alone decides which config is built.
+
+    Module level, not nested in the test: ``save`` stamps ``class_target(self)`` into ``meta.json``,
+    which a class defined inside a function has no importable path for.
+    """
+
+    CONFIG_CLASS: ClassVar[type[XGBoostConfig]] = _NarrowerConfig
+
+
+def test_load_builds_its_config_through_config_class(tmp_path: Path) -> None:
+    """``load`` must reach its config class through ``CONFIG_CLASS``, not by naming one again.
+
+    That identity is what makes the guard's verdict binding: the guard validates a saved
+    ``model_params`` against ``CONFIG_CLASS``, so a ``load`` that used some other class could still
+    reject a model the guard had passed — after promotion had replaced the champion.
+    """
+    _NarrowerConfigForecaster(XGBoostConfig(selected_features={"temperature_2m"})).save(tmp_path)
+
+    assert isinstance(load_forecaster_from_dir(tmp_path).model_params, _NarrowerConfig)
 
 
 def test_the_guard_accepts_a_subclass_own_hyperparameters(tmp_path: Path) -> None:

--- a/packages/ml_core/tests/test_production_helpers.py
+++ b/packages/ml_core/tests/test_production_helpers.py
@@ -231,15 +231,13 @@ def test_load_forecaster_from_dir_accepts_the_current_vocabulary(tmp_path: Path)
     )
 
 
-def test_the_feature_guard_ignores_a_subclass_own_hyperparameters(tmp_path: Path) -> None:
-    """The guard reads ``selected_features`` and nothing else out of a saved config.
+def test_the_guard_accepts_a_subclass_own_hyperparameters(tmp_path: Path) -> None:
+    """A saved ``model_params`` is a *subclass* instance, so it is validated as one.
 
-    A saved ``model_params`` is always a *subclass* instance, so it carries hyper-parameters the
-    base class never declares. ``BaseForecasterConfig`` forbids unknown keys, so validating the
-    whole mapping against the base class would reject every real model on its own
-    ``n_estimators`` — with a message blaming the feature vocabulary.
+    The negative control for the test below: validating against ``BaseForecasterConfig``, which
+    forbids unknown keys, would reject every real model on its own ``n_estimators``.
     """
-    config = XGBoostConfig(selected_features={"temperature_2m"}, n_estimators=17, device="cpu")
+    config = XGBoostConfig(selected_features={"temperature_2m"}, n_estimators=17)
     XGBoostForecaster(config).save(tmp_path)
     saved = json.loads((tmp_path / "meta.json").read_text())
     assert "n_estimators" in saved["model_params"], "this test is pointless if none are saved"
@@ -248,3 +246,23 @@ def test_the_feature_guard_ignores_a_subclass_own_hyperparameters(tmp_path: Path
 
     assert isinstance(loaded, XGBoostForecaster)
     assert loaded.model_params.n_estimators == 17
+
+
+def test_the_guard_rejects_a_hyperparameter_this_code_no_longer_declares(tmp_path: Path) -> None:
+    """A removed or renamed hyper-parameter is refused, exactly as a retired feature name is.
+
+    ``XGBoostConfig`` forbids unknown keys, so a model saved while the code still declared
+    ``gpu_id`` cannot be loaded once it is gone. The guard must say so, rather than let the
+    ``ValidationError`` surface from ``load`` — which in production means after promotion has
+    already replaced the champion.
+    """
+    XGBoostForecaster(XGBoostConfig(selected_features={"temperature_2m"})).save(tmp_path)
+    meta_path = tmp_path / "meta.json"
+    meta = json.loads(meta_path.read_text())
+    meta["model_params"]["gpu_id"] = 0
+    meta_path.write_text(json.dumps(meta))
+
+    with pytest.raises(ValueError, match="model_params") as exc_info:
+        load_forecaster_from_dir(tmp_path)
+
+    assert str(tmp_path) in str(exc_info.value)

--- a/packages/ml_core/tests/test_production_helpers.py
+++ b/packages/ml_core/tests/test_production_helpers.py
@@ -266,3 +266,6 @@ def test_the_guard_rejects_a_hyperparameter_this_code_no_longer_declares(tmp_pat
         load_forecaster_from_dir(tmp_path)
 
     assert str(tmp_path) in str(exc_info.value)
+    # This message reaches the same container log as the one pinned by
+    # test_the_rejection_message_never_mentions_the_experiment_tracker, under the same constraint.
+    assert "mlflow" not in str(exc_info.value).lower()

--- a/packages/xgboost_forecaster/src/xgboost_forecaster/forecaster.py
+++ b/packages/xgboost_forecaster/src/xgboost_forecaster/forecaster.py
@@ -3,7 +3,7 @@
 import json
 import shutil
 from pathlib import Path
-from typing import Any, Self, cast
+from typing import Any, ClassVar, Self, cast
 
 import numpy as np
 import patito as pt
@@ -78,6 +78,7 @@ class XGBoostForecaster(BaseForecaster):
 
     MODEL_NAME = "xgboost"
     MODEL_VERSION = 1
+    CONFIG_CLASS: ClassVar[type[XGBoostConfig]] = XGBoostConfig
 
     model_params: XGBoostConfig  # narrows the base class annotation for type checkers
 
@@ -237,7 +238,7 @@ class XGBoostForecaster(BaseForecaster):
         ``BaseForecaster.trained_time_series_ids``).
         """
         meta = json.loads((path / "meta.json").read_text())
-        config = XGBoostConfig.model_validate(meta["model_params"])
+        config = cls.CONFIG_CLASS.model_validate(meta["model_params"])
         instance = cls(config)
         for ts_id in meta["trained_time_series_ids"]:
             booster = xgb.Booster()

--- a/src/nged_substation_forecast/defs/production_assets.py
+++ b/src/nged_substation_forecast/defs/production_assets.py
@@ -127,8 +127,9 @@ def promoted_model(context: AssetExecutionContext, config: PromotedModelConfig) 
     which replaces the directory atomically), then reads back ``meta.json`` to report provenance.
     ``live_forecasts`` reads this directory with a plain disk load — never MLflow.
 
-    Promotion refuses a model whose ``selected_features`` this code cannot parse, and refuses it
-    before the directory is replaced, so the previous champion stays in place and keeps serving.
+    Promotion refuses a model whose saved config this code cannot rebuild — a feature name it
+    cannot parse, or a ``model_params`` key it no longer declares — and refuses it before the
+    directory is replaced, so the previous champion stays in place and keeps serving.
 
     Promotion as a Dagster materialisation gives an audit trail and lineage for free, rather than
     a bare script (a script wrapper for the eventual Docker build (#222) stays trivial by calling
@@ -215,12 +216,12 @@ def live_forecasts(context: AssetExecutionContext, config: LiveForecastsConfig) 
     Loads the production model from a plain disk directory (``load_forecaster_from_dir`` against
     ``Settings.production_model_path``, populated out-of-band by the ``promoted_model``
     asset) — **no MLflow import or call anywhere in this asset**; live performance is tracked by
-    production monitoring, never logged here. A model whose ``selected_features`` this code cannot
-    parse — one promoted before a feature was renamed — fails at that load, naming the feature,
-    rather than partway through feature engineering. Forecasts exactly
-    ``forecaster.trained_time_series_ids`` (never today's eligibility set — the train==predict
-    population invariant) across every NWP ensemble member, using single-run feature engineering
-    stamped with this partition's ``power_fcst_init_time``.
+    production monitoring, never logged here. A model whose saved config this code cannot rebuild
+    fails at that load rather than partway through feature engineering; promotion applies the same
+    check, so this only bites when the code changed after the champion was promoted. Forecasts
+    exactly ``forecaster.trained_time_series_ids`` (never today's eligibility set — the
+    train==predict population invariant) across every NWP ensemble member, using single-run feature
+    engineering stamped with this partition's ``power_fcst_init_time``.
 
     NWP availability is resolved via ``config.availability_mode``: the scheduled tick always
     uses ``"live"`` (freshest run actually present, no modelled delay); manual backfills of past


### PR DESCRIPTION
*Written by Claude Code.*

## The bug

Two changes that landed on 2026-08-11 interact badly. #531 added the promotion guard `_check_meta_features_are_parseable`, which deliberately validated only `{"selected_features": ...}` against `BaseForecasterConfig`, because a saved config is always a *subclass* instance and handing the whole mapping to the base class would reject every real model on its own `n_estimators`. #532 then set `model_config = ConfigDict(extra="forbid")` on `BaseForecasterConfig`.

Together they leave a second class of unservable model that promotion does not catch: one whose stored `model_params` carry a key the current code no longer declares, because a hyper-parameter was removed or renamed. `promoted_model` calls `fetch_model_artifacts`, the guard checks only `selected_features` and passes, the champion at `Settings.production_model_path` is atomically replaced, and `promoted_model` succeeds — it reads `meta.json` back only for provenance and never builds the subclass config. The failure surfaces at the next 6-hourly tick, when `live_forecasts` reaches `XGBoostConfig.model_validate(meta["model_params"])` inside `XGBoostForecaster.load` and raises `ValidationError`. That is exactly the failure the guard exists to prevent, reached through a different field, and it happens *after* the champion has been overwritten — so there is no previous model left serving.

## The fix

Give `BaseForecaster` a `CONFIG_CLASS` class-level constant: the config class that subclass's `load` rebuilds a saved `model_params` mapping through. There was no forecaster-class → config-class link in the code before this (`_resolve_forecaster_config` reads `config_target` from YAML, separately from `forecaster_target`, and neither is available to production, which has no YAML for a promoted model). `XGBoostForecaster.load` hard-coded `XGBoostConfig`, so the link existed conceptually and was simply not expressed; `load` now goes through `cls.CONFIG_CLASS`, so the class promotion validates against cannot drift from the class `load` uses.

With that, the guard — renamed `_check_meta_is_servable`, since it is no longer only about features — resolves `model_class`, reaches `CONFIG_CLASS`, and validates the *whole* of `model_params` against it before the atomic swap. That covers both classes of failure with one check and lets the "validate only the field this function reads" special case go. It returns the resolved forecaster class, so `load_forecaster_from_dir` no longer resolves `model_class` itself.

The `ParsedFeatures.from_strings` loop stays: validating against the subclass catches unknown *keys*, not unparseable *feature names*.

Two properties the change preserves deliberately:

- Promotion still refuses **before** the swap, so a refused promotion leaves the previous champion in place and serving.
- No message on this path contains the word "mlflow" (case-insensitively), which `scripts/build_and_verify_image.sh` greps the smoke-test container log for to prove the runtime is hermetic. The pydantic `ValidationError` is chained rather than interpolated into the message, so nothing from a saved config's *values* is spliced into text on that path.

## Tests

- `test_fetch_model_artifacts_keeps_the_previous_model_when_the_new_one_is_unservable` gains a third case — a saved `model_params` carrying a key the config class does not declare. It asserts the promotion is refused, the run id is named, and the previous champion is still in `dest` and still loadable. This is the regression test for the bug.
- `test_the_feature_guard_ignores_a_subclass_own_hyperparameters` asserted the guard *ignores* a subclass's hyper-parameters, which is no longer the intent. It is now `test_the_guard_accepts_a_subclass_own_hyperparameters` (the negative control: validating against the base class would reject every real model), paired with `test_the_guard_rejects_a_hyperparameter_this_code_no_longer_declares`.
- `_FakeForecaster` in `test_base_forecaster.py` now stamps a real `class_target(self)` into its `meta.json` rather than the string `"fake"`, because `fetch_model_artifacts` resolves `model_class` now that it needs the config class.

## Docs

`docs/live_service/operations.md` said the `live_forecasts` step raises "if its saved `model_params` carry a key this code no longer declares". Promotion catches that first now, so both the Step 2 promotion list and the `live_forecasts` step say so; the `live_forecasts` wording keeps the case that still reaches it, which is a code change made *after* the champion was promoted. The degradation-ladder row in `docs/design-philosophy/inherent-stability.md` is widened from "a model is promoted whose features this code no longer recognises" to cover the saved config as a whole.

## Out of scope, noted rather than fixed

- #541 landed while this was in flight and is merged in here. It refuses a downloaded run that has no `meta.json` at all, with its own message; this change does not make that moot, and both refusals now run before the swap.
- `CONFIG_CLASS` arguably makes `config_target` in `conf/model/*.yaml` (and the matching MLflow experiment tag) redundant, since a forecaster class whose `load` hard-codes one config class cannot honour a different one. Worth a look, but it touches experiment registration and identity-tag comparison, so it is not in this change.

## Reviews

Two independent sub-agents reviewed the diff after it was pushed.

The correctness review found no blocker. Accepted: `CONFIG_CLASS`'s docstring was re-explaining rationale that `_check_meta_is_servable` already carries ("One home per argument"), so it now states only the guarantee; `operations.md`'s "the trained boosters carry the old names too" only fitted the retired-feature case, and now reads "the boosters on disk were trained under the config it records"; `load_forecaster_from_dir`'s guarantee paragraph still named only the feature check while its own `Raises:` had been widened; and the "no message may contain 'mlflow'" pin covered only the pre-existing feature-parse path, so it is now parametrised over all three ways the guard can refuse a model. Rejected: reading `forecaster_cls.CONFIG_CLASS` outside the `try` block, so a subclass omitting it raises `AttributeError` rather than `ValueError`. A missing `CONFIG_CLASS` is a bug in a subclass, not a bad saved model — exactly like a missing `MODEL_NAME`, which is equally unenforced — and dressing it up as a `ValueError` on the promotion path would invite an operator to go and re-train something. It fails loudly, before the swap, and neither docstring claims `ValueError` is the only exception the function can raise.

The mutation review tried 15 mutations and 13 went red, including validating only `selected_features` again, swapping `CONFIG_CLASS` for `BaseForecasterConfig`, filtering `model_params` to declared fields, dropping or short-circuiting the feature loop, moving the check after the swap, deleting the check, returning the wrong class, and splicing "MLflow" into the remedy string. Two survived. Hard-coding `XGBoostConfig` in `XGBoostForecaster.load` instead of `cls.CONFIG_CLASS` left everything green, because the repo has one concrete forecaster — that identity is what makes the guard's verdict binding, so `test_load_builds_its_config_through_config_class` now pins it with a forecaster subclass that overrides `CONFIG_CLASS` and nothing else. The other survivor is dropping `sorted(...)` from the feature loop; that guards message determinism across processes, which no test can observe without depending on set iteration order, so it is left as the comment beside it explains.
