### PR TITLE
Delete the four dead references to the removed metadata/ directory

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -21,6 +21,3 @@
 
 !/conf
 !/conf/**
-
-!/metadata
-!/metadata/**

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,14 +53,13 @@ ENV GIT_SHA="${GIT_SHA}" \
 WORKDIR /app
 
 # contracts.settings.PROJECT_ROOT walks up to the nearest ancestor holding uv.lock, so copying
-# uv.lock here anchors every repo-relative default (conf/, metadata/) at /app — which is where
-# the COPYs below place those files. conf/ also keeps conf/model/ available so training jobs
-# (register_experiment_job) can run in-container.
+# uv.lock here anchors the repo-relative default (conf/) at /app — which is where the COPY below
+# places it. conf/ also keeps conf/model/ available so training jobs (register_experiment_job)
+# can run in-container.
 COPY --from=builder /app/.venv /app/.venv
 COPY uv.lock ./
 COPY data/production_model/ data/production_model/
 COPY conf/ conf/
-COPY metadata/ metadata/
 
 ENTRYPOINT ["dagster"]
 # This ENTRYPOINT exists for `docker run` smoke-test ergonomics. In the deployed service every

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -349,9 +349,9 @@ somewhere arbitrary in the other — the venv root, in the image's case — and 
 default then fails with `FileNotFoundError`
 ([#287](https://github.com/openclimatefix/nged-substation-forecast/issues/287)). The marker walk
 handles both layouts: a dev checkout resolves to the repo root, and the production image resolves
-to `/app` because the Dockerfile copies `uv.lock` there alongside `conf/` and `metadata/` — so the
-image needs no per-path env-var overrides, and `conf/model/` stays available for running training
-jobs in-container.
+to `/app` because the Dockerfile copies `uv.lock` there alongside `conf/` — so the image needs no
+per-path env-var overrides, and `conf/model/` stays available for running training jobs
+in-container.
 
 The fallback case — a wheel installed into a venv outside any workspace checkout — is a
 deployment shape we don't currently have. If one appears, it must either run with its working

--- a/packages/contracts/src/contracts/settings.py
+++ b/packages/contracts/src/contracts/settings.py
@@ -25,7 +25,7 @@ def _find_project_root(start: Path) -> Path:
     non-editable install (``uv sync --no-editable``) walks up from
     ``<repo>/.venv/lib/python*/site-packages/`` past the venv to the same root. The
     production Docker image copies ``uv.lock`` to ``/app``, so there the root resolves to
-    ``/app``, where the image's ``COPY conf/`` / ``COPY metadata/`` place the resource files.
+    ``/app``, where the image's ``COPY conf/`` places the resource files.
 
     When no ancestor holds a ``uv.lock`` — a wheel installed into a venv outside any
     workspace checkout — fall back to the current working directory. Such a deployment must
@@ -45,8 +45,7 @@ def _find_project_root(start: Path) -> Path:
 
 
 PROJECT_ROOT: Final[Path] = _find_project_root(Path(__file__))
-"""The repo root — anchor for the repo-relative defaults below (``conf/``, ``metadata/``,
-``data/``, ``.env``).
+"""The repo root — anchor for the repo-relative defaults below (``conf/``, ``data/``, ``.env``).
 
 Resolved by :func:`_find_project_root`; see its docstring for the per-install-mode behaviour
 and the caveat for wheels installed outside a workspace checkout.


### PR DESCRIPTION
🤖 This PR was written by [Claude Code](https://claude.com/claude-code).

Commit `2bbce54f` ("Delete the unused NwpMetaData CSV registry") removed `metadata/README.md` and `metadata/nwp_metadata.csv` but left four references to the directory behind. One of them was load-bearing: `Dockerfile:63`'s `COPY metadata/ metadata/` meant **no production image could be built at all**. `scripts/build_and_verify_image.sh` died with

```text
ERROR: failed to build: failed to solve: failed to compute cache key: "/metadata": not found
```

This has been broken on `main` for six days, and was found while doing step 3 of #590 (rebuild the image around the newly-promoted champion). The other three references are prose describing a path the image no longer needs: the `.dockerignore` un-ignore rules, the `PROJECT_ROOT` docstrings in `packages/contracts/src/contracts/settings.py`, and one sentence in `docs/architecture/production-deployment.md`.

## Verification

`scripts/build_and_verify_image.sh` now runs green end to end on the fixed tree:

- `linux/arm64` image `nged-forecast:80a8820932c8` built (2.82 GB).
- The offline `docker run --network=none` smoke test exits 1 for the one expected reason — `TableNotFoundError: Local path "/app/data/NWP" does not exist`, i.e. no NWP volume mounted — and for nothing else. The champion model loaded out of `/app/data/production_model` on the way there.
- `[PASS] zero MLflow mentions — runtime is hermetic.`

Plus `uv run ruff check .`, `uv run ruff format --check .`, `uv run ty check`, `uv run pymarkdown scan …` and `uv run pytest`.

## Scope

Out of scope for #590, so per CLAUDE.md this was raised before it was fixed rather than folded in silently. No sub-agent reviewed the diff — it deletes four references to a directory that does not exist, and the build script passing is the whole of the evidence.

One thing for the reviewer to note: the image built above carries `org.opencontainers.image.revision=a8a24cff`, the tip of `main` *before* this fix, because the build ran against an uncommitted working tree. The runtime contents are unaffected (nothing reads `metadata/`), but the provenance stamp names a commit that cannot build the image. The image wants rebuilding off merged `main` before it is pushed to ECR.
