### PR TITLE
Document the promotion failure this code never named

### DIFF
--- a/docs/design-philosophy/inherent-stability.md
+++ b/docs/design-philosophy/inherent-stability.md
@@ -145,6 +145,7 @@ code as it stands; "intended" describes where this principle takes it.
 | A whole ECMWF weather variable absent | `Nwp.validate` rejects it; `ecmwf_ens` turns each rejection into a retry for up to 4h, and once those are exhausted it manifests downstream as a missed run | Unchanged | No |
 | The promoted model is empty or unloadable | **Hard failure** — the asset raises | Unchanged: this is a promotion bug, not a data outage | Yes, next business day |
 | A model is promoted whose saved config this code can no longer rebuild — a feature name it does not recognise, or a `model_params` key it no longer declares | `promoted_model` refuses it before replacing the model on disk, so the outgoing champion stays and keeps forecasting | Unchanged | Yes, at promotion time |
+| The run named for promotion holds no model at all — usually a mistyped or stale run id | `promoted_model` fails on the download, again before replacing the model on disk, so the outgoing champion stays and keeps forecasting | Unchanged | Yes, at promotion time |
 | The service is not running at all | Sentry missed-check-in alarm fires from outside the deployment | Unchanged | Yes, next business day |
 | Any of the above during model R&D | Fails fast | Unchanged — see [R&D fails the other way](#rd-fails-the-other-way) | n/a |
 

--- a/packages/ml_core/src/ml_core/_production_helpers.py
+++ b/packages/ml_core/src/ml_core/_production_helpers.py
@@ -259,6 +259,9 @@ def fetch_model_artifacts(run_id: str, dest: Path) -> None:
         dest: Directory to populate — typically ``Settings.production_model_path``.
 
     Raises:
+        MlflowException: ``run_id`` names a run holding no model archive — most often a mistyped
+            or stale run id, since a run that trained a model has one. Raised by
+            ``ml_core.base_forecaster._download_and_unpack_model``, before ``dest`` is touched.
         ValueError: The run holds no ``meta.json``, or this code cannot serve the model it
             describes — see ``_check_meta_is_servable``. Re-train against the current code and
             promote that run instead.

--- a/packages/ml_core/tests/test_base_forecaster.py
+++ b/packages/ml_core/tests/test_base_forecaster.py
@@ -345,3 +345,24 @@ def test_fetch_model_artifacts_keeps_the_previous_model_when_the_new_one_is_unse
     assert unservable_run_id in str(exc_info.value)
     assert _FakeForecaster.load(dest).payload == "hello-model"
     assert json.loads((dest / "promotion.json").read_text())["mlflow_run_id"] == saved_run
+
+
+def test_fetch_model_artifacts_keeps_the_previous_model_when_the_run_holds_no_model(
+    saved_run: str, tmp_path: Path
+) -> None:
+    """A run id naming a run with no model saved to it must not displace the champion either.
+
+    The likeliest operator slip of the lot — a mistyped or stale run id names a real run that
+    simply never held a model — and the one refusal that happens in the download rather than in
+    ``_check_meta_is_servable``, so it needs its own case to pin that ``dest`` survives it.
+    """
+    dest = tmp_path / "production_model"
+    fetch_model_artifacts(run_id=saved_run, dest=dest)
+
+    with mlflow.start_run(experiment_id=mlflow.create_experiment("modelless")) as run:
+        modelless_run_id = run.info.run_id
+
+    with pytest.raises(MlflowException, match="re-materialise `trained_cv_model`"):
+        fetch_model_artifacts(run_id=modelless_run_id, dest=dest)
+
+    assert _FakeForecaster.load(dest).payload == "hello-model"

--- a/packages/ml_core/tests/test_base_forecaster.py
+++ b/packages/ml_core/tests/test_base_forecaster.py
@@ -352,9 +352,10 @@ def test_fetch_model_artifacts_keeps_the_previous_model_when_the_run_holds_no_mo
 ) -> None:
     """A run id naming a run with no model saved to it must not displace the champion either.
 
-    The likeliest operator slip of the lot — a mistyped or stale run id names a real run that
-    simply never held a model — and the one refusal that happens in the download rather than in
-    ``_check_meta_is_servable``, so it needs its own case to pin that ``dest`` survives it.
+    This is the likeliest operator slip of the three, because a mistyped or stale run id names a
+    real run that simply never held a model. It is also the only refusal that happens in the
+    download rather than in ``_check_meta_is_servable``, so it needs its own case to pin that
+    ``dest`` survives it.
     """
     dest = tmp_path / "production_model"
     fetch_model_artifacts(run_id=saved_run, dest=dest)

--- a/src/nged_substation_forecast/defs/production_assets.py
+++ b/src/nged_substation_forecast/defs/production_assets.py
@@ -131,6 +131,10 @@ def promoted_model(context: AssetExecutionContext, config: PromotedModelConfig) 
     cannot parse, or a ``model_params`` key it no longer declares — and refuses it before the
     directory is replaced, so the previous champion stays in place and keeps serving.
 
+    Every such refusal reaches the operator as a failed materialisation: this asset catches
+    nothing, unlike the rest of ``defs/``. The reasoning is in
+    <https://openclimatefix.github.io/nged-substation-forecast/design-philosophy/inherent-stability/#failure-modes>.
+
     Promotion as a Dagster materialisation gives an audit trail and lineage for free, rather than
     a bare script (a script wrapper for the eventual Docker build (#222) stays trivial by calling
     the same ``fetch_model_artifacts`` helper).

--- a/src/nged_substation_forecast/defs/production_assets.py
+++ b/src/nged_substation_forecast/defs/production_assets.py
@@ -133,7 +133,7 @@ def promoted_model(context: AssetExecutionContext, config: PromotedModelConfig) 
 
     Every such refusal reaches the operator as a failed materialisation: this asset catches
     nothing, unlike the rest of ``defs/``. The reasoning is in
-    <https://openclimatefix.github.io/nged-substation-forecast/design-philosophy/inherent-stability/#failure-modes>.
+    <https://openclimatefix.github.io/nged-substation-forecast/design-philosophy/inherent-stability/#the-rules>.
 
     Promotion as a Dagster materialisation gives an audit trail and lineage for free, rather than
     a bare script (a script wrapper for the eventual Docker build (#222) stays trivial by calling


### PR DESCRIPTION
*Written by Claude Code.*

The two follow-ups queued out of PR #541 and confirmed after #545 landed. No behaviour changes — a documented gap and a recorded decision.

## 1. The undocumented promotion failure

`fetch_model_artifacts` refuses two kinds of unservable model and documents both in its `Raises:`: a run with no `meta.json` (#541) and a run whose saved config this code cannot rebuild (#545). It lets a third failure through undocumented — a run id naming a run that holds no model archive raises `MlflowException` out of `_download_and_unpack_model`.

That is the likeliest of the three to actually happen, because it is what a mistyped or stale run id produces, and promotion takes the run id by hand off the MLflow leaderboard. The other two need a saved model to have outlived the code that wrote it. It was the only one of the three with no `Raises:` entry and no test on the promotion path — `_download_and_unpack_model` documents it, and `test_loading_a_run_with_no_archive_says_what_to_do_about_it` covers the *other* consumer, `load_from_mlflow`.

Added:

- The `Raises:` entry on `fetch_model_artifacts`, naming where it is raised from and that it fires before `dest` is touched.
- `test_fetch_model_artifacts_keeps_the_previous_model_when_the_run_holds_no_model`. It is a separate test rather than a fifth case on the existing parametrised one because `MlflowException` is not a `ValueError`, and because this is the one refusal that happens in the download rather than in `_check_meta_is_servable` — a different mechanism keeping `dest` intact deserves its own case.
- A row in the failure-modes table in [Inherent Stability](https://openclimatefix.github.io/nged-substation-forecast/design-philosophy/inherent-stability/#failure-modes), beside the config-rebuild row it belongs next to.

I did not fold it into the existing "The promoted model is empty or unloadable" row. That row describes failures caught *after* the swap, in `live_forecasts` — an empty model trips its `if not trained_ids` check, and an unloadable one trips `load_forecaster_from_dir`. Saying "refused before the model on disk is replaced" of that row would have been wrong, and the champion-survives guarantee does not hold for it.

## 2. Whether `promoted_model` should catch anything

It should not, and nothing changed. Promotion is operator-triggered, against our own artifact, one command at a time. A promotion that cannot be served is our own bug — the state [the rules](https://openclimatefix.github.io/nged-substation-forecast/design-philosophy/inherent-stability/#the-rules) reserve raising for — not the outside world misbehaving, and the failure-modes table already recorded it as a hard failure. Degrading here would mean serving a model we have just established we cannot serve.

The one thing worth adding was a sentence saying so in `promoted_model`'s docstring, pointing at the failure-modes table rather than restating the argument. The asset sits in `defs/`, where every other failure path degrades rather than raising, so the absence of a `try` reads as an oversight to anyone applying the doctrine by pattern-match — including a future agent.

## Review

One correctness review (Sonnet, fresh agent). No blocker. It confirmed the exception claim by tracing the call path, confirmed the new test bites by mutation-testing it in a scratch clone (reordering `fetch_model_artifacts` to delete `dest` before the download makes it fail), independently confirmed that the pre-existing "empty or unloadable" row is a `live_forecasts` failure rather than a promotion-time one, and confirmed nothing in the diff can put the word "mlflow" into the smoke test's log — `promoted_model` is not in `live_forecasts_job`.

Both its findings are applied: the docstring now links to `#the-rules`, which states when production code may raise at all, rather than `#failure-modes`, which only tabulates outcomes — matching what `_check_meta_is_servable` already links to for the same claim; and the new test's docstring is rewritten as full sentences.

## Verification

`ruff check`, `ruff format`, `uv run --all-packages ty check`, `uv run pytest` (616 passed, 1 skipped), `pymarkdown scan`, `mkdocs build --strict`. The `#failure-modes` anchor the new docstring links to was confirmed present in the built `site/`, not just assumed from the URL.
