### PR TITLE
Runbook: vacuum(full=True) reclaims the superseded NWP parquet

### DIFF
--- a/docs/live_service/operations.md
+++ b/docs/live_service/operations.md
@@ -325,16 +325,18 @@ Two things a re-run does cost:
   running.** The two writes contend and the loser fails with delta-rs' `CommitFailedError`. That
   costs a run, not the table, and re-running afterwards is safe. Partitions for *different* dates
   do not contend at all, so a backfill alongside the daily schedule is fine.
-- **The superseded rows stay on disk, and `vacuum` will not clear them.** Delta marks the old
-  parquet files as removed rather than deleting them, so replacing a V1 partition leaves ~7.24M
-  dead rows — about 137 MiB — behind. `DeltaTable.vacuum` reports deleting those files and does
-  not: the `init_time` partition directory's name is percent-encoded, and vacuum deletes at a
-  double-encoded path that does not exist, so it removes nothing while writing vacuum commits
-  saying it did
+- **The superseded rows stay on disk, and the default `vacuum` will not clear them.** Delta marks
+  the old parquet files as removed rather than deleting them, so replacing a V1 partition leaves
+  ~7.24M dead rows — about 137 MiB — behind. `DeltaTable.vacuum()` reports deleting those files and
+  does not: it re-encodes the `init_time` partition directory's already percent-encoded name,
+  deletes at a path that does not exist, and counts the resulting `NotFound` as a deletion
   ([issue #593](https://github.com/openclimatefix/nged-substation-forecast/issues/593)). Reads are
-  unaffected — every reader goes through the transaction log. Until that is fixed, reclaiming the
-  space means listing the current version's add actions, diffing them against what is on disk, and
-  deleting the orphans by hand.
+  unaffected — every reader goes through the transaction log. `vacuum(full=True)` does reclaim the
+  space, because it deletes at paths taken from a storage listing rather than from the tombstones.
+  Run it only when nothing needs an older version of the table: it removes a superseded file once
+  that file is older than the retention window, counting from when the file was *written* rather
+  than from when it was replaced, so time travel to the version before a re-materialisation can go
+  immediately instead of seven days later.
 
 Every materialisation whose completeness assessment succeeded also publishes `n_ensemble_members`,
 `n_valid_times`, `n_h3_cells` and the `valid_time` range as metadata, so the Dagster UI timeline


### PR DESCRIPTION
🤖 Written by Claude Code.

One bullet in the NWP runbook, corrected. Docs only, and the delta-rs bug it describes is still open — tracked in issue #593, which this does not close.

The bullet said reclaiming the superseded parquet files meant diffing the current version's add actions against what is on disk and deleting the orphans by hand. That is not true: `vacuum(full=True)` reclaims them. Full mode deletes at paths taken from a storage listing rather than from the tombstones, and listed paths are correctly encoded, so the delete lands. Verified on a four-cell repro — partition column type (`Timestamp` versus a `String` control) crossed with vacuum mode — where lite mode removed 0 of 1 eligible files and full mode removed 1 of 1.

The bullet also gains the condition that comes with the workaround. Full mode never matches our superseded file to its tombstone, because the tombstone path set is built with the same broken encoding, so it classifies the file as an untracked orphan and deletes it on physical file age. Age is counted from when the file was written, not from when it was replaced, so a re-materialised partition's previous version can become eligible immediately rather than after the seven-day retention window. That matters because reading from a pinned pre-rewrite version is a pattern we rely on, and the grace period that would normally forgive a mistimed vacuum is not there.

The root-cause sentence is corrected too. Vacuum does not fail to decode the path; it encodes an already-encoded one a second time, then counts the resulting `NotFound` as a successful deletion — which is what made the failure silent. Issue #593 now carries the source-level detail, the four-cell repro and a search of the delta-rs tracker showing the same encoding family reported three times before, though never on the vacuum path.

`pymarkdown scan` and `mkdocs build --strict` are clean, and the rendered HTML was read to confirm the bullet survived as one list item with its link intact.
