### PR TITLE
Document how thin a partially-covered H3 cell can get

### DIFF
--- a/docs/architecture/ecmwf-ens-known-issues.md
+++ b/docs/architecture/ecmwf-ens-known-issues.md
@@ -116,22 +116,13 @@ the upstream scatter documented above lands outside the small GB box we download
 therefore a correctness fix — the estimator was wrong, and a wholly-uncovered cell was a false
 zero — rather than a change that recovers much data.
 
-A surviving cell can rest on very little of its own area. `compute_h3_grid_weights_for_boundary`
-samples each cell with H3 children two resolutions finer — 49 of them — so every `proportion` is a
-multiple of 1/49, and the least a single grid point can carry is 2.0% of its cell. 572 of the V1
-grid's 1671 cells contain a point that thin, and 859 contain one under 10%. A cell reduced to one of
-those points is stored exactly like a fully-covered one: the `Nwp` contract has no column for the
-contributing weight, and `_aggregate_grid_points_to_h3_cells` drops it once the division is done.
-
-No per-run metric reports that weight either, because every available summary of it either
-duplicates a number `nwp_has_no_unexpected_nulls` already publishes or goes blind exactly when it
-would matter. Where the corruption is scattered, the count of partially-covered cells runs at 4.7
-times `n_null_nwp_grid_points` and the total weight deficit at 1.68 times it — the deficit being the
-mean total `proportion` a grid point carries across the 4.92 cells it feeds. Where it is clustered,
-which is the shape it takes in practice, both saturate: the interior of a corrupt patch goes null
-and is counted by `n_null_h3_cells`, so only the rim stays partially covered and the two numbers
-stop moving while the damage grows. The thinnest surviving weight is no better a summary, since it
-pins to the 1/49 floor on any run corrupt enough to ask about.
+A surviving cell can rest on very little of its own area. `compute_h3_grid_weights` samples each
+cell with H3 children two resolutions finer by default — 49 of them for a hexagon, 7² — and on the
+V1 grid every `proportion` comes out an exact multiple of 1/49, so the least a single grid point can
+carry is 2.0% of its cell. 294 of that grid's 1671 cells contain a point at the floor, 572 contain
+one under 5%, and 859 contain one under 10%. A cell reduced to one of those points is stored exactly
+like a fully-covered one: the `Nwp` contract has no column for the contributing weight, and
+`_aggregate_grid_points_to_h3_cells` drops it once the division is done.
 
 A cell where *no* point contributed is a different case, and it yields **null**, never `0.0`. That
 distinction is the whole reason the contributing weight is computed rather than assumed: Polars

--- a/docs/architecture/ecmwf-ens-known-issues.md
+++ b/docs/architecture/ecmwf-ens-known-issues.md
@@ -116,6 +116,23 @@ the upstream scatter documented above lands outside the small GB box we download
 therefore a correctness fix — the estimator was wrong, and a wholly-uncovered cell was a false
 zero — rather than a change that recovers much data.
 
+A surviving cell can rest on very little of its own area. `compute_h3_grid_weights_for_boundary`
+samples each cell with H3 children two resolutions finer — 49 of them — so every `proportion` is a
+multiple of 1/49, and the least a single grid point can carry is 2.0% of its cell. 572 of the V1
+grid's 1671 cells contain a point that thin, and 859 contain one under 10%. A cell reduced to one of
+those points is stored exactly like a fully-covered one: the `Nwp` contract has no column for the
+contributing weight, and `_aggregate_grid_points_to_h3_cells` drops it once the division is done.
+
+No per-run metric reports that weight either, because every available summary of it either
+duplicates a number `nwp_has_no_unexpected_nulls` already publishes or goes blind exactly when it
+would matter. Where the corruption is scattered, the count of partially-covered cells runs at 4.7
+times `n_null_nwp_grid_points` and the total weight deficit at 1.68 times it — the deficit being the
+mean total `proportion` a grid point carries across the 4.92 cells it feeds. Where it is clustered,
+which is the shape it takes in practice, both saturate: the interior of a corrupt patch goes null
+and is counted by `n_null_h3_cells`, so only the rim stays partially covered and the two numbers
+stop moving while the damage grows. The thinnest surviving weight is no better a summary, since it
+pins to the 1/49 floor on any run corrupt enough to ask about.
+
 A cell where *no* point contributed is a different case, and it yields **null**, never `0.0`. That
 distinction is the whole reason the contributing weight is computed rather than assumed: Polars
 sums an all-null group to `0.0`, which for weather is a physically plausible, in-bounds lie


### PR DESCRIPTION
*Written by Claude Code, from the investigation recorded on #506.*

Docs only — one paragraph added to [Known ECMWF ENS data-quality issues](https://openclimatefix.github.io/nged-substation-forecast/architecture/ecmwf-ens-known-issues/#spatial-aggregation-is-where-a-grid-points-null-is-resolved). No code changes.

## The gap

That section explains that the H3 aggregation renormalises each cell over the grid points that supplied a value, so a corrupt grid point costs only its own share of its cell. What it never says is how far that can go. A cell reduced to a single surviving point still yields a value, and it is stored exactly like a fully-covered one: the `Nwp` contract has no column for the contributing weight, and `_aggregate_grid_points_to_h3_cells` drops it once the division is done. A reader finishes the section knowing a null cell means "no point contributed", without knowing that a *non-null* cell might rest on almost nothing.

## What this adds

The bound, which is a fixed property of the geometry rather than a per-run number. `compute_h3_grid_weights` defaults `child_h3_res` to `h3_res + 2`, sampling each cell with 49 H3 children for a hexagon (7²), and on the V1 grid every `proportion` comes out an exact multiple of 1/49 — checked against `data/h3_grid_weights.parquet`, where multiplying by 49 leaves a maximum deviation from an integer of 1.4e-06 and every cell's numerators sum to exactly 49. So the least a single grid point can carry is 2.0% of its cell. Of that grid's 1671 cells, 294 contain a point at the floor, 572 contain one under 5%, and 859 contain one under 10%.

It is stated as a property of the V1 grid rather than as a guarantee of the code, because it is not one: the repo's own comment at `packages/geo/src/geo/h3.py:93` calls 49 a "~49 sample points per H3 cell (7^2)" heuristic, `child_h3_res` is overridable, and `h3_children_per_h3_parent` is counted per parent — a resolution-5 pentagon has 41 children at resolution 7. GB contains no pentagon, so the V1 figure is exact.

## Scope

Deliberately no code, and deliberately no metric. The measurements were made in a throwaway script against `data/h3_grid_weights.parquet`; nothing from it is committed, because the numbers are properties of a stored artefact anyone can recompute, and a test asserting them would pin the docs to one particular H3 grid.

Why no per-run metric reports the contributing weight is recorded on #506, not here. An earlier draft of this PR put that reasoning on the page; it was cut, because CLAUDE.md's prose rules name "listing what we are *not* doing" as material to delete, and the argument belongs on the issue tracker under the documentation guide's split.

## Review

Sized as simple: prose only, one file, no contract, no asset, no production path. One fresh adversarial sub-agent reviewed the new text against the code and the data, and it earned its keep — every load-bearing finding was confirmed independently before being applied:

- **The cell count was attached to the wrong threshold.** "572 … contain a point that thin" followed a sentence naming the 2.0% floor, but 572 is the count under 5%; at the floor it is 294. Fixed by giving all three levels.
- **The 49 was attributed to the wrong function** — `compute_h3_grid_weights_for_boundary` forwards `child_h3_res` unchanged; the default and the sampling are in `compute_h3_grid_weights` — **and stated too strongly**, as a guarantee of the code rather than a fact about this grid. Both fixed.
- **A whole second paragraph was cut.** It argued why no per-run metric exists, and was wrong in three independent ways: its multipliers were measured per grid point *that feeds a cell* but stated against `n_null_nwp_grid_points`, whose denominator is the whole downloaded 48 × 45 box (2160 points, against the 997 that feed a cell); its "saturation" claim required 30–40% of the grid nulled in a single slice, against a worst archived run of 0.014%; and it read a run total summed over ~4284 slices as though it were one slice.

The first two commits are the original text and the fixes, kept separate so the review is legible in the history.

## Verification

`pymarkdown scan -r docs README.md CLAUDE.md packages/*/README.md` and `mkdocs build --strict` both clean, and the rendered HTML under `site/` was read to confirm the paragraph renders as one paragraph with its code spans intact — the mkdocs-authoring skill is explicit that both linters can pass on visibly broken rendering. `ruff`, `ty` and `pytest` were not run: no Python file is touched, and no test reads `docs/`.
