### PR TITLE
Ignore a data symlink, not just a data directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,10 @@ packages/dashboard/.env.s3
 # Data storage
 # Anchored: an unanchored `data/` also matches `packages/*/tests/data/`, which hold *tracked* test
 # fixtures — and because ruff respects .gitignore, that hid two tracked Python files from
-# `ruff check .` and from CI while pre-commit still checked them.
-/data/
+# `ruff check .` and from CI while pre-commit still checked them. No trailing slash, because that
+# would match only a directory: a git worktree reaches the data root through a `data` symlink,
+# which would then show up as an untracked file in every worktree.
+/data
 
 #######################
 # Dagster


### PR DESCRIPTION
*This PR was written by Claude Code.*

`/data/` matched a directory but not a symlink, and a git worktree reaches the data root through a `data` symlink — so every worktree showed `?? data` in `git status`, one `git add -A` away from committing it. Dropping the trailing slash matches both.

The anchoring stays: `/data` is still rooted, so the tracked fixtures under `packages/*/tests/data/` are untouched. Verified that the symlink is now ignored, that the real directory still is, and that `git ls-files 'packages/*/tests/data/*'` still lists its tracked files.

Found while testing #520 in a worktree.
