### PR TITLE
Make Metrics.time_series_type non-nullable

### DIFF
--- a/packages/contracts/src/contracts/ml_schemas.py
+++ b/packages/contracts/src/contracts/ml_schemas.py
@@ -329,11 +329,13 @@ class Metrics(pt.Model):
     metric rows and have the asset enrich them with scope/window provenance before the frame is
     written to the ``forecast_metrics`` Delta table."""
 
-    time_series_type: str | None = pt.Field(
+    time_series_type: str = pt.Field(
         dtype=pl.Enum(TIME_SERIES_TYPE_SLICES),
         allow_missing=True,
         description=(
-            "The time-series category for this row. Null when metadata is unavailable for a series."
+            "The time-series category for this row. Never null: `compute_metrics` raises if any "
+            "scored series has no metadata row, because a null would drop that series out of "
+            "every per-type aggregate while still counting towards the overall mean."
         ),
     )
 

--- a/packages/ml_core/src/ml_core/metrics.py
+++ b/packages/ml_core/src/ml_core/metrics.py
@@ -265,7 +265,7 @@ def compute_metrics(
             Deduplicated on ``(time_series_id, time)`` before the join — a duplicated actual
             would otherwise double the ensemble members and corrupt the member-aware metrics.
         metadata: Substation metadata used to join ``time_series_type`` onto each metric row.
-            Series absent from ``metadata`` receive a null ``time_series_type``.
+            Must cover every scored ``time_series_id``.
         capacity: Pre-computed per-series effective capacity; ``effective_capacity_mw`` is the
             NMAE denominator. Must cover every scored ``time_series_id``.
 
@@ -277,7 +277,8 @@ def compute_metrics(
             period with no observed data).
         ValueError: If any forecast row has a negative lead time (``valid_time`` before
             ``power_fcst_init_time`` — an undeliverable hindcast row; see issue #346), if
-            any scored series has no row in ``capacity``, or if any computed metric value is
+            any scored series has no row in ``capacity`` or in ``metadata``, or if any
+            computed metric value is
             non-finite (NaN/inf — which ``Metrics.validate`` would otherwise accept, since
             NaN is not null, and which would poison the MLflow aggregate means).
     """
@@ -417,11 +418,22 @@ def compute_metrics(
             f"silently poison the MLflow aggregate means. First offenders:\n{offenders.head(10)}"
         )
 
-    # Join time_series_type from metadata (left — keeps all metric rows; unmatched → null).
+    # Join time_series_type from metadata. Left, so a series with no metadata row surfaces as a
+    # null to be named below rather than vanishing from the leaderboard.
     type_map = metadata.select(["time_series_id", "time_series_type"])
     metrics_tall = metrics_tall.join(type_map, on="time_series_id", how="left").with_columns(
         time_series_type=pl.col("time_series_type").cast(pl.Enum(TIME_SERIES_TYPE_SLICES))
     )
+
+    # Every scored series must have a metadata row. A null here would drop the series out of every
+    # per-type MLflow aggregate while still counting towards the overall mean, so two experiments
+    # scored over the same population would not be comparable.
+    missing_type = metrics_tall.filter(pl.col("time_series_type").is_null())["time_series_id"]
+    if missing_type.len() > 0:
+        raise ValueError(
+            f"No metadata row for time_series_id(s) {sorted(set(missing_type.to_list()))}; "
+            "materialise the time-series metadata for these series before scoring."
+        )
 
     return Metrics.validate(metrics_tall, allow_superfluous_columns=True)
 
@@ -494,12 +506,11 @@ def build_mlflow_aggregate_metrics(
 
     result: dict[str, float] = {}
 
-    # Per-type aggregates (only for non-null time_series_type values).
+    # Per-type aggregates. The column is `allow_missing` on `Metrics`, so guard its presence —
+    # but never its nullability: `compute_metrics` raises rather than emit a null type.
     if "time_series_type" in base.columns:
-        per_type = (
-            base.filter(pl.col("time_series_type").is_not_null())
-            .group_by(["metric_key", "time_series_type"])
-            .agg(mean_value=pl.col("metric_value").mean())
+        per_type = base.group_by(["metric_key", "time_series_type"]).agg(
+            mean_value=pl.col("metric_value").mean()
         )
         for row in per_type.iter_rows(named=True):
             key = f"{row['metric_key']}__{_type_slug(str(row['time_series_type']))}"

--- a/packages/ml_core/tests/test_metrics.py
+++ b/packages/ml_core/tests/test_metrics.py
@@ -256,14 +256,20 @@ def test_compute_metrics_populates_time_series_type():
     assert (result["time_series_type"] == "PV").all()
 
 
-def test_compute_metrics_unknown_series_gets_null_type():
-    """Series absent from metadata receive null time_series_type (left join)."""
+def test_compute_metrics_raises_for_series_with_no_metadata_row():
+    """A scored series absent from metadata is a hard error, not a null type.
+
+    A null would drop the series out of every per-type MLflow aggregate while still counting
+    towards the overall mean, so two experiments scored over the same population would not be
+    comparable — and metrics is R&D, which fails fast.
+    """
     times = [_utc(2022, 1, 1, 0, 0)]
     actuals = _make_actuals(1, times, [10.0])
     forecasts = _make_cv_forecasts(1, times, [10.0])
+
     # ts_id=1 is absent — metadata only knows about ts_id=99.
-    result = compute_metrics(forecasts, actuals, _make_metadata([99]), _make_capacity([1], [10.0]))
-    assert result["time_series_type"].is_null().all()
+    with pytest.raises(ValueError, match=r"No metadata row for time_series_id\(s\) \[1\]"):
+        compute_metrics(forecasts, actuals, _make_metadata([99]), _make_capacity([1], [10.0]))
 
 
 # ---------------------------------------------------------------------------
@@ -695,8 +701,12 @@ def test_build_mlflow_aggregate_metrics_sliced_keys():
     assert "rmse__wind__day_ahead" not in result
 
 
-def test_build_mlflow_aggregate_metrics_null_type_excluded_from_per_type():
-    """Series with null time_series_type contribute to 'all' but not to per-type keys."""
+def test_build_mlflow_aggregate_metrics_keys_every_type_present():
+    """Every series reaches both its per-type key and the overall 'all' key.
+
+    `Metrics.time_series_type` is non-nullable, so there is no null-type population to exclude
+    and the two key families cover the same rows.
+    """
     rows = [
         {
             "time_series_id": 1,
@@ -710,17 +720,16 @@ def test_build_mlflow_aggregate_metrics_null_type_excluded_from_per_type():
             "time_series_id": 2,
             "metric_name": "rmse",
             "metric_value": 4.0,
-            "time_series_type": None,
+            "time_series_type": "Wind",
             "horizon_slice": "all",
             "metric_param": "all",
         },
     ]
     df = pl.DataFrame(rows).cast({"time_series_id": pl.Int32, "metric_value": pl.Float32})
     result = build_mlflow_aggregate_metrics(df)
-    # null type: only "pv" per-type key, not a null-type key
-    assert "rmse__pv" in result
-    assert all("__none" not in k and "null" not in k for k in result)
-    # "all" includes both series
+
+    assert math.isclose(result["rmse__pv"], 2.0, rel_tol=1e-5)
+    assert math.isclose(result["rmse__wind"], 4.0, rel_tol=1e-5)
     assert math.isclose(result["rmse__all"], 3.0, rel_tol=1e-5)
 
 


### PR DESCRIPTION
🤖 Written by Claude Code.

`Metrics.time_series_type` was declared `str | None`, described as "Null when metadata is unavailable for a series". It is now `str`, and `compute_metrics` raises rather than emit a null.

A null there is not a degraded row, it is a broken leaderboard. `build_mlflow_aggregate_metrics` filtered nulls out of the per-type keys but left them in the overall `__all` mean, so a series with no metadata row silently contributed to one aggregate and not the other. Two experiments scored over the same population would not have been comparable, which is the whole point of the shared eligible population.

The check mirrors the `effective_capacity` coverage check twelve lines above it — same shape, same message form, naming the offending `time_series_id`s:

```
No metadata row for time_series_id(s) [1]; materialise the time-series metadata for these series before scoring.
```

Failing fast is right here: metrics is R&D, and CLAUDE.md's inherent-stability rule is explicit that the CV, training and metrics assets fail fast because a quietly-degraded run poisons every comparison built on it. Nothing in the live service is affected.

The join stays a **left** join. An inner join would drop the series instead of naming it, which is the failure this change exists to prevent.

Two knock-on changes:

- The `is_not_null()` filter in the per-type aggregate is now unreachable, so it goes. The `"time_series_type" in base.columns` guard stays, because the column is `allow_missing` on `Metrics` and a caller can hand `build_mlflow_aggregate_metrics` a frame without it.
- `test_compute_metrics_unknown_series_gets_null_type` pinned the old behaviour and now asserts the raise. `test_build_mlflow_aggregate_metrics_null_type_excluded_from_per_type` had no null population left to test, so it now checks that every series reaches both its per-type key and `__all`.

Verified by mutation: stubbing the raise out makes the new test fail. `Metrics.validate` catches the same case as a second line of defence, but only as `64 missing values`, which does not tell you which series to fix — that is why the explicit check is worth its five lines.

`ruff check`, `ruff format --check`, `uv run --all-packages ty check` and `pymarkdown scan` all clean. **670 passed, 1 skipped.**

## Noticed while here, not changed

`TIME_SERIES_TYPE_SLICES` is `("all", *LIST_OF_TIME_SERIES_TYPES)` and supplies the Enum dtype for this column, but no producer ever writes `"all"` into it — the `__all` MLflow key is built from a string literal, not from a row. So the column's dtype admits a value the column never holds. Worth deciding separately whether the dtype should just be `LIST_OF_TIME_SERIES_TYPES`.
