### PR TITLE
Give each caller of the archive download its own remedy

### DIFF
--- a/packages/ml_core/src/ml_core/_production_helpers.py
+++ b/packages/ml_core/src/ml_core/_production_helpers.py
@@ -270,7 +270,11 @@ def fetch_model_artifacts(run_id: str, dest: Path) -> None:
             promote that run instead.
     """
     with tempfile.TemporaryDirectory() as tmp_dir:
-        downloaded_dir = _download_and_unpack_model(run_id, Path(tmp_dir))
+        downloaded_dir = _download_and_unpack_model(
+            run_id=run_id,
+            work_dir=Path(tmp_dir),
+            remedy="check the run id, since a run that trained a model has this artifact.",
+        )
         meta_path = downloaded_dir / "meta.json"
         if not meta_path.exists():
             raise ValueError(

--- a/packages/ml_core/src/ml_core/_production_helpers.py
+++ b/packages/ml_core/src/ml_core/_production_helpers.py
@@ -273,7 +273,7 @@ def fetch_model_artifacts(run_id: str, dest: Path) -> None:
         downloaded_dir = _download_and_unpack_model(
             run_id=run_id,
             work_dir=Path(tmp_dir),
-            remedy="check the run id, since a run that trained a model has this artifact.",
+            remedy="check the run id, and pick one whose training completed.",
         )
         meta_path = downloaded_dir / "meta.json"
         if not meta_path.exists():

--- a/packages/ml_core/src/ml_core/base_forecaster.py
+++ b/packages/ml_core/src/ml_core/base_forecaster.py
@@ -60,7 +60,7 @@ def _archive_model_dir(model_dir: Path, archive_path: Path) -> None:
             tar.add(item, arcname=item.name)
 
 
-def _download_and_unpack_model(run_id: str, work_dir: Path) -> Path:
+def _download_and_unpack_model(run_id: str, work_dir: Path, remedy: str) -> Path:
     """Download an MLflow run's model archive into ``work_dir`` and unpack it.
 
     Shared by ``BaseForecaster.load_from_mlflow`` and
@@ -74,6 +74,10 @@ def _download_and_unpack_model(run_id: str, work_dir: Path) -> Path:
         run_id: The MLflow run the model was saved under.
         work_dir: A scratch directory (typically a ``TemporaryDirectory``) to download and
             extract into. Needs room for the archive *and* its unpacked contents.
+        remedy: What the reader should do when the run holds no archive, appended to the
+            message. The two callers reach this state by different routes — a CV fold run that
+            no training has written yet, versus a run id an operator chose — so neither wording
+            is right for both, and the caller that knows which one it is supplies it.
 
     Returns:
         The directory holding the unpacked model, ready to hand to a subclass's ``load``. It
@@ -81,8 +85,7 @@ def _download_and_unpack_model(run_id: str, work_dir: Path) -> Path:
         cannot appear in it.
 
     Raises:
-        MlflowException: The run holds no model archive — re-materialise ``trained_cv_model``
-            for this fold.
+        MlflowException: The run holds no model archive, followed by ``remedy``.
     """
     try:
         archive_path = Path(
@@ -92,8 +95,7 @@ def _download_and_unpack_model(run_id: str, work_dir: Path) -> Path:
         )
     except MlflowException as error:
         raise MlflowException(
-            f"MLflow run {run_id} has no {_MLFLOW_MODEL_ARTIFACT} artifact — re-materialise "
-            "`trained_cv_model` for this fold."
+            f"MLflow run {run_id} has no {_MLFLOW_MODEL_ARTIFACT} artifact — {remedy}"
         ) from error
     # Unpack beside the archive rather than over it: download_artifacts has already claimed the
     # archive's own name inside work_dir.
@@ -301,7 +303,13 @@ class BaseForecaster(ABC):
             The reconstructed, trained forecaster.
         """
         with tempfile.TemporaryDirectory() as tmp_dir:
-            return cls.load(_download_and_unpack_model(run_id, Path(tmp_dir)))
+            return cls.load(
+                _download_and_unpack_model(
+                    run_id=run_id,
+                    work_dir=Path(tmp_dir),
+                    remedy="re-materialise `trained_cv_model` for this fold.",
+                )
+            )
 
     @abstractmethod
     def train(self, data: pt.LazyFrame[AllFeatures], time_series_ids: list[int]) -> None:

--- a/packages/ml_core/src/ml_core/base_forecaster.py
+++ b/packages/ml_core/src/ml_core/base_forecaster.py
@@ -76,8 +76,8 @@ def _download_and_unpack_model(run_id: str, work_dir: Path, remedy: str) -> Path
             extract into. Needs room for the archive *and* its unpacked contents.
         remedy: What the reader should do when the run holds no archive, appended to the
             message. The two callers reach this state by different routes — a CV fold run that
-            no training has written yet, versus a run id an operator chose — so neither wording
-            is right for both, and the caller that knows which one it is supplies it.
+            no training has written yet, versus a run id an operator chose — so no one wording
+            is right for both.
 
     Returns:
         The directory holding the unpacked model, ready to hand to a subclass's ``load``. It
@@ -85,7 +85,7 @@ def _download_and_unpack_model(run_id: str, work_dir: Path, remedy: str) -> Path
         cannot appear in it.
 
     Raises:
-        MlflowException: The run holds no model archive, followed by ``remedy``.
+        MlflowException: The run holds no model archive; the message ends with ``remedy``.
     """
     try:
         archive_path = Path(

--- a/packages/ml_core/tests/test_base_forecaster.py
+++ b/packages/ml_core/tests/test_base_forecaster.py
@@ -355,6 +355,10 @@ def test_fetch_model_artifacts_keeps_the_previous_model_when_the_run_holds_no_mo
     real run that simply never held a model. It is also the only refusal that happens in the
     download rather than in ``_check_meta_is_servable``, so it needs its own case to pin that
     ``dest`` survives it.
+
+    The message must send the operator back to the run id they chose. Re-materialising
+    ``trained_cv_model`` is the remedy for the *other* caller of the same download helper, and
+    would be no help to someone who mistyped a run id here.
     """
     dest = tmp_path / "production_model"
     fetch_model_artifacts(run_id=saved_run, dest=dest)
@@ -362,7 +366,7 @@ def test_fetch_model_artifacts_keeps_the_previous_model_when_the_run_holds_no_mo
     with mlflow.start_run(experiment_id=mlflow.create_experiment("modelless")) as run:
         modelless_run_id = run.info.run_id
 
-    with pytest.raises(MlflowException, match="re-materialise `trained_cv_model`"):
+    with pytest.raises(MlflowException, match="check the run id"):
         fetch_model_artifacts(run_id=modelless_run_id, dest=dest)
 
     assert _FakeForecaster.load(dest).payload == "hello-model"

--- a/packages/ml_core/tests/test_base_forecaster.py
+++ b/packages/ml_core/tests/test_base_forecaster.py
@@ -357,8 +357,7 @@ def test_fetch_model_artifacts_keeps_the_previous_model_when_the_run_holds_no_mo
     ``dest`` survives it.
 
     The message must send the operator back to the run id they chose. Re-materialising
-    ``trained_cv_model`` is the remedy for the *other* caller of the same download helper, and
-    would be no help to someone who mistyped a run id here.
+    ``trained_cv_model`` is the remedy for the *other* caller of the same download helper.
     """
     dest = tmp_path / "production_model"
     fetch_model_artifacts(run_id=saved_run, dest=dest)


### PR DESCRIPTION
> 🤖 **This PR was written by [Claude Code](https://claude.com/claude-code)**, acting on Jack's behalf.

Closes #567. `_download_and_unpack_model` ended every message with "re-materialise `trained_cv_model` for this fold" — right for `load_from_mlflow`, which `cv_power_forecasts` reaches for a fold run, and wrong for `fetch_model_artifacts`, which `promoted_model` reaches with an operator-typed run id.

## The fix

The remedy is a parameter, supplied by the caller that knows which route reached the failure. `fetch_model_artifacts` sends the operator back to the run id they chose, matching the diagnosis its own docstring already gave.

The issue's smaller option — drop the remedy entirely — was rejected because `cv_assets.py` prints that remedy only for the zero-trained-series failure, not for a missing archive, so dropping it would leave the CV reader with no action at all.

## The promotion remedy does not claim more than it can

It says "check the run id, and pick one whose training completed" rather than asserting that a run which trained a model always has the artifact. That stronger claim would be false and reachably so: `trained_cv_model` creates the fold run *before* uploading the archive, `cv_power_forecasts` creates one before loading, and `list_promotable_runs` filters on `cv_role=fold` alone — so a modelless fold run reaches the candidate table `promoted_model`'s docstring tells the operator to copy from. Telling that operator to hunt for a typo would send them after a bug that is not there.

## Tests

`test_fetch_model_artifacts_keeps_the_previous_model_when_the_run_holds_no_model` now matches `"check the run id"`. I confirmed it fails against `main`'s source: with the new assertion and `main`'s two source files checked out, that test fails and the other eleven pass.

The CV-path test keeps its assertion unchanged, which pins that this did **not** alter the caller whose remedy was already correct.

## Verification

`ruff check`, `ruff format --check`, `ty check`, and the full suite: **627 passed, 1 skipped**. No docs page quotes either message, and the message is unreachable from the `live_forecasts_job` smoke test that `scripts/build_and_verify_image.sh` greps for hermeticity.
