### PR TITLE
Stop metrics crashing on live rows; two MLflow/memory fixes beside it

### DIFF
--- a/docs/ml_experimentation/dagster-workflow.md
+++ b/docs/ml_experimentation/dagster-workflow.md
@@ -170,8 +170,11 @@ Experiment "xgboost_smoke_test"
 4. Writes to the `power_forecasts` Delta table keyed by `(experiment_name, fold_id)`: the **first**
    chunk overwrites the partition (clearing any prior run), the rest **append**, so a full
    re-materialisation replaces the fold's rows without ever holding all forecasts in memory.
-5. Logs `val_start`/`val_end` tags and `n_forecast_rows`/`n_forecast_time_series`/
-   `n_ensemble_members` metrics to the fold run.
+5. Tags the fold run with `val_start`/`val_end` and the `n_forecast_rows`/
+   `n_forecast_time_series`/`n_ensemble_members` counters. All five are tags rather than params or
+   metrics because they legitimately change — and can shrink — between materialisations of the
+   same fold run: params are write-once, and MLflow reports a metric's latest value as the max
+   over all its writes, so a shrunk count would read back too high.
 
 ---
 
@@ -225,7 +228,13 @@ in the run config dialog before launching.
    partition columns (`experiment_name` / `fold_id`) are `String`, matching what delta-rs stores,
    so the predicates push straight into the Delta scan: naming an experiment/fold prunes to just
    that partition rather than reading the whole (unbounded) table.
-2. Discovers the matching `(experiment_name, fold_id)` groups, then loads and scores **one group at
+2. In `leaderboard` scope, drops any group whose `fold_id` is not defined in the CV config, naming
+   the dropped ids in a warning and in the asset's `skipped_fold_ids` metadata. The live service
+   writes to this same table under `fold_id="live"`, so an unfiltered leaderboard run finds it;
+   leaderboard scope dates its evaluation window from the CV config and has none for those rows.
+   To score live output, run the asset with `evaluation_scope="ad_hoc"`, which takes the window
+   from the forecast rows themselves.
+3. Discovers the matching `(experiment_name, fold_id)` groups, then loads and scores **one group at
    a time** — peak memory is a single fold, not the entire matched population. (A whole fold is
    the *coarsest* chunk Polars can safely materialise: fine at V1 scale, but a V2-scale fold will
    need sub-fold chunking — see
@@ -242,7 +251,7 @@ in the run config dialog before launching.
       `window_label`), `computed_at`, and the MLflow fold run id (leaderboard scope only).
    c. Writes to `forecast_metrics` Delta, partitioned by `(experiment_name, fold_id)` with an
       idempotent overwrite predicate — safe to re-run without duplicating rows.
-3. For `evaluation_scope="leaderboard"`: builds an aggregate metric dict and logs it to the
+4. For `evaluation_scope="leaderboard"`: builds an aggregate metric dict and logs it to the
    fold's MLflow child run, then averages across folds and logs the mean to the parent run.
    The key token is `{metric_name}` for scalar metrics and `{metric_name}_{metric_param}` for
    parametric ones, in three families: overall (`rmse__all`, `crps__all`), per type

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -570,8 +570,13 @@ def cv_power_forecasts(context: AssetExecutionContext) -> None:
         )
         is_first = False
         n_rows += forecasts.height
-        time_series_seen.update(forecasts["time_series_id"].to_list())
-        ensemble_members_seen.update(forecasts["ensemble_member"].to_list())
+        # `.unique()` before `.to_list()`: only the distinct values reach the set, so this builds
+        # a ~30-element Python list per chunk rather than a ~14M-element one. Measured on a
+        # 14M-row Int32 column: 2.78 s and 560 MB peak, against 0.05 s and no measurable
+        # allocation. The 560 MB landed inside the loop whose whole job is holding the frame at
+        # 2-3 GB.
+        time_series_seen.update(forecasts["time_series_id"].unique().to_list())
+        ensemble_members_seen.update(forecasts["ensemble_member"].unique().to_list())
 
     n_time_series = len(time_series_seen)
     n_ensemble_members = len(ensemble_members_seen)
@@ -594,11 +599,16 @@ def cv_power_forecasts(context: AssetExecutionContext) -> None:
                 storage_options=settings.storage_options,
             )
         )
-        mlflow.log_metrics(
+        # Tags, not metrics, for the same reason the training counters are tags (see
+        # `trained_cv_model`): all three shrink when the trained population shrinks or the
+        # validation window is narrowed, and MLflow resolves a metric's "latest" value as the max
+        # over (step, timestamp, value) rather than the newest write — so a shrunk count would be
+        # under-reported. Tags are last-write-wins, which is the semantic wanted here.
+        mlflow.set_tags(
             {
-                "n_forecast_rows": float(n_rows),
-                "n_forecast_time_series": float(n_time_series),
-                "n_ensemble_members": float(n_ensemble_members),
+                "n_forecast_rows": str(n_rows),
+                "n_forecast_time_series": str(n_time_series),
+                "n_ensemble_members": str(n_ensemble_members),
             }
         )
 
@@ -954,6 +964,12 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     fold's MLflow child run and the mean-across-folds aggregates to the experiment's parent run.
     Lookup is by tag (§4.1.1) so this is idempotent under Dagster retries.
 
+    ``power_forecasts`` also holds the live service's output under ``fold_id="live"``. Leaderboard
+    scope skips any ``fold_id`` the CV config does not define, naming them in a warning and in the
+    ``skipped_fold_ids`` output metadata, because it dates its evaluation window from that config
+    and has none for them. Use ``evaluation_scope="ad_hoc"`` to score live rows: it takes the
+    window from the rows themselves.
+
     Args:
         context: Dagster execution context; used for logging and ``add_output_metadata``.
         config: Population filter and evaluation scope for this materialisation. Defaults to
@@ -986,9 +1002,30 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
         .collect(engine="streaming")
         .rows()
     )
+    # `live_forecasts` writes its output to this same table under `fold_id="live"`, so an
+    # unfiltered leaderboard run — which the operator guide tells you to launch, leaving
+    # `fold_id` null to score every fold — discovers a group the CV config has never heard of.
+    # Leaderboard scope dates its window from that config, so those rows have no window to be
+    # scored against; skip them rather than fail the whole run on the first one. Ad-hoc scope
+    # takes its window from the rows themselves and is the supported way to score live output.
+    skipped_fold_ids: list[str] = []
+    if config.evaluation_scope == "leaderboard":
+        configured_fold_ids = set(_cv_config.fold_ids)
+        skipped_fold_ids = sorted({fold for _, fold in groups if fold not in configured_fold_ids})
+        if skipped_fold_ids:
+            context.log.warning(
+                f"Skipping {skipped_fold_ids} — not folds in the CV config "
+                f"({sorted(configured_fold_ids)}), so leaderboard scope has no evaluation window "
+                'for them. Score these with evaluation_scope="ad_hoc", which dates its window '
+                "from the forecast rows themselves."
+            )
+            groups = [group for group in groups if group[1] in configured_fold_ids]
+
     if not groups:
         context.log.warning("No forecasts matched the population filter — nothing to score.")
-        context.add_output_metadata({"n_rows_written": 0, "n_groups": 0})
+        context.add_output_metadata(
+            {"n_rows_written": 0, "n_groups": 0, "skipped_fold_ids": str(skipped_fold_ids)}
+        )
         return
 
     actuals_lf = pt.LazyFrame.from_existing(
@@ -1071,5 +1108,6 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
             "n_groups": len(groups),
             "evaluation_scope": config.evaluation_scope,
             "groups": str(groups),
+            "skipped_fold_ids": str(skipped_fold_ids),
         }
     )

--- a/tests/test_cv_power_forecasts.py
+++ b/tests/test_cv_power_forecasts.py
@@ -189,7 +189,9 @@ def test_cv_power_forecasts_predicts_validation_fold(
         filter_string=f"tags.cv_role = 'fold' and tags.fold_id = '{FOLD_ID}'",
     )
     assert len(fold_runs) == 1
-    assert fold_runs[0].data.metrics["n_forecast_rows"] == float(forecasts.height)
+    # A tag, not a metric: the count shrinks when the trained population or the validation window
+    # does, and MLflow reports a metric's latest value as the max over all writes.
+    assert fold_runs[0].data.tags["n_forecast_rows"] == str(forecasts.height)
 
 
 def test_cv_power_forecasts_storage_format(

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -649,6 +649,68 @@ def test_metrics_no_filter_scores_every_group(
     assert scored_experiments == {EXPERIMENT_NAME, second_experiment}
 
 
+def _append_live_fold_rows(forecasts_path: str) -> None:
+    """Copy the produced forecasts into a ``fold_id="live"`` partition of the same table.
+
+    This is what ``live_forecasts`` writes: production output shares ``power_forecasts`` with the
+    CV folds, keyed by ``(experiment_name, fold_id="live")``.
+    """
+    live = pl.read_delta(forecasts_path).with_columns(fold_id=pl.lit("live"))
+    write_deltalake(
+        table_or_uri=forecasts_path,
+        data=live.to_arrow(),
+        mode="append",
+        partition_by=["experiment_name", "fold_id"],
+    )
+
+
+def test_metrics_leaderboard_skips_fold_ids_the_cv_config_does_not_define(
+    file_mlflow_env: dict[str, Path], dagster_instance: DagsterInstance
+) -> None:
+    """An unfiltered leaderboard run ignores ``fold_id="live"`` instead of failing on it.
+
+    Leaderboard scope dates its evaluation window from the CV config, which has no entry for
+    ``"live"``. Before this was handled the run raised ``KeyError`` — after paying for the
+    group's full per-series scoring, and on the first group, since ``"live"`` sorts first.
+    """
+    _run_cv_pipeline(dagster_instance)
+    _append_live_fold_rows(str(file_mlflow_env["forecasts"]))
+
+    result = materialize(
+        [metrics],
+        run_config=RunConfig(ops={"metrics": MetricsConfig(evaluation_scope="leaderboard")}),
+        instance=dagster_instance,
+    )
+    assert result.success
+
+    fm = pl.read_delta(str(file_mlflow_env["metrics"]))
+    assert set(fm["fold_id"].unique().to_list()) == {FOLD_ID}
+
+    (materialisation,) = result.asset_materializations_for_node("metrics")
+    assert materialisation.metadata["skipped_fold_ids"].value == "['live']"
+
+
+def test_metrics_ad_hoc_scores_fold_ids_the_cv_config_does_not_define(
+    file_mlflow_env: dict[str, Path], dagster_instance: DagsterInstance
+) -> None:
+    """Ad-hoc scope is the supported way to score live rows, so it must not skip them.
+
+    It takes the evaluation window from the forecast rows themselves rather than the CV config,
+    so a ``fold_id`` the config has never heard of is no obstacle.
+    """
+    _run_cv_pipeline(dagster_instance)
+    _append_live_fold_rows(str(file_mlflow_env["forecasts"]))
+
+    assert materialize(
+        [metrics],
+        run_config=RunConfig(ops={"metrics": MetricsConfig(evaluation_scope="ad_hoc")}),
+        instance=dagster_instance,
+    ).success
+
+    fm = pl.read_delta(str(file_mlflow_env["metrics"]))
+    assert set(fm["fold_id"].unique().to_list()) == {FOLD_ID, "live"}
+
+
 # ---------------------------------------------------------------------------
 # Full-stack cross-process test (real mlflow server)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
🤖 Written by Claude Code.

Three findings from the clean-room review of `cv_assets.py`. Only the first changes behaviour; the other two are a correctness fix and a memory fix, both one-liners.

## 1. An unfiltered leaderboard `metrics` run crashed on production's rows

`live_forecasts` writes to the same `power_forecasts` table under `fold_id="live"` (`production_assets.py:306`). Leaderboard scope dates its evaluation window from the CV config, which has never heard of it:

```text
KeyError: "No fold with fold_id='live'; available folds: ['mid_2025_to_mid_2026', 'smoke_test']"
```

This was not a corner case. `dagster-workflow.md` tells operators to leave `fold_id` null to score every fold, so the documented workflow walked straight into it. And the failure was as unhelpful as it could be: `"live"` sorts before every real fold id, so it was the *first* group scored, and `_resolve_eval_window` is called *after* the group's full per-series batch scoring — the run paid for all that work and then threw it away.

**Fix:** leaderboard scope now drops any `fold_id` the CV config does not define, naming the dropped ids in a warning and in the asset's `skipped_fold_ids` metadata. This is not a degradation — live rows are a different population under a different protocol, and scoring them against a CV fold's window would be wrong even if a window existed.

**Ad-hoc scope is deliberately untouched.** It takes its window from the forecast rows themselves, so it already worked on live rows, and it is the supported route for scoring them (issue #224 plans a dedicated `production_monitoring` scope later). There is now a test pinning that ad-hoc still scores them, so the fix cannot quietly grow into "live rows are never scoreable".

## 2. `cv_power_forecasts` logged shrinkable counters as MLflow metrics

`n_forecast_rows`, `n_forecast_time_series` and `n_ensemble_members` went in via `log_metrics`, while `trained_cv_model` explains 160 lines above why counters must be tags: MLflow resolves a metric's "latest" value as the max over `(step, timestamp, value)`, not the newest write, so a count that legitimately shrinks — narrower validation window, smaller trained population — reads back too high forever.

Commit `59c4456a` made exactly this fix and stopped at the neighbouring asset. Now they are tags. The existing assertion in `test_cv_power_forecasts.py` moves from `.data.metrics` to `.data.tags`, and `dagster-workflow.md` is updated with the reason.

## 3. A ~14M-element Python list built twice per chunk

`forecasts["time_series_id"].to_list()` materialised the whole column as Python objects just to feed a `set` — inside the loop whose entire purpose is holding the frame at 2–3 GB. Measured here on a 14M-row `Int32` column with realistic (non-cached) id values:

| | time | peak |
|---|---|---|
| `to_list()` | 2.78 s | 560 MB |
| `unique().to_list()` | 0.05 s | ~0 MB |

Identical result — only distinct values ever reach the set. Two calls per chunk over ~28 chunks. Introduced by `a0ce8570`, the memory-bounding commit itself.

## Verification

- **The leaderboard test fails without the fix.** Neutering just the skip line reproduces the `KeyError`, while the ad-hoc test stays green — so the new test discriminates rather than merely passing.
- `ruff check`, `ruff format --check`, `ty check` (all packages), `pymarkdown`, `pytest` (616 passed, 1 skipped) all green.

## Not fixed here

`dagster-workflow.md`'s Step 8 still says `metrics` scores "one group at a time — peak memory is a single fold". Per-series batching (`_METRICS_SERIES_BATCH_SIZE`) made that false. It sits two lines from an edit in this PR, but it is a separate defect and belongs in its own change.
