### PR TITLE
Pin the power-data staleness threshold in a test

### DIFF
--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -106,28 +106,19 @@ def test_stale_series_flagged_most_stale_first() -> None:
     assert result.late["hours_late"].to_list() == pytest.approx([72.0, 30.0])
 
 
-@pytest.mark.parametrize(
-    ("age", "expected_n_stale"),
-    [
-        (timedelta(hours=23, minutes=59), 0),
-        (timedelta(hours=24, minutes=1), 1),
-    ],
-)
-def test_the_production_staleness_threshold_is_twenty_four_hours(
-    age: timedelta, expected_n_stale: int
-) -> None:
-    """The only case that reads ``_POWER_DATA_STALENESS_THRESHOLD`` rather than ``_THRESHOLD``.
-
-    Every other case passes its own threshold, so they pin the shape of the boundary while leaving
-    the production number free to drift in either direction; a minute either side pins the number.
-    """
+def test_the_production_staleness_threshold_is_twenty_four_hours() -> None:
+    """Series 8 is a minute past the threshold and series 7 a minute short of it, so retuning
+    ``_POWER_DATA_STALENESS_THRESHOLD`` has to change this test too. Every other case passes its own
+    ``_THRESHOLD``, which pins the shape of the boundary but not the production number."""
     result = evaluate_power_freshness(
-        coverage=_coverage({7: _NOW - age}),
-        roster_ids=_roster([7]),
+        coverage=_coverage(
+            {7: _NOW - timedelta(hours=23, minutes=59), 8: _NOW - timedelta(hours=24, minutes=1)}
+        ),
+        roster_ids=_roster([7, 8]),
         now=_NOW,
         threshold=checks._POWER_DATA_STALENESS_THRESHOLD,
     )
-    assert result.n_stale == expected_n_stale
+    assert result.late["time_series_id"].to_list() == [8]
 
 
 def test_never_reported_ids_flagged_from_roster() -> None:

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -106,6 +106,30 @@ def test_stale_series_flagged_most_stale_first() -> None:
     assert result.late["hours_late"].to_list() == pytest.approx([72.0, 30.0])
 
 
+@pytest.mark.parametrize(
+    ("age", "expected_n_stale"),
+    [
+        (timedelta(hours=23, minutes=59), 0),
+        (timedelta(hours=24, minutes=1), 1),
+    ],
+)
+def test_the_production_staleness_threshold_is_twenty_four_hours(
+    age: timedelta, expected_n_stale: int
+) -> None:
+    """The only case that reads ``_POWER_DATA_STALENESS_THRESHOLD`` rather than ``_THRESHOLD``.
+
+    Every other case passes its own threshold, so they pin the shape of the boundary while leaving
+    the production number free to drift in either direction; a minute either side pins the number.
+    """
+    result = evaluate_power_freshness(
+        coverage=_coverage({7: _NOW - age}),
+        roster_ids=_roster([7]),
+        now=_NOW,
+        threshold=checks._POWER_DATA_STALENESS_THRESHOLD,
+    )
+    assert result.n_stale == expected_n_stale
+
+
 def test_never_reported_ids_flagged_from_roster() -> None:
     """A roster id with no rows in the Delta table counts as late with a null ``last_seen``."""
     coverage = _coverage({1: _NOW - timedelta(hours=1)})

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -516,6 +516,35 @@ def test_power_data_is_fresh_silences_the_configured_dead_series(
     assert "Ignoring 1 known-dead time series: 99." in result.description
 
 
+def test_power_data_is_fresh_uses_the_production_threshold(env: Path) -> None:
+    """The check's own boundary, not just the constant's value: series 7, a minute short of
+    ``_POWER_DATA_STALENESS_THRESHOLD``, is fresh, and series 8, a minute past it, is stale.
+
+    Both times are derived from the constant, so a deliberate retune leaves this test passing and
+    only the wiring going astray — a literal threshold, or a shifted ``now`` — fails it.
+    """
+    now = datetime.now(UTC)
+    threshold = checks._POWER_DATA_STALENESS_THRESHOLD
+    settings = Settings()
+    pl.DataFrame(
+        {
+            "time_series_id": pl.Series([7, 8], dtype=pl.Int32),
+            "time": pl.Series(
+                [now - threshold + timedelta(minutes=1), now - threshold - timedelta(minutes=1)]
+            ).cast(UTC_DATETIME_DTYPE),
+            "power": pl.Series([1.0, 2.0], dtype=pl.Float32),
+        }
+    ).write_delta(settings.power_time_series_data_path)
+    _write_metadata_roster(settings.metadata_path, ids=[7, 8])
+
+    result = checks.power_data_is_fresh()
+    assert isinstance(result, AssetCheckResult)
+    assert result.metadata["n_stale"].value == 1
+    late_table = result.metadata["late_time_series"]
+    assert isinstance(late_table, TableMetadataValue)
+    assert [r.data["time_series_id"] for r in late_table.records] == [8]
+
+
 def test_power_data_is_fresh_no_data_yet_warns(env: Path) -> None:
     """No Delta table and no roster → not healthy, WARN, 'no data yet'."""
     result = checks.power_data_is_fresh()


### PR DESCRIPTION
*Written by Claude Code.*

Closes #570.

`_POWER_DATA_STALENESS_THRESHOLD` could be changed from `timedelta(hours=24)` to `timedelta(hours=25)` with the whole suite green: every unit test of `evaluate_power_freshness` passes `tests/test_checks.py`'s own `_THRESHOLD`, and the end-to-end series are 1 h and 48 h old. Two tests close that, and no production code changes.

`test_the_production_staleness_threshold_is_twenty_four_hours` feeds the constant itself into the pure function, with one series a minute past 24 hours and one a minute short of it. Bisected by hand, it leaves the constant free to drift from 23 h 59 m 00 s to 24 h 00 m 59 s and no further, and fails on `hours=25`, `hours=23`, `hours=24, minutes=30` and `hours=23, minutes=30`.

`test_power_data_is_fresh_uses_the_production_threshold` drives the real check against a temp Delta table and derives its two series times *from* the constant. It pins the wiring rather than the number: replacing the `threshold=` argument at the call site with a 48 h literal, or shifting the `now=` argument back 12 hours, previously survived the entire suite — the end-to-end tests' 1 h and 48 h series left a 46-hour hole. Both mutations now fail, and a deliberate retune of the constant leaves the test passing.

The report that prompted #570 named two other mutations at this boundary; #570 records why both were already dead.
