### PR TITLE
Scope which Polars ops drop the Patito model, and which are typed as plain

### DIFF
--- a/.claude/skills/polars-patito-gotchas/SKILL.md
+++ b/.claude/skills/polars-patito-gotchas/SKILL.md
@@ -44,11 +44,22 @@ every column to the *model's* declared dtypes. So `df.cast({"foo": pl.Int8})` on
 and your `foo` cast is silently ignored while unrelated columns are reverted to model dtypes. The
 result usually only surfaces later as a confusing `validate()` dtype error.
 
-The trap fires only when the model is still attached. Many Polars ops **drop** the model
-(`group_by(...).agg(...)`, `.collect()`, `.unpivot()`, `.as_polars()`), so a dict-`.cast` after
-them is plain Polars and fine. But **iterating** `group_by` (`for k, g in df.group_by(...)`) yields
-sub-frames that **keep** the model, and `pl.concat` keeps it too — so a dict-`.cast` on the
-concatenated result hits the trap.
+The trap fires only when the model is still attached, and which operations detach it is not
+guessable. Measured on patito 0.8.6:
+
+Only three operations **drop** it, and a dict-`.cast` after one of those is plain Polars and fine:
+
+- `group_by(...).agg(...)`, eager and lazy — but *iterating* `group_by` keeps it
+- `pl.concat([...])`, whether or not the inputs share a model
+- `.as_polars()`
+
+Everything else **keeps** it, so a dict-`.cast` after any of them is swallowed: `.collect()`,
+`.unpivot()`, `.filter()`, `.sort()`, `.select()`, `.with_columns()`, `.head()`, `.unique()`,
+`.drop()`, `.rename()`, `.join()` and `.with_row_index()`.
+
+`.collect()` is the one to watch, because it reads as the boundary back into plain Polars and is
+not. `pt.LazyFrame(...).set_model(S).collect().cast({"a": pl.Int8})` leaves `a` as `Int64` — no
+error, no warning — where the same call on a plain frame gives `Int8`.
 
 Workaround: strip the Patito model before a `{column: dtype}` cast (mirrors the join gotcha above):
 
@@ -92,16 +103,19 @@ error[invalid-assignment]: Object of type `polars.lazyframe.frame.LazyFrame`
 is not assignable to `patito.polars.LazyFrame[PowerForecast]`
 ```
 
-**This is a type-annotation gap, not a runtime one.** At runtime the model survives: `.filter()`,
-`.sort()`, `.select()`, `.with_columns()`, `.head()` and `.unique()` on a `pt.LazyFrame` all return
-the model-bearing subclass with `.model` still set. Nothing is lost and nothing needs restoring —
-the re-wrap below exists only to satisfy the annotation.
+**This is a type-annotation gap, not a runtime one.** At runtime the model survives every one of
+these methods, on both frame types — see the table under
+[`.cast({...})` on a model-bearing frame](#cast-on-a-model-bearing-frame). Nothing is lost and
+nothing needs restoring; the re-wrap below exists only to satisfy the annotation.
 
-The asymmetry is in `patito/polars.py`: `patito.polars.DataFrame` carries a block of
-type-annotation overrides re-declaring `filter`/`select`/`with_columns` as `(self: DF) -> DF`, and
-`patito.polars.LazyFrame` has no such block, so it inherits Polars' own annotations.
-**`pt.DataFrame` is therefore unaffected** — `df.filter(...)` stays `pt.DataFrame[Schema]` to `ty`
-as well as at runtime, and needs no workaround.
+The gap is in `patito/polars.py`, and it is narrower than "lazy versus eager".
+`patito.polars.DataFrame` carries a block of type-annotation overrides re-declaring exactly three
+methods — `filter`, `select` and `with_columns` — as `(self: DF) -> DF`. Those three, on a
+`pt.DataFrame`, need no workaround. **Every other method on either frame type does**, because
+`patito.polars.LazyFrame` has no such block at all and `DataFrame`'s block stops at three. So
+`df.sort(...)`, `df.head(...)`, `df.unique()` and `df.rename(...)` on an *eager* `pt.DataFrame`
+raise the same `invalid-assignment` as the lazy case. (`df.drop(...)` happens not to, because
+Polars annotates `DataFrame.drop` as returning `Self`.)
 
 **Upgrading `ty` will not fix this, because `ty` is not wrong.** Polars annotates
 `LazyFrame.filter`, `.sort`, `.select`, `.with_columns`, `.head`, `.unique`, `.drop` and `.rename`
@@ -110,8 +124,7 @@ as returning `LazyFrame`, not `Self`, so every conforming checker must infer the
 those return annotations to `Self`, or Patito giving its `LazyFrame` the same override block its
 `DataFrame` already has. Until one of those lands, the re-wrap below is the workaround.
 
-Workaround, for the lazy case only: rebind to a plain `pl.LazyFrame` local for the filter
-accumulation, then re-wrap before returning:
+Workaround: rebind to a plain local for the accumulation, then re-wrap before returning.
 
 ```python
 def apply(self, scan: pt.LazyFrame[MySchema]) -> pt.LazyFrame[MySchema]:
@@ -120,6 +133,14 @@ def apply(self, scan: pt.LazyFrame[MySchema]) -> pt.LazyFrame[MySchema]:
         lf = lf.filter(pl.col("foo") == self.foo)
     return pt.LazyFrame.from_existing(lf).set_model(MySchema)  # zero-copy re-wrap
 ```
+
+There is no `pt.DataFrame.from_existing`, so the eager re-wrap spells the same thing as
+`pt.DataFrame._from_pydf(df._df).set_model(MySchema)`.
+
+The runtime and `patito/polars.py` claims in this section and the `.cast` table above are measured
+against **patito 0.8.6 / polars 1.43.2**; `pyproject.toml` pins `polars>=1.0.0` and does not pin
+`patito` at all, so re-check them after an upgrade to either. The `ty` claim needs no such caveat:
+it follows from Polars' own annotations, so no checker version changes it.
 
 ## Delta Lake dictionary-encoded columns: declare Delta filter/partition columns as `String`
 

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -791,8 +791,10 @@ def _group_scan(
         fold_id: Fold identifier of the group.
 
     Returns:
-        A lazy scan of this one group's rows, annotated as a plain ``pl.LazyFrame`` because that
-        is how ``.filter()`` is typed; the per-batch loader re-validates on collect.
+        A lazy scan of this one group's rows. Left as a plain ``pl.LazyFrame`` rather than
+        re-wrapped as ``pt.LazyFrame[PowerForecast]``, because every consumer takes it plain and
+        ``_load_series_batch`` validates each batch on collect — a re-wrap here would be discarded
+        unused.
     """
     return pruned_scan.filter(
         (pl.col("experiment_name") == exp_name) & (pl.col("fold_id") == fold_id)


### PR DESCRIPTION
🤖 Written by Claude Code.

Follow-up to #551. The Sonnet 5 adversarial review of that PR came back AMBER and was right twice. I verified both findings independently before applying them.

## 1. #551's own headline claim was an unscoped overclaim

It said "`pt.DataFrame` is therefore unaffected" — which is the same failure mode #551 existed to correct, one section further down the page.

Patito's `# --- Type annotation overrides ---` block re-declares **exactly three** methods: `filter`, `select`, `with_columns`. Those three on a `pt.DataFrame` genuinely need no workaround. Everything else does:

```text
error[invalid-assignment]: Object of type `polars.dataframe.frame.DataFrame`
is not assignable to `patito.polars.DataFrame[PowerForecast]`
   df = df.sort("a")     ← same for .head(2), .unique(), .rename({...})
```

So the gap is "three methods on `pt.DataFrame`", not "lazy versus eager". Going slightly further than the reviewer: `.rename()` fails too (they missed it), and `.drop()` does *not*, because Polars annotates `DataFrame.drop` as returning `Self`.

## 2. The adjacent `.cast` section had three runtime claims backwards

Not part of #551's diff, but the same question — "does operation X drop the model?" — two sections up. Two of the three errors point the dangerous way:

| Claim in the skill | Actually |
|---|---|
| `.collect()` drops the model | **keeps** it |
| `.unpivot()` drops the model | **keeps** it |
| `pl.concat` keeps the model | **drops** it, shared model or not |

The first two told readers a dict-cast after `.collect()` was "plain Polars and fine". It isn't — it's silently swallowed:

```python
pt.LazyFrame({"a": [1, 2]}).set_model(S).collect().cast({"a": pl.Int8})
# -> Schema({'a': Int64})   ...plain Polars gives Int8
```

Only `group_by(...).agg(...)` (eager and lazy), `pl.concat` and `.as_polars()` drop it. Iterating `group_by` keeps it, as the skill already said.

## No code is affected — checked, not assumed

There is exactly one dict-cast in the repo on a frame that could carry a model: `_compute_effective_capacity` in `cv_assets.py`, which casts after a lazy `group_by(...).agg(...)`. That genuinely does drop the model, so the cast is plain Polars. Verified end to end by calling the helper: `effective_capacity_mw` comes back `Float32`. The other four call sites are on plain frames, and `delta_store/nwp.py` already strips the model explicitly.

## Also in this PR

- **There is no `pt.DataFrame.from_existing`.** I nearly shipped a workaround using it; the eager re-wrap is `pt.DataFrame._from_pydf(df._df).set_model(Schema)`.
- **Version scoping**, which the reviewer asked for and I'd argued against. They were right for the runtime claims: `pyproject.toml` pins `polars>=1.0.0` and doesn't pin `patito` at all, so those need a re-check signal. The `ty` claim still needs no caveat — it follows from Polars' own annotations, so no checker version changes it.
- **`_group_scan`'s docstring**, which #551 gave the wrong reason. It returns a plain `pl.LazyFrame` because every consumer takes it plain and `_load_series_batch` validates each batch on collect — not because of the typing gap. A re-wrap there would be discarded unused.

## Verification

`ruff check`, `ruff format --check`, `ty check` (all packages), `pymarkdown`, `pytest` (614 passed, 1 skipped) all green.
