### PR TITLE
Replace the dead plans/dagster_plan.md section references with docs links

### DIFF
--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -622,7 +622,10 @@ def cv_power_forecasts(context: AssetExecutionContext) -> None:
 
 
 class PopulationFilter(Config):
-    """Typed filter over ``power_forecasts`` rows to score (§4.8).
+    """Typed filter over ``power_forecasts`` rows to score.
+
+    Every field is tabulated with a worked example under "Step 8 — Materialise ``metrics``":
+    <https://openclimatefix.github.io/nged-substation-forecast/ml_experimentation/dagster-workflow/>
 
     All fields default to ``None`` (= no filter on that dimension). A mistyped field name is a
     Dagster config validation error, not a silent wrong population — that is the whole point of
@@ -672,7 +675,11 @@ class PopulationFilter(Config):
 
 
 class MetricsConfig(Config):
-    """Run config for the ``metrics`` asset (§4.8)."""
+    """Run config for the ``metrics`` asset.
+
+    Filled in from the Dagster run-config dialog; see "Step 8 — Materialise ``metrics``":
+    <https://openclimatefix.github.io/nged-substation-forecast/ml_experimentation/dagster-workflow/>
+    """
 
     population_filter: PopulationFilter = PopulationFilter()
     evaluation_scope: EvalScopeType = "leaderboard"
@@ -952,7 +959,9 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
 
     For ``evaluation_scope="leaderboard"``, also logs per-type + overall aggregate metrics to each
     fold's MLflow child run and the mean-across-folds aggregates to the experiment's parent run.
-    Lookup is by tag (§4.1.1) so this is idempotent under Dagster retries.
+    Lookup is by tag — never by a handle passed between assets — so this is idempotent under
+    Dagster retries and safe across processes; see "Cross-process run resolution" in
+    <https://openclimatefix.github.io/nged-substation-forecast/architecture/ml-orchestration/>.
 
     Args:
         context: Dagster execution context; used for logging and ``add_output_metadata``.

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -6,8 +6,8 @@ Tests at two tiers:
    without a network server. Covers leaderboard loop, idempotency, and ad_hoc scope.
 
 2. **Full-stack cross-process** (real ``mlflow server`` subprocess + temp Delta): the one test
-   from §7.10 that proves the by-tag cross-process run resolution (§4.1.1) and the artifact
-   upload/download round-trip (§4.5). Runs against a real HTTP tracking server so each
+   that proves the by-tag cross-process run resolution and the artifact upload/download
+   round-trip. Runs against a real HTTP tracking server so each
    ``materialize()`` call — like a separate Dagster process — uses a fresh MlflowClient
    connection to resolve runs by tag.
 """
@@ -692,7 +692,7 @@ def test_full_stack_real_mlflow_server(
 ) -> None:
     """Full-stack test: real HTTP MLflow server + artifact round-trip + tag resolution.
 
-    Proves §4.1.1 (cross-call tag resolution) and §4.5 (artifact upload/download).
+    Proves cross-call tag resolution and the artifact upload/download round-trip.
     Each ``materialize()`` call starts with a fresh ``mlflow.set_tracking_uri`` inside
     the asset body — simulating what happens when assets run in separate Dagster processes.
     The artifact round-trip is proved by ``cv_power_forecasts`` downloading the model


### PR DESCRIPTION
🤖 Written by Claude Code.

Six `§N.N` references in `cv_assets.py` and `tests/test_metrics.py` point at sections of `plans/dagster_plan.md`. That file no longer exists — commit `80dc03d8` (#217) absorbed it into `docs/architecture/ml-orchestration.md` and `docs/ml_experimentation/dagster-workflow.md`, and `plans/` now holds only its README. A reader who follows `§4.8` has nowhere to go.

Found while a sub-agent was extracting a black-box requirements spec for `cv_assets.py`; verified before acting on it.

## What each one becomes

| Was | Now |
|---|---|
| `PopulationFilter` — "(§4.8)" | "Step 8 — Materialise `metrics`" in `dagster-workflow` |
| `MetricsConfig` — "(§4.8)" | same |
| `metrics` — "Lookup is by tag (§4.1.1)" | "Cross-process run resolution" in `ml-orchestration` |
| `test_metrics.py` module docstring — "§7.10", "§4.1.1", "§4.5" | plain prose |
| `test_full_stack_real_mlflow_server` — "§4.1.1", "§4.5" | plain prose |

The three in `cv_assets.py` become links, since the content genuinely landed somewhere durable and the code-style rule wants code linking to durable docs spelled as the rendered URL. The section name goes in prose and the link points at the page, so the line fits inside 100 characters — wrapping a URL is not an option here, because a continuation line starting with `#` renders as a heading (the `mkdocs-authoring` trap).

The three in the tests become plain prose instead. `§7.10` named a section of a test plan that was deleted rather than absorbed, so there is nothing to link; the sentences read no worse without a citation.

`precision.py`'s `§4.4` is deliberately untouched — it cites the *Handbook of Floating-Point Arithmetic*, not the plan.

## Noticed in passing, not fixed here

`dagster-workflow.md`'s Step 8 says the `metrics` asset "loads and scores **one group at a time** — peak memory is a single fold". That stopped being true when per-series batching landed (`_METRICS_SERIES_BATCH_SIZE`): a whole fold is now explicitly too big to materialise. Out of scope for a link-fixing PR — flagging rather than fixing.

## Verification

`ruff check`, `ruff format --check`, `ty check` (all packages), `pymarkdown`, `pytest` (614 passed, 1 skipped) all green.
