### PR TITLE
Record two gh CLI traps that misreport what happened

### DIFF
--- a/.claude/skills/github-graphql/SKILL.md
+++ b/.claude/skills/github-graphql/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: github-graphql
 description: >-
-  Concrete `gh api graphql` invocations for the four GitHub operations plain `gh issue`/`gh pr`
-  can't do: attaching a sub-issue to its parent epic, reordering sub-issues, setting an issue's
-  org-level Type, and setting a Projects (v2) field (Status/Project/Area). Load before running any
-  of them for openclimatefix/nged-substation-forecast, or whenever you'd reach for `gh api graphql`
-  and aren't sure of the mutation name, its input fields, or how to get the node IDs it needs.
+  Concrete `gh api graphql` invocations for the GitHub operations plain `gh issue`/`gh pr` can't
+  do: attaching a sub-issue to its parent epic, reordering sub-issues, setting an issue's org-level
+  Type, setting a Projects (v2) field (Status/Project/Area), and reading back where an issue sits
+  on the board. Load before running any of them for openclimatefix/nged-substation-forecast, or
+  whenever you'd reach for `gh api graphql` and aren't sure of the mutation name, its input fields,
+  or how to get the node IDs it needs.
 ---
 
 # GitHub GraphQL cheatsheet
@@ -109,3 +110,27 @@ gh api graphql -f query='
   }' -f projectId="<project node id>" -f itemId="<item node id>" \
      -f fieldId="<field node id>" -f optionId="<option id>"
 ```
+
+## Read an issue's project fields
+
+To check whether an issue is on the board and how its fields are set, ask **the issue**, not the
+project:
+
+```bash
+gh api graphql -f query='
+  query($n: Int!) { repository(owner: "openclimatefix", name: "nged-substation-forecast") {
+    issue(number: $n) { projectItems(first: 5) { nodes {
+      project { number }
+      fieldValues(first: 20) { nodes { ... on ProjectV2ItemFieldSingleSelectValue {
+        name field { ... on ProjectV2SingleSelectField { name } }
+      } } }
+    } } } } }' -F n=<issue number>
+```
+
+`gh project item-list 33 --owner openclimatefix` is the tempting alternative, and it hides what it
+leaves out: it returns at most `--limit` items with no indication that more exist, and this board
+holds more items than a limit you would think to pass. **Getting back exactly as many items as you
+asked for is the tell that you are holding one page rather than the board.** An issue can be on the
+board, correctly configured, and still be absent from that output, so never conclude an issue is
+missing from the project by searching it. Raising `--limit` is not the fix either — a large enough
+page exhausts the GraphQL rate limit and the command fails outright.

--- a/.claude/skills/github-issue-pr-workflow/SKILL.md
+++ b/.claude/skills/github-issue-pr-workflow/SKILL.md
@@ -99,6 +99,20 @@ on `main` and are invisible to `closingIssuesReferences` beforehand — that fie
 up to the merge. Prose *about* a closure counts: "Merging #514 closed #512" in a commit message
 closes 512. Keep those words away from any issue reference when writing about one.
 
+**Don't pass `--delete-branch`.** The repo has `delete_branch_on_merge` turned on, so GitHub deletes
+the head branch on merge by itself. The flag only adds a *local* branch deletion, and that step
+first checks out another branch — usually `main`, which the primary worktree already holds. Git
+refuses, and `gh` reports the refusal as its own exit status:
+
+```text
+failed to run git: fatal: 'main' is already used by worktree at '/home/jack/dev/python/...'
+```
+
+The merge has already gone through by then. **A non-zero exit from `gh pr merge` does not mean the
+merge failed**, so confirm the outcome rather than retrying the command or reporting a failure:
+`gh pr view <N> --json state,mergeCommit` and the issue's own state say what actually landed.
+Delete the local branch afterwards, from a worktree that is not sitting on it.
+
 When something is closed that should not have been: `gh issue reopen <N>`, then put its project
 Status back explicitly. The board automation moves a closed issue to Done, and reopening lands it
 on In Progress rather than Todo — see the `github-graphql` skill for `gh project item-edit`.


### PR DESCRIPTION
> 🤖 **This PR was written by [Claude Code](https://claude.com/claude-code)**, acting on Jack's behalf.

Two `gh` commands misreported what they had done during the #513/#567 sessions, and in both cases the honest-looking reading was the wrong one. Neither trap was written down anywhere, so the next session would hit them again.

## `gh pr merge --delete-branch` exits non-zero after a successful merge

`github-issue-pr-workflow`, under "Merging pull requests".

Deleting the *local* branch means checking another one out first, normally `main` — which the primary worktree already holds, so git refuses with `fatal: 'main' is already used by worktree at …` and `gh` surfaces that as its own exit status. The merge itself has already landed. The flag buys nothing here in any case: the repo has `delete_branch_on_merge` turned on (confirmed via `gh api repos/... --jq '{delete_branch_on_merge}'` → `true`), so GitHub deletes the head branch by itself.

The generalisable half is the sentence in bold: a non-zero exit from `gh pr merge` does not mean the merge failed, so check `gh pr view <N> --json state,mergeCommit` rather than retrying or reporting a failure.

## `gh project item-list` truncates silently

`github-graphql`, new "Read an issue's project fields" section, plus the mutation-only framing in the skill description.

It returns at most `--limit` items with no indication that more exist, and project 33 holds more than a limit you would think to pass. Searching that output for an issue therefore reports board members as absent: #513 and #567 are both on the board with Status/Project/Area set, and neither appears in an 800-item page. The tell is getting back *exactly* as many items as you asked for.

Raising the limit is not the fix, which is why the section says so: `--limit 2000` exhausted the GraphQL rate limit and returned nothing at all.

The replacement query asks the issue for its `projectItems`. I ran it verbatim as documented against #567 and it returns `Status=Done`, `Project=NGED`, `Area=ML`.

## Verification

`pre-commit` on the two changed files: `pymarkdown` and `ty` pass, every Python hook skipped as no Python changed. Nothing outside `.claude/skills/` is touched, so the test suite is unaffected and I did not run it.
