### PR TITLE
Document how thin a partially-covered H3 cell can get

### DIFF
--- a/docs/architecture/ecmwf-ens-known-issues.md
+++ b/docs/architecture/ecmwf-ens-known-issues.md
@@ -116,6 +116,23 @@ the upstream scatter documented above lands outside the small GB box we download
 therefore a correctness fix — the estimator was wrong, and a wholly-uncovered cell was a false
 zero — rather than a change that recovers much data.
 
+A surviving cell can rest on very little of its own area. `compute_h3_grid_weights_for_boundary`
+samples each cell with H3 children two resolutions finer — 49 of them — so every `proportion` is a
+multiple of 1/49, and the least a single grid point can carry is 2.0% of its cell. 572 of the V1
+grid's 1671 cells contain a point that thin, and 859 contain one under 10%. A cell reduced to one of
+those points is stored exactly like a fully-covered one: the `Nwp` contract has no column for the
+contributing weight, and `_aggregate_grid_points_to_h3_cells` drops it once the division is done.
+
+No per-run metric reports that weight either, because every available summary of it either
+duplicates a number `nwp_has_no_unexpected_nulls` already publishes or goes blind exactly when it
+would matter. Where the corruption is scattered, the count of partially-covered cells runs at 4.7
+times `n_null_nwp_grid_points` and the total weight deficit at 1.68 times it — the deficit being the
+mean total `proportion` a grid point carries across the 4.92 cells it feeds. Where it is clustered,
+which is the shape it takes in practice, both saturate: the interior of a corrupt patch goes null
+and is counted by `n_null_h3_cells`, so only the rim stays partially covered and the two numbers
+stop moving while the damage grows. The thinnest surviving weight is no better a summary, since it
+pins to the 1/49 floor on any run corrupt enough to ask about.
+
 A cell where *no* point contributed is a different case, and it yields **null**, never `0.0`. That
 distinction is the whole reason the contributing weight is computed rather than assumed: Polars
 sums an all-null group to `0.0`, which for weather is a physically plausible, in-bounds lie


### PR DESCRIPTION
*Written by Claude Code, from the investigation recorded on #506.*

Docs only — two paragraphs added to [Known ECMWF ENS data-quality issues](https://openclimatefix.github.io/nged-substation-forecast/architecture/ecmwf-ens-known-issues/#spatial-aggregation-is-where-a-grid-points-null-is-resolved). No code changes.

## The gap

That page explains that the H3 aggregation renormalises each cell over the grid points that supplied a value, so a corrupt grid point costs only its own share of its cell. What it never says is how far that can go. A cell reduced to a single surviving point still yields a value, and it is stored exactly like a fully-covered one: the `Nwp` contract has no column for the contributing weight, and `_aggregate_grid_points_to_h3_cells` drops it once the division is done. A reader finishes the section knowing a null cell means "no point contributed" without knowing that a *non-null* cell might rest on almost nothing.

## What was added

**The bound**, which is a fixed property of the geometry rather than a per-run number. `compute_h3_grid_weights_for_boundary` defaults `child_h3_res` to `h3_res + 2`, so each cell is sampled with 49 H3 children and every `proportion` is a multiple of 1/49 — verified against `data/h3_grid_weights.parquet`, where the maximum deviation from an integer after multiplying by 49 is 1.9e-06. The least a single grid point can carry is therefore 2.0% of its cell. 572 of the V1 grid's 1671 cells contain a point that thin, and 859 contain one under 10%.

**Why no per-run metric reports the weight**, so the question does not get reopened by the next person who notices the gap. Measured on the real V1 geometry by nulling *k* grid points and computing each candidate summary against `n_null_nwp_grid_points`, 20 trials per point:

| | scattered | clustered |
|---|---|---|
| partially-covered cells | 4.7 × `n_null_nwp_grid_points` | saturates at ~55 |
| total weight deficit | 1.68 × `n_null_nwp_grid_points` | saturates at ~27.7 |
| thinnest surviving weight | pins to the 1/49 floor | pins to the 1/49 floor |

The scattered multipliers are arithmetic rather than coincidence: 1.68 is the mean total `proportion` a grid point carries across the 4.92 cells it feeds. Under clustered corruption — the shape [the page already says](https://openclimatefix.github.io/nged-substation-forecast/architecture/ecmwf-ens-known-issues/#nulls-in-the-de-accumulated-variables-tolerated) it takes in practice — the interior of a corrupt patch goes null and is counted by `n_null_h3_cells`, leaving only the rim partially covered, so both counts stop moving while the damage keeps growing. For scale, the worst archived run (2025-06-04 00Z, 339 null cells) sits inside that saturated regime.

So every available summary either duplicates a number `nwp_has_no_unexpected_nulls` already publishes or goes blind exactly when it would matter. That is the finding that closed #506 as not planned, and this PR is the part of it worth keeping.

## Scope

Deliberately no code. The measurements above were made in a throwaway script against `data/h3_grid_weights.parquet`; nothing from it is committed, because the numbers are properties of a stored artefact that anyone can recompute, and a test asserting them would pin the docs to one particular H3 grid.

The `nwp_grid_point` / `h3_cell` metadata keys named in the new prose are the ones #573 introduced, so this sits on top of that work rather than changing it.

## Review

Sized as simple: prose only, one file, no contract, no asset, no production path. A single adversarial sub-agent reviewed the new text for factual accuracy against the code and data.

## Verification

`pymarkdown scan -r docs README.md CLAUDE.md packages/*/README.md` and `mkdocs build --strict` both clean, and the rendered HTML under `site/` was read to confirm the two paragraphs render as paragraphs — no stray headings, code spans intact. `ruff`, `ty` and `pytest` were not run: no Python file is touched, and no test reads `docs/`.
