### PR TITLE
Document why each defensive code path is required

### DIFF
--- a/docs/architecture/code-style.md
+++ b/docs/architecture/code-style.md
@@ -139,12 +139,13 @@ Three places where a positional argument is right:
   find it.
 - **Say why a guard exists, when the reason is not "this state happens"** — validation that
   defends a reusable package's public API, rather than a state production can reach, says so in a
-  clause: `# Reusable-package input validation: unreachable from the ecmwf_ens asset, which always
-  sources h3_grid from the h3_grid_weights asset.` A defence that only makes sense on one substrate
-  names that substrate, since production data lives on S3 where a torn object write cannot happen.
-  Without the clause a reviewer traces the one production call path, finds the state impossible,
-  and proposes deleting the guard — correctly, on the evidence the code gave them. Repeated
-  validation needs the same treatment: say what each call catches that the one above it did not.
+  clause: `# Reusable-package input validation, not a reachable production state: the ecmwf_ens
+  asset always sources h3_grid from h3_grid_weights.` A defence that only makes sense on one
+  substrate names that substrate, since production data lives on S3 where a torn object write
+  cannot happen. Without the clause a reviewer traces the one production call path, finds the state
+  impossible, and proposes deleting the guard — correctly, on the evidence the code gave them.
+  Repeated validation needs the same treatment: say what each call catches that the one above it
+  did not.
 - **MkDocs-compatible constant docs** — document module-level constants with a string literal
   immediately after the assignment, not with Sphinx-style `#:` comments. This is correct:
 

--- a/docs/architecture/code-style.md
+++ b/docs/architecture/code-style.md
@@ -137,6 +137,14 @@ Three places where a positional argument is right:
   might rot is cheaper than a copy that rots invisibly. It cuts the other way too — rationale
   worth a paragraph does not belong *only* in a docstring, where no reader browsing the docs will
   find it.
+- **Say why a guard exists, when the reason is not "this state happens"** — validation that
+  defends a reusable package's public API, rather than a state production can reach, says so in a
+  clause: `# Reusable-package input validation: unreachable from the ecmwf_ens asset, which always
+  sources h3_grid from the h3_grid_weights asset.` A defence that only makes sense on one substrate
+  names that substrate, since production data lives on S3 where a torn object write cannot happen.
+  Without the clause a reviewer traces the one production call path, finds the state impossible,
+  and proposes deleting the guard — correctly, on the evidence the code gave them. Repeated
+  validation needs the same treatment: say what each call catches that the one above it did not.
 - **MkDocs-compatible constant docs** — document module-level constants with a string literal
   immediately after the assignment, not with Sphinx-style `#:` comments. This is correct:
 

--- a/packages/dynamical_data/src/dynamical_data/ecmwf_ens/download.py
+++ b/packages/dynamical_data/src/dynamical_data/ecmwf_ens/download.py
@@ -73,7 +73,7 @@ def open_ecmwf_ens_run(
     if utc_nwp_init_time not in ds.init_time.values:
         raise NwpRunNotYetAvailable(f"{utc_nwp_init_time} is not in ds.init_time.values")
 
-    # These two guard the Dynamical.org catalog itself, which is an external substrate we neither
+    # This guards the Dynamical.org catalog itself, which is an external substrate we neither
     # control nor version-pin, so its shape can change under us between runs.
     if ds.longitude.size == 0 or ds.latitude.size == 0:
         raise ValueError("Dataset has empty longitude or latitude coordinates.")

--- a/packages/dynamical_data/src/dynamical_data/ecmwf_ens/download.py
+++ b/packages/dynamical_data/src/dynamical_data/ecmwf_ens/download.py
@@ -53,6 +53,10 @@ def open_ecmwf_ens_run(
     #     uv run pytest --run-network -m network
     # See
     # <https://openclimatefix.github.io/nged-substation-forecast/architecture/testing/#network-gated-tests>.
+
+    # Reusable-package input validation, not a reachable production state: the `ecmwf_ens` asset
+    # always sources `h3_grid` from `h3_grid_weights`, which raises on an empty cell list before
+    # writing anything, so the file it reads can never hold zero rows.
     if h3_grid.is_empty():
         raise ValueError("h3_grid is empty. Cannot download ECMWF data for an empty grid.")
 
@@ -69,7 +73,8 @@ def open_ecmwf_ens_run(
     if utc_nwp_init_time not in ds.init_time.values:
         raise NwpRunNotYetAvailable(f"{utc_nwp_init_time} is not in ds.init_time.values")
 
-    # Check for empty coordinates before computing bounds to fail gracefully.
+    # These two guard the Dynamical.org catalog itself, which is an external substrate we neither
+    # control nor version-pin, so its shape can change under us between runs.
     if ds.longitude.size == 0 or ds.latitude.size == 0:
         raise ValueError("Dataset has empty longitude or latitude coordinates.")
 

--- a/packages/geo/src/geo/h3.py
+++ b/packages/geo/src/geo/h3.py
@@ -70,6 +70,9 @@ def compute_h3_grid_weights(
         f" with child_res {child_h3_res} for {len(h3_index)} H3 indicies..."
     )
 
+    # Reusable-package input validation, not a reachable production state: the one asset call path
+    # arrives via `compute_h3_grid_weights_for_boundary`, which has already raised on an empty
+    # cell list. This guards the direct callers — notebooks passing their own `h3_index`.
     if len(h3_index) == 0:
         raise ValueError("h3_index is empty.")
 

--- a/packages/geo/src/geo/h3.py
+++ b/packages/geo/src/geo/h3.py
@@ -70,9 +70,9 @@ def compute_h3_grid_weights(
         f" with child_res {child_h3_res} for {len(h3_index)} H3 indicies..."
     )
 
-    # Reusable-package input validation, not a reachable production state: the one asset call path
-    # arrives via `compute_h3_grid_weights_for_boundary`, which has already raised on an empty
-    # cell list. This guards the direct callers — notebooks passing their own `h3_index`.
+    # Reusable-package input validation, not a reachable production state: the only non-test caller
+    # is `compute_h3_grid_weights_for_boundary` above, which has already raised on an empty cell
+    # list. This guards direct callers of the public function; `test_h3.py` exercises it.
     if len(h3_index) == 0:
         raise ValueError("h3_index is empty.")
 

--- a/packages/ml_core/src/ml_core/_production_helpers.py
+++ b/packages/ml_core/src/ml_core/_production_helpers.py
@@ -236,10 +236,10 @@ def fetch_model_artifacts(run_id: str, dest: Path) -> None:
 
     Downloads and unpacks into a temporary directory first, so a failed or interrupted download
     never touches ``dest`` — only a fully-downloaded model is moved into place (via ``rmtree`` +
-    ``move``). ``dest`` is always local disk (``Settings.production_model_path`` derives from
-    ``local_artifacts_path``), so unlike the Delta tables this is a directory of many files on a
-    filesystem with no commit protocol, and a part-written one would be served. The run holds the
-    model as a single archive artifact
+    ``move``). ``dest`` is local disk by convention — ``Settings.production_model_path`` derives
+    from ``local_artifacts_path``, though nothing enforces that — so unlike the Delta tables this is
+    a directory of many files with no commit protocol over it, and a part-written one would be
+    served. The run holds the model as a single archive artifact
     (``ml_core.base_forecaster._MLFLOW_MODEL_ARTIFACT``), so ``dest`` gets exactly the files the
     last ``save_to_mlflow`` wrote and can never inherit a stale file from an earlier, larger model.
 

--- a/packages/ml_core/src/ml_core/_production_helpers.py
+++ b/packages/ml_core/src/ml_core/_production_helpers.py
@@ -236,7 +236,10 @@ def fetch_model_artifacts(run_id: str, dest: Path) -> None:
 
     Downloads and unpacks into a temporary directory first, so a failed or interrupted download
     never touches ``dest`` — only a fully-downloaded model is moved into place (via ``rmtree`` +
-    ``move``). The run holds the model as a single archive artifact
+    ``move``). ``dest`` is always local disk (``Settings.production_model_path`` derives from
+    ``local_artifacts_path``), so unlike the Delta tables this is a directory of many files on a
+    filesystem with no commit protocol, and a part-written one would be served. The run holds the
+    model as a single archive artifact
     (``ml_core.base_forecaster._MLFLOW_MODEL_ARTIFACT``), so ``dest`` gets exactly the files the
     last ``save_to_mlflow`` wrote and can never inherit a stale file from an earlier, larger model.
 

--- a/packages/nged_data/src/nged_data/storage.py
+++ b/packages/nged_data/src/nged_data/storage.py
@@ -388,6 +388,9 @@ def upsert_metadata(
     """
     COMPRESSION: Final[str] = "zstd"
 
+    # The annotation is not enforced at runtime and this is the package's entry point, so check the
+    # caller's snapshot rather than trust it. The three validations below each catch something this
+    # one cannot; none of the four is redundant.
     new_metadata = TimeSeriesMetadata.validate(new_metadata.sort("time_series_id"))
 
     if not object_exists(metadata_path, storage_options):
@@ -409,6 +412,10 @@ def upsert_metadata(
     existing_metadata = pl.read_parquet(
         metadata_path, storage_options=typeddict_to_dict(storage_options)
     )
+    # The stored roster is outside this code's control — an older writer, a hand-edit, a truncated
+    # upload — so an off-contract file must not be merged blind into the one we write back. Raising
+    # here is contained rather than fatal: the asset records `metadata_upsert_failed` and lets the
+    # power write proceed (see `defs/assets.py`).
     TimeSeriesMetadata.validate(existing_metadata)
 
     # `how="diagonal"` because the snapshot and the stored roster can differ in both width and
@@ -422,6 +429,9 @@ def upsert_metadata(
     # Compare metadata. `metadata_diff` contains all rows in `new_metadata` that do not have an
     # exact match in `existing_metadata`. Adapted from https://stackoverflow.com/a/79888719
     metadata_diff = new_rows.filter(~new_rows.hash_rows().is_in(stored_rows.hash_rows().implode()))
+    # First frame that has been through the diagonal concat, which null-fills the four
+    # `allow_missing` fields for whichever side lacked them — so this catches a null landing in a
+    # field the snapshot itself carried non-null, which validating the two inputs cannot.
     TimeSeriesMetadata.validate(metadata_diff)
 
     if metadata_diff.is_empty():
@@ -439,6 +449,8 @@ def upsert_metadata(
     # Merge metadata. Put new_metadata first so that unique(keep="first") keeps the new version
     merged_metadata = combined.unique(subset="time_series_id", keep="first").sort("time_series_id")
 
+    # The last gate before the stored roster is overwritten. `unique` draws rows from both sides of
+    # the concat, so this row set is one no validation above has seen.
     TimeSeriesMetadata.validate(merged_metadata)
 
     merged_metadata.write_parquet(

--- a/packages/nged_data/src/nged_data/storage.py
+++ b/packages/nged_data/src/nged_data/storage.py
@@ -388,9 +388,8 @@ def upsert_metadata(
     """
     COMPRESSION: Final[str] = "zstd"
 
-    # The annotation is not enforced at runtime and this is the package's entry point, so check the
-    # caller's snapshot rather than trust it. The three validations below each catch something this
-    # one cannot; none of the four is redundant.
+    # The annotation is not enforced at runtime and this is the package's only public entry point,
+    # so check the caller's snapshot rather than trust it.
     new_metadata = TimeSeriesMetadata.validate(new_metadata.sort("time_series_id"))
 
     if not object_exists(metadata_path, storage_options):
@@ -413,9 +412,9 @@ def upsert_metadata(
         metadata_path, storage_options=typeddict_to_dict(storage_options)
     )
     # The stored roster is outside this code's control — an older writer, a hand-edit, a truncated
-    # upload — so an off-contract file must not be merged blind into the one we write back. Raising
-    # here is contained rather than fatal: the asset records `metadata_upsert_failed` and lets the
-    # power write proceed (see `defs/assets.py`).
+    # upload — so an off-contract file must not be merged blind into the one we write back. As with
+    # any raise from this function, the asset contains it rather than failing: it records
+    # `metadata_upsert_failed` and lets the power write proceed (see `defs/assets.py`).
     TimeSeriesMetadata.validate(existing_metadata)
 
     # `how="diagonal"` because the snapshot and the stored roster can differ in both width and
@@ -429,9 +428,10 @@ def upsert_metadata(
     # Compare metadata. `metadata_diff` contains all rows in `new_metadata` that do not have an
     # exact match in `existing_metadata`. Adapted from https://stackoverflow.com/a/79888719
     metadata_diff = new_rows.filter(~new_rows.hash_rows().is_in(stored_rows.hash_rows().implode()))
-    # First frame that has been through the diagonal concat, which null-fills the four
-    # `allow_missing` fields for whichever side lacked them — so this catches a null landing in a
-    # field the snapshot itself carried non-null, which validating the two inputs cannot.
+    # The first frame carrying the union of both inputs' columns: the concat adds to the snapshot's
+    # rows any `allow_missing` field only the stored roster had. All four of those are nullable, so
+    # this is a shape check on a frame neither validation above saw rather than a guard against a
+    # known fault — the weakest of the four, and the first to reconsider if these get trimmed.
     TimeSeriesMetadata.validate(metadata_diff)
 
     if metadata_diff.is_empty():


### PR DESCRIPTION
🤖 Written by Claude Code.

A sub-agent swept the production code for defences against states that cannot occur, and came back nearly empty: two findings, both LOW/MEDIUM confidence, both arguably legitimate. Its "considered and rejected" list was three times longer than its findings, and every entry had a real argument behind it.

The problem is that those arguments existed only in the report. So this PR writes them down at the call sites — because the next reviewer, human or agent, will otherwise reach the same "unreachable, delete it" conclusion, and will be right on the evidence the code gives them.

## What the check found

The split is sharp. The **deliberate degradation paths are documented to an unusually high standard** — `except BaseException` in `checks.py` names the `pyo3` `PanicException` reason and cites inherent-stability rule 7; the `ecmwf_ens` retry is justified across four files including the measured 3h25m republication incident; the fatal-vs-warning split in `weather_schemas.py` has a "Two things a caller must not assume" block and links to the rendered known-issues page. Nothing to do there.

**Validation that defends a package's public API, rather than a reachable state, carried no explanation at all.** That is exactly why both of the sub-agent's findings were boundary guards: with nothing to read, it reasoned from call sites, correctly found "unreachable from the one production path", and then had to talk itself back down.

## The convention

One bullet in `docs/architecture/code-style.md`, under Comments: a guard that exists for the public API rather than for a reachable state says so in a clause; a defence that only makes sense on one substrate names the substrate; repeated validation says what each call catches that the one above it did not.

## The three gaps filled

**`upsert_metadata`'s four `TimeSeriesMetadata.validate()` calls** — four calls, zero comments. `git log -S` traces the disk-read one to "Stop an unusable metadata roster wedging the hourly power ingest", then "Cut the self-healing roster rebuild" — a real incident fix whose over-built parts a previous simplicity review has already trimmed. The surviving core was load-bearing with its reasoning only in commit messages. Each call now says what it catches that the others cannot.

**`fetch_model_artifacts`' atomic directory swap** — the docstring explained the mechanism but not why atomicity applies here, when the project's stance is that torn writes are a local-root-only fault. It now says that `dest` is always local disk and is a many-file directory with no commit protocol, unlike the Delta tables.

**The two empty-input guards** (`download.py`, `geo/h3.py`) — both now marked as reusable-package input validation, naming the production path that makes them unreachable. I also replaced a "fail gracefully" comment in `download.py` with the actual reason: the Dynamical.org catalog is external and not version-pinned.

## Verification

`ruff check`, `ruff format --check`, `uv run --all-packages ty check`, `pymarkdown`, and the full `pytest` suite (613 passed, 1 skipped) are all green. Comments and one docstring only — no behaviour change.

One thing I checked rather than assumed: I had planned to justify a validate call by saying `.filter()` drops the Patito model, per the `polars-patito-gotchas` skill. It does not, for a `pt.Model.DataFrame` on this version — both `.sort()` and `.filter()` preserve the subclass. That claim is not in the diff. It may be worth checking whether the skill's wording is scoped to `pt.LazyFrame`, separately from this PR.
