### PR TITLE
Record that unparenthesised except tuples are valid Python 3.14

### DIFF
--- a/docs/architecture/code-style.md
+++ b/docs/architecture/code-style.md
@@ -244,6 +244,10 @@ confusing failure:
 ## Error Handling
 
 - Use specific exceptions.
+- **Unparenthesised `except` tuples are valid.** `except OSError, ValueError, TypeError:` looks
+  like the Python 2 syntax that Python 3 rejected for years, but
+  [PEP 758](https://peps.python.org/pep-0758/) made it legal in Python 3.14. Parentheses are still
+  required to bind the exception to a name: `except (OSError, ValueError) as err:`.
 - Leverage Sentry for observability in production-like code.
 - Validate data at boundaries using data contracts.
 


### PR DESCRIPTION
🤖 Written by Claude Code.

One bullet added to the Error Handling section of [Code Style Guidelines](https://openclimatefix.github.io/nged-substation-forecast/architecture/code-style/), recording that `except OSError, ValueError, TypeError:` is valid Python.

It reads as the Python 2 syntax that Python 3 rejected for years, so it keeps getting flagged as a bug on sight — including by me, an hour ago, against `defs/checks.py:773`. [PEP 758](https://peps.python.org/pep-0758/) made the unparenthesised form legal in Python 3.14, which is this repo's floor. Parentheses are still required to bind the exception to a name.

It goes in `docs/architecture/code-style.md` rather than in the `code-style` skill because that skill says to: the page is the single source of truth and the skill is a pointer to it, so that two copies can't drift.

`pymarkdown` passes.
