### PR TITLE
Add a Common Incident Classes page to design-philosophy

### DIFF
--- a/docs/design-philosophy/common-incident-classes.md
+++ b/docs/design-philosophy/common-incident-classes.md
@@ -1,0 +1,133 @@
+# Common incident classes in production forecasting services
+
+Production services that ingest third-party weather, satellite or telemetry feeds tend to fail in
+a small number of recurring shapes, largely independent of the specific stack behind them. This
+page catalogues those shapes and states, for each, which mechanism in this project's design
+targets it — honestly marking what already exists against what is designed but not yet built, and
+naming the gaps outright. It is the same field-report standard the rest of this section holds
+itself to: a practice that is not yet covered is more useful named than left implicit.
+
+This page is broader than [Inherent Stability](inherent-stability.md), which argues the largest of
+these shapes — an input going missing or stale — in full. Several of the shapes below sit outside
+inherent stability's remit entirely: shared-compute contention, deploy drift, and fault
+propagation across independent units of work are blast-radius and process concerns, not
+input-degradation ones.
+
+## Upstream data outage
+
+A third-party feed — weather, satellite imagery, telemetry — stops arriving, for anywhere from
+minutes to days, for reasons entirely outside the consuming service's control.
+
+This is the shape [Inherent Stability](inherent-stability.md) is built around: the
+[degradation ladder](inherent-stability.md#the-degradation-ladder) states what the forecast should
+still produce at each stage of loss, from one missed weather-model run through to no fresh data at
+all. Telemetry already degrades this way today — a stalled meter widens nothing yet, but it does
+not stop the forecast either. Weather data is the sharper case: a sustained NWP outage currently
+makes the live-forecast asset **raise** rather than degrade, which is the one hard failure left in
+the [failure-modes table](inherent-stability.md#failure-modes)
+([#446](https://github.com/openclimatefix/nged-substation-forecast/issues/446)) — the gap is
+tracked, and the fix is deliberately sequenced behind training the model against realistic
+outages, so that a degraded forecast is measured rather than merely produced.
+
+## Upstream data malformed or silently reshaped
+
+A feed keeps arriving on schedule, but the payload is wrong: null-filled, wrongly shaped, or
+carrying a provider-side schema or unit change nobody announced.
+
+The [strict-contracts principle](design-principles.md#7-strict-contracts-at-every-boundary) is the
+direct answer — every tabular boundary is a validated Patito schema rather than an assumed shape,
+with the deliberate asymmetry that structurally broken data is rejected outright while a tolerable
+amount of local corruption is absorbed rather than discarded wholesale. [Known ECMWF ENS
+data-quality issues](../architecture/ecmwf-ens-known-issues.md) is what that policy looks like
+applied in full to one real, messy upstream feed. This is one of the better-covered shapes here,
+precisely because it was designed for from the start rather than retrofitted after a malformed
+payload reached a model.
+
+## Silent output corruption
+
+The forecast pipeline runs cleanly end to end and delivers a value — but the value itself is
+wrong: an implausible magnitude, an internally inconsistent set of quantiles, or a forecast that
+quietly diverges from reality — and nothing rejects or flags it before a consumer notices.
+
+Two mechanisms already point the right way. Delivering `power_fcst` normalised to
+**[−1, +1]** ([#246](https://github.com/openclimatefix/nged-substation-forecast/issues/246)) makes
+an order-of-magnitude output error structurally harder, since the value is capacity-bounded by
+construction rather than by a downstream check someone has to remember to run. And quantile
+crossing — one quantile level coming out below a lower one — is a *named* failure mode with a
+designed fix already: sorting each member's quantiles at predict time
+([Probabilistic Forecasting](../techniques/probabilistic-forecasting.md#the-tempting-shortcut-that-doesnt-work-averaging-the-quantiles),
+[#263](https://github.com/openclimatefix/nged-substation-forecast/issues/263)).
+
+The gap: unlike NWP inputs, which get a WARN-level asset check naming exactly which slices are
+anomalous, the forecast **output** has no equivalent check today. Every other boundary in this
+project follows the same pattern — validate, and warn on what validation can't reject outright —
+and the output boundary is the one place that pattern has not yet been applied
+([#560](https://github.com/openclimatefix/nged-substation-forecast/issues/560)).
+
+## Shared-compute blast radius
+
+One heavy or misbehaving component — an expensive dashboard query, a bulk API request, an
+ad-hoc analytical query — exhausts a resource (memory, database connections, disk) shared with
+unrelated services, and takes all of them down together rather than just itself.
+
+[Every write is atomic, idempotent and confined to one partition](design-principles.md#10-every-write-is-atomic-and-idempotent-and-every-failure-is-confined-to-one-partition)
+is the data-layer answer, and the [accepted AWS architecture](../roadmap/live-service.md#aws-architecture)
+extends the same instinct to compute: every live and backtest run dispatches to its own ephemeral
+Fargate task, so a bad run cannot starve another one. The gap sits on the always-on control-plane
+box itself, where the Dagster daemon, webserver and dashboard run as separate processes sharing
+one machine's memory and disk with no per-process limit — today's mitigation is restart-on-failure
+plus the [missed-check-in alarm](../roadmap/live-service.md#alert-on-absence-the-missed-check-in-alarm),
+both reactive rather than preventive
+([#561](https://github.com/openclimatefix/nged-substation-forecast/issues/561)).
+
+## Orchestrator or scheduler silently stops
+
+The process responsible for triggering scheduled work dies, hangs, or stops firing — and because
+nothing failed loudly, the absence produces no alert of its own. It surfaces only when someone
+notices stale output, which can be hours or days later.
+
+This is the shape the
+[missed-check-in alarm](../roadmap/live-service.md#alert-on-absence-the-missed-check-in-alarm)
+exists to close, and closes about as directly as a single mechanism can: it is evaluated from
+**outside** the deployment, on the logic that a dead process cannot be relied on to report its own
+death, and it fires on the absence of a successful run rather than on any particular failure
+signal. Of every shape on this page, this is the one with the most direct, already-shipped answer.
+
+## Deploy or configuration drift between environments
+
+A change — a schema migration, a container image, a configuration value — is verified in one
+environment and assumed, never actually confirmed, to be live in another. The two silently diverge
+until a run fails on the difference, or worse, produces a wrong answer that passes.
+
+[One execution path from research to production](design-principles.md#3-one-execution-path-from-research-to-production)
+removes an entire class of this: there is no second, separately deployed implementation for
+research versus production to drift apart from. Atomic Delta commits and `promoted_model`'s
+all-or-nothing swap — it refuses to replace the model on disk at all if the incoming config can't
+be rebuilt — close the model-promotion instance of this shape specifically. What is not yet
+addressed is a staged or canary rollout for a **code** deploy itself, as opposed to a model
+promotion; today a new image goes live everywhere the next run picks it up. Left as an open
+question rather than a proposed change — the single-image, single-environment deployment this
+project runs today is a narrower target than a multi-service system, so the shape may not earn a
+dedicated mechanism until the architecture grows past that.
+
+## Fault propagation across independent units of work
+
+A single malformed or missing record inside a larger batch — one site, one time series, one
+partition — takes down the entire job, rather than being isolated to the piece it actually
+affects.
+
+Per-`(experiment, fold)` partitioning and Patito's own null-tolerance policy — reject a
+structurally empty column outright, but absorb a locally corrupt value the model can tolerate —
+both push in the right direction by construction. Whether a single malformed `time_series_id`
+inside a live-forecast run can currently take down the whole materialisation, rather than just
+that series, has not been verified empirically, and is worth checking directly rather than
+assuming either way.
+
+## How to use this page
+
+None of the above is a request to build every mitigation at once — several of these shapes are
+already fully addressed, one is an open question rather than a proposed change, and the rest are
+tracked as the linked issues. The value of naming a shape here is the same as elsewhere in this
+section: a gap that is written down can be weighed against everything else on the roadmap, and a
+mechanism that already exists can be pointed to instead of re-argued from scratch the next time
+this class of failure comes up.

--- a/docs/design-philosophy/common-incident-classes.md
+++ b/docs/design-philosophy/common-incident-classes.md
@@ -23,11 +23,13 @@ This is the shape [Inherent Stability](inherent-stability.md) is built around: t
 still produce at each stage of loss, from one missed weather-model run through to no fresh data at
 all. Telemetry already degrades this way today — a stalled meter widens nothing yet, but it does
 not stop the forecast either. Weather data is the sharper case: a sustained NWP outage currently
-makes the live-forecast asset **raise** rather than degrade, which is the one hard failure left in
-the [failure-modes table](inherent-stability.md#failure-modes)
-([#446](https://github.com/openclimatefix/nged-substation-forecast/issues/446)) — the gap is
-tracked, and the fix is deliberately sequenced behind training the model against realistic
-outages, so that a degraded forecast is measured rather than merely produced.
+makes the live-forecast asset **raise** rather than degrade — one of two hard-failure rows in the
+[failure-modes table](inherent-stability.md#failure-modes), and the only one tracked to change
+([#446](https://github.com/openclimatefix/nged-substation-forecast/issues/446)); the other, an
+empty or unloadable promoted model, stays a deliberate raise because it is a promotion bug rather
+than a data outage. The NWP gap is tracked, and the fix is deliberately sequenced behind training
+the model against realistic outages, so that a degraded forecast is measured rather than merely
+produced.
 
 ## Upstream data malformed or silently reshaped
 
@@ -49,20 +51,22 @@ The forecast pipeline runs cleanly end to end and delivers a value — but the v
 wrong: an implausible magnitude, an internally inconsistent set of quantiles, or a forecast that
 quietly diverges from reality — and nothing rejects or flags it before a consumer notices.
 
-Two mechanisms already point the right way. Delivering `power_fcst` normalised to
-**[−1, +1]** ([#246](https://github.com/openclimatefix/nged-substation-forecast/issues/246)) makes
-an order-of-magnitude output error structurally harder, since the value is capacity-bounded by
-construction rather than by a downstream check someone has to remember to run. And quantile
-crossing — one quantile level coming out below a lower one — is a *named* failure mode with a
-designed fix already: sorting each member's quantiles at predict time
-([Probabilistic Forecasting](../techniques/probabilistic-forecasting.md#the-tempting-shortcut-that-doesnt-work-averaging-the-quantiles),
+Two mechanisms already point the right way, both 🚧 planned rather than shipped. Normalising
+`power_fcst` to **[−1, +1]**
+([#246](https://github.com/openclimatefix/nged-substation-forecast/issues/246), the code today
+still forecasts raw MW/MVA) will make an order-of-magnitude output error structurally harder,
+since the value becomes capacity-bounded by construction rather than by a downstream check someone
+has to remember to run. And quantile crossing — one quantile level coming out below a lower one —
+is a *named* failure mode with a designed fix already: sorting each member's quantiles at predict
+time
+([Probabilistic Forecasting](../techniques/probabilistic-forecasting.md#turning-51-quantile-sets-into-one-the-pooling-recipe),
 [#263](https://github.com/openclimatefix/nged-substation-forecast/issues/263)).
 
-The gap: unlike NWP inputs, which get a WARN-level asset check naming exactly which slices are
-anomalous, the forecast **output** has no equivalent check today. Every other boundary in this
-project follows the same pattern — validate, and warn on what validation can't reject outright —
-and the output boundary is the one place that pattern has not yet been applied
-([#560](https://github.com/openclimatefix/nged-substation-forecast/issues/560)).
+The gap: `live_forecasts_are_healthy` already warns on a null, NaN or infinite `power_fcst`, but
+nothing checks a *finite, plausible-looking* output for implausible magnitude or, once quantiles
+ship, crossed levels — the same "validate, and warn on what validation can't reject outright"
+pattern every input boundary in this project follows has not yet been applied to the output
+itself ([#560](https://github.com/openclimatefix/nged-substation-forecast/issues/560)).
 
 ## Shared-compute blast radius
 
@@ -127,7 +131,4 @@ assuming either way.
 
 None of the above is a request to build every mitigation at once — several of these shapes are
 already fully addressed, one is an open question rather than a proposed change, and the rest are
-tracked as the linked issues. The value of naming a shape here is the same as elsewhere in this
-section: a gap that is written down can be weighed against everything else on the roadmap, and a
-mechanism that already exists can be pointed to instead of re-argued from scratch the next time
-this class of failure comes up.
+tracked as the linked issues.

--- a/docs/design-philosophy/index.md
+++ b/docs/design-philosophy/index.md
@@ -43,7 +43,7 @@ worth their cost here, which we declined, which we have not yet absorbed — and
 failed. A practice that did not survive contact with our data is as useful a finding as one that
 did.
 
-Three pages, in reading order:
+Four pages, in reading order:
 
 - **[Design Principles](design-principles.md)** — the constraints we impose on our own decisions,
   each with the failure it prevents, a real decision it made, and the hypothesis it serves. Includes
@@ -55,6 +55,9 @@ Three pages, in reading order:
 - **[Inherent Stability](inherent-stability.md)** — the largest principle argued in full: how the
   service behaves as its inputs degrade, the degradation ladder, and the rules to follow when
   changing production code.
+- **[Common Incident Classes](common-incident-classes.md)** — the recurring failure shapes
+  production forecasting services see in practice, and which mechanism above (if any) targets
+  each one.
 
 The boundary with the [Architecture](../architecture/overview.md) section is deliberate: this
 section holds the transferable argument, while `architecture/` describes what we actually built,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -50,6 +50,7 @@ nav:
       - Design Principles: design-philosophy/design-principles.md
       - Engineering Hypotheses: design-philosophy/engineering-hypotheses.md
       - Inherent Stability: design-philosophy/inherent-stability.md
+      - Common Incident Classes: design-philosophy/common-incident-classes.md
   - Background & Challenges:
       - NGED Network: background/network.md
       - Requirements: background/requirements.md


### PR DESCRIPTION
> 🤖 **This PR description was written by [Claude Code](https://claude.com/claude-code)**, acting on Jack's behalf.

## Summary

Adds a fourth `docs/design-philosophy/` page, [Common Incident Classes](https://openclimatefix.github.io/nged-substation-forecast/design-philosophy/common-incident-classes/), cataloguing the recurring failure shapes production forecasting and data-pipeline services see in practice — upstream outages, malformed input, silent output corruption, shared-compute blast radius, orchestrator liveness, deploy drift, and fault propagation across independent units of work — and mapping each to the mechanism in this project's design that targets it, honestly marking what is built against what is only designed.

This came out of a review of a large corpus of real production-incident postmortems from a comparable service, done at Jack's request. The page itself names no proprietary detail — only the generic failure shapes, which is what's actually transferable.

The review surfaced two concrete gaps that this repo's existing mechanisms don't yet cover, filed as new issues rather than fixed here (both out of scope for a docs PR):

- [#560](https://github.com/openclimatefix/nged-substation-forecast/issues/560) — no WARN-level asset check on the forecast **output** itself (implausible magnitude, quantile ordering), unlike every other tabular boundary in this project.
- [#561](https://github.com/openclimatefix/nged-substation-forecast/issues/561) — the Dagster daemon, webserver and Marimo dashboard share one control-plane box's memory with no per-process limit.

It also added a comment to [#446](https://github.com/openclimatefix/nged-substation-forecast/issues/446) (NWP-outage hard failure) noting that its `#424` blocker has landed and that the review's findings independently support sequencing it sooner once the remaining `#445` blocker lands — and set its project Priority to P2, without touching the deliberate training-gate sequencing already argued on that issue.

## Verification

- `uv run ruff check .` / `uv run ruff format --check .` — clean (no code changed).
- `uv run --all-packages ty check` — clean.
- `uv run pytest` — 627 passed, 1 skipped (pre-existing skip, unrelated to this change).
- `uv run pymarkdown scan -r docs README.md CLAUDE.md packages/*/README.md` — clean.
- `uv run mkdocs build --strict` — clean, and read the rendered HTML (not just the linter, per the `mkdocs-authoring` skill) to confirm all internal links resolve and the anchors the new issues and the `#446` comment link into match the built page.

## Test plan

- [x] Rendered page checked in `site/` after `mkdocs build --strict` (headings, internal links, no stray markdown artifacts).
- [ ] Jack review.
