### PR TITLE
Add mobile telecoms as evidence for H1's unattended-operation claim

### DIFF
--- a/docs/design-philosophy/design-principles.md
+++ b/docs/design-philosophy/design-principles.md
@@ -34,8 +34,11 @@ We deliberately researched best practices across multiple industries. Several of
 pages are borrowed from disciplines that have been solving the same shape of problem for longer than
 data engineering has existed: *inherent stability* comes from vehicle dynamics, *fail-operational*
 from avionics autoland (the flight-deck technology that fully automates the landing phase) and
-ISO 26262, *blast radius* from site reliability engineering. Borrowing across disciplines is the
-point, not a flourish: some of them have been shipping safety-critical systems for fifty years.
+ISO 26262, *blast radius* from site reliability engineering, and mobile telecoms supplies the case
+that a heavily-corrupted channel can still run genuinely unattended — see
+[H1](engineering-hypotheses.md#h1-a-service-that-mostly-runs-itself). Borrowing across disciplines
+is the point, not a flourish: some of them have been shipping safety-critical systems for fifty
+years.
 
 Not every borrowed idea survives contact with reality, and we record those outcomes too — that is
 what makes this a field report rather than a manifesto. *Error budgets* were examined and declined

--- a/docs/design-philosophy/engineering-hypotheses.md
+++ b/docs/design-philosophy/engineering-hypotheses.md
@@ -30,6 +30,20 @@ this is a defensive argument (an outage does not cost much) whereas H1 is a stro
 (interventions will be rare). The positive claim is the one actually in dispute, and a sceptic is
 not moved by "it's fine when it breaks".
 
+Mobile telecoms is where that positive claim already holds, in an environment far noisier than any
+input this project depends on. A phone call crossing between cell towers rides a radio channel
+disrupted by multipath fading, interference and a lift shaft blocking the signal outright, and it
+degrades to a choppy few seconds rather than dropping — with nobody watching a dashboard per call.
+Forward error correction and packet-loss concealment absorb that corruption structurally, which is
+the same shape of claim H1 is making about the forecast: build the tolerance into the system so
+that nobody has to operate it awake. The analogy has a real limit, worth stating rather than
+glossing over: telecoms mostly reconstructs the *exact* signal, through redundancy and
+retransmission, where we have no retransmission to reach for — a gap in yesterday's telemetry is
+simply gone, not resendable — so our recovery is a wider uncertainty band, not a recovered fact.
+What the analogy proves is narrower than "the two systems work the same way"; it proves that a
+system living in continuous, heavy corruption can still run unattended, which is the part of H1 a
+sceptic doubts.
+
 **T1.1 — Operability.** Interventions per quarter, classified by cause, counted from the
 [intervention log](#the-intervention-log). The headline quote says "only"; the test operationalises
 that at ≥90% so a single fluke cannot falsify the claim on its own. "Zero out-of-hours" means no


### PR DESCRIPTION
Generated with [Claude Code](https://claude.com/claude-code).

## Summary

Jack and I discussed whether "we expect the service to just work in operation" is a departure worth documenting, and landed on: it's not a new principle, it's evidence for the H1 claim already on the page (a service that mostly runs itself). Mobile telecoms is the strongest existence proof available — a phone call surviving a noisy radio channel across a cell-tower handoff, degrading rather than dropping, with nobody watching a dashboard per call.

- Adds mobile telecoms as a fifth borrowed-industry example in the "Where these principles come from" section of [Design Principles](https://openclimatefix.github.io/nged-substation-forecast/design-philosophy/design-principles/#where-these-principles-come-from), alongside vehicle dynamics, avionics and SRE.
- Adds a paragraph to [H1](https://openclimatefix.github.io/nged-substation-forecast/design-philosophy/engineering-hypotheses/#h1-a-service-that-mostly-runs-itself) on [Engineering Hypotheses](https://openclimatefix.github.io/nged-substation-forecast/design-philosophy/engineering-hypotheses/) making the telecoms analogy, right after the existing text that names the sceptic's actual objection ("a sceptic is not moved by 'it's fine when it breaks'").
- States the analogy's limit explicitly: telecoms mostly recovers the exact signal through redundancy and retransmission, where we have no retransmission for a gap in yesterday's telemetry — our recovery is a wider uncertainty band, not a recovered fact.

## Test plan

- [x] `uv run pymarkdown scan` on both changed files — clean
- [x] `uv run mkdocs build --strict` — no warnings or errors
- [x] Read the rendered HTML for both additions to confirm the paragraphs and the cross-page link render correctly
