### PR TITLE
Dispose the DagsterInstance every directly-invoked asset check builds

### DIFF
--- a/docs/architecture/testing.md
+++ b/docs/architecture/testing.md
@@ -58,9 +58,11 @@ tests: Polars row counts wrapping past 2³² rows, in
   leftover parquet. Keep the *server* module-scoped for speed, but give each test a
   **function-scoped** fixture that `POST`s to `/moto-api/reset` and recreates the bucket before
   the test body runs, so every test starts pristine and independent of execution order.
-- **Take the `dagster_instance` fixture; never call `DagsterInstance.ephemeral()` in a test.** The
-  fixture (in `tests/conftest.py`) enters the instance as a context manager, so `dispose()` runs
-  when the test ends.
+- **Take the `dagster_instance` fixture, or enter the instance as a context manager — never leave
+  a `DagsterInstance.ephemeral()` unowned.** The fixture (in `tests/conftest.py`) enters the
+  instance for you, so `dispose()` runs when the test ends. A module-level test helper that a
+  fixture cannot reach — `_run_live_check` in `tests/test_checks.py` — takes the second form
+  instead, and disposes on the way out of the helper.
 
     `DagsterInstance` has no finaliser, so an undisposed instance defers two cleanups to whenever
     the garbage collector reaches it. Both then surface as failures owned by no test:
@@ -100,12 +102,26 @@ tests: Polars row counts wrapping past 2³² rows, in
   `tests/test_assets.py::test_ecmwf_ens_retries_when_run_not_yet_available` — probing right after
   that test's teardown with **no forced `gc.collect()`** found 2 open connections before the fix,
   0 after, every time.
+- **`build_asset_check_context()` is the exception: give it `instance=`, because it cannot be
+  entered.** `DirectAssetCheckExecutionContext` defines no `__enter__`, so the context-manager
+  form above is a `TypeError`, and the `with` block has to hold the instance instead. Dagster
+  builds one of these for a directly-invoked check that declares *no* context parameter too, so
+  `power_data_is_fresh()` leaks an instance on a call that mentions Dagster nowhere; pass it a
+  context anyway, which Dagster accepts and uses in place of the one it would build. Worked
+  examples: `_run_freshness_check` and `_run_live_check` in `tests/test_checks.py`.
 - **`materialize()` and `JobDefinition.execute_in_process()` do *not* need this.** Both wrap their
   default instance in their own internal `with ephemeral_instance_if_missing(instance):`, entered
   and exited inside the call, so disposal is already deterministic however the caller uses the
   return value. The distinguishing question for any Dagster helper that can default-construct an
   instance is whether *the helper itself* closes the `with` block, or hands you an object that
   expects *you* to.
+- **An autouse fixture fails whichever test leaks one.**
+  `_fail_on_an_undisposed_dagster_instance` in `tests/conftest.py` wraps `DagsterInstance.ephemeral`
+  and `DagsterInstance.dispose` for the duration of each test, then asserts at teardown that every
+  instance created was disposed — so the fault is reported by name instead of against an unrelated
+  test. It catches a leak, not an omission: an unreferenced context is freed as soon as the helper
+  that built it returns, so a missing `instance=` can still pass green until something pins the
+  frame holding it.
 
 ## Warnings are errors
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ unit suites.
 """
 
 from collections.abc import Iterator
+from typing import Any
 
 import pytest
 from dagster import DagsterInstance
@@ -33,3 +34,40 @@ def dagster_instance() -> Iterator[DagsterInstance]:
     """
     with DagsterInstance.ephemeral() as instance:
         yield instance
+
+
+@pytest.fixture(autouse=True)
+def _fail_on_an_undisposed_dagster_instance(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """Fail the test that leaves a ``DagsterInstance.ephemeral()`` instance for the collector.
+
+    Being autouse, this fixture is set up before the ones a test asks for by name and so torn down
+    after them, which is what lets it see ``dagster_instance`` dispose.
+
+    It catches an instance that *survives* the test, not a call that forgot to own one: CPython
+    frees an unreferenced context as soon as the invoking helper returns, so a missing
+    ``instance=`` still passes green until something — a captured traceback, most often — pins the
+    frame holding it. Instances made by any route other than ``ephemeral()``, such as
+    ``local_temp()``, are invisible to it.
+    """
+    undisposed: set[DagsterInstance] = set()
+    make_ephemeral = DagsterInstance.ephemeral
+    dispose = DagsterInstance.dispose
+
+    def _tracked_ephemeral(*args: Any, **kwargs: Any) -> DagsterInstance:
+        instance = make_ephemeral(*args, **kwargs)
+        undisposed.add(instance)
+        return instance
+
+    def _tracked_dispose(self: DagsterInstance) -> None:
+        undisposed.discard(self)
+        dispose(self)
+
+    monkeypatch.setattr(DagsterInstance, "ephemeral", _tracked_ephemeral)
+    monkeypatch.setattr(DagsterInstance, "dispose", _tracked_dispose)
+
+    yield
+
+    assert not undisposed, (
+        f"{len(undisposed)} ephemeral DagsterInstance(s) outlived this test. Take the "
+        "`dagster_instance` fixture, or enter the instance as a context manager."
+    )

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -249,6 +249,19 @@ def _write_metadata_roster(path: str, ids: list[int]) -> None:
     TimeSeriesMetadata.DataFrame(rows).cast().validate().write_parquet(path)
 
 
+def _run_freshness_check() -> AssetCheckResult:
+    """Invoke ``power_data_is_fresh`` directly, on an instance closed before we return.
+
+    Dagster builds a context even though this check declares no context parameter, and never
+    disposes the instance inside it:
+    <https://openclimatefix.github.io/nged-substation-forecast/architecture/testing/#fixtures-and-mocking>.
+    """
+    with DagsterInstance.ephemeral() as instance:
+        result = checks.power_data_is_fresh(build_asset_check_context(instance=instance))
+    assert isinstance(result, AssetCheckResult)  # narrows the directly-invoked check's return
+    return result
+
+
 def test_power_data_is_fresh_end_to_end(env: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """One fresh series, one stale series, one never-reported roster id → a WARN naming all late."""
     # Freeze "now" so the fresh/stale split is deterministic regardless of wall-clock.
@@ -266,8 +279,7 @@ def test_power_data_is_fresh_end_to_end(env: Path, monkeypatch: pytest.MonkeyPat
     ).write_delta(settings.power_time_series_data_path)
     _write_metadata_roster(settings.metadata_path, ids=[1, 2, 99])
 
-    result = checks.power_data_is_fresh()
-    assert isinstance(result, AssetCheckResult)  # narrows the directly-invoked check's return
+    result = _run_freshness_check()
 
     assert result.passed is False
     assert result.severity == AssetCheckSeverity.WARN
@@ -297,8 +309,7 @@ def test_power_data_is_fresh_all_current_passes(env: Path) -> None:
     ).write_delta(settings.power_time_series_data_path)
     _write_metadata_roster(settings.metadata_path, ids=[1, 2])
 
-    result = checks.power_data_is_fresh()
-    assert isinstance(result, AssetCheckResult)
+    result = _run_freshness_check()
     assert result.passed is True
     assert result.metadata["n_late"].value == 0
     # Emitted even when nothing is late, so the key keeps one type across runs and stays plottable.
@@ -307,8 +318,7 @@ def test_power_data_is_fresh_all_current_passes(env: Path) -> None:
 
 def test_power_data_is_fresh_no_data_yet_warns(env: Path) -> None:
     """No Delta table and no roster → not healthy, WARN, 'no data yet'."""
-    result = checks.power_data_is_fresh()
-    assert isinstance(result, AssetCheckResult)
+    result = _run_freshness_check()
     assert result.passed is False
     assert result.severity == AssetCheckSeverity.WARN
     assert result.metadata["n_series_total"].value == 0
@@ -358,8 +368,7 @@ def test_power_data_is_fresh_hands_evaluated_result_to_sentry(
     ).write_delta(settings.power_time_series_data_path)
     _write_metadata_roster(settings.metadata_path, ids=[1])
 
-    check_result = checks.power_data_is_fresh()
-    assert isinstance(check_result, AssetCheckResult)
+    check_result = _run_freshness_check()
     assert len(captured) == 1
     assert captured[0] is sentinel  # the exact evaluated object, not a recomputation
     # ...and that same object drove the returned check result (n_late == n_stale + n_never == 7).
@@ -423,8 +432,7 @@ def test_power_data_is_fresh_degrades_on_a_corrupt_metadata_parquet(env: Path) -
     _write_one_fresh_series(settings)
     Path(settings.metadata_path).write_bytes(b"not a parquet file")
 
-    result = checks.power_data_is_fresh()
-    assert isinstance(result, AssetCheckResult)
+    result = _run_freshness_check()
     assert result.passed is False
     assert result.severity == AssetCheckSeverity.WARN
     assert "Could not evaluate power-data freshness" in str(result.description)
@@ -490,8 +498,7 @@ def test_power_data_is_fresh_degrades_on_a_rust_panic(
         lambda check_name, exc: reported.append((check_name, exc)),
     )
 
-    result = checks.power_data_is_fresh()
-    assert isinstance(result, AssetCheckResult)
+    result = _run_freshness_check()
     assert result.passed is False
     assert result.severity == AssetCheckSeverity.WARN
     assert "simulated rust panic inside the check" in str(result.description)
@@ -515,7 +522,7 @@ def test_power_data_is_fresh_re_raises_a_cancelled_run(
     monkeypatch.setattr(checks, "report_check_degradation", _never_called)
 
     with pytest.raises(DagsterExecutionInterruptedError):
-        checks.power_data_is_fresh()
+        _run_freshness_check()
 
 
 # ---------------------------------------------------------------------------
@@ -897,7 +904,13 @@ def _write_promoted_model_meta(
 
 
 def _run_live_check() -> AssetCheckResult:
-    result = checks.live_forecasts_are_healthy(build_asset_check_context())
+    """Invoke ``live_forecasts_are_healthy`` directly, on an instance closed before we return.
+
+    Dagster default-constructs an instance for a directly-invoked check and never disposes it:
+    <https://openclimatefix.github.io/nged-substation-forecast/architecture/testing/#fixtures-and-mocking>.
+    """
+    with DagsterInstance.ephemeral() as instance:
+        result = checks.live_forecasts_are_healthy(build_asset_check_context(instance=instance))
     assert isinstance(result, AssetCheckResult)  # narrows the directly-invoked check's return
     return result
 


### PR DESCRIPTION
_Written by Claude Code._

Closes #562.

## What was wrong

`uv run pytest` printed `616 passed, 1 skipped` and exited **1**, with `sqlite3.ProgrammingError: Cannot operate on a closed database` tracebacks after the summary line. Six tests in `tests/test_checks.py` left an ephemeral `DagsterInstance` undisposed; because `DirectOpExecutionContext` closes its `ExitStack` only from `__exit__` or `__del__`, whether the fault appeared at all turned on when the garbage collector ran, which is why CI failed intermittently on unchanged code.

`_run_live_check` called `build_asset_check_context()`, which defaults to `DagsterInstance.ephemeral()`. Less obviously, `checks.power_data_is_fresh()` leaked one too: it declares no context parameter and names Dagster nowhere at the call site, but `direct_invocation_result` builds a context for it regardless. All ~25 call sites created an instance; only six *survived*, because the exception each of those tests captures holds a traceback pinning the frame that holds the context.

## What changed

Both helpers hold the instance in a `with` block and pass it as `instance=`. The context-manager form the testing docs prescribed for `build_asset_context()` is not available here — `DirectAssetCheckExecutionContext` defines no `__enter__`, so `with build_asset_check_context() as context:` is a `TypeError`. The docs now say that, say that a context has to be passed even to a check that takes none, and sanction a module-level test helper owning the instance itself, since no fixture can reach one.

`tests/conftest.py` gains an autouse fixture that wraps `DagsterInstance.ephemeral` and `DagsterInstance.dispose` for the duration of each test and asserts at teardown that every instance created was disposed. Against the pre-fix helpers it errors on exactly the six tests above, by name. Its limits are worth knowing and are written into its docstring: it catches a leak rather than an omission, because an unreferenced context is freed as soon as the helper that built it returns, and it sees only instances made through `ephemeral()`.

`materialize()` and `JobDefinition.execute_in_process()` need none of this — both enter and exit `ephemeral_instance_if_missing` inside the call. `tests/test_live_forecasts.py`, `tests/test_register_experiment_job.py`, `tests/test_jobs.py` and every `packages/*/tests` module were already clean, established by tracking creation against disposal per test across the whole suite with cyclic GC disabled so no collector pass could hide a leak.

## Verification

`ruff check`, `ruff format --check`, `ty check`, `pymarkdown scan` and `mkdocs build --strict` all pass. `uv run pytest` was run eight times end to end plus three times over `tests/test_checks.py` alone: exit 0 every time, with no post-summary tracebacks.
