### PR TITLE
Skill: closingIssuesReferences is not a pre-merge check

### DIFF
--- a/.claude/skills/github-issue-pr-workflow/SKILL.md
+++ b/.claude/skills/github-issue-pr-workflow/SKILL.md
@@ -90,7 +90,7 @@ git log origin/main..HEAD --format='%B' | grep -inE "$KW"
 ```
 
 **`closingIssuesReferences` proves nothing before the merge.** It stays `[]` right up to the point
-the merge lands and only then fills in. A PR body reading "tracked in issue #593, which this does
+the merge lands and only then fills in. A PR body reading "tracked in issue \#593, which this does
 not close" reported `[]` when checked minutes before merging, registered a closing link on merge,
 and closed 593. Commit-message keywords are invisible to the field for the same reason. Treat an
 empty result as no evidence at all.

--- a/.claude/skills/github-issue-pr-workflow/SKILL.md
+++ b/.claude/skills/github-issue-pr-workflow/SKILL.md
@@ -79,25 +79,37 @@ Never squash-merge. We keep the full commit history in `main`, so use a merge co
 (`gh pr merge --merge`) or rebase (`gh pr merge --rebase`), not `gh pr merge --squash`. Under the
 `implement-issue` routine you stop for human review rather than merging at all.
 
-**Check what the merge will close, before you merge.** Issues are closed by two independent
-routes, and you have to check both — neither one shows you the other's:
+**Check what the merge will close, before you merge.** Issues are closed by two independent routes,
+the **PR body** and the **commit messages**, and neither is reliably visible in
+`closingIssuesReferences` beforehand. Read the text yourself:
 
 ```bash
-gh pr view <N> --json closingIssuesReferences --jq '.closingIssuesReferences[].number'
-git log origin/main..HEAD --format='%B' | grep -inE '(close[sd]?|fix(e[sd])?|resolve[sd]?) +#[0-9]+'
+KW='(clos|fix|resolv)[a-z]*.{0,60}#[0-9]+|#[0-9]+.{0,60}(clos|fix|resolv)'
+gh pr view <N> --json body --jq .body | grep -inE "$KW"
+git log origin/main..HEAD --format='%B' | grep -inE "$KW"
 ```
 
-The first lists the links registered from the **PR body** (and the Development sidebar). That list
-is *sticky*: GitHub registers a link when the text containing the keyword is first saved and does
-not drop it when the text is edited away. A PR whose body now reads "filed rather than fixed, see
-\#512" can still hold a closing link to 512 from an early draft, so reading the current body proves
-nothing. A link you did not intend cannot be edited out either — close the PR and open it again
-from the same branch with a clean body.
+**`closingIssuesReferences` proves nothing before the merge.** It stays `[]` right up to the point
+the merge lands and only then fills in. A PR body reading "tracked in issue #593, which this does
+not close" reported `[]` when checked minutes before merging, registered a closing link on merge,
+and closed 593. Commit-message keywords are invisible to the field for the same reason. Treat an
+empty result as no evidence at all.
 
-The second catches keywords in **commit messages**, which close their issue when the commit lands
-on `main` and are invisible to `closingIssuesReferences` beforehand — that field stays `[]` right
-up to the merge. Prose *about* a closure counts: "Merging #514 closed #512" in a commit message
-closes 512. Keep those words away from any issue reference when writing about one.
+**Word order does not save you, and neither does a negation.** GitHub matches the keyword whether
+it falls before or after the reference, and it ignores the "not": both `closes #512` and "#512,
+which this does not close" register the link. Prose *about* a closure counts too — "Merging #514
+closed #512" in a commit message closes 512. When writing about an issue the PR leaves open, keep
+close, fix and resolve out of the sentence entirely. "Tracked separately in #512" and "issue #512
+stays open" are safe; anything pairing the word with the number is not.
+
+**The link is sticky once registered.** GitHub records it when the text containing the keyword is
+first saved and does not drop it when the text is edited away, so a body that now reads "filed
+rather than fixed, see \#512" can still hold a closing link from an early draft. A link you did not
+intend cannot be edited out — close the PR and open it again from the same branch with a clean
+body.
+
+**Check every issue the PR mentioned once the merge lands.** The pre-merge checks tell you about
+the text, not about what GitHub decided to do with it.
 
 **Don't pass `--delete-branch`.** The repo has `delete_branch_on_merge` turned on, so GitHub deletes
 the head branch on merge by itself. The flag only adds a *local* branch deletion, and that step


### PR DESCRIPTION
🤖 Written by Claude Code.

The `github-issue-pr-workflow` skill's "check what the merge will close" section presents `gh pr view --json closingIssuesReferences` as the reliable half of a two-part check. It is not reliable, and following the section as written let a merge close an issue that had to be reopened.

Two things the section got wrong, both learned the hard way this week:

**The field is empty until the merge lands.** The skill already says this about commit-message keywords. It is also true of keywords in the PR body (the reference is written as a placeholder here, because writing it literally would re-trigger the bug this PR documents): a body reading "tracked in issue \<N\>, which this does not close" returned `[]` on the documented check minutes before merging, then registered a closing link at merge time and closed that issue. So the check that was meant to be the safe one reports a clean result in exactly the case it exists to catch. The section now says to treat an empty result as no evidence, and greps the body text directly instead.

**Word order and negation do not matter.** The old grep only matched `<keyword> #<number>`, in that order, which is what GitHub documents. GitHub also matches the keyword *after* the reference and ignores the "not" — which is how the sentence above registered a link at all. The grep is now a single pattern matching either order, applied to the body and the commits alike, and the guidance is to keep close, fix and resolve out of any sentence containing a `#` reference rather than relying on phrasing to disarm them.

The sticky-link paragraph survives unchanged in substance, since that behaviour is real and separate. A closing sentence tells the reader to check every mentioned issue after the merge, handing off to the recovery paragraph already at the end of the section.

`pymarkdown scan` is clean and no line exceeds 100 characters.

Worth knowing before merge: your working copy has uncommitted edits under `.claude/skills/`, so this may conflict with them. This branch is based on `main` and touches only the one section of the one file.
