### PR TITLE
Data contracts are the authoritative account of what the data means

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,8 +86,8 @@ by rendering both to PNG at 2× and comparing pixel by pixel). Unoptimised expor
 
 ### Prose style
 
-These four rules apply to everything we write in prose: `docs/` pages, READMEs, docstrings, code
-comments, and GitHub issue and PR bodies.
+These five rules apply to everything we write in prose: `docs/` pages, READMEs, `SKILL.md` files,
+docstrings, code comments, and GitHub issue and PR bodies.
 
 **Be concrete and plain; write for a skim-reader.** Assume the reader is skimming and wants the
 meaning to jump off the page, not to spend effort decoding a clever, abstract or metaphorical
@@ -122,6 +122,14 @@ to describe the new behaviour rather than appending a note about what changed. T
 "comments and docs must reflect current state only" rule in
 [`docs/architecture/code-style.md`](docs/architecture/code-style.md), applied to prose.
 
+**Don't name individuals.** Write the rule, not who asked for it: "get a contract change agreed
+before making it", never "ask so-and-so before changing a contract". One person maintains this repo
+today, but the docs and skills outlive that, and a name that reads as "the person responsible" to
+us reads as an unknown third party to whoever picks the work up next. Where the sentence needs an
+actor, name the role — the reviewer, the maintainer, whoever runs the pipeline. Real GitHub
+handles used as data are fine (the `JackKelly` assignee, a commit's `Co-Authored-By`); it is prose
+about a named person that this forbids.
+
 ## How planning works
 
 Full description and a "which place do I use?" table: `docs/documentation-guide.md`. In brief:
@@ -145,13 +153,13 @@ never-squash-merge rule and ship-time triage. Load it before you run either comm
 
 ## How work gets done
 
-Two skills, in order, and they are deliberately separate so that Jack approves a design before
+Two skills, in order, and they are deliberately separate so that a design is approved before
 any code moves:
 
 1. **`plan-issue`** (`/plan-issue <N>`) reads the issue, decides whether it is worth implementing
    at all, writes `plans/<branch-name>.md`, has two fresh sub-agents adversarially review that
    plan in turn — the first hunting for a simpler approach, the second checking correctness and
-   testability — and stops for Jack. It writes no code.
+   testability — and stops for review. It writes no code.
 2. **`implement-issue`** picks up an approved plan: worktree, implement, the green-before-push
    verification set, PR with labels and assignee, then two *further independent* adversarial
    reviews of the diff — the first for correctness and for cutting the code, tests and prose
@@ -160,15 +168,15 @@ any code moves:
 
 Stay inside the issue's scope; report unrelated design mistakes rather than fixing them.
 
-**Ask Jack before changing a Patito data contract.** The schemas in `packages/contracts/` are the
+**Ask before changing a Patito data contract.** The schemas in `packages/contracts/` are the
 authoritative account of what the data means, so code that violates one is usually the thing at
 fault. Widening a field to `| None` or relaxing a range to make a failing `validate()` pass hides
 the defect in the one place the rest of the system trusts. Reasoning and the rest of the rule:
 [`packages/contracts/README.md`](packages/contracts/README.md).
 
-**Why:** Jack reviews diffs in GitHub's UI and wants a PR to already have survived an
-adversarial pass by the time he looks at it, so his review is the last line of defence rather
-than the first. The fresh-reviewer requirement exists so the reviewer cannot be anchored by the
+**Why:** diffs are reviewed in GitHub's UI, and a PR should already have survived an
+adversarial pass by the time a human opens it, so that human review is the last line of defence
+rather than the first. The fresh-reviewer requirement exists so the reviewer cannot be anchored by the
 implementer's rationale; the triage step exists because reviewer findings are often wrong and
 must not be applied uncritically. Simplicity gets its own reviewer, and gets it first, because a
 plan that is more complicated than the issue requires is the failure mode that survives a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,6 +160,12 @@ any code moves:
 
 Stay inside the issue's scope; report unrelated design mistakes rather than fixing them.
 
+**Ask Jack before changing a Patito data contract.** The schemas in `packages/contracts/` are the
+authoritative account of what the data means, so code that violates one is usually the thing at
+fault. Widening a field to `| None` or relaxing a range to make a failing `validate()` pass hides
+the defect in the one place the rest of the system trusts. Reasoning and the rest of the rule:
+[`packages/contracts/README.md`](packages/contracts/README.md).
+
 **Why:** Jack reviews diffs in GitHub's UI and wants a PR to already have survived an
 adversarial pass by the time he looks at it, so his review is the last line of defence rather
 than the first. The fresh-reviewer requirement exists so the reviewer cannot be anchored by the

--- a/docs/architecture/code-style.md
+++ b/docs/architecture/code-style.md
@@ -169,7 +169,11 @@ Three places where a positional argument is right:
   annotations (`pt.DataFrame[MySchema]`, `pt.LazyFrame[MySchema]`) whenever a function consumes or
   returns data that conforms to an existing schema — whether the function is public or private.
   Don't invent a new schema just to annotate a private helper; if no existing schema fits, use
-  plain `pl.DataFrame` / `pl.LazyFrame`.
+  plain `pl.DataFrame` / `pl.LazyFrame`. **A schema is the authoritative account of what the data
+  means, so when code and contract disagree the code is the first suspect** — never widen a field
+  or relax a range just to make a failing `validate()` pass, and ask Jack before changing a
+  contract at all. The reasoning is in
+  [Contracts / Design Principles](../api/contracts/index.md).
 - **Patito friction budget**: the `polars-patito-gotchas` skill documents five Patito gotchas
   (cross-model LazyFrame joins, dict-`.cast` on model-bearing frames, `ge`/`le` silently ignored
   on a datetime field, `pt.LazyFrame` methods typed as plain `pl.LazyFrame`, and Delta

--- a/docs/architecture/code-style.md
+++ b/docs/architecture/code-style.md
@@ -62,9 +62,9 @@ gets read before any Python is written or edited. Change a rule here and nowhere
 
 ## Type hints and signatures
 
-**Prefer self-documenting type hints over bare containers — a signature is documentation.** Jack
-strongly prefers expressive signatures and is happy to spend a few extra lines of code to get
-them, as long as complexity stays low. Whenever you would write `dict[str, str]` (or a bare `str`
+**Prefer self-documenting type hints over bare containers — a signature is documentation.** This
+repo prefers expressive signatures and is happy to spend a few extra lines of code to get them, as
+long as complexity stays low. Whenever you would write `dict[str, str]` (or a bare `str`
 for a value from a fixed set, or a tuple of positional values), stop and ask whether a more
 self-documenting type is practical. Reach for:
 
@@ -171,8 +171,8 @@ Three places where a positional argument is right:
   Don't invent a new schema just to annotate a private helper; if no existing schema fits, use
   plain `pl.DataFrame` / `pl.LazyFrame`. **A schema is the authoritative account of what the data
   means, so when code and contract disagree the code is the first suspect** — never widen a field
-  or relax a range just to make a failing `validate()` pass, and ask Jack before changing a
-  contract at all. The reasoning is in
+  or relax a range just to make a failing `validate()` pass, and get any contract change agreed
+  before making it. The reasoning is in
   [Contracts / Design Principles](../api/contracts/index.md).
 - **Patito friction budget**: the `polars-patito-gotchas` skill documents five Patito gotchas
   (cross-model LazyFrame joins, dict-`.cast` on model-bearing frames, `ge`/`le` silently ignored

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -20,6 +20,14 @@ This package is designed to be extremely lightweight. It defines the *shape* of 
 
 ## Design Principles
 
+- **The contract is the authoritative account of what the data means.** It says what the data
+  *should* be, not what some current code path happens to produce. So when code and contract
+  disagree, the code is the first suspect: a null the contract forbids usually means an upstream
+  join kept a row it should have dropped, or a caller passed input it should have rejected.
+  Widening a field to `| None`, or relaxing a range, so that a failing `validate()` passes buries
+  that defect in the one place the rest of the system trusts. Fix the code instead, and change the
+  contract only when you can say what the data now means and why that meaning is right. **Ask Jack
+  before changing a contract**, including a widening that looks like a formality.
 - **Column naming**: Prefer `snake_case`, except for acronyms or SI units. Capitalise "DER" (distributed energy resource) and use uppercase for "MW" (megawatts).
 - **Semantic checks**: Range validation should be generous — the aim is to catch physically impossible values (e.g., 1 GW from a 1 MW solar farm), not possible-but-unlikely values.
 - **Datetime ranges**: Timestamps on the columns where external data enters — `PowerTimeSeries.time`, `Nwp.init_time` and `Nwp.valid_time` — are bounded to `[MIN_PLAUSIBLE_DATETIME, MAX_PLAUSIBLE_DATETIME]` (2000-01-01 to 2100-01-01, inclusive), which rejects a corrupt feed or an epoch-unit mix-up without ever excluding a real reading. The check lives in each model's `validate` override via `check_datetime_bounds`, because Patito silently ignores `ge`/`le` on a datetime field — it derives its bounds checks from the JSON schema's `minimum`/`maximum`, which JSON Schema defines for numbers only. Columns on our own *output* schemas (`PowerForecast`, `EffectiveCapacity`, `AllFeatures`) have not opted in: they are computed from already-bounded inputs rather than received from outside.

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -26,8 +26,9 @@ This package is designed to be extremely lightweight. It defines the *shape* of 
   join kept a row it should have dropped, or a caller passed input it should have rejected.
   Widening a field to `| None`, or relaxing a range, so that a failing `validate()` passes buries
   that defect in the one place the rest of the system trusts. Fix the code instead, and change the
-  contract only when you can say what the data now means and why that meaning is right. **Ask Jack
-  before changing a contract**, including a widening that looks like a formality.
+  contract only when you can say what the data now means and why that meaning is right. **Get the
+  change agreed before making it**, including a widening that looks like a formality — every
+  reader of `contracts` is relying on it to still mean what it said yesterday.
 - **Column naming**: Prefer `snake_case`, except for acronyms or SI units. Capitalise "DER" (distributed energy resource) and use uppercase for "MW" (megawatts).
 - **Semantic checks**: Range validation should be generous — the aim is to catch physically impossible values (e.g., 1 GW from a 1 MW solar farm), not possible-but-unlikely values.
 - **Datetime ranges**: Timestamps on the columns where external data enters — `PowerTimeSeries.time`, `Nwp.init_time` and `Nwp.valid_time` — are bounded to `[MIN_PLAUSIBLE_DATETIME, MAX_PLAUSIBLE_DATETIME]` (2000-01-01 to 2100-01-01, inclusive), which rejects a corrupt feed or an epoch-unit mix-up without ever excluding a real reading. The check lives in each model's `validate` override via `check_datetime_bounds`, because Patito silently ignores `ge`/`le` on a datetime field — it derives its bounds checks from the JSON schema's `minimum`/`maximum`, which JSON Schema defines for numbers only. Columns on our own *output* schemas (`PowerForecast`, `EffectiveCapacity`, `AllFeatures`) have not opted in: they are computed from already-bounded inputs rather than received from outside.


### PR DESCRIPTION
🤖 Written by Claude Code.

Writes down a rule we had been following inconsistently: a Patito contract is the authoritative account of what the data *means*, not a description of what some current code path happens to produce.

This came out of #577, where I widened `AllFeatures.time_series_type` to `str | None` because the serving path could produce a null. That was backwards. The null meant the pipeline was keeping a time series it had no metadata for and predicting on it with every weather feature null — a real defect, and widening the contract would have buried it in the one file the rest of the system trusts. The fix was a semi-join in `_engineer_features`; the contract went back to `str`.

Three touches, no duplication between them:

- **`packages/contracts/README.md`** carries the rule and its reasoning, as the first Design Principle. That package owns the concept, and the README is included into the rendered API page at `api/contracts/`.
- **`docs/architecture/code-style.md`** extends the existing Data Contracts bullet with one sentence and a link. This is the page the `code-style` skill makes mandatory before any Python is written, so it is where the rule is actually needed.
- **`CLAUDE.md`** adds the "agree it first" half under "How work gets done", next to "stay inside the issue's scope". That is a workflow guard-rail rather than a style rule, which is why it sits there and not under Code Style.

The substantive half is that when code and contract disagree, the code is the first suspect: a forbidden null usually means an upstream join kept a row it should have dropped, or a caller passed input it should have rejected. The procedural half is that a contract change — including a widening that looks like a formality — has to be agreed before it is made, because every reader of `contracts` is relying on it to still mean what it said yesterday.

## Second commit: don't name individuals in prose

A fifth prose-style rule in CLAUDE.md, and the scope line above it now covers `SKILL.md` files as well. Docs and skills outlive whoever maintains the repo today, so a name that reads as "the person responsible" to us reads as an unknown third party to whoever picks the work up next. Where a sentence needs an actor, it names the role instead — the reviewer, the maintainer, whoever runs the pipeline. GitHub handles used as data are explicitly still fine: the `JackKelly` assignee, a commit's `Co-Authored-By`.

Applied to the four passages in the two files this PR already touches:

- "so that Jack approves a design before any code moves" → "so that a design is approved before any code moves"
- "and stops for Jack" → "and stops for review"
- "**Why:** Jack reviews diffs in GitHub's UI and wants a PR to already have survived an adversarial pass by the time he looks at it" → "**Why:** diffs are reviewed in GitHub's UI, and a PR should already have survived an adversarial pass by the time a human opens it"
- "Jack strongly prefers expressive signatures" → "This repo prefers expressive signatures"

## Not swept, awaiting your call

49 more mentions remain, in files this PR does not touch: `docs/roadmap/live-service.md` (2) and six skills — `plan-wave` (15), `plan-issue` (10), `implement-issue` (7), `simplicity-clean-room` (6), `github-issue-pr-workflow` (5), `code-style` (1). Rewriting those is mechanical but touches behavioural instructions, so it wants its own PR and its own read-through rather than being buried in this one. Say the word and I will do it.

`pymarkdown scan` clean. No code changes, so no test impact.
