### PR TITLE
Bump every workspace package to 0.2.0

### DIFF
--- a/packages/contracts/pyproject.toml
+++ b/packages/contracts/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "contracts"
-version = "0.1.0"
+version = "0.2.0"
 description = "Data contracts for the NGED substation forecast project"
 requires-python = ">=3.14"
 dependencies = [

--- a/packages/dashboard/pyproject.toml
+++ b/packages/dashboard/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dashboard"
-version = "0.1.0"
+version = "0.2.0"
 description = "Interactive dashboard web apps for visualising NGED data and forecasts"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/delta_store/pyproject.toml
+++ b/packages/delta_store/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "delta_store"
-version = "0.1.0"
+version = "0.2.0"
 description = "Physical storage policy for the project's Delta tables: parquet writer properties, compression-friendly sort orders, and significand-precision rounding"
 readme = "README.md"
 authors = [

--- a/packages/dynamical_data/pyproject.toml
+++ b/packages/dynamical_data/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dynamical-data"
-version = "0.1.0"
+version = "0.2.0"
 description = "Download & process NWPs from Dynamical.org"
 readme = "README.md"
 authors = [

--- a/packages/geo/pyproject.toml
+++ b/packages/geo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "geo"
-version = "0.1.0"
+version = "0.2.0"
 description = "Generic geospatial logic and data"
 readme = "README.md"
 authors = [

--- a/packages/ml_core/pyproject.toml
+++ b/packages/ml_core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ml_core"
-version = "0.1.0"
+version = "0.2.0"
 description = "Unified ML model interface and shared utilities for substation forecasting."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/nged_data/pyproject.toml
+++ b/packages/nged_data/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nged_data"
-version = "0.1.0"
+version = "0.2.0"
 description = "Package for handling NGED JSON data"
 requires-python = ">=3.14"
 dependencies = [

--- a/packages/notebooks/pyproject.toml
+++ b/packages/notebooks/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "notebooks"
-version = "0.1.0"
+version = "0.2.0"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/plotting/pyproject.toml
+++ b/packages/plotting/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "plotting"
-version = "0.1.0"
+version = "0.2.0"
 description = "OCF brand Altair theme"
 requires-python = ">=3.14"
 dependencies = [

--- a/packages/weather_utils/pyproject.toml
+++ b/packages/weather_utils/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "weather_utils"
-version = "0.1.0"
+version = "0.2.0"
 description = "Shared NWP query helpers reused across the dashboard and the feature pipeline"
 readme = "README.md"
 authors = [

--- a/packages/xgboost_forecaster/pyproject.toml
+++ b/packages/xgboost_forecaster/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "xgboost-forecaster"
-version = "0.1.0"
+version = "0.2.0"
 description = "Add your description here"
 readme = "README.md"
 authors = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 # Metadata (see https://peps.python.org/pep-0621/)
 [project]
 name = "nged-substation-forecast"
-version = "0.1.0"
+version = "0.2.0"
 description = "Forecast net demand at primary, BSP, and GSP substations, and split the forecast into gross demand, solar, and wind per substation for National Grid Electricity Distribution (NGED)"
 readme = {file = "README.md", content-type = "text/markdown"}
 requires-python = ">=3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -736,7 +736,7 @@ wheels = [
 
 [[package]]
 name = "contracts"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/contracts" }
 dependencies = [
     { name = "deltalake" },
@@ -1094,7 +1094,7 @@ wheels = [
 
 [[package]]
 name = "dashboard"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/dashboard" }
 dependencies = [
     { name = "altair" },
@@ -1156,7 +1156,7 @@ wheels = [
 
 [[package]]
 name = "delta-store"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/delta_store" }
 dependencies = [
     { name = "contracts" },
@@ -1275,7 +1275,7 @@ wheels = [
 
 [[package]]
 name = "dynamical-data"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/dynamical_data" }
 dependencies = [
     { name = "contracts" },
@@ -1445,7 +1445,7 @@ wheels = [
 
 [[package]]
 name = "geo"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/geo" }
 dependencies = [
     { name = "contracts" },
@@ -2582,7 +2582,7 @@ wheels = [
 
 [[package]]
 name = "ml-core"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/ml_core" }
 dependencies = [
     { name = "contracts" },
@@ -2818,7 +2818,7 @@ wheels = [
 
 [[package]]
 name = "nged-data"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/nged_data" }
 dependencies = [
     { name = "contracts" },
@@ -2839,7 +2839,7 @@ requires-dist = [
 
 [[package]]
 name = "nged-substation-forecast"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "altair" },
@@ -2939,7 +2939,7 @@ wheels = [
 
 [[package]]
 name = "notebooks"
-version = "0.1.0"
+version = "0.2.0"
 source = { virtual = "packages/notebooks" }
 dependencies = [
     { name = "altair" },
@@ -3337,7 +3337,7 @@ wheels = [
 
 [[package]]
 name = "plotting"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/plotting" }
 dependencies = [
     { name = "altair" },
@@ -4874,7 +4874,7 @@ wheels = [
 
 [[package]]
 name = "weather-utils"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/weather_utils" }
 dependencies = [
     { name = "polars" },
@@ -5031,7 +5031,7 @@ wheels = [
 
 [[package]]
 name = "xgboost-forecaster"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/xgboost_forecaster" }
 dependencies = [
     { name = "contracts" },


### PR DESCRIPTION
🤖 This PR was written by [Claude Code](https://claude.com/claude-code).

`v0.2.0` is marked by an annotated git tag, but the declared package versions stayed at `0.1.0`, so `pip list` inside the production image reported the wrong release. This bumps the root project and all eleven workspace packages in lockstep, and re-locks.

The `uv.lock` change is exactly 12 version lines and nothing else — no dependency drift.

## Why the lock has to move with it

`uv.lock` records workspace member versions, and `Dockerfile:38` runs `uv sync --frozen`. A bump without a re-lock fails the image build outright rather than degrading quietly, which is the good failure mode but still a failure.

## Declarative only

Nothing reads these numbers at runtime. There is no `__version__` attribute and no `importlib.metadata` call anywhere in `src/`, `packages/` or `scripts/`, and nothing here is published to PyPI. The one thing the bump buys is that the release is legible from inside the container without git.

Worth naming the cost, since it is the argument that kept these at `0.1.0`: lockstep numbers overclaim. `geo` going to `0.2.0` implies `geo` changed, when the number really only tracks the repo. With no downstream consumers nobody is misled, but a future reader might read more into it than is there.

## Verification

`uv run ruff check .`, `uv run --all-packages ty check`, `uv run pytest` (690 passed, 1 skipped), and the pre-commit hook. Grepped for stale `0.1.0` references outside `uv.lock` — none.

## Follow-ups for the reviewer

The image built for the `v0.2.0` push carries the pre-bump wheels, so it wants rebuilding off this commit if the installed metadata is to match the tag — and that raises the question of whether `v0.2.0` should be re-pointed here (nothing consumes the tag yet, so it is cheap either way).

There is also no written release procedure anywhere in `docs/` — no page describes tagging, bumping, or the order of the two. That is what made this step ambiguous in #383. Happy to write one if you want it, but it is out of scope here.

## Scope

No sub-agent reviewed this diff: it is 12 one-line version changes plus the lock they imply.
