### PR TITLE
Correct the pt.LazyFrame.filter() gotcha: a typing gap, not a runtime loss

### DIFF
--- a/.claude/skills/polars-patito-gotchas/SKILL.md
+++ b/.claude/skills/polars-patito-gotchas/SKILL.md
@@ -3,18 +3,19 @@ name: polars-patito-gotchas
 description: >-
   Five Patito/Polars/Delta traps that fail silently rather than raising: cross-model LazyFrame
   joins, a `{column: dtype}` cast swallowed on a model-bearing frame, `ge`/`le` ignored on a
-  datetime field, `.filter()` dropping the Patito subclass, and dictionary-encoded columns
-  blocking Delta predicate pushdown. Load before writing Polars/Patito code that joins, casts,
-  filters a `pt.LazyFrame`, declares a Patito field, or reads/writes Delta — or when a
-  `validate()` dtype error, a `.join()` TypeError, or an over-reading Delta scan looks
-  inexplicable.
+  datetime field, `pt.LazyFrame` methods typed as plain `pl.LazyFrame`, and dictionary-encoded
+  columns blocking Delta predicate pushdown. Load before writing Polars/Patito code that joins,
+  casts, filters a `pt.LazyFrame`, declares a Patito field, or reads/writes Delta — or when a
+  `validate()` dtype error, a `.join()` TypeError, an `invalid-assignment` on a filtered scan, or
+  an over-reading Delta scan looks inexplicable.
 ---
 
 # Patito + Polars + Delta gotchas
 
-Every trap below produces **no error at the point of the mistake**. They surface later as a
-confusing `validate()` failure, a `ty` complaint several lines away, or a query that quietly
-reads the whole table. That is why they are written down.
+**None of the traps below points at itself.** Most produce no error where the mistake is, surfacing
+later as a confusing `validate()` failure or a query that quietly reads the whole table; the rest
+raise on the spot but name types and operations that send you after the wrong cause. That is why
+they are written down.
 
 ## Cross-model LazyFrame joins
 
@@ -80,18 +81,34 @@ the worked examples. A `constraints=` Polars expression on the field also works,
 message is the generic "1 row does not match custom constraints", so prefer the explicit check when
 you want the error to say which bound was broken.
 
-## `pt.LazyFrame.filter()` drops the Patito subclass
+## `pt.LazyFrame` methods are *typed* as plain `pl.LazyFrame`
 
-Most Polars operations on a `pt.LazyFrame` return a plain `pl.LazyFrame`, including `.filter()`.
-Reassigning `scan = scan.filter(...)` where `scan: pt.LazyFrame[Schema]` therefore fails `ty`'s
-assignment check.
+`ty` types `scan.filter(...)` on a `scan: pt.LazyFrame[Schema]` as
+`polars.lazyframe.frame.LazyFrame`, so reassigning `scan = scan.filter(...)` fails its assignment
+check:
 
-Workaround: rebind to a plain `pl.LazyFrame` local for the filter accumulation, then re-wrap before
-returning:
+```text
+error[invalid-assignment]: Object of type `polars.lazyframe.frame.LazyFrame`
+is not assignable to `patito.polars.LazyFrame[PowerForecast]`
+```
+
+**This is a type-annotation gap, not a runtime one.** At runtime the model survives: `.filter()`,
+`.sort()`, `.select()`, `.with_columns()`, `.head()` and `.unique()` on a `pt.LazyFrame` all return
+the model-bearing subclass with `.model` still set. Nothing is lost and nothing needs restoring —
+the re-wrap below exists only to satisfy the annotation.
+
+The asymmetry is in `patito/polars.py`: `patito.polars.DataFrame` carries a block of type-annotation
+overrides re-declaring `filter`/`select`/`with_columns` as `(self: DF) -> DF`, and
+`patito.polars.LazyFrame` has no such block, so it inherits Polars' own annotations. **`pt.DataFrame`
+is therefore unaffected** — `df.filter(...)` stays `pt.DataFrame[Schema]` to `ty` as well as at
+runtime, and needs no workaround.
+
+Workaround, for the lazy case only: rebind to a plain `pl.LazyFrame` local for the filter
+accumulation, then re-wrap before returning:
 
 ```python
 def apply(self, scan: pt.LazyFrame[MySchema]) -> pt.LazyFrame[MySchema]:
-    lf: pl.LazyFrame = scan  # .filter() drops the pt subclass; accumulate on a plain LazyFrame
+    lf: pl.LazyFrame = scan  # .filter() is typed as plain pl.LazyFrame; accumulate on one
     if self.foo is not None:
         lf = lf.filter(pl.col("foo") == self.foo)
     return pt.LazyFrame.from_existing(lf).set_model(MySchema)  # zero-copy re-wrap

--- a/.claude/skills/polars-patito-gotchas/SKILL.md
+++ b/.claude/skills/polars-patito-gotchas/SKILL.md
@@ -97,11 +97,18 @@ is not assignable to `patito.polars.LazyFrame[PowerForecast]`
 the model-bearing subclass with `.model` still set. Nothing is lost and nothing needs restoring —
 the re-wrap below exists only to satisfy the annotation.
 
-The asymmetry is in `patito/polars.py`: `patito.polars.DataFrame` carries a block of type-annotation
-overrides re-declaring `filter`/`select`/`with_columns` as `(self: DF) -> DF`, and
-`patito.polars.LazyFrame` has no such block, so it inherits Polars' own annotations. **`pt.DataFrame`
-is therefore unaffected** — `df.filter(...)` stays `pt.DataFrame[Schema]` to `ty` as well as at
-runtime, and needs no workaround.
+The asymmetry is in `patito/polars.py`: `patito.polars.DataFrame` carries a block of
+type-annotation overrides re-declaring `filter`/`select`/`with_columns` as `(self: DF) -> DF`, and
+`patito.polars.LazyFrame` has no such block, so it inherits Polars' own annotations.
+**`pt.DataFrame` is therefore unaffected** — `df.filter(...)` stays `pt.DataFrame[Schema]` to `ty`
+as well as at runtime, and needs no workaround.
+
+**Upgrading `ty` will not fix this, because `ty` is not wrong.** Polars annotates
+`LazyFrame.filter`, `.sort`, `.select`, `.with_columns`, `.head`, `.unique`, `.drop` and `.rename`
+as returning `LazyFrame`, not `Self`, so every conforming checker must infer the base class — and
+`pyright` reports the identical error. The fix has to come from upstream: either Polars switching
+those return annotations to `Self`, or Patito giving its `LazyFrame` the same override block its
+`DataFrame` already has. Until one of those lands, the re-wrap below is the workaround.
 
 Workaround, for the lazy case only: rebind to a plain `pl.LazyFrame` local for the filter
 accumulation, then re-wrap before returning:

--- a/docs/architecture/code-style.md
+++ b/docs/architecture/code-style.md
@@ -172,11 +172,11 @@ Three places where a positional argument is right:
   plain `pl.DataFrame` / `pl.LazyFrame`.
 - **Patito friction budget**: the `polars-patito-gotchas` skill documents five Patito gotchas
   (cross-model LazyFrame joins, dict-`.cast` on model-bearing frames, `ge`/`le` silently ignored
-  on a datetime field, `.filter()` dropping the Patito subclass, and Delta dictionary-encoded
-  columns). Five workarounds is an acceptable price for schema validation — but if a sixth becomes
-  necessary, revisit the approach: either validate only at I/O boundaries (typed annotations
-  everywhere, `.validate()` only at persistence edges) or evaluate an alternative such as
-  `dataframely`.
+  on a datetime field, `pt.LazyFrame` methods typed as plain `pl.LazyFrame`, and Delta
+  dictionary-encoded columns). Five workarounds is an acceptable price for schema validation — but
+  if a sixth becomes necessary, revisit the approach: either validate only at I/O boundaries (typed
+  annotations everywhere, `.validate()` only at persistence edges) or evaluate an alternative such
+  as `dataframely`.
 - **Never row-count a table that can exceed 2³² rows with Polars.** Default Polars builds use a
   32-bit row index, so past ~4.29 billion rows `pl.len()` and `group_by(...).agg(pl.len())` wrap
   modulo 2³² with **no error**. Use the Delta log instead — `DeltaTable(path).count()`, or sum

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -339,7 +339,8 @@ def _load_engineering_inputs(
     )
     if ensemble_members is not None:
         nwp_scan = nwp_scan.filter(pl.col("ensemble_member").is_in(ensemble_members))
-    # ``.filter`` returns a plain ``pl.LazyFrame``; re-attach the model. (Zero-copy re-wrap.)
+    # ``.filter`` is *typed* as a plain ``pl.LazyFrame`` even though the model survives at runtime,
+    # so re-wrap to satisfy the return annotation. (Zero-copy.)
     nwp_lf = pt.LazyFrame.from_existing(nwp_scan).set_model(Nwp)
 
     return power_ts, metadata_df, nwp_lf
@@ -649,9 +650,9 @@ class PopulationFilter(Config):
 
         Returns:
             The same scan with the filter predicates applied, re-wrapped as a
-            ``pt.LazyFrame[PowerForecast]`` (``.filter()`` drops the Patito subclass).
+            ``pt.LazyFrame[PowerForecast]`` (``.filter()`` is typed as a plain ``pl.LazyFrame``).
         """
-        # .filter() drops the pt subclass; accumulate on a plain LazyFrame, re-wrap on return.
+        # .filter() is typed as plain pl.LazyFrame; accumulate on one, re-wrap on return.
         lf: pl.LazyFrame = scan
         if self.experiment_name is not None:
             lf = lf.filter(pl.col("experiment_name") == self.experiment_name)
@@ -790,8 +791,8 @@ def _group_scan(
         fold_id: Fold identifier of the group.
 
     Returns:
-        A lazy scan of this one group's rows (a plain ``pl.LazyFrame`` — ``.filter()`` drops
-        the Patito subclass; the per-batch loader re-validates on collect).
+        A lazy scan of this one group's rows, annotated as a plain ``pl.LazyFrame`` because that
+        is how ``.filter()`` is typed; the per-batch loader re-validates on collect.
     """
     return pruned_scan.filter(
         (pl.col("experiment_name") == exp_name) & (pl.col("fold_id") == fold_id)


### PR DESCRIPTION
🤖 Written by Claude Code.

The `polars-patito-gotchas` skill claimed `.filter()` "drops the Patito subclass". It doesn't, and the claim was unscoped enough to read as applying to `pt.DataFrame` as well as `pt.LazyFrame`.

## What's actually true

**At runtime the model survives.** On patito 0.8.6 / polars 1.43.2, `.filter()`, `.sort()`, `.select()`, `.with_columns()`, `.head()` and `.unique()` on a `pt.LazyFrame` *and* on a `pt.DataFrame` all return the model-bearing subclass with `.model` still set. Nothing is dropped and nothing needs restoring.

**The trap is a type-annotation gap.** `ty` types `scan.filter(...)` on a `scan: pt.LazyFrame[Schema]` as `polars.lazyframe.frame.LazyFrame`, so `scan = scan.filter(...)` fails:

```text
error[invalid-assignment]: Object of type `polars.lazyframe.frame.LazyFrame` is not assignable to `patito.polars.LazyFrame[PowerForecast]`
```

**`pt.DataFrame` is unaffected, in both senses.** `patito/polars.py` gives `patito.polars.DataFrame` a `# --- Type annotation overrides ---` block re-declaring `filter`/`select`/`with_columns` as `(self: DF) -> DF`; `patito.polars.LazyFrame` has no such block and inherits Polars' own annotations. So `df.filter(...)` on a `pt.DataFrame[S]` stays `pt.DataFrame[S]` to `ty` and needs no workaround at all.

## What changed

- The skill section, rewritten with the real mechanism, the actual `ty` error text, and an explicit "`pt.DataFrame` is unaffected" note. The workaround code is unchanged — it was always correct, it just wasn't doing what the prose said.
- The skill's front-matter description and intro paragraph. The intro said every trap "produces no error at the point of the mistake", which sat awkwardly above a section whose whole content is the error you get; it now says none of them *points at itself*, which covers both kinds.
- `docs/architecture/code-style.md`, where the Patito friction budget summarises the five gotchas by name.
- Three comments in `cv_assets.py` that repeated the wrong wording verbatim.

No behaviour change; comments, docs and one skill only.

## How this was found

While documenting boundary validation in #550 I nearly repeated the `.filter()` claim in a code comment, tested it first, and found it false for `pt.DataFrame`. This PR is the follow-up: I checked runtime behaviour across six methods on both frame types, then checked what `ty` infers for each, then read `patito/polars.py` to find why the two disagree.

## Verification

`ruff check`, `ruff format --check`, `ty check` (all packages), `pymarkdown` and `pytest` (614 passed, 1 skipped) all green.
