### PR TITLE
Record the v0.1 retirement and v0.2 deployment in the intervention log

### DIFF
--- a/docs/live_service/intervention-log.md
+++ b/docs/live_service/intervention-log.md
@@ -78,10 +78,9 @@ the plainest possible case of the selective reading these hypotheses exist to pr
 
 ## The log
 
-*No interventions recorded yet.*
-
 | Date | Trigger | Cause | Minutes | Runbook? | Notes |
 |---|---|---|---|---|---|
+| 2026-08-13 19:56 | Sentry alarm — but from the pre-v0.2 code on a laptop, not from AWS | `upstream-outage` | <5 | yes | Dynamical.org first published the 2026-08-09 00Z ECMWF run with a variable wholly missing, and v0.1 treated that as fatal, so the partition was re-materialised by hand. Four forecast slots ran on the previous day's run in the meantime. [#493](https://github.com/openclimatefix/nged-substation-forecast/pull/493) added the retry that covers it |
 
 ## Periods covered
 
@@ -90,48 +89,65 @@ empty log with no stated period is indistinguishable from a log nobody kept.
 
 | Period | Version | Scope | Interventions | Scores T1.1? |
 |---|---|---|---|---|
-| 2026-07-15 18:00 UTC → 2026-08-13 19:00 UTC | v0.1 | 28 time series, 6-hourly `live_forecasts` on AWS | 0 | No — pre-v1.0 |
-| 2026-08-14 00:00 UTC → ongoing | v0.2 | 31 time series, 6-hourly `live_forecasts` on AWS, every slot checked by `live_forecasts_are_healthy` | 0 | No — pre-v1.0 |
+| 2026-07-15 18:00 UTC → 2026-08-14 00:00 UTC | v0.1 | 28 time series, 6-hourly `live_forecasts` on AWS | 1 | No — pre-v1.0 |
+| 2026-08-14 00:00 UTC → ongoing | v0.2 | 31 time series, 6-hourly `live_forecasts` on AWS, with `live_forecasts_are_healthy` reporting on each slot | 0 | No — pre-v1.0 |
 
-Figures below are stated as of **08:00 UTC on 14 August 2026**. Every count in this section moves
+Figures below are stated as of **07:00 UTC on 14 August 2026**. Every count in this section moves
 within the day, so the as-of instant is part of the measurement rather than a formality.
 
 ### v0.1 on AWS, 2026-07-15 to 2026-08-13
 
 The first `live_forecasts` run on AWS was the 18:00 UTC slot on 15 July 2026, and the last was the
 18:00 UTC slot on 13 August 2026, an hour before the v0.1 stack was retired at roughly 19:00 UTC
-that evening to make way for v0.2. That is a window of 29 days and 1 hour, over which the schedule
-called for 117 consecutive 6-hourly forecast slots and a daily `ecmwf_ens` run, with **zero
-interventions and zero observed failures**. Every expected forecast exists.
+that evening to make way for v0.2. Over that window the schedule called for 117 consecutive
+6-hourly forecast slots, and **every one of them produced a forecast for all 28 time series**. One
+ECMWF run was lost and one human intervention was needed, both described below.
 
-The VM was deployed once, on 15 July, and was not touched again until it was retired: no code was
-pushed to AWS during the period. So the window is genuinely unattended rather than quietly
-maintained.
+The VM was deployed once, on 15 July, and no code was pushed to AWS until it was retired. The one
+operator action in the window was the NWP backfill logged above, so the period is close to
+unattended but not entirely so.
 
 *Verified by* counting distinct `power_fcst_init_time` values with `fold_id = "live"` and
 `experiment_name = "xgboost_cv_0001"` — v0.1's promoted model — in the `power_forecasts` Delta
 table on S3. All 117 scheduled slots are present, every consecutive pair is exactly six hours
-apart, and all 28 time series appear in every one of the 117. Cross-checked against the Dagster run
-history and the Sentry missed-check-in monitor, which never alarmed.
+apart, and all 28 time series appear in every one of the 117.
 
-Three caveats, without which the number would be worth less than it looks:
+### The 9 August ECMWF run, and what it shows
 
-- **"Zero observed failures" is a weaker claim than "zero failures".** v0.1 implemented very little
-  failure detection: `live_forecasts_are_healthy` — the check that reads each slot's rows back and
-  reports missed NWP runs — arrives with v0.2, after this window closed. What is
-  genuinely verified is that every scheduled slot produced output, not that nothing degraded
-  quietly on the way. A silently-stale input is precisely the failure mode this stack is built to
-  make visible, and at v0.1 it would not yet be visible.
+Dynamical.org publishes each ECMWF run as roughly 40 separate Icechunk commits, so a run can be
+readable and incomplete at the same time. The 2026-08-09 00Z run was first published with a weather
+variable wholly missing, and repaired 3 hours 25 minutes later. v0.1 treated a wholly-missing
+variable as fatal, so its `ecmwf_ens` run failed and no partition was written for 9 August. The
+partition was re-materialised by hand on 13 August at 19:56 UTC.
+
+The forecast did not stop. Four slots — 2026-08-09 12:00 UTC through 2026-08-10 06:00 UTC — ran on
+the 8 August 00Z run instead, at 36, 42, 48 and 54 hours old against the 12–30 hours a healthy slot
+sees. Every other slot in the window used NWP no older than 30 hours.
+
+That is [Principle 1](../design-philosophy/design-principles.md) — the power forecast never stops —
+working in production rather than on paper, and it is the more interesting result on this page. A
+missing input degraded the forecast instead of stopping it, and the degradation was bounded and
+visible after the fact. v0.2 closes the gap that made the intervention necessary at all: a
+wholly-missing variable is now a retryable "not ready yet" rather than a fatal error, with a
+four-hour retry budget that covers the 3h25m this republication took.
+
+Three caveats, without which the window would be worth more than it is:
+
+- **Nothing alerted us from AWS.** The Sentry alarm that surfaced the missed run came from the
+  pre-v0.2 code running on a laptop, not from the deployed stack, and the missed-check-in monitor
+  never fired. `live_forecasts_are_healthy` — the check that reads each slot's rows back and
+  reports missed NWP runs — landed in v0.2, after this window closed. The four degraded slots were
+  reconstructable only because `nwp_init_time` travels on every forecast row. So the degradation
+  was recoverable from the data, but nothing in the deployment announced it.
 - **A month is short, and this is the easy case.** v0.1 is 28 time series and one ECMWF run
-  per day. The dominant cause T1.1 predicts — an upstream contract change — may simply not have
-  happened yet in a window this short. A quiet four weeks is consistent both with "the design
-  works" and with "nothing has been thrown at it".
+  per day. The dominant cause T1.1 predicts — an upstream contract change — did not happen in a
+  window this short; a partial publication is a milder fault than a changed schema.
 - **It does not score.** The window opens at v1.0, [as above](#the-scoring-window-opens-at-v10).
 
 So what this is, stated plainly: **weak, non-scoring evidence for H1, drawn from a window the
-scoring rule excludes and gathered with detection too thin to see quiet degradation.** The deployed
-stack served every scheduled slot for 29 days without a human touching it. That is worth recording,
-and it is not worth more than that.
+scoring rule excludes.** The deployed stack served all 117 scheduled slots over 29 days, absorbed
+one lost NWP run by degrading rather than stopping, and cost a human about a minute. That is worth
+recording, and it is not worth more than that.
 
 ### v0.2 on AWS, from 2026-08-14
 
@@ -143,10 +159,16 @@ in [the log](#the-log).
 v0.2 forecasts 31 time series, three more than v0.1, under the promoted model
 `xgboost_cv_0003`. The 00:00 and 06:00 UTC slots on 14 August both carry all 31.
 
-The window is too young to say anything about yet. What is different from v0.1, and what makes the
-next stretch worth more than the last one, is that `live_forecasts_are_healthy` now reads each
-slot's rows back and reports missed NWP runs — so a slot that produces output from stale inputs is
-visible rather than silent, and the first caveat above no longer applies from here on.
+Two things make the next stretch better evidence than the last. `live_forecasts_are_healthy` reads
+each succeeding slot's rows back and reports missed NWP runs, so a slot forecasting from stale
+inputs is recorded as degraded rather than passing unremarked. And a wholly-missing NWP variable is
+now retried for four hours instead of failing, which is what would have made the 9 August
+intervention unnecessary.
+
+Both narrow the first caveat above without closing it. The check is `WARN` and non-blocking, so it
+colours the slot in the Dagster Checks view and alerts nobody; a slot whose run raised fails
+outright rather than being checked; and the 9 August alarm reached us from a laptop rather than
+from AWS, which nothing in v0.2 changes.
 
 ## See also
 

--- a/docs/live_service/intervention-log.md
+++ b/docs/live_service/intervention-log.md
@@ -90,10 +90,10 @@ empty log with no stated period is indistinguishable from a log nobody kept.
 
 | Period | Version | Scope | Interventions | Scores T1.1? |
 |---|---|---|---|---|
-| 2026-07-15 18:00 UTC → 2026-08-13 19:00 UTC | v0.1 | 32 time series, 6-hourly `live_forecasts` on AWS | 0 | No — pre-v1.0 |
-| 2026-08-14 00:00 UTC → ongoing | v0.2 | 6-hourly `live_forecasts` on AWS, every slot checked by `live_forecasts_are_healthy` | 0 | No — pre-v1.0 |
+| 2026-07-15 18:00 UTC → 2026-08-13 19:00 UTC | v0.1 | 28 time series, 6-hourly `live_forecasts` on AWS | 0 | No — pre-v1.0 |
+| 2026-08-14 00:00 UTC → ongoing | v0.2 | 31 time series, 6-hourly `live_forecasts` on AWS, every slot checked by `live_forecasts_are_healthy` | 0 | No — pre-v1.0 |
 
-Figures below are stated as of **06:00 UTC on 14 August 2026**. Every count in this section moves
+Figures below are stated as of **08:00 UTC on 14 August 2026**. Every count in this section moves
 within the day, so the as-of instant is part of the measurement rather than a formality.
 
 ### v0.1 on AWS, 2026-07-15 to 2026-08-13
@@ -102,18 +102,17 @@ The first `live_forecasts` run on AWS was the 18:00 UTC slot on 15 July 2026, an
 18:00 UTC slot on 13 August 2026, an hour before the v0.1 stack was retired at roughly 19:00 UTC
 that evening to make way for v0.2. That is a window of 29 days and 1 hour, over which the schedule
 called for 117 consecutive 6-hourly forecast slots and a daily `ecmwf_ens` run, with **zero
-interventions and zero observed failures**.
+interventions and zero observed failures**. Every expected forecast exists.
 
 The VM was deployed once, on 15 July, and was not touched again until it was retired: no code was
 pushed to AWS during the period. So the window is genuinely unattended rather than quietly
 maintained.
 
-*Verified by* counting distinct `power_fcst_init_time` values with `fold_id = "live"` in the
-`power_forecasts` Delta table across the period, cross-checked against the Dagster run history and
-the Sentry missed-check-in monitor, which never alarmed. That count was last run on 7 August, when
-it matched the 91 slots the schedule called for by then; the final 26 slots of the window are
-recorded here on the strength of the Dagster run history and the silent monitor alone, and the
-distinct-`power_fcst_init_time` count still needs re-running over the closed window.
+*Verified by* counting distinct `power_fcst_init_time` values with `fold_id = "live"` and
+`experiment_name = "xgboost_cv_0001"` — v0.1's promoted model — in the `power_forecasts` Delta
+table on S3. All 117 scheduled slots are present, every consecutive pair is exactly six hours
+apart, and all 28 time series appear in every one of the 117. Cross-checked against the Dagster run
+history and the Sentry missed-check-in monitor, which never alarmed.
 
 Three caveats, without which the number would be worth less than it looks:
 
@@ -123,7 +122,7 @@ Three caveats, without which the number would be worth less than it looks:
   genuinely verified is that every scheduled slot produced output, not that nothing degraded
   quietly on the way. A silently-stale input is precisely the failure mode this stack is built to
   make visible, and at v0.1 it would not yet be visible.
-- **A month is short, and this is the easy case.** v0.1 is 32 time series and one ECMWF run
+- **A month is short, and this is the easy case.** v0.1 is 28 time series and one ECMWF run
   per day. The dominant cause T1.1 predicts — an upstream contract change — may simply not have
   happened yet in a window this short. A quiet four weeks is consistent both with "the design
   works" and with "nothing has been thrown at it".
@@ -140,6 +139,9 @@ v0.2 was deployed on the evening of 13 August 2026, replacing the v0.1 stack at 
 Its first `live_forecasts` run was the 00:00 UTC slot on 14 August 2026, which is where this period
 starts. The deployment itself is a deliberate upgrade, so it is not an intervention and has no row
 in [the log](#the-log).
+
+v0.2 forecasts 31 time series, three more than v0.1, under the promoted model
+`xgboost_cv_0003`. The 00:00 and 06:00 UTC slots on 14 August both carry all 31.
 
 The window is too young to say anything about yet. What is different from v0.1, and what makes the
 next stretch worth more than the last one, is that `live_forecasts_are_healthy` now reads each

--- a/docs/live_service/intervention-log.md
+++ b/docs/live_service/intervention-log.md
@@ -90,44 +90,61 @@ empty log with no stated period is indistinguishable from a log nobody kept.
 
 | Period | Version | Scope | Interventions | Scores T1.1? |
 |---|---|---|---|---|
-| 2026-07-15 18:00 UTC → ongoing | v0.1 | 32 time series, 6-hourly `live_forecasts` on AWS | 0 | No — pre-v1.0 |
+| 2026-07-15 18:00 UTC → 2026-08-13 19:00 UTC | v0.1 | 32 time series, 6-hourly `live_forecasts` on AWS | 0 | No — pre-v1.0 |
+| 2026-08-14 00:00 UTC → ongoing | v0.2 | 6-hourly `live_forecasts` on AWS, every slot checked by `live_forecasts_are_healthy` | 0 | No — pre-v1.0 |
 
-Figures below are stated as of **06:00 UTC on 7 August 2026**. Every count in this section moves
+Figures below are stated as of **06:00 UTC on 14 August 2026**. Every count in this section moves
 within the day, so the as-of instant is part of the measurement rather than a formality.
 
-### v0.1 on AWS, from 2026-07-15
+### v0.1 on AWS, 2026-07-15 to 2026-08-13
 
-The first `live_forecasts` run on AWS was the 18:00 UTC slot on 15 July 2026. That is 22 days and
-12 hours at the time of writing (7th August 2026) — 91 consecutive 6-hourly forecast slots, and 22
-daily `ecmwf_ens` runs — with **zero interventions and zero observed failures**. Every expected
-forecast exists.
+The first `live_forecasts` run on AWS was the 18:00 UTC slot on 15 July 2026, and the last was the
+18:00 UTC slot on 13 August 2026, an hour before the v0.1 stack was retired at roughly 19:00 UTC
+that evening to make way for v0.2. That is a window of 29 days and 1 hour, over which the schedule
+called for 117 consecutive 6-hourly forecast slots and a daily `ecmwf_ens` run, with **zero
+interventions and zero observed failures**.
 
-The VM was deployed once, on 15 July, and has not been touched since: no code has been pushed to
-AWS during the period, and the next deployment will be v0.2. So the period is genuinely unattended
-rather than quietly maintained.
+The VM was deployed once, on 15 July, and was not touched again until it was retired: no code was
+pushed to AWS during the period. So the window is genuinely unattended rather than quietly
+maintained.
 
 *Verified by* counting distinct `power_fcst_init_time` values with `fold_id = "live"` in the
 `power_forecasts` Delta table across the period, cross-checked against the Dagster run history and
-the Sentry missed-check-in monitor, which never alarmed.
+the Sentry missed-check-in monitor, which never alarmed. That count was last run on 7 August, when
+it matched the 91 slots the schedule called for by then; the final 26 slots of the window are
+recorded here on the strength of the Dagster run history and the silent monitor alone, and the
+distinct-`power_fcst_init_time` count still needs re-running over the closed window.
 
 Three caveats, without which the number would be worth less than it looks:
 
 - **"Zero observed failures" is a weaker claim than "zero failures".** v0.1 implemented very little
   failure detection: `live_forecasts_are_healthy` — the check that reads each slot's rows back and
-  reports missed NWP runs — landed in v0.2, after this window closed. What is
+  reports missed NWP runs — arrives with v0.2, after this window closed. What is
   genuinely verified is that every scheduled slot produced output, not that nothing degraded
   quietly on the way. A silently-stale input is precisely the failure mode this stack is built to
   make visible, and at v0.1 it would not yet be visible.
-- **Twenty-two days is short, and this is the easy case.** v0.1 is 32 time series and one ECMWF run
+- **A month is short, and this is the easy case.** v0.1 is 32 time series and one ECMWF run
   per day. The dominant cause T1.1 predicts — an upstream contract change — may simply not have
-  happened yet in a window this short. A quiet three weeks is consistent both with "the design
+  happened yet in a window this short. A quiet four weeks is consistent both with "the design
   works" and with "nothing has been thrown at it".
 - **It does not score.** The window opens at v1.0, [as above](#the-scoring-window-opens-at-v10).
 
 So what this is, stated plainly: **weak, non-scoring evidence for H1, drawn from a window the
 scoring rule excludes and gathered with detection too thin to see quiet degradation.** The deployed
-stack served every scheduled slot for 22 days without a human touching it. That is worth recording,
+stack served every scheduled slot for 29 days without a human touching it. That is worth recording,
 and it is not worth more than that.
+
+### v0.2 on AWS, from 2026-08-14
+
+v0.2 was deployed on the evening of 13 August 2026, replacing the v0.1 stack at roughly 19:00 UTC.
+Its first `live_forecasts` run was the 00:00 UTC slot on 14 August 2026, which is where this period
+starts. The deployment itself is a deliberate upgrade, so it is not an intervention and has no row
+in [the log](#the-log).
+
+The window is too young to say anything about yet. What is different from v0.1, and what makes the
+next stretch worth more than the last one, is that `live_forecasts_are_healthy` now reads each
+slot's rows back and reports missed NWP runs — so a slot that produces output from stale inputs is
+visible rather than silent, and the first caveat above no longer applies from here on.
 
 ## See also
 


### PR DESCRIPTION
*This PR was written by Claude Code.*

The v0.1 stack was retired from AWS at roughly 19:00 UTC on 13 August 2026 and replaced with v0.2, whose first `live_forecasts` run was the 2026-08-14T00Z slot. This records both, and — after an adversarial review of the first draft — records the NWP outage the v0.1 window actually contained, which the page had been about to describe as a clean sweep.

## The v0.1 window was not clean

The first draft of this PR carried the page's existing claim of "zero interventions and zero observed failures" forward across the closed window. That claim was wrong, and the production Delta tables show it:

- **The 9 August `ecmwf_ens` run produced nothing.** The NWP table's history jumps from version 24 (`2026-08-08T08:31:39Z`) straight to version 25 (`2026-08-10T08:31:30Z`). Every other day in the window has an ~08:31 UTC write.
- **Four forecast slots ran degraded.** 2026-08-09 12:00 through 2026-08-10 06:00 UTC all forecast from the 2026-08-08 00Z run, at 36/42/48/54 hours old. Every one of the other 113 slots used NWP no older than 30 hours.
- **A human re-materialised the partition on 13 August at 19:56 UTC.** Version 29 is the only write in the NWP table's entire history carrying a predicate, and it targets exactly `init_time = 2026-08-09T00:00:00`.

The cause was an upstream partial publication: Dynamical.org publishes each run as ~40 Icechunk commits, and this one was first published with a weather variable wholly missing, then repaired 3h25m later. v0.1 treated that as fatal. #493 has since made it a retryable "not ready yet" with a four-hour budget, which covers the observed republication delay.

**This makes the window better evidence for H1 than a clean sweep would have been.** A missing input degraded the forecast instead of stopping it — Principle 1 working in production rather than on paper — and the degradation was bounded and reconstructable after the fact from `nwp_init_time` on each forecast row.

It also exposes a real detection gap, now stated on the page: the Sentry alarm that surfaced the missed run came from pre-v0.2 code running on a laptop, not from the deployed stack, and the missed-check-in monitor never fired.

## What changed

- **The log has its first row** — `2026-08-13 19:56`, `upstream-outage`, `<5` minutes, Runbook? `yes`.
- **Periods table** — v0.1 closed at `2026-08-14 00:00 UTC` with 1 intervention; v0.2 added from that instant, so the backfill does not fall into a gap between the two periods. Time-series counts corrected from 32 to 28 (v0.1) and 31 (v0.2); 32 is the trial-area size, not what the promoted model forecasts.
- **v0.1 section** — retitled to the closed range, verified end to end, and a new subsection on the 9 August run and what it shows.
- **New v0.2 section** — the deployment, the first slot, and the two things that make the next stretch better evidence: the health check, and the NWP retry.

## Verification

Every figure on the page was read from the production `power_forecasts` table in the delivery bucket (`fold_id = "live"`) and the `NWP` table in the internal bucket:

| Claim | Result |
|---|---|
| v0.1 range 2026-07-15 18:00 → 2026-08-13 18:00 UTC | confirmed |
| 117 slots, no gaps, every consecutive pair exactly 6h apart | confirmed |
| 28 time series in every one of the 117 slots | confirmed |
| v0.2: 31 series, 00Z and 06Z on 14 Aug, both carrying all 31 | confirmed; the 28 are a strict subset of the 31 |
| Four slots at 36–54h NWP age, all others ≤30h | confirmed |
| No NWP write on 9 August; predicated backfill at 13 Aug 19:56 UTC | confirmed |

`pymarkdown scan` and `mkdocs build --strict` pass, and the rendered HTML was read back — per the `mkdocs-authoring` skill, both linters can pass on markdown that renders visibly wrong.

Two figures rest on the maintainer's account rather than on data, and both are hedged in the page: the retirement at "roughly 19:00 UTC" (corroborated by the v0.2.0 version-bump merge at 19:00:29 UTC) and the intervention costing about a minute.

Docs only; no code changed. One adversarial sub-agent reviewed the diff; its findings are triaged in the comments below.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
