### PR TITLE
Say that a WARN check not alerting is an omission, not a limit

### DIFF
--- a/docs/live_service/intervention-log.md
+++ b/docs/live_service/intervention-log.md
@@ -165,10 +165,13 @@ inputs is recorded as degraded rather than passing unremarked. And a wholly-miss
 now retried for four hours instead of failing, which is what would have made the 9 August
 intervention unnecessary.
 
-Both narrow the first caveat above without closing it. The check is `WARN` and non-blocking, so it
-colours the slot in the Dagster Checks view and alerts nobody; a slot whose run raised fails
-outright rather than being checked; and the 9 August alarm reached us from a laptop rather than
-from AWS, which nothing in v0.2 changes.
+Both narrow the first caveat above without closing it. A degraded slot is recorded but not
+announced: `live_forecasts_are_healthy` returns its warning to Dagster's Checks view and sends
+nothing to Sentry, and the slot's check-in still reports the service healthy, so a degraded run
+looks like a good one from outside. Nothing about `WARN` severity forces that — `power_data_is_fresh`
+warns *and* raises a Sentry event through `report_power_freshness` — it is simply not wired up on
+this path. A slot whose run raised is checked by nothing at all, and the 9 August alarm reached us
+from a laptop rather than from AWS, which nothing in v0.2 changes.
 
 ## See also
 

--- a/docs/live_service/operations.md
+++ b/docs/live_service/operations.md
@@ -286,8 +286,10 @@ raising with Dynamical.org. Only a variable empty in *every* slice is rejected a
 the time you read it.** Everything short of a wholly-empty variable lands, so
 `n_whole_null_h3_slices` is not merely informational — it is the sole signal distinguishing a run
 that lost two slices from one that lost nearly all of them, and both land looking equally green.
-Nothing downstream consumes it: no training filter, no metric, and no Sentry alert, because
-Sentry fires on a failed *run* and a WARN check is not one. Correcting a badly-degraded run means
+Nothing downstream consumes it: no training filter, no metric, and no Sentry alert. That last one
+is an omission rather than a limit — a warning check can raise a Sentry event without failing its
+run, which is exactly what `power_data_is_fresh` does through `report_power_freshness`; this check
+simply does not do it. Correcting a badly-degraded run means
 re-materialising its partition by hand, once the upstream data is fixed. So if this count is ever
 large rather than a handful, treat it as an incident to act on deliberately — the pipeline will not
 act on it for you. Making a large count escalate is tracked in


### PR DESCRIPTION
*This PR was written by Claude Code.*

Two pages explained the missing Sentry alert on a degradation warning by claiming Sentry only fires on a failed *run*, so a non-blocking `WARN` check cannot notify anyone. That is not true, and it framed the silence as a property of `WARN` rather than as the gap it is. Keeping the forecast running while telling us it degraded is the design; one path just does not do the telling.

## What the code actually does

**`power_data_is_fresh` notifies.** On its normal path it calls `report_power_freshness` (`checks.py:399`), which sends a `warning`-level Sentry event whenever the result is unhealthy, fingerprinted per environment so hourly re-reports collapse into a single issue. The check still returns `WARN`, the run still passes, and an email still goes out.

**`live_forecasts_are_healthy` does not.** Its only Sentry call is `report_check_degradation` (`checks.py:1016`), and it sits inside the `except` handler — it fires when the check cannot evaluate its own inputs, not when it successfully finds `n_missed_nwp_runs > 0` or a missing slice of the trained population. That path runs through `_to_live_forecast_check_result` (`checks.py:936`), which builds an `AssetCheckResult` and stops. Nothing leaves the process.

**The heartbeat does not know either.** `send_forecast_checkin` fires after any successful live write (`production_assets.py:326`), gated on `availability_mode == "live"` and not on health, so a degraded slot actively signals that the service is alive and well.

Had the 9 August NWP outage recorded in the intervention log happened under v0.2, the result would have been a yellow tick in Dagster's Checks view and a healthy check-in.

## What changed

- **`docs/live_service/intervention-log.md`** — the v0.2 paragraph said the check "colours the slot in the Dagster Checks view and alerts nobody", presented as following from `WARN` being non-blocking. It now says a degraded slot is recorded but not announced, names `power_data_is_fresh`/`report_power_freshness` as the counter-example, and adds that the check-in still reports the service healthy.
- **`docs/live_service/operations.md`** — "no Sentry alert, because Sentry fires on a failed *run* and a WARN check is not one" becomes "no Sentry alert. That last one is an omission rather than a limit", with the same counter-example. That passage is about the NWP `n_whole_null_h3_slices` count, whose escalation is already tracked in #501; only the stated reason was wrong.

No issue filed for the `live_forecasts_are_healthy` gap, at the maintainer's direction. For the record, the closest roadmap item is the per-task failure email alerting follow-up in `docs/roadmap/live-service.md`, but that covers failed *runs* — the case that is already loud — not the WARN-degradation path.

## Verification

`pymarkdown scan` and `mkdocs build --strict` pass on both files, and both rendered passages were read back out of `site/` — per the `mkdocs-authoring` skill, both linters can pass on markdown that renders visibly wrong.

Docs only; no code changed. No sub-agent reviewed this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
