### PR TITLE
Size the planning and review process to the issue

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -3,22 +3,33 @@ name: implement-issue
 description: >-
   The routine for implementing an approved plan for a GitHub issue in
   openclimatefix/nged-substation-forecast: isolated worktree, implement, the green-before-push
-  verification set, PR with labels and the JackKelly assignee, then two fresh sub-agents
+  verification set, PR with labels and the JackKelly assignee, then up to two fresh sub-agents
   adversarially review the diff in turn — one for correctness and for keeping the code, tests and
   prose as short as they can be, then one that mutation-tests the change — triaging and pushing
-  after each, stop for Jack, never merge. Load before writing any code for an issue, and when
-  dispatching a sub-agent or a fresh session to solve one. To decide *what* to build, use
-  `plan-issue` first.
+  after each, stop for human review, never merge. How many of those reviews run is set by the issue
+  size: a simple issue arrives here with no plan and gets none. Load before writing any code for an
+  issue, and when dispatching a sub-agent or a fresh session to solve one. To decide *what* to
+  build, use `plan-issue` first.
 ---
 
 # Implement a GitHub issue
 
 This routine starts from an **approved plan**. The `plan-issue` skill (invoked as
 `/plan-issue <N>`) is how you get one: it reads the issue, decides whether it is worth
-implementing at all, writes `plans/<branch-name>.md`, has two fresh sub-agents adversarially
-review the plan — one for simplicity, one for correctness and testability — and stops for Jack. It
-also does step 1 below, so when it hands over, the worktree and branch already exist and
-implementation resumes at step 2.
+implementing at all, sizes how much process the issue needs, writes `plans/<branch-name>.md`, puts
+it through up to two adversarial sub-agent reviews — one for simplicity, one for correctness and
+testability — and stops for human review. It also does step 1 below, so when it hands over, the
+worktree and branch already exist and implementation resumes at step 2.
+
+The one issue that arrives here **without** a plan is one `plan-issue` sized as simple: a
+mechanical change with no design to approve, which runs steps 1 to 4 and then stops for human
+review with no adversarial pass at all. If you reach this skill without having gone through
+`plan-issue` — a direct instruction to fix something, say — make that sizing judgement first,
+using the criteria in `plan-issue` step 3, and say which size you picked before you start.
+
+**How many of the two reviews below to run** comes from that sizing: both for a complex issue,
+none for a simple one, and between zero and two for a medium one — your choice, under the rules in
+`plan-issue` step 3. Running only one means running step 5, not step 7.
 
 When dispatching a sub-agent (or a fresh Claude Code/Desktop session), give it these steps up
 front — a report back after step 1 is not finished work.
@@ -47,15 +58,20 @@ front — a report back after step 1 is not finished work.
    `uv run pymarkdown scan -r docs README.md CLAUDE.md packages/*/README.md` and
    `uv run mkdocs build --strict`.
 
-4. **Push and open the PR** against `main`, with labels and `JackKelly` as assignee (`gh pr
-   create` can't set either — follow with `gh pr edit --add-label <label>` and `gh pr edit
+4. **Commit, push and open the PR** against `main`, with labels and `JackKelly` as assignee (`gh
+   pr create` can't set either — follow with `gh pr edit --add-label <label>` and `gh pr edit
    --add-assignee JackKelly`), linking the issue so it closes on merge. Commit messages end
    with `Co-Authored-By: Claude <noreply@anthropic.com>`. See the `github-issue-pr-workflow`
    skill for the full PR checklist and the never-squash-merge rule.
 
-5. **First adversarial review: correctness, and cutting the change down.** Spawn a *new*,
-   independent sub-agent and give it only the PR number, not the implementer's reasoning, so it
-   isn't anchored by it. It attacks four things:
+    The body says **how the issue was sized and which adversarial reviews it is getting** — and
+    where that is none, says so outright. A PR that no sub-agent has attacked is one where human
+    review is the first line of defence rather than the last, and the reviewer has to know that
+    before reading the diff.
+
+5. **First adversarial review: correctness, and cutting the change down.** Run this if the sizing
+   called for it. Spawn a *new*, independent sub-agent and give it only the PR number, not the
+   implementer's reasoning, so it isn't anchored by it. It attacks four things:
 
     - **Correctness.** Tailor this part to the issue rather than asking for a generic review:
       name the failure modes most worth attacking — the risky claim, a behaviour change hiding
@@ -82,15 +98,16 @@ front — a report back after step 1 is not finished work.
     Ask for each finding as a concrete deletion or replacement. The standard is that the PR adds
     no more lines of code, tests or prose than the change absolutely needs.
 
-6. **Triage and push** — verify each finding against the code rather than accepting it, fix the
-   genuine ones, re-run the step-3 verification set, push, and record each rejected finding with
-   its one-line reason.
+6. **Triage, commit and push** — verify each finding against the code rather than accepting it,
+   fix the genuine ones, re-run the step-3 verification set, commit and push, and record each
+   rejected finding with its one-line reason. Every review step ends with the branch pushed, so
+   what is on GitHub always shows the state the last review left behind.
 
-7. **Second adversarial review: mutation testing.** Spawn *another* new sub-agent — not the one
-   from step 5, and again with no account of your reasoning. Its job is to break the production
-   code the PR touches and find out whether the tests notice. There is no mutation-testing tool
-   in this repo, so it does this by hand, in its own detached worktree, which keeps a mutation
-   off the branch:
+7. **Second adversarial review: mutation testing.** Run this if the sizing called for it. Spawn
+   *another* new sub-agent — not the one from step 5, and again with no account of your reasoning.
+   Its job is to break the production code the PR touches and find out whether the tests notice.
+   There is no mutation-testing tool in this repo, so it does this by hand, in its own detached
+   worktree, which keeps a mutation off the branch:
 
     ```bash
     git worktree add --detach .claude/worktrees/mutate-<branch-name> <branch-name>
@@ -105,13 +122,13 @@ front — a report back after step 1 is not finished work.
     remove`). It never commits or pushes. The table under "NWP grid → H3 orientation coverage"
     in `docs/architecture/testing.md` is what a finished pass of this looks like.
 
-8. **Triage and push** — on the same terms as step 6. A surviving mutation is a gap only where
-   the behaviour it breaks is behaviour we rely on; where it is, tighten or add a test and
+8. **Triage, commit and push** — on the same terms as step 6. A surviving mutation is a gap only
+   where the behaviour it breaks is behaviour we rely on; where it is, tighten or add a test and
    confirm that test goes red against the mutation and green without it. Re-run the step-3
-   verification set and push.
+   verification set, commit and push.
 
-9. **Stop and wait for Jack's review. Never merge.** Report what each of the two reviews changed
-   and what each found that you rejected.
+9. **Stop and wait for human review. Never merge.** Report the size the issue was given, which
+   reviews ran, what each of them changed, and what each found that you rejected.
 
 Stay inside the issue's scope; report unrelated design mistakes rather than fixing them.
 
@@ -123,3 +140,10 @@ must not be applied uncritically. Mutation testing goes second because it should
 tests that survive the first round, not at ones the first round deletes — and it gets its own
 reviewer because a green suite proves nothing on its own: the only way to learn whether a test
 would catch the bug it exists for is to write that bug and watch.
+
+**Why the reviews are sized rather than always run:** an adversarial pass costs wall-clock time
+and produces findings that have to be triaged, and on a change whose correctness is visible in the
+diff it finds nothing that the diff did not already show. Spending it there delays the change and
+buries the human reviewer in process for no gain. The number is a judgement call precisely because
+the cost of getting it wrong is asymmetric — a review too many wastes a sub-agent, a review too
+few puts an unattacked design in `main` — so when the call is close, run the review.

--- a/.claude/skills/plan-issue/SKILL.md
+++ b/.claude/skills/plan-issue/SKILL.md
@@ -3,19 +3,21 @@ name: plan-issue
 description: >-
   Turn a GitHub issue in openclimatefix/nged-substation-forecast into a reviewed implementation
   plan, writing no code: read the issue and its comments, decide whether it is worth implementing
-  at all, write a plan that may overrule a stale issue body, put it through two fresh adversarial
-  sub-agent reviews — one hunting for a simpler approach, then one checking correctness and
-  testability — triage the findings, stop for Jack. Load whenever Jack asks for a plan for an issue,
-  says "plan issue N" or "/plan-issue N", asks whether an issue is worth doing, or asks you to
-  think through an implementation before touching code. To implement an approved plan, use
-  `implement-issue` instead.
+  at all, size how much process it needs, write a plan that may overrule a stale issue body, put it
+  through up to two fresh adversarial sub-agent reviews — one hunting for a simpler approach, then
+  one checking correctness and testability — triage the findings, stop for human review. A very
+  simple issue skips the plan entirely and goes straight to `implement-issue`. Load whenever Jack
+  asks for a plan for an issue, says "plan issue N" or "/plan-issue N", asks whether an issue is
+  worth doing, or asks you to think through an implementation before touching code. To implement an
+  approved plan, use `implement-issue` instead.
 ---
 
 # Plan a GitHub issue
 
-The output is a **plan file and a recommendation**, never a code change. Jack approves a plan
-before any code moves, so his review of the eventual diff checks execution rather than discovering
-the design for the first time.
+The output is a **plan file and a recommendation**, never a code change. A human approves the plan
+before any code moves, so the review of the eventual diff checks execution rather than discovering
+the design for the first time. The exception is an issue simple enough that there is no design to
+approve: step 3 sizes the issue, and a simple one skips this skill entirely.
 
 Take the issue number from the invocation (`/plan-issue 500`). If several are given, run the whole
 procedure once per issue, each on its own branch — do not merge them into one plan unless the
@@ -96,7 +98,61 @@ If the verdict is "worth it, roughly as described", continue — but you are sti
 any specific mechanism the issue proposes. Say plainly which parts of the issue body you are
 departing from and why.
 
-## 3. Write the plan
+## 3. Size the process to the issue
+
+Not every issue needs a plan, and not every plan needs two reviews. Pick one of three sizes,
+**state it in your reply with a one-line reason before doing anything else**, and let the human
+override it.
+
+**Simple — no plan, and no agentic review at all.** Skip the rest of this skill and go straight to
+`implement-issue` at its step 1: worktree, implement, the verification set, PR, stop for human
+review. An issue is simple when all of these hold:
+
+- The change is mechanical, and reading the diff is enough to see whether it is right — a rename or
+  a find-and-replace across files, a prose or docs edit, deleting dead code, a dependency bump, a
+  one-line fix whose failing test you can name before you start.
+- There is one obvious way to do it, so there is no design to approve.
+- It touches no Patito contract, no production degradation path, no asset graph, and nothing about
+  what gets stored.
+- The green-before-push verification set is the whole of the risk: if `ruff`, `ty`, `pytest` and
+  the markdown lint pass, the change is right.
+
+Issue #583 — replace one word across seven skill and docs files — is the shape to picture. Say in
+the same reply that you are taking this path, and open it with `Implementing:` rather than the
+`Planning:` prefix from step 1a.
+
+**Complex — the full routine**: a plan, both plan reviews below, and both diff reviews in
+`implement-issue`. An issue is complex when any of these hold:
+
+- It adds or changes a Patito model, a Delta table, an asset, or anything else about what gets
+  stored.
+- It touches the production serving path, or a degradation rule in
+  `docs/design-philosophy/inherent-stability.md`.
+- More than one design would defensibly satisfy it, so the choice wants approving before code moves.
+- It spans enough code that you could not name every caller of what it changes without searching.
+
+**Medium — everything else.** Write the plan, then choose how much review to spend on it: between
+zero and two of the plan reviews below (steps 5 and 7, each with its triage step), and between
+zero and two of the diff reviews in `implement-issue`. The choice is yours, under four rules:
+
+- **Run the earlier of a pair first.** One plan review means the simplicity review, not the
+  correctness one, because a plan bigger than its issue survives a correctness review intact. One
+  diff review means the correctness-and-cut-it-down review, not the mutation pass.
+- **Spend a plan review** on a plan that adds an abstraction, a config field, a column or a new
+  file (the simplicity review), or on a plan whose account of current behaviour was hard to pin
+  down or whose tests are the risky part (the correctness review).
+- **Spend a diff review** on a diff that came out larger than the plan implied or grew a lot of
+  prose (the first review), or on a change whose whole value is a behaviour the tests are meant to
+  pin down — a boundary, an ordering, a join key, a warning path that must not raise (the mutation
+  pass).
+- **When you cannot decide, run it.** A review costs one sub-agent; the other error puts a design
+  nobody attacked into `main`.
+
+Carry the size and the chosen counts forward: they go in the plan file (step 4), in the report
+(step 9), and into the PR body when `implement-issue` opens it, so whoever reviews the diff knows
+what scrutiny it has already had.
+
+## 4. Write the plan
 
 The plan is a committed file on the issue's own branch, so set up the worktree now rather than
 leaving it to implementation — this is step 1 of the `implement-issue` skill, pulled forward:
@@ -107,7 +163,19 @@ cd .claude/worktrees/<branch-name>
 ln -s /home/jack/dev/python/nged-substation-forecast/.env .env   # if it exists and isn't already there
 ```
 
-Then write the plan to **`plans/<branch-name>.md`** inside that worktree, and commit it.
+Then write the plan to **`plans/<branch-name>.md`** inside that worktree, commit it and push the
+branch:
+
+```bash
+git push -u origin <branch-name>
+```
+
+**Then hand over the plan before anything else happens to it.** Say in your next reply that the
+plan is ready and give a **clickable markdown link** to it, written as the path relative to the
+worktree so the terminal turns it into a link: `[plans/<branch-name>.md](plans/<branch-name>.md)`.
+Do this *before* launching any reviewer. The reviews take minutes, and whoever wants to read the
+first draft — or to stop the work outright — should not have to wait for them, nor work out
+afterwards which parts of the plan the reviews wrote.
 
 One worktree per issue means `plans/` holds exactly one file on each branch, so the "at most one
 plan" rule in `plans/README.md` holds with no coordination between parallel sessions. Committing
@@ -122,8 +190,8 @@ the file-by-file detail.
 
 The plan covers:
 
-- **Verdict and departures** — the step-2 conclusion, and every point where the plan differs
-  from the issue body, each with its reason.
+- **Verdict, size and departures** — the step-2 conclusion, the step-3 size with the reviews it
+  buys, and every point where the plan differs from the issue body, each with its reason.
 - **What changes, file by file** — named files and functions, with what happens to each. Prefer
   naming the actual symbols over describing the change in the abstract.
 - **Design-philosophy check** — how the change sits against
@@ -149,9 +217,10 @@ The plan covers:
 
 Do not paste large code blocks into the plan. Name the change; the implementer writes the code.
 
-## 4. First adversarial review: is there a simpler way?
+## 5. First adversarial review: is there a simpler way?
 
-The plan now goes through **two** reviews, by two separate fresh sub-agents, in this order:
+Run this if step 3 called for it — always for a complex issue, and for a medium one whenever it is
+the review you chose. The two reviews go to two separate fresh sub-agents, in this order:
 simplicity first, then correctness. Simplifying a plan can break it, so the correctness reviewer
 has to see the plan that simplification left behind, not the one that went in.
 
@@ -205,7 +274,7 @@ A proposal that big has to arrive with its case made, not as a suggestion:
   rearchitecture as its own issue afterwards? That is usually the answer, and saying so is not a
   weaker recommendation.
 
-## 5. Triage and revise
+## 6. Triage and revise
 
 Verify each proposed simplification against the code rather than accepting it — **reviewer
 findings are often wrong, and applying them uncritically makes the plan worse**. Take the genuine
@@ -213,7 +282,8 @@ ones into the plan file. Reject a simplification when it drops something the iss
 for, or trades away a rule in `docs/design-philosophy/` — and say which, in one line.
 
 For each finding you reject, record the finding and the one-line reason in the plan file, so Jack
-can see what was considered and dismissed. Commit the revised plan.
+can see what was considered and dismissed. Commit the revised plan and push, so the branch on
+GitHub is never behind what the reviews have already done.
 
 **A proposed rearchitecture is Jack's call, not yours** — it is bigger than the issue, so neither
 adopting it nor dropping it silently is right. Put it in the plan's "Risks and open questions" with
@@ -221,10 +291,10 @@ the reviewer's pros and cons, your view of whether it is genuinely simpler, and 
 whether it should become its own issue. Then plan the issue under the current architecture unless
 Jack says otherwise.
 
-## 6. Second adversarial review: correctness and testability
+## 7. Second adversarial review: correctness and testability
 
-Launch **another** new sub-agent — not the one from step 4, and again with no account of your
-reasoning or of what the first review changed. Give it the issue number and the path to the
+Run this if step 3 called for it. Launch **another** new sub-agent — not the one from step 5, and
+again with no account of your reasoning or of what the first review changed. Give it the issue number and the path to the
 revised plan file. Its job is to establish whether the plan, as now written, is correct and whether
 its tests would actually catch it being wrong.
 
@@ -245,19 +315,19 @@ The attacks worth naming, when they apply:
 Ask the reviewer for findings with file/line evidence, and for an explicit verdict on each: real
 defect, or not.
 
-## 7. Triage the findings
+## 8. Triage the findings
 
-Verify each finding against the code, on the same terms as step 5: fix the genuine ones in the
-plan file, and record each rejected finding with its one-line reason. Commit the updated plan, so
-the branch carries the original plan and what both reviews did to it.
+Verify each finding against the code, on the same terms as step 6: fix the genuine ones in the
+plan file, and record each rejected finding with its one-line reason. Commit and push the updated
+plan, so the branch carries the original plan and what each review did to it.
 
-## 8. Stop
+## 9. Stop
 
-Report to Jack: the verdict from step 2, a short summary of the plan, what each of the two reviews
-changed, and what each found that you rejected. Give the branch name and the path to the plan
-file.
+Report: the verdict from step 2, the size from step 3 and which reviews it bought, a short summary
+of the plan, what each review that ran changed, and what each found that you rejected. Give the
+branch name and, again, the clickable link to the plan file.
 
-**Do not write any code, and do not open a PR.** Once Jack approves the plan, implementation runs
+**Do not write any code, and do not open a PR.** Once the plan is approved, implementation runs
 under the `implement-issue` skill, resuming at its step 2 in the worktree this skill already
-created — implement, verify, PR, then two further independent adversarial reviews of the *diff*,
-triaging and pushing after each, stop.
+created — implement, verify, PR, then the diff reviews step 3 called for, each by a further
+independent sub-agent, triaging and pushing after each, stop.

--- a/.claude/skills/plan-wave/SKILL.md
+++ b/.claude/skills/plan-wave/SKILL.md
@@ -139,8 +139,8 @@ step 1a: the chip title becomes the spawned session's title, the app's auto-titl
 Each chip prompt has to stand alone — the session cannot see this conversation — and carries:
 
 1. The issue number, the wave number, and `/plan-wave`'s standing instruction: run
-   `/plan-issue <N>` first, write no code until Jack approves the plan, then follow
-   `implement-issue`.
+   `/plan-issue <N>` first, and let it size the issue — if it writes a plan, write no code until
+   that plan is approved; if it sizes the issue simple, go straight on to `implement-issue`.
 
 2. An instruction to keep the `W<n>:` prefix when `plan-issue` step 1a asks it to state a session
    title, so the session does not retitle itself out of the wave.
@@ -177,7 +177,8 @@ attribution line every GitHub body written by Claude carries, and do not hard-wr
 `github-issue-pr-workflow` skill for both rules.
 
 Then stop. Do not plan the wave after this one, and do not write per-issue plans — each session
-does its own under `plan-issue`, in its own worktree, with its own adversarial reviews.
+does its own under `plan-issue`, in its own worktree, with whatever adversarial reviews that
+issue's size warrants.
 
 **Why the collision rule is the whole design:** these sessions branch from `main` and merge back
 independently, with no coordination between them and no shared context. Everything else — the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,9 +50,9 @@ needed one, the mistake is already written.
 | `marimo-notebooks` | creating or editing a Marimo notebook (`packages/dashboard/*.py`, `packages/notebooks/*.py`) |
 | `ty-workarounds` | acting on a `ty` error in Altair chart code or numpy `.view()` code, or adding any `# ty: ignore` |
 | `plan-wave` | choosing the next batch of issues under an epic to run in parallel (`/plan-wave <EPIC>`) |
-| `plan-issue` | deciding what to build for a GitHub issue (`/plan-issue <N>`) — writes a reviewed plan, no code |
+| `plan-issue` | deciding what to build for a GitHub issue (`/plan-issue <N>`) — sizes the issue, then writes a reviewed plan unless it is trivial, no code |
 | `simplicity-clean-room` | testing whether an existing module is more complicated than its problem requires |
-| `implement-issue` | writing code for an approved plan: worktree, verify set, PR, two adversarial reviews, stop |
+| `implement-issue` | writing code for an approved plan: worktree, verify set, PR, up to two adversarial reviews, stop |
 | `github-issue-pr-workflow` | `gh issue create`, `gh pr create`, `gh pr merge`, or ship-time triage |
 | `github-graphql` | any `gh api graphql` call — sub-issue attach/reorder, issue Type, project fields |
 
@@ -145,7 +145,8 @@ Full description and a "which place do I use?" table: `docs/documentation-guide.
   never renumber.
 - **`plans/`** holds at most one file: the in-flight branch's implementation plan, written by the
   `plan-issue` skill before any code is touched and deleted on merge. One worktree per branch is
-  what keeps it to one file, so parallel sessions never collide. Usually empty on `main`.
+  what keeps it to one file, so parallel sessions never collide. Usually empty on `main`, and empty
+  on a branch whose issue was simple enough to need no plan.
 
 **Creating an issue or a PR has a checklist** — labels, org issue Type, OCF project membership
 and its fields, sub-issue ordering, the `JackKelly` assignee — and none of it can be set by `gh
@@ -162,14 +163,28 @@ before any code moves:
    launched as its own Claude Code session. It plans one wave and stops, because the epic gains
    issues while a wave is in flight. Skip it when the issue to work on has already been named.
 2. **`plan-issue`** (`/plan-issue <N>`) reads the issue, decides whether it is worth implementing
-   at all, writes `plans/<branch-name>.md`, has two fresh sub-agents adversarially review that
-   plan in turn — the first hunting for a simpler approach, the second checking correctness and
-   testability — and stops for review. It writes no code.
+   at all, and sizes how much process it needs. It writes `plans/<branch-name>.md`, links to the
+   plan as soon as it is committed and pushed, has up to two fresh sub-agents adversarially review
+   that plan in turn — the first hunting for a simpler approach, the second checking correctness
+   and testability — and stops for review. It writes no code.
 3. **`implement-issue`** picks up an approved plan: worktree, implement, the green-before-push
-   verification set, PR with labels and assignee, then two *further independent* adversarial
+   verification set, PR with labels and assignee, then up to two *further independent* adversarial
    reviews of the diff — the first for correctness and for cutting the code, tests and prose
-   down to what the change needs, the second mutation-testing the change — triaging and pushing
-   after each, stop. **Never merge.**
+   down to what the change needs, the second mutation-testing the change — committing, triaging
+   and pushing after each, stop. **Never merge.**
+
+**How much process an issue gets is sized to the issue**, in step 3 of `plan-issue`:
+
+- **Simple** — a mechanical change with one obvious way to do it, touching no contract, no
+  production degradation path and nothing stored, where the verification set is the whole of the
+  risk. It gets **no plan and no agentic review**: implement it, open the PR saying that no
+  sub-agent reviewed it, and stop for human review.
+- **Complex** — anything that changes what gets stored, touches the production serving path or a
+  degradation rule, or admits more than one defensible design. It gets the plan and **all four**
+  reviews.
+- **Medium** — everything else. It gets a plan, and Claude chooses between zero and two of the
+  plan reviews and between zero and two of the diff reviews, running the earlier of each pair
+  first and erring towards running one more when the call is close.
 
 Stay inside the issue's scope; report unrelated design mistakes rather than fixing them.
 
@@ -187,7 +202,9 @@ must not be applied uncritically. Simplicity gets its own reviewer, and gets it 
 plan that is more complicated than the issue requires is the failure mode that survives a
 correctness review intact. Mutation testing gets the last reviewer because a green suite proves
 nothing on its own: whether a test would catch the bug it exists for is only settled by writing
-that bug and watching.
+that bug and watching. The sizing exists because that machinery costs wall-clock time and a round
+of triage: on a change whose correctness is visible in the diff it finds nothing the diff did not
+already show, and the process then delays the change instead of protecting it.
 
 ## Architecture
 

--- a/plans/README.md
+++ b/plans/README.md
@@ -2,7 +2,9 @@
 
 This directory holds **at most one** file — `<branch-name>.md`, the implementation plan for the
 work in flight on this branch, written by the `plan-issue` skill before any code is touched and
-deleted when that work merges (paste the plan, or a summary, into the PR body first). One worktree
-per branch is what keeps it to a single file, so parallel sessions never collide; on `main` the
-directory is empty. Everything durable belongs elsewhere, and nothing may link here from code or
-`docs/`: see "How planning works" in `docs/roadmap/index.md`.
+deleted when that work merges (paste the plan, or a summary, into the PR body first). An issue
+`plan-issue` sizes as simple gets no plan at all, so a branch with an empty `plans/` is not
+necessarily one where the step was skipped. One worktree per branch is what keeps it to a single
+file, so parallel sessions never collide; on `main` the directory is empty. Everything durable
+belongs elsewhere, and nothing may link here from code or `docs/`: see "How planning works" in
+`docs/roadmap/index.md`.


### PR DESCRIPTION
🤖 Written by Claude Code.

Every issue currently gets the same four adversarial reviews, whether it needs them or not. This adds a sizing gate so the process fits the change.

## The gate

New step 3 of `plan-issue`, straight after the "is this worth doing at all" gate. It picks one of three sizes, states it with a one-line reason before doing anything else, and can be overridden by the human:

- **Simple** — mechanical, one obvious way to do it, touching no Patito contract, no production degradation path, no asset graph and nothing about what gets stored, where the green-before-push set is the whole of the risk. It skips the rest of `plan-issue` and goes straight to `implement-issue` step 1: **no plan file and no agentic review**, then a PR and human review. #583 is named in the skill as the shape to picture.
- **Complex** — changes what gets stored, touches the production serving path or a degradation rule, admits more than one defensible design, or spans more code than you could enumerate the callers of. Full routine: plan, both plan reviews, both diff reviews.
- **Medium** — everything else: a plan, plus between zero and two plan reviews and between zero and two diff reviews. The count is Claude's choice, under four rules — run the earlier of each pair first (simplicity before correctness, cut-it-down before mutation testing), what each review is worth spending on, and "when you cannot decide, run it".

The size and the chosen counts travel with the work: into the plan file's verdict section, into the PR body, and into the closing report. A PR that no sub-agent attacked has to say so, because human review is then the first line of defence rather than the last.

## Commit, push, and hand over the plan early

`plan-issue` now commits the plan and pushes the branch as soon as the plan is written, then replies with a clickable link to `plans/<branch-name>.md` **before** launching any reviewer — so the first draft can be read, or the work stopped, without waiting on the reviews or working out afterwards which parts of the plan they wrote. Both skills now commit and push after every review step, so what is on GitHub always shows the state the last review left behind.

## Files

- `.claude/skills/plan-issue/SKILL.md` — the new step 3, the commit/push/link step, conditional reviews, renumbering.
- `.claude/skills/implement-issue/SKILL.md` — review count comes from the sizing (and is made afresh if this skill is entered directly), PR body states the sizing, commit-and-push at each step, a "why sized rather than always run" note.
- `.claude/skills/plan-wave/SKILL.md` — the standing chip instruction now lets `plan-issue` size the issue instead of always waiting for a plan.
- `CLAUDE.md` — skills table, the `plans/` line, "How work gets done", and the "Why" paragraph.
- `plans/README.md` — an empty `plans/` on a work branch may mean the issue was simple, not that the step was skipped.

Existing prose naming Jack was left alone throughout, to avoid colliding with #583; everything added here is de-named.
