### PR TITLE
Theme the docs with the OCF brand palette

### DIFF
--- a/docs/stylesheets/ocf.css
+++ b/docs/stylesheets/ocf.css
@@ -1,0 +1,70 @@
+/* OCF brand colours for the MkDocs Material theme.
+ *
+ * The hex values below are copied from `packages/plotting/src/plotting/ocf_theme.py`, which is
+ * the single source of truth for the OCF brand palette. Keep the two in step: CSS cannot import
+ * the Python constants, so a change to the palette has to be made in both places.
+ */
+
+:root {
+  --ocf-orange-red: #ff4901;
+  --ocf-blue: #306bff;
+  --ocf-brown: #bf4f04;
+  --ocf-background: #fffbf5;
+  --ocf-grid: #eaeaea;
+  --ocf-text: #292b2b;
+}
+
+[data-md-color-scheme="default"] {
+  /* Header and search bar. BLUE rather than ORANGE_RED: a full-width orange-red bar reads as a
+   * warning banner. The --light and --dark tints are not palette colours; Material needs them
+   * for the header shadow and the mobile browser chrome, so they are tints of BLUE.
+   */
+  --md-primary-fg-color: var(--ocf-blue);
+  --md-primary-fg-color--light: #6d94ff;
+  --md-primary-fg-color--dark: #1f4bc4;
+  --md-primary-bg-color: var(--ocf-background);
+  --md-primary-bg-color--light: #fffbf5b3;
+
+  /* Hover and focus states. */
+  --md-accent-fg-color: var(--ocf-orange-red);
+  --md-accent-fg-color--transparent: #ff49011a;
+  --md-accent-bg-color: var(--ocf-background);
+  --md-accent-bg-color--light: #fffbf5b3;
+
+  /* Page background and body text. The background matches the chart background exactly, so an
+   * exported Altair SVG sits on the page with no visible panel edge.
+   */
+  --md-default-bg-color: var(--ocf-background);
+  --md-default-bg-color--light: #fffbf5b3;
+  --md-default-bg-color--lighter: #fffbf54d;
+  --md-default-bg-color--lightest: #fffbf51f;
+  --md-default-fg-color: #292b2bde;
+  --md-default-fg-color--light: #292b2b8a;
+  --md-default-fg-color--lighter: #292b2b52;
+  --md-default-fg-color--lightest: #292b2b12;
+  --md-typeset-color: var(--ocf-text);
+
+  /* ORANGE_RED reaches only 3.4:1 against the cream background, below the 4.5:1 needed for body
+   * text, so links use the palette's darker BROWN (4.7:1) and brighten to ORANGE_RED on hover.
+   */
+  --md-typeset-a-color: var(--ocf-brown);
+
+  /* Warm the code blocks and table rules so they read as a tint of the page, not grey on cream. */
+  --md-code-fg-color: var(--ocf-text);
+  --md-code-bg-color: #f5efe5;
+  --md-code-bg-color--light: #f5efe5b3;
+  --md-code-bg-color--lighter: #f5efe54d;
+  --md-code-hl-color: var(--ocf-blue);
+  --md-code-hl-color--light: #306bff1a;
+  --md-typeset-table-color: var(--ocf-grid);
+  --md-typeset-table-color--light: #eaeaea59;
+  --md-typeset-kbd-color: #f5efe5;
+  --md-typeset-kbd-accent-color: var(--ocf-background);
+  --md-typeset-kbd-border-color: #d8cfc2;
+
+  --md-footer-fg-color: var(--ocf-background);
+  --md-footer-fg-color--light: #fffbf5b3;
+  --md-footer-fg-color--lighter: #fffbf573;
+  --md-footer-bg-color: var(--ocf-text);
+  --md-footer-bg-color--dark: #1c1e1e;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,10 @@ validation:
 
 theme:
   name: material
+  palette:
+    scheme: default
+    primary: custom
+    accent: custom
   features:
     - content.code.copy
 
@@ -14,6 +18,9 @@ markdown_extensions:
       generic: true
   - pymdownx.highlight
   - pymdownx.superfences
+
+extra_css:
+  - stylesheets/ocf.css
 
 extra_javascript:
   - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js


### PR DESCRIPTION
*This PR was written by Claude Code.*

The docs site used MkDocs Material's stock indigo-on-white defaults, which matched nothing else we ship. `docs/stylesheets/ocf.css` now overrides Material's CSS custom properties with the colours from `plotting.ocf_theme`, so the docs, the Altair charts and the dashboards share one palette.

## The mapping

| Docs element | OCF constant |
|---|---|
| Page background | `BACKGROUND` `#FFFBF5` |
| Body text | `#292B2B` (the theme's `_TEXT`) |
| Header and search bar | `BLUE` `#306BFF` |
| Body links (active nav, hover) | `BROWN` `#BF4F04`, hovering to `ORANGE_RED` `#FF4901` |
| Table rules | `GRID` `#EAEAEA` |
| Code blocks | `#F5EFE5`, a warm tint of the page rather than Material's grey |
| Footer | `#292B2B` with cream text |

## Three choices worth flagging

**The page background is the chart background.** Both are `#FFFBF5`, so `example_power_forecast.svg` sits on the home page with no visible panel edge.

**Body links are `BROWN`, not `ORANGE_RED`.** Orange-red reaches only 3.4:1 against the cream background, under the 4.5:1 WCAG AA needs for body text. Brown gets 4.7:1 and still reads as the brand colour, and orange-red is the hover state, so the signature colour appears where it means "interactive".

**The header is `BLUE`, not `ORANGE_RED`.** A full-width orange-red bar reads as a warning banner. Blue also raises the header text contrast from 3.3:1 to 4.4:1. If you later want it comfortably past AA, darkening to `#2A5FE0` gets 5.4:1, at the cost of no longer being the exact palette blue.

Two tints in the stylesheet — `#6D94FF` and `#1F4BC4` — are not palette colours. Material needs a light and a dark variant of the primary colour for the header shadow and the mobile browser chrome; they are commented as tints of `BLUE`.

CSS cannot import the Python constants, so the stylesheet carries a header comment naming `plotting.ocf_theme` as the source of truth, and saying the two have to be kept in step.

## Verification

- `uv run mkdocs build --strict` is clean.
- Rendered the site and read back the computed styles: page background, body text, header, links, code blocks, tables, footer and the mkdocstrings API pages all resolve to the intended colours, with no console errors.
- Every body-text contrast ratio measured in the browser is 4.7:1 or better; the header is 4.4:1 as described above.
