### PR TITLE
Design the two £ cost-savings leaderboard metrics

### DIFF
--- a/docs/roadmap/cost-savings-metrics.md
+++ b/docs/roadmap/cost-savings-metrics.md
@@ -58,8 +58,8 @@ $$
 
 where $V_{i,t}$ is the volume the model would have bought (or curtailed) for time series $i$ in
 half-hour $t$, and $N_{i,t}$ is the volume that turned out to be needed. Measuring unmet *energy*
-rather than counting missed events matters: at a p99 limit the events are rare, and a count of them
-is too noisy to rank models by.
+rather than counting missed events matters: exceedances of the limit are rare by construction, and
+a count of them is too noisy to rank models by.
 
 **$\tau$ is calibrated on training folds only.** Tuning it on the fold being scored would let a
 model see its own future, and every pound of the resulting "saving" would be lookahead.
@@ -142,26 +142,23 @@ experiment.
 ## Choosing the limit
 
 Real network limits move with ambient temperature, with how long an overload lasts, with season and
-with switching state, so no single number is correct. We use a **synthetic limit** — a percentile
-of each series' own full observation history, for the same full-history stability reason the
-[NMAE denominator](metrics-and-leaderboard.md#normalising-nmae-by-effective_capacity) uses — and
-report the metric at **both the 95th and 99th percentiles**, labelled `hist_p95` and `hist_p99`.
+with switching state, so no single number is correct. We use a **synthetic limit**: the **95th
+percentile of each series' own full observation history**, for the same full-history stability
+reason the [NMAE denominator](metrics-and-leaderboard.md#normalising-nmae-by-effective_capacity)
+uses. Its label is `historical_p95`, kept distinct from the forecast-quantile label `p95` — one is
+a fixed power level derived from history, the other a level of the forecast distribution.
+
+This is the same single rung the [tail and exceedance
+metrics](metrics-and-leaderboard.md#tail-exceedance-metrics-scoring-the-question-nged-actually-asks)
+use, so the leaderboard carries one threshold concept rather than several. We chose the 95th over
+the 99th because 99th-percentile exceedances are rare enough that the resulting numbers may be too
+noisy to separate models — but NGED talked in terms of the 99th, so
+[question 6](#questions-for-nged) puts the choice back to them.
 
 NGED offered real firm and flex capacities for the trial area, and we want them — for the case
-studies below, and to check that the synthetic limits land somewhere sensible. They cannot replace
-the synthetic limit for ranking, because a real rating that was never breached during the scoring
-window produces zero exceedance events, and no model can be graded on events that never happened.
-
-The 99th percentile is the better stand-in for a network close to its limit only at winter peak.
-The 95th exists because 99th-percentile exceedances may be too rare to separate models, and that is
-a question for data rather than assumption. If the two rank models identically we keep the 99th
-alone.
-
-**This ladder differs from the one the tail and exceedance metrics use** (the 90th and 98th
-percentiles, `hist_p90` / `hist_p98`). NGED endorsed the 95th/99th for procurement decisions; the
-older rungs were our own choice, made before that conversation. Two ladders on one leaderboard is
-not a good end state and [#254](https://github.com/openclimatefix/nged-substation-forecast/issues/254)
-should reconcile them.
+studies below, and to check that the synthetic limit lands somewhere sensible. They cannot replace
+it for ranking, because a real rating that was never breached during the scoring window produces
+zero exceedance events, and no model can be graded on events that never happened.
 
 ## What these numbers do not capture
 
@@ -187,9 +184,9 @@ should reconcile them.
 - **Ensemble size limits how finely $\tau$ can be tuned.** Manual review has 13 analogues, so its
   quantiles come in coarse steps; a 51-member ensemble is far finer. Models of different ensemble
   size cannot be landed on exactly the same risk.
-- **Costs are per fold, and folds are seasonal.** A 99th-percentile limit concentrates exceedances
-  at winter peak, so annualising a fold that does not span a whole year is meaningless. A fold with
-  no exceedance at all leaves the unmet fraction undefined.
+- **Costs are per fold, and folds are seasonal.** The limit concentrates exceedances at winter
+  peak, so annualising a fold that does not span a whole year is meaningless. A fold with no
+  exceedance at all leaves the unmet fraction undefined.
 - **Nothing is validated against real spend**, except at the trial-area sites that sit in an actual
   flexibility zone. There are a couple, and they are the case studies that tell us whether these
   numbers are the right order of magnitude.
@@ -211,7 +208,10 @@ should reconcile them.
    procured-versus-needed volumes for a single zone would anchor it.
 5. **Is the 95th percentile of the 13 analogues the operating point** you actually work from, and
    what reliability do you target — how much genuinely-needed flexibility may go unbought?
-6. **Which trial-area sites have curtailable generation**, which sit in a real flexibility zone with
+6. **Is the 95th percentile the right limit to score against?** You talked in terms of the 99th. We
+   went with the 95th because 99th-percentile exceedances look too rare to rank models cleanly, but
+   the choice is yours to overrule.
+7. **Which trial-area sites have curtailable generation**, which sit in a real flexibility zone with
    procurement history we can use as a case study, and can we have the firm and flex capacities?
 
 ## Implementation details (deleted when this ships)
@@ -219,12 +219,11 @@ should reconcile them.
 - Two functions in `packages/ml_core/src/ml_core/metrics.py`, sharing a private helper taking the
   limit, the price and the direction. They consume the same ensemble-member rows as the existing
   quantile metrics.
-- **This needs a `Metrics` contract change, to be agreed before it is written**: `METRIC_NAMES`
-  gains `flex_procurement_cost_gbp`, `curtailment_cost_gbp` and `unmet_fraction`, and
-  `METRIC_PARAMS` gains `hist_p95` / `hist_p99`. The `hist_` prefix is not decoration — bare
-  `"p95"` and `"p99"` already exist in `QUANTILE_METRIC_PARAMS` meaning *forecast* quantiles, and
-  the tail-metric design chose the prefix precisely to keep a history-derived power level distinct
-  from a level of the forecast distribution.
+- **This needs a `Metrics` contract change, still to be reviewed and agreed when we implement**:
+  `METRIC_NAMES` gains `flex_procurement_cost_gbp`, `curtailment_cost_gbp` and `unmet_fraction`,
+  and `METRIC_PARAMS` gains `historical_p95`. The prefix is not decoration — bare `"p95"` already
+  exists in `QUANTILE_METRIC_PARAMS` meaning a *forecast* quantile, and a history-derived power
+  level has to stay distinct from a level of the forecast distribution.
 - Costs are stored **per `time_series_id`**, summed over time only, so they fit the existing primary
   key; the portfolio headline is their sum. Only $\tau$ and the unmet target are pooled across
   series.

--- a/docs/roadmap/cost-savings-metrics.md
+++ b/docs/roadmap/cost-savings-metrics.md
@@ -199,8 +199,6 @@ of each series' distribution, so they cannot carry the cross-series leaderboard.
   [data quality](../background/data-quality.md)). At those sites an export event would be billed as
   demand-side procurement, and multiplying MVA by half an hour gives MVAh, which is not the
   megawatt-hour a flexibility price is quoted against.
-- **The risk target binds only in-sample**, and $\tau$ is fitted on data the model was trained on,
-  which biases it in the direction that flatters the saving.
 - **Unmet energy is pooled across series and half-hours.** A model can hit the 5% target by covering
   the largest site well and abandoning many small ones, and 5% concentrated in one deep breach is
   far worse operationally than the same 5% spread thinly. Harm grows faster than depth; equalising
@@ -229,8 +227,7 @@ of each series' distribution, so they cannot carry the cross-series leaderboard.
 ## Questions for NGED
 
 1. **Flexibility prices** — what are the availability and utilisation rates separately, and which
-   published dataset should we take them from? The split matters more than the level:
-   over-procurement is charged at the availability rate, so it sets the whole ranking.
+   published dataset should we take them from?
 2. **Curtailment price** — is £100/MWh of network access right, and is the £2M saved last year on
    the same basis, so we can check our totals against it?
 3. **Who bears the curtailment cost** — NGED, or the generator under a non-firm connection? This

--- a/docs/roadmap/cost-savings-metrics.md
+++ b/docs/roadmap/cost-savings-metrics.md
@@ -3,164 +3,196 @@
 > **Status: 🚧 Planned (v0.3).** Epic:
 > [#6](https://github.com/openclimatefix/nged-substation-forecast/issues/6); issue:
 > [#606](https://github.com/openclimatefix/nged-substation-forecast/issues/606). This page is the
-> plan for two leaderboard metrics that express forecast skill in pounds. It is written to be
-> read by anyone numerate, and is the page to send NGED for review. See the
-> [roadmap index](index.md) for status conventions.
+> plan for two leaderboard metrics that express forecast skill in pounds. It is written to be read
+> by anyone numerate. See the [roadmap index](index.md) for status conventions.
 
-## Read this first: the pounds are a yardstick, not an audit
+## Read this first: these pounds rank models, they do not cost anything
 
-These metrics put a **£** figure against every model we train. That figure is a **rough proxy**,
-built on a synthetic network limit and a single average price per megawatt-hour. It is not a cost
-analysis, it is not a business case, and it must not be quoted as either. Its one job is to rank
-forecasts on the axis NGED actually cares about, so that "this model has a lower threshold-weighted
-CRPS" becomes "this model would have spent less to keep the network within limits".
-
-We use pounds anyway, rather than a unitless score, for two reasons: the parameters genuinely are
-prices in pounds, and a pound figure is the only forecast-quality number most readers can act on.
-The risk we accept is that a skim-reader mistakes it for rigour — hence this warning, the health
-warning on every headline number, and the [limitations](#what-these-numbers-do-not-capture)
-section.
+These metrics put a **£** figure against every model we train. That figure rests on an invented
+network limit and a single average price per megawatt-hour, so it is a **rough proxy**: not a cost
+analysis, not a business case, and not quotable as either. Its one job is to rank forecasts on the
+axis NGED care about, turning "this model has a lower threshold-weighted continuous ranked
+probability score" into "this model would have spent less to keep the network within limits". We
+use pounds rather than a unitless score because the parameters genuinely are prices, and because a
+pound figure is the only forecast-quality number most readers can act on.
 
 ## Two savings, measured separately
 
-A better forecast saves NGED money through two different mechanisms, with different prices and
-different physics. We compute them as **two metrics, reported as two numbers**, and never add them
-up:
+A better forecast creates value through two different mechanisms, with different prices and
+different beneficiaries. We compute them as **two metrics, reported as two numbers**, and never add
+them up:
 
-1. **Flexibility procurement.** NGED pay flexible customers to reduce demand when a substation
-   risks running beyond its limit. They are risk-averse and knowingly over-procure. A sharper
-   forecast buys less flexibility for the same security.
-2. **Curtailment of generation.** NGED curtail connected generators to keep exports within network
-   limits. Curtailment forgone is generation sold. A sharper forecast curtails less.
+1. **Flexibility procurement.** NGED pay flexible customers to reduce demand when a site risks
+   running beyond its limit. They are risk-averse and knowingly over-procure. A sharper forecast
+   buys less flexibility for the same security. This is money NGED spend.
+2. **Curtailment of generation.** Generators are curtailed to keep exports within network limits.
+   Curtailment avoided is generation sold. Who this saves money *for* — NGED, or the connected
+   generator under a non-firm connection — is [question 3](#questions-for-nged) below, and it
+   changes how the number should be read.
 
 A third saving — the engineer-hours freed by replacing a manual review of time-series plots with an
-automated forecast — is real and was raised by NGED, but it is **not a leaderboard metric**: it is
-the same for every model we train, so it cannot rank them. It belongs in the project's final
-report, priced in engineer-hours.
+automated forecast — is real, but it is **not a leaderboard metric**: it is identical for every
+model we train, so it cannot rank them. It belongs in the project's final report, priced in
+engineer-hours.
 
 ## The shared idea: same risk, then compare the spend
 
-The obvious way to price a forecast is to charge it for what goes wrong: £X per action taken, £Y
-per limit breach that nobody saw coming. We cannot do that, because £Y — the true cost of a breach
-— is a number NGED do not have in a usable form, and it is politically loaded (deferred
-reinforcement, transformer loss-of-life, regulatory exposure).
+The textbook way to price a forecast charges it for what goes wrong: £X per action taken, £Y per
+limit breach nobody saw coming. We cannot do that, because £Y — the cost of a breach — is not a
+figure NGED hold in a form we can use.
 
-So we invert the question. **Every model is required to be equally safe, and we compare what each
-one spends to get there.** Concretely, each model is allowed to be as conservative as it likes, and
-we tune that conservatism until every model leaves the same small amount of risk unaddressed. Then
-the only thing left to compare is cost. This matches NGED's own description of the problem: they
-are not trying to avoid a breach they currently suffer, they are trying to stop over-buying to
-avoid one.
+So we invert the question. **Models are aimed at equal safety, and we compare what each one spends
+to get there.** Each model may be as conservative as it likes, and we tune that conservatism until
+it leaves the same small amount of risk unaddressed. Then the only thing left to compare is cost.
+This matches NGED's account of the problem: they are not trying to avoid a breach they currently
+suffer, they are trying to stop over-buying to avoid one.
 
-The knob we tune is the **procurement quantile** $\tau$ — how far up its own forecast distribution
-a model looks when deciding to act. A timid model uses a high $\tau$, buys a lot, and is rarely
-caught out; an aggressive model uses a low $\tau$ and is caught out often. Calibration finds each
-model's $\tau$ such that its **unmet fraction** — the share of genuinely-needed megawatt-hours it
-failed to cover — equals a common target (5% to begin with).
+The knob is the **procurement quantile** $\tau$ — how far up its own forecast distribution a model
+looks when deciding to act. A timid model uses a high $\tau$, buys a lot, and is rarely caught out.
+Calibration picks each model's $\tau$ so that its **unmet fraction** — the share of
+genuinely-needed megawatt-hours it failed to cover — hits a common target (5% to begin with):
 
 $$
-\text{unmet fraction} = \frac{\sum_{s,t} \max(0,\; N_{s,t} - V_{s,t})}{\sum_{s,t} N_{s,t}}
+\text{unmet fraction} = \frac{\sum_{i,t} \max(0,\; N_{i,t} - V_{i,t})}{\sum_{i,t} N_{i,t}}
 $$
 
-where $V_{s,t}$ is the volume the model would have bought (or curtailed) for substation $s$ in
-half-hour $t$, and $N_{s,t}$ is the volume that actually turned out to be needed. Measuring unmet
-*energy* rather than counting missed events matters: at a p99 limit the events are rare, and a
-count of them is too noisy to rank models by.
+where $V_{i,t}$ is the volume the model would have bought (or curtailed) for time series $i$ in
+half-hour $t$, and $N_{i,t}$ is the volume that turned out to be needed. Measuring unmet *energy*
+rather than counting missed events matters: at a p99 limit the events are rare, and a count of them
+is too noisy to rank models by.
 
-**$\tau$ is calibrated on training folds only.** Tuning it on the fold being scored would let the
+**$\tau$ is calibrated on training folds only.** Tuning it on the fold being scored would let a
 model see its own future, and every pound of the resulting "saving" would be lookahead.
+
+**Equal risk is a target, not a guarantee, and this is the design's main weakness.** Because $\tau$
+is fixed in advance, what a model *realises* on the scored fold is whatever its tail calibration
+delivers there. An underdispersed model overshoots the target, spends less, and can top the
+leaderboard while being materially less safe. The **realised out-of-sample unmet fraction is
+therefore reported beside every cost, and a cost read without it is meaningless.** Two models are
+only comparable on cost when their realised unmet fractions are close.
 
 ## Metric 1 — flexibility procurement cost
 
-For each substation $s$ and half-hour $t$, with **demand limit** $L_s$ and flexibility price
-$p_{\text{flex}}$ (£/MWh):
+For time series $i$ and half-hour $t$, with **limit** $L_i$ and flexibility price $p_{\text{flex}}$
+(£/MWh):
 
 | Quantity | Definition |
 |---|---|
-| Volume procured | $V_{s,t} = \max(0,\; \hat q_{s,t}(\tau) - L_s) \times 0.5$ MWh |
-| Volume needed | $N_{s,t} = \max(0,\; y_{s,t} - L_s) \times 0.5$ MWh |
-| Cost | $C = p_{\text{flex}} \sum_{s,t} V_{s,t}$ |
+| Volume procured | $V_{i,t} = \max(0,\; \hat q_{i,t}(\tau) - L_i) \times 0.5$ MWh |
+| Volume needed | $N_{i,t} = \max(0,\; y_{i,t} - L_i) \times 0.5$ MWh |
+| Cost | $C = p_{\text{flex}} \sum_{i,t} V_{i,t}$ |
 
-$\hat q_{s,t}(\tau)$ is the model's $\tau$-quantile forecast and $y_{s,t}$ the observed power; the
-$\times 0.5$ converts MW held for a half-hour into MWh. Power is positive towards end-users, so
-demand exceedance is power above $L_s$ (see the
-[sign convention](forecast-building-blocks.md#sign-convention)).
+$\hat q_{i,t}(\tau)$ is the model's $\tau$-quantile forecast, $y_{i,t}$ the observed power measured
+in the **constraint-side direction** for that series (below), and $\times 0.5$ converts MW held for
+a half-hour into MWh.
 
-**Worked example.** A primary substation with a p99 demand limit of 28 MW, on one winter evening
+**Worked example.** A primary substation whose limit sits at 28 MW, on one winter evening
 half-hour. Manual review forecasts 31 MW, so it procures $(31 - 28) \times 0.5 = 1.5$ MWh. Demand
 turns out to be 28.6 MW, so only 0.3 MWh was needed. At £750/MWh that half-hour cost £1,125, of
-which £225 was useful. A model forecasting 29.0 MW at the same calibrated risk procures 0.5 MWh —
-£375, saving £750 in that half-hour. The metric is this sum over every half-hour and every
-substation, scaled to £/year.
+which £225 was useful. A model forecasting 29.0 MW procures 0.5 MWh — £375, saving £750 in that
+half-hour. The metric sums this over every half-hour and every series.
 
 ## Metric 2 — curtailment cost
 
-Identical in shape, applied to exports, with the **export limit** $E_s$ and curtailment price
-$p_{\text{curt}}$ (£/MWh of network access). Let $g_{s,t} = \max(0,\, -y_{s,t})$ be the export
-magnitude (power is negative when generation flows back into the grid) and $\hat g_{s,t}(\tau)$ its
-$\tau$-quantile forecast:
+Identical arithmetic on the export side, with the export limit $E_i$ and the curtailment price
+$p_{\text{curt}}$ (£/MWh of network access). $V_{i,t}$ is the volume curtailed, $N_{i,t}$ the
+volume that needed curtailing, and the cost is $p_{\text{curt}} \sum_{i,t} V_{i,t}$.
 
-| Quantity | Definition |
-|---|---|
-| Volume curtailed | $V_{s,t} = \max(0,\; \hat g_{s,t}(\tau) - E_s) \times 0.5$ MWh |
-| Volume needed | $N_{s,t} = \max(0,\; g_{s,t} - E_s) \times 0.5$ MWh |
-| Cost | $C = p_{\text{curt}} \sum_{s,t} V_{s,t}$ |
+**Worked example.** A generation-dominated feeder with an export limit of 8.5 MW. The forecast at
+its calibrated quantile says 9.6 MW, so 0.55 MWh is curtailed; actual export is 8.7 MW, so 0.1 MWh
+needed curtailing. At £100/MWh that is £55 against £10 of real constraint — £45 of generation
+curtailed for nothing.
 
-**Worked example.** A generation-dominated feeder with a p99 export limit of 8.5 MW. The forecast
-at its calibrated quantile says 9.6 MW, so 0.55 MWh is curtailed; actual export is 8.7 MW, so 0.1
-MWh needed curtailing. At £100/MWh that is £55 spent against £10 of real constraint — £45 of
-generation curtailed for nothing.
+The two ship as **two functions returning two numbers**, sharing a private helper, because their
+prices, limits, direction and beneficiaries differ.
 
-The two metrics share their arithmetic but ship as **two functions returning two numbers**, because
-their prices, their limits and their direction differ, and because reporting one combined figure
-would hide which mechanism a model is good at.
+### Which direction is the constraint on?
+
+There is no single sign rule. This repo carries two conventions — at a substation, positive power
+flows towards end-users; at a customer's meter, positive means the customer is *generating* (see
+[sign convention](forecast-building-blocks.md#sign-convention)) — and the trial area contains both,
+plus battery sites that both charge and discharge. Constraint-side direction is therefore resolved
+**per `time_series_type`**, reusing the mapping the [tail and exceedance
+metrics](metrics-and-leaderboard.md#tail-exceedance-metrics-scoring-the-question-nged-actually-asks)
+already need, with the ambiguous types confirmed by NGED. Applying one global rule would silently
+score £0 for every generator meter in the trial area.
 
 ## What each number is compared against
 
-A cost in isolation means nothing, so every model's cost is reported beside two reference points,
-computed the same way on the same substations and half-hours:
+Every model's cost is reported beside two reference points, computed on the same series and
+half-hours:
 
-- **Manual review** — NGED's method today: the 13-analogue ensemble read off a plot at its
-  95th percentile ([the incumbent forecast](../background/nged-incumbent-forecast.md)). This is
-  the bar. "Manual review" is NGED's own name for it and is more accurate than calling it a
-  forecast.
-- **Perfect forecast** — truth used as the forecast, procuring exactly $N_{s,t}$ with nothing
-  unmet. This is the floor: no forecast can spend less and stay within limits, so it bounds the
-  saving that is available to win at all.
+- **Manual review** — NGED's method today: the 13-analogue ensemble, read off a plot, taking the
+  95th percentile if a single number is needed ([the incumbent
+  forecast](../background/nged-incumbent-forecast.md); we have not confirmed with NGED that the
+  95th percentile is what they use, and [question 5](#questions-for-nged) asks). It is scored at
+  that **actual operating point, not calibrated to the common risk target**, because the point is
+  to measure what NGED do today. Its realised unmet fraction is therefore an output — the number
+  that says what risk level they currently work to — and the saving against it mixes a change in
+  spend with a change in risk. Both are reported; neither is meaningful alone.
+- **Perfect forecast** — truth used as the forecast, held to the **same unmet target** as every
+  model. This is the floor: the least that can be spent at that risk level. Holding it to zero
+  unmet instead would let a calibrated model spend less than "perfect" and score above 100% of the
+  available saving.
 
-The headline presentation is therefore *"£X/year less than manual review, which is Y% of the £Z/year
-that a perfect forecast would save"*. Both metrics are computed for **every experiment** and carried
-on the leaderboard.
+The headline is *"£X less than manual review, which is Y% of the £Z a perfect forecast would
+save"*, always alongside the realised unmet fractions. Both metrics are computed for every
+experiment.
 
-## Choosing the limit: p95 and p99, both reported
+## Choosing the limit
 
 Real network limits move with ambient temperature, with how long an overload lasts, with season and
-with switching state, so no single number is correct. We use a **synthetic limit** — a percentile of
-each substation's own history — and report the metric at **both p95 and p99**, side by side.
+with switching state, so no single number is correct. We use a **synthetic limit** — a percentile
+of each series' own full observation history, for the same full-history stability reason the
+[NMAE denominator](metrics-and-leaderboard.md#normalising-nmae-by-effective_capacity) uses — and
+report the metric at **both the 95th and 99th percentiles**, labelled `hist_p95` and `hist_p99`.
 
-p99 is the more realistic stand-in for a network that is close to its limit only at winter peak.
-p95 exists because p99 exceedances are rare enough that the resulting metric may be too noisy to
-separate models, and that is a question to settle with data rather than assumption. If the two rank
-models identically, we keep p99 alone.
+NGED offered real firm and flex capacities for the trial area, and we want them — for the case
+studies below, and to check that the synthetic limits land somewhere sensible. They cannot replace
+the synthetic limit for ranking, because a real rating that was never breached during the scoring
+window produces zero exceedance events, and no model can be graded on events that never happened.
 
-This is the same choice, for the same reasons, as the static thresholds used by the
-[tail and exceedance metrics](metrics-and-leaderboard.md#tail-exceedance-metrics-scoring-the-question-nged-actually-asks).
+The 99th percentile is the better stand-in for a network close to its limit only at winter peak.
+The 95th exists because 99th-percentile exceedances may be too rare to separate models, and that is
+a question for data rather than assumption. If the two rank models identically we keep the 99th
+alone.
+
+**This ladder differs from the one the tail and exceedance metrics use** (the 90th and 98th
+percentiles, `hist_p90` / `hist_p98`). NGED endorsed the 95th/99th for procurement decisions; the
+older rungs were our own choice, made before that conversation. Two ladders on one leaderboard is
+not a good end state and [#254](https://github.com/openclimatefix/nged-substation-forecast/issues/254)
+should reconcile them.
 
 ## What these numbers do not capture
 
-- **The limits are invented.** A percentile of history is not a network rating. Substations that
-  are genuinely unconstrained get a limit anyway, and are scored as though flexibility were bought
+- **The limits are invented.** A percentile of history is not a network rating. Sites that are
+  genuinely unconstrained get a limit anyway, and are scored as though flexibility were bought
   there.
+- **The history is already post-intervention.** At a genuinely constrained site the metered power
+  reflects flexibility that *was* dispatched and generation that *was* curtailed. So $N$ understates
+  true need, and the percentile limit derived from that same history is itself shaped by the
+  interventions we are pricing.
+- **The risk target binds only in-sample**, as set out above; the realised unmet fraction is the
+  guard against this and must be read with every cost.
+- **Unmet energy is pooled across series and half-hours.** A model can hit the 5% target by
+  covering the largest site well and abandoning many small ones, and 5% concentrated in one deep
+  breach is far worse operationally than the same 5% spread thinly. Harm grows faster than depth;
+  equalising energy does not equalise harm. The per-series distribution of unmet energy is reported
+  for this reason.
 - **The prices are single averages.** One £/MWh figure stands in for a tendered market with
   availability payments, utilisation payments, zone-by-zone clearing prices and finite liquidity.
-- **Procurement is not per-half-hour.** NGED tender flexibility ahead, in blocks and windows, not
-  half-hour by half-hour on the day. Our arithmetic assumes perfectly granular buying, which
-  flatters every model equally but overstates the achievable saving.
-- **The decision rule is mechanical.** A real operator applies judgement, local knowledge and
-  discretion that a quantile threshold does not model.
-- **Nothing is validated against real spend**, except where a trial-area substation sits in an
-  actual flexibility zone. There are a couple of those, and they are the case studies that tell us
-  whether the synthetic numbers are the right order of magnitude.
+- **Procurement is not per-half-hour.** NGED tender flexibility ahead, in blocks and windows. Our
+  arithmetic assumes perfectly granular buying, which flatters every model equally but overstates
+  the achievable saving.
+- **Ensemble size limits how finely $\tau$ can be tuned.** Manual review has 13 analogues, so its
+  quantiles come in coarse steps; a 51-member ensemble is far finer. Models of different ensemble
+  size cannot be landed on exactly the same risk.
+- **Costs are per fold, and folds are seasonal.** A 99th-percentile limit concentrates exceedances
+  at winter peak, so annualising a fold that does not span a whole year is meaningless. A fold with
+  no exceedance at all leaves the unmet fraction undefined.
+- **Nothing is validated against real spend**, except at the trial-area sites that sit in an actual
+  flexibility zone. There are a couple, and they are the case studies that tell us whether these
+  numbers are the right order of magnitude.
 - **Asset failure and outage costs are excluded.** NGED identified outage quantification as
   valuable but harder; it is not in this design.
 - **Over-procurement has a deliberate component.** NGED over-buy partly to stimulate the
@@ -169,34 +201,38 @@ This is the same choice, for the same reasons, as the static thresholds used by 
 
 ## Questions for NGED
 
-1. **Flexibility price** — is £500–1000/MWh the right range for dispatched flexibility, which
-   published dataset should we take it from, and does it cover availability payments as well as
-   utilisation?
-2. **Curtailment price** — is £100/MWh of network access the right figure, and is the £2M saved
-   last year on the same basis, so we can sanity-check our totals against it?
-3. **How much do you currently over-procure?** The entire saving is measured against this. Even
-   historical procured-versus-needed volumes for a single zone would anchor it.
-4. **What reliability are you actually targeting?** We assume 5% of needed megawatt-hours may go
-   uncovered. What figure do you work to?
-5. **How far ahead is the procurement decision made?** We assume day-ahead, which sets the forecast
-   lead time the metric scores.
-6. **Which trial-area substations have curtailable generation**, and which sit in a real flexibility
-   zone with procurement history we can use as a case study?
+1. **Flexibility price** — is £500–1000/MWh right for dispatched flexibility, which published
+   dataset should we take it from, and does it cover availability payments as well as utilisation?
+2. **Curtailment price** — is £100/MWh of network access right, and is the £2M saved last year on
+   the same basis, so we can check our totals against it?
+3. **Who bears the curtailment cost** — NGED, or the generator under a non-firm connection? This
+   decides whether metric 2 measures NGED's saving or the connected customer's.
+4. **How much do you currently over-procure?** The entire saving is measured against this. Even
+   procured-versus-needed volumes for a single zone would anchor it.
+5. **Is the 95th percentile of the 13 analogues the operating point** you actually work from, and
+   what reliability do you target — how much genuinely-needed flexibility may go unbought?
+6. **Which trial-area sites have curtailable generation**, which sit in a real flexibility zone with
+   procurement history we can use as a case study, and can we have the firm and flex capacities?
 
 ## Implementation details (deleted when this ships)
 
-- Two functions in `packages/ml_core/src/ml_core/metrics.py`, sharing a private helper that takes
-  the limit, the price and the direction. They consume the same ensemble-member rows as
-  [CRPS and the quantile metrics](../techniques/evaluation-metrics.md).
-- Results land in the `forecast_metrics` Delta table as `flex_procurement_cost_gbp` and
-  `curtailment_cost_gbp`, with `metric_param` carrying the limit level (`"p95"` / `"p99"`), so the
-  two limits occupy separate rows rather than separate columns.
-- Costs are **sums over time**, not means like every other metric in the table. Rows must therefore
-  record the number of half-hours summed, or the totals cannot be rescaled to £/year or compared
-  across folds of unequal length.
-- The calibrated $\tau$ per model is an output worth storing — it says how conservative a model had
-  to be to hit the common risk target, which is interpretable on its own.
-- Prices and the risk target are configuration, not constants in code, so NGED's answers can be
-  applied without a retrain.
-- Scored on a single lead-time slice (`day_ahead` until question 5 is answered) rather than all
-  horizons pooled, because a procurement decision happens once at a known lead time.
+- Two functions in `packages/ml_core/src/ml_core/metrics.py`, sharing a private helper taking the
+  limit, the price and the direction. They consume the same ensemble-member rows as the existing
+  quantile metrics.
+- **This needs a `Metrics` contract change, to be agreed before it is written**: `METRIC_NAMES`
+  gains `flex_procurement_cost_gbp`, `curtailment_cost_gbp` and `unmet_fraction`, and
+  `METRIC_PARAMS` gains `hist_p95` / `hist_p99`. The `hist_` prefix is not decoration — bare
+  `"p95"` and `"p99"` already exist in `QUANTILE_METRIC_PARAMS` meaning *forecast* quantiles, and
+  the tail-metric design chose the prefix precisely to keep a history-derived power level distinct
+  from a level of the forecast distribution.
+- Costs are stored **per `time_series_id`**, summed over time only, so they fit the existing primary
+  key; the portfolio headline is their sum. Only $\tau$ and the unmet target are pooled across
+  series.
+- Costs are sums over time, unlike every other metric in the table, so a row must record the number
+  of half-hours it covers or the totals cannot be compared across folds of unequal length.
+- The calibrated $\tau$ is worth storing: it says how conservative a model had to be to reach the
+  common risk target, which is interpretable on its own.
+- Prices, the risk target and the limit percentiles are configuration, not constants in code, so
+  NGED's answers can be applied without a retrain.
+- Scored on a single lead-time slice (`day_ahead` until we know when the procurement decision is
+  actually made) rather than all horizons pooled.

--- a/docs/roadmap/cost-savings-metrics.md
+++ b/docs/roadmap/cost-savings-metrics.md
@@ -4,17 +4,18 @@
 > [#6](https://github.com/openclimatefix/nged-substation-forecast/issues/6); issue:
 > [#606](https://github.com/openclimatefix/nged-substation-forecast/issues/606). This page is the
 > plan for two leaderboard metrics that express forecast skill in pounds. It is written to be read
-> by anyone numerate. See the [roadmap index](index.md) for status conventions.
+> by anyone numerate. Everything attributed to NGED below comes from a meeting in July 2026 and is
+> flagged for them to confirm. See the [roadmap index](index.md) for status conventions.
 
 ## Read this first: these pounds rank models, they do not cost anything
 
 These metrics put a **£** figure against every model we train. That figure rests on an invented
-network limit and a single average price per megawatt-hour, so it is a **rough proxy**: not a cost
-analysis, not a business case, and not quotable as either. Its one job is to rank forecasts on the
-axis NGED care about, turning "this model has a lower threshold-weighted continuous ranked
-probability score" into "this model would have spent less to keep the network within limits". We
-use pounds rather than a unitless score because the parameters genuinely are prices, and because a
-pound figure is the only forecast-quality number most readers can act on.
+network limit and a couple of average prices, so it is a **rough proxy**: not a cost analysis, not
+a business case, and not quotable as either. Its one job is to rank forecasts on the axis NGED
+care about, turning "this model has a lower threshold-weighted continuous ranked probability score"
+into "this model would have spent less to keep the network within limits". We use pounds rather
+than a unitless score because the parameters genuinely are prices, and because pounds are what the
+decisions these forecasts feed are actually made in.
 
 ## Two savings, measured separately
 
@@ -23,12 +24,12 @@ different beneficiaries. We compute them as **two metrics, reported as two numbe
 them up:
 
 1. **Flexibility procurement.** NGED pay flexible customers to reduce demand when a site risks
-   running beyond its limit. They are risk-averse and knowingly over-procure. A sharper forecast
-   buys less flexibility for the same security. This is money NGED spend.
+   running beyond its limit. They told us they are risk-averse and knowingly over-procure. A
+   sharper forecast buys less flexibility for the same security. This is money NGED spend.
 2. **Curtailment of generation.** Generators are curtailed to keep exports within network limits.
    Curtailment avoided is generation sold. Who this saves money *for* — NGED, or the connected
-   generator under a non-firm connection — is [question 3](#questions-for-nged) below, and it
-   changes how the number should be read.
+   generator under a non-firm connection — is [question 3](#questions-for-nged), and it changes how
+   the number should be read.
 
 A third saving — the engineer-hours freed by replacing a manual review of time-series plots with an
 automated forecast — is real, but it is **not a leaderboard metric**: it is identical for every
@@ -44,8 +45,8 @@ figure NGED hold in a form we can use.
 So we invert the question. **Models are aimed at equal safety, and we compare what each one spends
 to get there.** Each model may be as conservative as it likes, and we tune that conservatism until
 it leaves the same small amount of risk unaddressed. Then the only thing left to compare is cost.
-This matches NGED's account of the problem: they are not trying to avoid a breach they currently
-suffer, they are trying to stop over-buying to avoid one.
+This matches what NGED described: the problem is not a breach they currently suffer, it is
+over-buying to avoid one.
 
 The knob is the **procurement quantile** $\tau$ — how far up its own forecast distribution a model
 looks when deciding to act. A timid model uses a high $\tau$, buys a lot, and is rarely caught out.
@@ -58,53 +59,67 @@ $$
 
 where $V_{i,t}$ is the volume the model would have bought (or curtailed) for time series $i$ in
 half-hour $t$, and $N_{i,t}$ is the volume that turned out to be needed. Measuring unmet *energy*
-rather than counting missed events matters: exceedances of the limit are rare by construction, and
-a count of them is too noisy to rank models by.
+rather than counting missed events matters: exceedances are rare by construction, and a count of
+them is too noisy to rank models by.
 
-**$\tau$ is calibrated on training folds only.** Tuning it on the fold being scored would let a
-model see its own future, and every pound of the resulting "saving" would be lookahead.
+**$\tau$ is calibrated on the training window of the leaderboard fold, never on the validation
+window it is scored on** — otherwise a model sees its own future and every pound of the "saving" is
+lookahead. That has a price: the training window is data the model was fitted to, so its residuals
+are smaller than they will be out of sample, $\tau$ comes out too low, and every model
+under-procures on the scored window. The model that overfits hardest gains most from this.
 
-**Equal risk is a target, not a guarantee, and this is the design's main weakness.** Because $\tau$
-is fixed in advance, what a model *realises* on the scored fold is whatever its tail calibration
-delivers there. An underdispersed model overshoots the target, spends less, and can top the
-leaderboard while being materially less safe. The **realised out-of-sample unmet fraction is
-therefore reported beside every cost, and a cost read without it is meaningless.** Two models are
-only comparable on cost when their realised unmet fractions are close.
+**Equal risk is therefore a target, not a guarantee, and this is the design's main weakness.** What
+a model *realises* on the scored window is whatever its tail calibration delivers there. A model
+that overshoots the target spends less and can top the leaderboard while being materially less
+safe. The **realised out-of-sample unmet fraction is reported beside every cost, and a cost read
+without it is meaningless.** Two models are only comparable on cost when their realised unmet
+fractions are close.
+
+## What the volumes cost
+
+Flexibility is bought in two parts, and the distinction is the whole point of these metrics.
+**Availability** is paid on every megawatt-hour held ready, whether or not it is called;
+**utilisation** is paid only on what is actually dispatched. Over-procurement therefore costs the
+*availability* price on the excess, not the far larger utilisation price:
+
+$$
+C = p_{\text{avail}} \sum_{i,t} V_{i,t} \;+\; p_{\text{util}} \sum_{i,t} \min(V_{i,t},\, N_{i,t})
+$$
+
+The second term is nearly identical for every model — it is set by what the network actually
+needed — so the ranking is carried by the first. Charging one blended price against all procured
+volume would overstate the cost of over-procurement several times over. Both prices are
+configuration, and [question 1](#questions-for-nged) asks NGED for them.
 
 ## Metric 1 — flexibility procurement cost
 
-For time series $i$ and half-hour $t$, with **limit** $L_i$ and flexibility price $p_{\text{flex}}$
-(£/MWh):
+For time series $i$ and half-hour $t$, with demand-side limit $L_i$:
 
 | Quantity | Definition |
 |---|---|
 | Volume procured | $V_{i,t} = \max(0,\; \hat q_{i,t}(\tau) - L_i) \times 0.5$ MWh |
 | Volume needed | $N_{i,t} = \max(0,\; y_{i,t} - L_i) \times 0.5$ MWh |
-| Cost | $C = p_{\text{flex}} \sum_{i,t} V_{i,t}$ |
 
-$\hat q_{i,t}(\tau)$ is the model's $\tau$-quantile forecast, $y_{i,t}$ the observed power measured
-in the **constraint-side direction** for that series (below), and $\times 0.5$ converts MW held for
-a half-hour into MWh.
+$\hat q_{i,t}(\tau)$ is the model's $\tau$-quantile forecast, $y_{i,t}$ the observed power, and
+$\times 0.5$ converts MW held for a half-hour into MWh.
 
-**Worked example.** A primary substation whose limit sits at 28 MW, on one winter evening
-half-hour. Manual review forecasts 31 MW, so it procures $(31 - 28) \times 0.5 = 1.5$ MWh. Demand
-turns out to be 28.6 MW, so only 0.3 MWh was needed. At £750/MWh that half-hour cost £1,125, of
-which £225 was useful. A model forecasting 29.0 MW procures 0.5 MWh — £375, saving £750 in that
-half-hour. The metric sums this over every half-hour and every series.
+**Worked example.** A substation whose limit sits at 30 MW, on one winter evening half-hour, with
+availability at £75/MWh and utilisation at £750/MWh (both placeholders). Manual review forecasts 33
+MW, so it procures $(33 - 30) \times 0.5 = 1.5$ MWh. Demand turns out to be 30.6 MW, so 0.3 MWh was
+needed. It pays £112.50 availability and £225 utilisation. A model forecasting 31.0 MW procures 0.5
+MWh, pays £37.50 and the same £225 — saving £75. The metric sums this over every half-hour and
+every series.
 
 ## Metric 2 — curtailment cost
 
-Identical arithmetic on the export side, with the export limit $E_i$ and the curtailment price
-$p_{\text{curt}}$ (£/MWh of network access). $V_{i,t}$ is the volume curtailed, $N_{i,t}$ the
-volume that needed curtailing, and the cost is $p_{\text{curt}} \sum_{i,t} V_{i,t}$.
+Identical arithmetic on the export side, with the export-side limit and the curtailment price
+$p_{\text{curt}}$ (£/MWh of network access) charged against total volume curtailed, since curtailed
+generation is lost whether or not the constraint was real.
 
 **Worked example.** A generation-dominated feeder with an export limit of 8.5 MW. The forecast at
 its calibrated quantile says 9.6 MW, so 0.55 MWh is curtailed; actual export is 8.7 MW, so 0.1 MWh
 needed curtailing. At £100/MWh that is £55 against £10 of real constraint — £45 of generation
 curtailed for nothing.
-
-The two ship as **two functions returning two numbers**, sharing a private helper, because their
-prices, limits, direction and beneficiaries differ.
 
 ### Which direction is the constraint on?
 
@@ -114,8 +129,13 @@ flows towards end-users; at a customer's meter, positive means the customer is *
 plus battery sites that both charge and discharge. Constraint-side direction is therefore resolved
 **per `time_series_type`**, reusing the mapping the [tail and exceedance
 metrics](metrics-and-leaderboard.md#tail-exceedance-metrics-scoring-the-question-nged-actually-asks)
-already need, with the ambiguous types confirmed by NGED. Applying one global rule would silently
-score £0 for every generator meter in the trial area.
+already need, with the ambiguous types confirmed by NGED.
+
+A series constrained in both directions gets **a limit in each**, so the threshold is one scalar
+per `(time_series_id, direction)` rather than per series alone. Each metric is computed only where
+its direction is constrained: a demand primary with no connected generation gets no curtailment
+cost, and a solar meter gets no flexibility procurement cost. Applying one global rule instead
+would silently score £0 for every generator meter in the trial area.
 
 ## What each number is compared against
 
@@ -124,82 +144,93 @@ half-hours:
 
 - **Manual review** — NGED's method today: the 13-analogue ensemble, read off a plot, taking the
   95th percentile if a single number is needed ([the incumbent
-  forecast](../background/nged-incumbent-forecast.md); we have not confirmed with NGED that the
-  95th percentile is what they use, and [question 5](#questions-for-nged) asks). It is scored at
-  that **actual operating point, not calibrated to the common risk target**, because the point is
-  to measure what NGED do today. Its realised unmet fraction is therefore an output — the number
-  that says what risk level they currently work to — and the saving against it mixes a change in
-  spend with a change in risk. Both are reported; neither is meaningful alone.
-- **Perfect forecast** — truth used as the forecast, held to the **same unmet target** as every
-  model. This is the floor: the least that can be spent at that risk level. Holding it to zero
-  unmet instead would let a calibrated model spend less than "perfect" and score above 100% of the
-  available saving.
+  forecast](../background/nged-incumbent-forecast.md); we have not confirmed that the 95th
+  percentile is what they use, and [question 5](#questions-for-nged) asks). It is scored at that
+  **actual operating point, not calibrated to the common risk target**, because the point is to
+  measure what NGED do today. Its realised unmet fraction is therefore an output — the number
+  saying what risk level they currently work to — and the saving against it mixes a change in spend
+  with a change in risk. Both are reported; neither means much alone.
+- **Perfect forecast** — the least that can be spent while leaving no more than the target fraction
+  $u$ unmet. Truth is not a distribution, so there is no quantile to calibrate: the floor is the
+  cost of procuring exactly $(1-u)N_{i,t}$ in every half-hour, put straight through the same price
+  formula. Setting it at zero unmet instead would put it *above* a model calibrated to 5%, and
+  models would routinely score over 100% of the available saving.
 
 The headline is *"£X less than manual review, which is Y% of the £Z a perfect forecast would
-save"*, always alongside the realised unmet fractions. Both metrics are computed for every
-experiment.
+save"*, always alongside the realised unmet fractions. Note that a model whose realised unmet
+fraction overshoots the target can still exceed 100%; that is a signal to read the risk column, not
+a bug.
 
 ## Choosing the limit
 
 Real network limits move with ambient temperature, with how long an overload lasts, with season and
-with switching state, so no single number is correct. We use a **synthetic limit**: the **95th
-percentile of each series' own full observation history**, for the same full-history stability
-reason the [NMAE denominator](metrics-and-leaderboard.md#normalising-nmae-by-effective_capacity)
-uses. Its label is `historical_p95`, kept distinct from the forecast-quantile label `p95` — one is
-a fixed power level derived from history, the other a level of the forecast distribution.
+with switching state, so no single number is correct — the fuller version of this caveat is in
+[the threshold-choice
+discussion](../techniques/evaluation-metrics.md#choosing-the-thresholds-static-per-series-quantile-derived).
+We use a **synthetic limit**: the **99th percentile of each series' own full observation history**,
+in the constrained direction, labelled `historical_p99` to keep it distinct from the
+forecast-quantile label `p99` — one is a fixed power level derived from history, the other a level
+of the forecast distribution.
 
-This is the same single rung the [tail and exceedance
+This is the rung NGED described ("set capacity at the 99th percentile, and assume everything is
+slightly overloaded in winter"), and it is the same single rung the [tail and exceedance
 metrics](metrics-and-leaderboard.md#tail-exceedance-metrics-scoring-the-question-nged-actually-asks)
-use, so the leaderboard carries one threshold concept rather than several. We chose the 95th over
-the 99th because 99th-percentile exceedances are rare enough that the resulting numbers may be too
-noisy to separate models — but NGED talked in terms of the 99th, so
-[question 6](#questions-for-nged) puts the choice back to them.
+use, so the leaderboard carries one threshold concept rather than several. The percentile sets the
+absolute size of every £ figure on this page — a lower rung would multiply them — which is another
+reason to read these numbers as a ranking instrument rather than a total.
 
-NGED offered real firm and flex capacities for the trial area, and we want them — for the case
-studies below, and to check that the synthetic limit lands somewhere sensible. They cannot replace
-it for ranking, because a real rating that was never breached during the scoring window produces
-zero exceedance events, and no model can be graded on events that never happened.
+Where NGED supply a real firm or flex rating we will compute the same metrics against it, as a
+case study. A rating never breached during the scored window is not useless here — procurement
+volume is driven by the *forecast* crossing the limit, so models still rank — but the unmet
+fraction goes undefined, and ratings are not available for every series and sit at different points
+of each series' distribution, so they cannot carry the cross-series leaderboard.
 
 ## What these numbers do not capture
 
-- **The limits are invented.** A percentile of history is not a network rating. Sites that are
-  genuinely unconstrained get a limit anyway, and are scored as though flexibility were bought
-  there.
+- **The limit is invented, and fitted on the scored window.** A percentile of history is not a
+  network rating, and it is computed over the full history including the months being scored. It is
+  model-independent, so it cannot favour one entrant, but it is not an out-of-sample quantity.
 - **The history is already post-intervention.** At a genuinely constrained site the metered power
   reflects flexibility that *was* dispatched and generation that *was* curtailed. So $N$ understates
   true need, and the percentile limit derived from that same history is itself shaped by the
   interventions we are pricing.
-- **The risk target binds only in-sample**, as set out above; the realised unmet fraction is the
-  guard against this and must be read with every cost.
-- **Unmet energy is pooled across series and half-hours.** A model can hit the 5% target by
-  covering the largest site well and abandoning many small ones, and 5% concentrated in one deep
-  breach is far worse operationally than the same 5% spread thinly. Harm grows faster than depth;
-  equalising energy does not equalise harm. The per-series distribution of unmet energy is reported
-  for this reason.
-- **The prices are single averages.** One £/MWh figure stands in for a tendered market with
-  availability payments, utilisation payments, zone-by-zone clearing prices and finite liquidity.
+- **Ten trial-area sites cannot see direction at all.** They are metered in MVA, which reports the
+  magnitude of flow, so reverse power flow appears as a *rise* rather than a sign change (see
+  [data quality](../background/data-quality.md)). At those sites an export event would be billed as
+  demand-side procurement, and multiplying MVA by half an hour gives MVAh, which is not the
+  megawatt-hour a flexibility price is quoted against.
+- **The risk target binds only in-sample**, and $\tau$ is fitted on data the model was trained on,
+  which biases it in the direction that flatters the saving.
+- **Unmet energy is pooled across series and half-hours.** A model can hit the 5% target by covering
+  the largest site well and abandoning many small ones, and 5% concentrated in one deep breach is
+  far worse operationally than the same 5% spread thinly. Harm grows faster than depth; equalising
+  energy does not equalise harm. The per-series distribution of unmet energy is reported for this
+  reason.
+- **The prices are single averages.** Two numbers stand in for a tendered market with zone-by-zone
+  clearing prices and finite liquidity.
 - **Procurement is not per-half-hour.** NGED tender flexibility ahead, in blocks and windows. Our
   arithmetic assumes perfectly granular buying, which flatters every model equally but overstates
   the achievable saving.
 - **Ensemble size limits how finely $\tau$ can be tuned.** Manual review has 13 analogues, so its
   quantiles come in coarse steps; a 51-member ensemble is far finer. Models of different ensemble
   size cannot be landed on exactly the same risk.
-- **Costs are per fold, and folds are seasonal.** The limit concentrates exceedances at winter
-  peak, so annualising a fold that does not span a whole year is meaningless. A fold with no
-  exceedance at all leaves the unmet fraction undefined.
+- **Costs are per fold, and folds are seasonal.** The limit concentrates exceedances at winter peak,
+  so annualising a fold that does not span a whole year is meaningless, and a fold with no
+  exceedance leaves the unmet fraction undefined.
 - **Nothing is validated against real spend**, except at the trial-area sites that sit in an actual
   flexibility zone. There are a couple, and they are the case studies that tell us whether these
   numbers are the right order of magnitude.
 - **Asset failure and outage costs are excluded.** NGED identified outage quantification as
   valuable but harder; it is not in this design.
-- **Over-procurement has a deliberate component.** NGED over-buy partly to stimulate the
-  flexibility market and to support their capital programme. That portion is policy, not forecast
-  error, and a better forecast should not be credited with removing it.
+- **Over-procurement has a deliberate component.** NGED told us they over-buy partly to stimulate
+  the flexibility market and to support their capital programme. That portion is policy, not
+  forecast error, and a better forecast should not be credited with removing it.
 
 ## Questions for NGED
 
-1. **Flexibility price** — is £500–1000/MWh right for dispatched flexibility, which published
-   dataset should we take it from, and does it cover availability payments as well as utilisation?
+1. **Flexibility prices** — what are the availability and utilisation rates separately, and which
+   published dataset should we take them from? The split matters more than the level:
+   over-procurement is charged at the availability rate, so it sets the whole ranking.
 2. **Curtailment price** — is £100/MWh of network access right, and is the £2M saved last year on
    the same basis, so we can check our totals against it?
 3. **Who bears the curtailment cost** — NGED, or the generator under a non-firm connection? This
@@ -208,30 +239,32 @@ zero exceedance events, and no model can be graded on events that never happened
    procured-versus-needed volumes for a single zone would anchor it.
 5. **Is the 95th percentile of the 13 analogues the operating point** you actually work from, and
    what reliability do you target — how much genuinely-needed flexibility may go unbought?
-6. **Is the 95th percentile the right limit to score against?** You talked in terms of the 99th. We
-   went with the 95th because 99th-percentile exceedances look too rare to rank models cleanly, but
-   the choice is yours to overrule.
-7. **Which trial-area sites have curtailable generation**, which sit in a real flexibility zone with
-   procurement history we can use as a case study, and can we have the firm and flex capacities?
+6. **Which trial-area sites have curtailable generation**, which are constrained on export as well
+   as demand, which sit in a real flexibility zone with procurement history we can use as a case
+   study, and can we have the firm and flex capacities?
 
 ## Implementation details (deleted when this ships)
 
 - Two functions in `packages/ml_core/src/ml_core/metrics.py`, sharing a private helper taking the
-  limit, the price and the direction. They consume the same ensemble-member rows as the existing
+  limit, the prices and the direction. They consume the same ensemble-member rows as the existing
   quantile metrics.
 - **This needs a `Metrics` contract change, still to be reviewed and agreed when we implement**:
   `METRIC_NAMES` gains `flex_procurement_cost_gbp`, `curtailment_cost_gbp` and `unmet_fraction`,
-  and `METRIC_PARAMS` gains `historical_p95`. The prefix is not decoration — bare `"p95"` already
-  exists in `QUANTILE_METRIC_PARAMS` meaning a *forecast* quantile, and a history-derived power
-  level has to stay distinct from a level of the forecast distribution.
+  and `METRIC_PARAMS` gains a `historical_p99` label per constrained direction. Bare `"p99"`
+  already exists in `QUANTILE_METRIC_PARAMS` meaning a *forecast* quantile, so a history-derived
+  power level has to stay distinct from a level of the forecast distribution.
+- **Two things the design needs to store have nowhere to live in `Metrics` today**: the number of
+  half-hours a cost row covers (without it, totals cannot be compared across folds of unequal
+  length) and the calibrated $\tau$ (which says how conservative a model had to be to reach the
+  common risk target, and is interpretable on its own). Both need resolving with the contract
+  change.
 - Costs are stored **per `time_series_id`**, summed over time only, so they fit the existing primary
-  key; the portfolio headline is their sum. Only $\tau$ and the unmet target are pooled across
-  series.
-- Costs are sums over time, unlike every other metric in the table, so a row must record the number
-  of half-hours it covers or the totals cannot be compared across folds of unequal length.
-- The calibrated $\tau$ is worth storing: it says how conservative a model had to be to reach the
-  common risk target, which is interpretable on its own.
-- Prices, the risk target and the limit percentiles are configuration, not constants in code, so
+  key. Only $\tau$ and the unmet target are pooled across series.
+- **`_log_metrics_to_mlflow` aggregates with `mean()`**, which is right for every metric that exists
+  today and wrong for these: the portfolio headline is a *sum* over series, and pooled
+  `unmet_fraction` is $\sum N$-weighted, not an unweighted mean that a tiny site can dominate. The
+  MLflow aggregation needs a per-metric rule before these land.
+- Prices, the risk target and the limit percentile are configuration, not constants in code, so
   NGED's answers can be applied without a retrain.
 - Scored on a single lead-time slice (`day_ahead` until we know when the procurement decision is
   actually made) rather than all horizons pooled.

--- a/docs/roadmap/cost-savings-metrics.md
+++ b/docs/roadmap/cost-savings-metrics.md
@@ -1,0 +1,202 @@
+# Estimating the money a better forecast saves
+
+> **Status: 🚧 Planned (v0.3).** Epic:
+> [#6](https://github.com/openclimatefix/nged-substation-forecast/issues/6); issue:
+> [#606](https://github.com/openclimatefix/nged-substation-forecast/issues/606). This page is the
+> plan for two leaderboard metrics that express forecast skill in pounds. It is written to be
+> read by anyone numerate, and is the page to send NGED for review. See the
+> [roadmap index](index.md) for status conventions.
+
+## Read this first: the pounds are a yardstick, not an audit
+
+These metrics put a **£** figure against every model we train. That figure is a **rough proxy**,
+built on a synthetic network limit and a single average price per megawatt-hour. It is not a cost
+analysis, it is not a business case, and it must not be quoted as either. Its one job is to rank
+forecasts on the axis NGED actually cares about, so that "this model has a lower threshold-weighted
+CRPS" becomes "this model would have spent less to keep the network within limits".
+
+We use pounds anyway, rather than a unitless score, for two reasons: the parameters genuinely are
+prices in pounds, and a pound figure is the only forecast-quality number most readers can act on.
+The risk we accept is that a skim-reader mistakes it for rigour — hence this warning, the health
+warning on every headline number, and the [limitations](#what-these-numbers-do-not-capture)
+section.
+
+## Two savings, measured separately
+
+A better forecast saves NGED money through two different mechanisms, with different prices and
+different physics. We compute them as **two metrics, reported as two numbers**, and never add them
+up:
+
+1. **Flexibility procurement.** NGED pay flexible customers to reduce demand when a substation
+   risks running beyond its limit. They are risk-averse and knowingly over-procure. A sharper
+   forecast buys less flexibility for the same security.
+2. **Curtailment of generation.** NGED curtail connected generators to keep exports within network
+   limits. Curtailment forgone is generation sold. A sharper forecast curtails less.
+
+A third saving — the engineer-hours freed by replacing a manual review of time-series plots with an
+automated forecast — is real and was raised by NGED, but it is **not a leaderboard metric**: it is
+the same for every model we train, so it cannot rank them. It belongs in the project's final
+report, priced in engineer-hours.
+
+## The shared idea: same risk, then compare the spend
+
+The obvious way to price a forecast is to charge it for what goes wrong: £X per action taken, £Y
+per limit breach that nobody saw coming. We cannot do that, because £Y — the true cost of a breach
+— is a number NGED do not have in a usable form, and it is politically loaded (deferred
+reinforcement, transformer loss-of-life, regulatory exposure).
+
+So we invert the question. **Every model is required to be equally safe, and we compare what each
+one spends to get there.** Concretely, each model is allowed to be as conservative as it likes, and
+we tune that conservatism until every model leaves the same small amount of risk unaddressed. Then
+the only thing left to compare is cost. This matches NGED's own description of the problem: they
+are not trying to avoid a breach they currently suffer, they are trying to stop over-buying to
+avoid one.
+
+The knob we tune is the **procurement quantile** $\tau$ — how far up its own forecast distribution
+a model looks when deciding to act. A timid model uses a high $\tau$, buys a lot, and is rarely
+caught out; an aggressive model uses a low $\tau$ and is caught out often. Calibration finds each
+model's $\tau$ such that its **unmet fraction** — the share of genuinely-needed megawatt-hours it
+failed to cover — equals a common target (5% to begin with).
+
+$$
+\text{unmet fraction} = \frac{\sum_{s,t} \max(0,\; N_{s,t} - V_{s,t})}{\sum_{s,t} N_{s,t}}
+$$
+
+where $V_{s,t}$ is the volume the model would have bought (or curtailed) for substation $s$ in
+half-hour $t$, and $N_{s,t}$ is the volume that actually turned out to be needed. Measuring unmet
+*energy* rather than counting missed events matters: at a p99 limit the events are rare, and a
+count of them is too noisy to rank models by.
+
+**$\tau$ is calibrated on training folds only.** Tuning it on the fold being scored would let the
+model see its own future, and every pound of the resulting "saving" would be lookahead.
+
+## Metric 1 — flexibility procurement cost
+
+For each substation $s$ and half-hour $t$, with **demand limit** $L_s$ and flexibility price
+$p_{\text{flex}}$ (£/MWh):
+
+| Quantity | Definition |
+|---|---|
+| Volume procured | $V_{s,t} = \max(0,\; \hat q_{s,t}(\tau) - L_s) \times 0.5$ MWh |
+| Volume needed | $N_{s,t} = \max(0,\; y_{s,t} - L_s) \times 0.5$ MWh |
+| Cost | $C = p_{\text{flex}} \sum_{s,t} V_{s,t}$ |
+
+$\hat q_{s,t}(\tau)$ is the model's $\tau$-quantile forecast and $y_{s,t}$ the observed power; the
+$\times 0.5$ converts MW held for a half-hour into MWh. Power is positive towards end-users, so
+demand exceedance is power above $L_s$ (see the
+[sign convention](forecast-building-blocks.md#sign-convention)).
+
+**Worked example.** A primary substation with a p99 demand limit of 28 MW, on one winter evening
+half-hour. Manual review forecasts 31 MW, so it procures $(31 - 28) \times 0.5 = 1.5$ MWh. Demand
+turns out to be 28.6 MW, so only 0.3 MWh was needed. At £750/MWh that half-hour cost £1,125, of
+which £225 was useful. A model forecasting 29.0 MW at the same calibrated risk procures 0.5 MWh —
+£375, saving £750 in that half-hour. The metric is this sum over every half-hour and every
+substation, scaled to £/year.
+
+## Metric 2 — curtailment cost
+
+Identical in shape, applied to exports, with the **export limit** $E_s$ and curtailment price
+$p_{\text{curt}}$ (£/MWh of network access). Let $g_{s,t} = \max(0,\, -y_{s,t})$ be the export
+magnitude (power is negative when generation flows back into the grid) and $\hat g_{s,t}(\tau)$ its
+$\tau$-quantile forecast:
+
+| Quantity | Definition |
+|---|---|
+| Volume curtailed | $V_{s,t} = \max(0,\; \hat g_{s,t}(\tau) - E_s) \times 0.5$ MWh |
+| Volume needed | $N_{s,t} = \max(0,\; g_{s,t} - E_s) \times 0.5$ MWh |
+| Cost | $C = p_{\text{curt}} \sum_{s,t} V_{s,t}$ |
+
+**Worked example.** A generation-dominated feeder with a p99 export limit of 8.5 MW. The forecast
+at its calibrated quantile says 9.6 MW, so 0.55 MWh is curtailed; actual export is 8.7 MW, so 0.1
+MWh needed curtailing. At £100/MWh that is £55 spent against £10 of real constraint — £45 of
+generation curtailed for nothing.
+
+The two metrics share their arithmetic but ship as **two functions returning two numbers**, because
+their prices, their limits and their direction differ, and because reporting one combined figure
+would hide which mechanism a model is good at.
+
+## What each number is compared against
+
+A cost in isolation means nothing, so every model's cost is reported beside two reference points,
+computed the same way on the same substations and half-hours:
+
+- **Manual review** — NGED's method today: the 13-analogue ensemble read off a plot at its
+  95th percentile ([the incumbent forecast](../background/nged-incumbent-forecast.md)). This is
+  the bar. "Manual review" is NGED's own name for it and is more accurate than calling it a
+  forecast.
+- **Perfect forecast** — truth used as the forecast, procuring exactly $N_{s,t}$ with nothing
+  unmet. This is the floor: no forecast can spend less and stay within limits, so it bounds the
+  saving that is available to win at all.
+
+The headline presentation is therefore *"£X/year less than manual review, which is Y% of the £Z/year
+that a perfect forecast would save"*. Both metrics are computed for **every experiment** and carried
+on the leaderboard.
+
+## Choosing the limit: p95 and p99, both reported
+
+Real network limits move with ambient temperature, with how long an overload lasts, with season and
+with switching state, so no single number is correct. We use a **synthetic limit** — a percentile of
+each substation's own history — and report the metric at **both p95 and p99**, side by side.
+
+p99 is the more realistic stand-in for a network that is close to its limit only at winter peak.
+p95 exists because p99 exceedances are rare enough that the resulting metric may be too noisy to
+separate models, and that is a question to settle with data rather than assumption. If the two rank
+models identically, we keep p99 alone.
+
+This is the same choice, for the same reasons, as the static thresholds used by the
+[tail and exceedance metrics](metrics-and-leaderboard.md#tail-exceedance-metrics-scoring-the-question-nged-actually-asks).
+
+## What these numbers do not capture
+
+- **The limits are invented.** A percentile of history is not a network rating. Substations that
+  are genuinely unconstrained get a limit anyway, and are scored as though flexibility were bought
+  there.
+- **The prices are single averages.** One £/MWh figure stands in for a tendered market with
+  availability payments, utilisation payments, zone-by-zone clearing prices and finite liquidity.
+- **Procurement is not per-half-hour.** NGED tender flexibility ahead, in blocks and windows, not
+  half-hour by half-hour on the day. Our arithmetic assumes perfectly granular buying, which
+  flatters every model equally but overstates the achievable saving.
+- **The decision rule is mechanical.** A real operator applies judgement, local knowledge and
+  discretion that a quantile threshold does not model.
+- **Nothing is validated against real spend**, except where a trial-area substation sits in an
+  actual flexibility zone. There are a couple of those, and they are the case studies that tell us
+  whether the synthetic numbers are the right order of magnitude.
+- **Asset failure and outage costs are excluded.** NGED identified outage quantification as
+  valuable but harder; it is not in this design.
+- **Over-procurement has a deliberate component.** NGED over-buy partly to stimulate the
+  flexibility market and to support their capital programme. That portion is policy, not forecast
+  error, and a better forecast should not be credited with removing it.
+
+## Questions for NGED
+
+1. **Flexibility price** — is £500–1000/MWh the right range for dispatched flexibility, which
+   published dataset should we take it from, and does it cover availability payments as well as
+   utilisation?
+2. **Curtailment price** — is £100/MWh of network access the right figure, and is the £2M saved
+   last year on the same basis, so we can sanity-check our totals against it?
+3. **How much do you currently over-procure?** The entire saving is measured against this. Even
+   historical procured-versus-needed volumes for a single zone would anchor it.
+4. **What reliability are you actually targeting?** We assume 5% of needed megawatt-hours may go
+   uncovered. What figure do you work to?
+5. **How far ahead is the procurement decision made?** We assume day-ahead, which sets the forecast
+   lead time the metric scores.
+6. **Which trial-area substations have curtailable generation**, and which sit in a real flexibility
+   zone with procurement history we can use as a case study?
+
+## Implementation details (deleted when this ships)
+
+- Two functions in `packages/ml_core/src/ml_core/metrics.py`, sharing a private helper that takes
+  the limit, the price and the direction. They consume the same ensemble-member rows as
+  [CRPS and the quantile metrics](../techniques/evaluation-metrics.md).
+- Results land in the `forecast_metrics` Delta table as `flex_procurement_cost_gbp` and
+  `curtailment_cost_gbp`, with `metric_param` carrying the limit level (`"p95"` / `"p99"`), so the
+  two limits occupy separate rows rather than separate columns.
+- Costs are **sums over time**, not means like every other metric in the table. Rows must therefore
+  record the number of half-hours summed, or the totals cannot be rescaled to £/year or compared
+  across folds of unequal length.
+- The calibrated $\tau$ per model is an output worth storing — it says how conservative a model had
+  to be to hit the common risk target, which is interpretable on its own.
+- Prices and the risk target are configuration, not constants in code, so NGED's answers can be
+  applied without a retrain.
+- Scored on a single lead-time slice (`day_ahead` until question 5 is answered) rather than all
+  horizons pooled, because a procurement decision happens once at a known lead time.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -24,6 +24,9 @@ Technical plans change as we learn more — treat this as a best-estimate, not a
   forecasts, sign conventions, and worked examples.
 - [Metrics & leaderboard](metrics-and-leaderboard.md) — cross-fold validation protocol, evaluation
   metrics, horizon time-slices, and leaderboard grouping tags.
+- [Estimating the money a better forecast saves](cost-savings-metrics.md) — the two £ leaderboard
+  metrics (flexibility procurement and curtailment), the equal-risk method that avoids needing a
+  price for a network breach, their limitations, and the open questions for NGED.
 - [Data sources](data-sources.md) — NGED power data + supporting files, network topology, and the
   weather datasets (ECMWF ENS, ERA5, CM SAF).
 - [Live service](live-service.md) — the v0.1 deployment: the `live_forecasts` inference
@@ -110,6 +113,10 @@ AWS — see [Live service](live-service.md).
   items in [Metrics & leaderboard](metrics-and-leaderboard.md))
 - Time-slice filters: nowcasting (0–6 h), day-ahead (6–36 h), medium range (Day 2–7), extended range (Day 8–14), peak events (top 5%)
 - Baseline forecasters (persistence + climatology) so leaderboard scores are interpretable
+- **Cost-savings metrics (£)** — two figures per leaderboard row, for flexibility procurement and
+  for curtailment, scored against manual review and against a perfect forecast; see
+  [Estimating the money a better forecast saves](cost-savings-metrics.md). Expected to be the
+  metrics NGED read first, so they land early in this milestone.
 - Production monitoring of the live service (`production_monitoring` metrics scope)
 - **Failure-scenario evaluation** — the evaluation machinery must precede the v0.5 experiments it
   is meant to judge, or v0.5 picks a champion blind to how it behaves when inputs degrade:
@@ -367,7 +374,6 @@ delivery of the v2 live service)*
 
 - Forecast *unmetered* solar and wind power at each primary substation
 - Disaggregate additional DERs (price-sensitive assets like batteries) from substation power flow
-- Estimate cost savings (£) attributable to each forecasting approach in the leaderboard
 - Build a REST API on top of the Delta Lake delivery mechanism (purely additive — see [when a REST API would earn its keep](../architecture/forecast-delivery.md#when-would-a-rest-api-earn-its-keep))
 
 ---

--- a/docs/roadmap/metrics-and-leaderboard.md
+++ b/docs/roadmap/metrics-and-leaderboard.md
@@ -645,17 +645,19 @@ reference](../techniques/evaluation-metrics.md#tail-and-exceedance-metrics):
   "70% chance of rain" forecast; the most *decision-legible* number, scoring exactly the
   warning NGED acts on.
 
-All three fit the existing `Metrics` schema — `metric_param` carries the threshold or quantile
-label — so there is no schema change.
+All three fit the existing `Metrics` shape — `metric_param` carries the threshold or quantile
+label — but they need a contract change to get there: `METRIC_NAMES` has no `twcrps` or `brier`
+entry, and `METRIC_PARAMS` no `historical_p99`, and both fields are `pl.Enum`.
 
 **Thresholds: static, per-series, quantile-derived.** A substation's true limit is not a
 single number (ratings vary with ambient temperature; transformers tolerate short overloads,
 so exceedance *duration* matters; switching changes what a feeder carries — NGED's own limit
 line is a time-varying "Flex Profile"). We deliberately do not model any of that for scoring.
-Each series gets one static threshold — the P95 of its full observation history, in the series
+Each series gets one static threshold — the P99 of its full observation history, in the series
 type's constraint-side direction (high load for demand; reverse power flow for generation) —
 chosen because it guarantees every series a scoreable event rate, means the same thing across
-series, and stays stable across CV folds. NGED endorsed the P95; it is the same rung the
+series, and stays stable across CV folds. NGED described setting capacity at the 99th percentile
+when we discussed this in July 2026; it is the same rung the
 [cost-savings metrics](cost-savings-metrics.md#choosing-the-limit) use, so the leaderboard
 carries one threshold concept rather than several. Physical firm/flex ratings, where NGED
 supplies them, feed ad-hoc case studies and dashboard overlays instead: a rating that is never
@@ -678,7 +680,7 @@ before/after instruments for Phases C and D.
 
 #### Implementation details — tail & exceedance metrics (deleted when this ships)
 
-- **Thresholds:** compute a per-series `historical_p95` scalar from the full observation
+- **Thresholds:** compute a per-series `historical_p99` scalar from the full observation
   history alongside (or within) the `effective_capacity` asset — same full-history stability
   rationale, same join shape (`time_series_id`-only). Constraint-side direction resolved per
   `time_series_type`; confirm the mapping with NGED for ambiguous types (BESS charges *and*
@@ -691,7 +693,7 @@ before/after instruments for Phases C and D.
 - **Brier score:** exceedance probability = member fraction above the threshold; outcome
   indicator from `y`; squared difference, averaged.
 - **MLflow allowlist:** extend `_MLFLOW_LOGGED_PARAMETRIC` with a small headline subset (e.g.
-  `twcrps@historical_p95`, exceedance rate at p95, `brier@historical_p95`); decide the exact set at
+  `twcrps@historical_p99`, exceedance rate at p95, `brier@historical_p99`); decide the exact set at
   implementation time and keep it small — everything is in Delta regardless.
 - **Peak-events diagnostic slice:** one more named population filter on the shared mechanism
   (with the Tricky-days filter), flagged in the leaderboard UI as diagnostic-only.

--- a/docs/roadmap/metrics-and-leaderboard.md
+++ b/docs/roadmap/metrics-and-leaderboard.md
@@ -985,5 +985,7 @@ NWP?"). Example tags:
 | `switching_event_detection` | none, simple_statistical |
 | `pre_training` | none, ERA5 |
 
-> Estimating **cost savings (£)** attributable to each forecasting approach, per leaderboard row, is
-> a 🔬 v2 stretch goal.
+> Every leaderboard row also carries two **cost savings (£)** figures — one for flexibility
+> procurement, one for curtailment — designed in
+> [Estimating the money a better forecast saves](cost-savings-metrics.md). They are deliberately
+> rough proxies, not a cost analysis.

--- a/docs/roadmap/metrics-and-leaderboard.md
+++ b/docs/roadmap/metrics-and-leaderboard.md
@@ -652,10 +652,12 @@ label — so there is no schema change.
 single number (ratings vary with ambient temperature; transformers tolerate short overloads,
 so exceedance *duration* matters; switching changes what a feeder carries — NGED's own limit
 line is a time-varying "Flex Profile"). We deliberately do not model any of that for scoring.
-Each series gets two static thresholds — the P90 and P98 of its full observation history, in
-the series type's constraint-side direction (high load for demand; reverse power flow for
-generation) — chosen because they guarantee every series a scoreable event rate, mean the same
-thing across series, and stay stable across CV folds. Physical firm/flex ratings, where NGED
+Each series gets one static threshold — the P95 of its full observation history, in the series
+type's constraint-side direction (high load for demand; reverse power flow for generation) —
+chosen because it guarantees every series a scoreable event rate, means the same thing across
+series, and stays stable across CV folds. NGED endorsed the P95; it is the same rung the
+[cost-savings metrics](cost-savings-metrics.md#choosing-the-limit) use, so the leaderboard
+carries one threshold concept rather than several. Physical firm/flex ratings, where NGED
 supplies them, feed ad-hoc case studies and dashboard overlays instead: a rating that is never
 breached in the validation window yields zero events, and a warning system cannot be graded on
 events that never happen. The full rationale, and the explicit "this is a proxy" caveat, live
@@ -676,20 +678,20 @@ before/after instruments for Phases C and D.
 
 #### Implementation details — tail & exceedance metrics (deleted when this ships)
 
-- **Thresholds:** compute per-series `hist_p90` / `hist_p98` scalars from the full observation
+- **Thresholds:** compute a per-series `historical_p95` scalar from the full observation
   history alongside (or within) the `effective_capacity` asset — same full-history stability
   rationale, same join shape (`time_series_id`-only). Constraint-side direction resolved per
   `time_series_type`; confirm the mapping with NGED for ambiguous types (BESS charges *and*
   discharges).
 - **twCRPS:** transform members and observation with `pl.max_horizontal(col, threshold)` and
   reuse the existing fair-CRPS expression (sorted-member identity, Float64 accumulation)
-  verbatim, once per threshold rung.
+  verbatim.
 - **Exceedance rates:** compare `y` against the already-computed empirical quantile columns
   for p80, p90, p95, p98, p99 — one boolean mean per level.
 - **Brier score:** exceedance probability = member fraction above the threshold; outcome
   indicator from `y`; squared difference, averaged.
 - **MLflow allowlist:** extend `_MLFLOW_LOGGED_PARAMETRIC` with a small headline subset (e.g.
-  `twcrps@hist_p98`, exceedance rate at p95, `brier@hist_p98`); decide the exact set at
+  `twcrps@historical_p95`, exceedance rate at p95, `brier@historical_p95`); decide the exact set at
   implementation time and keep it small — everything is in Delta regardless.
 - **Peak-events diagnostic slice:** one more named population filter on the shared mechanism
   (with the Tricky-days filter), flagged in the leaderboard UI as diagnostic-only.

--- a/docs/techniques/evaluation-metrics.md
+++ b/docs/techniques/evaluation-metrics.md
@@ -371,9 +371,9 @@ $$
 
 Because it reuses the fair form, twCRPS inherits CRPS's one crucial comparability property:
 it is unbiased across ensemble sizes, so the 13-member `nged_incumbent` and the 51-member ML
-models can be compared on it directly. It is computed per threshold in the
-[per-series threshold ladder](#choosing-the-thresholds-static-per-series-quantile-derived),
-with `metric_param` carrying the threshold label.
+models can be compared on it directly. It is computed against the [per-series
+threshold](#choosing-the-thresholds-static-per-series-quantile-derived), with `metric_param`
+carrying the threshold label.
 
 ### Exceedance rate of the upper delivery quantiles
 
@@ -440,18 +440,19 @@ their scoring properties**, and state plainly that they are a proxy — these me
 "skill near a fixed line standing where the limit typically lives", not operational breach
 prediction:
 
-- **The threshold: the P95 of each series' full observation history** (of power in the
-  constraint-side direction — see below), the rung NGED endorsed. Its label in `metric_param`
-  is `historical_p95`, deliberately distinct from the forecast-quantile label `p95`: one names
-  a fixed power level derived from history, the other a level of the forecast distribution.
-  The prefix is spelled out rather than shortened to `hist_`, which reads as "histogram".
+- **The threshold: the P99 of each series' full observation history** (of power in the
+  constraint-side direction — see below), the rung NGED described when we discussed this in
+  July 2026. Its label in `metric_param` is `historical_p99`, deliberately distinct from the
+  forecast-quantile label `p99`: one names a fixed power level derived from history, the other
+  a level of the forecast distribution. The prefix is spelled out rather than shortened to
+  `hist_`, which reads as "histogram".
 
 - **Why historical quantiles rather than the physical ratings:** ratings are not available
   for every series; a rating that is never breached in a 12-month validation window yields
   *zero events* — and a warning system cannot be graded on events that never happen; and
   per-series ratings sit at wildly different points of each series' distribution, breaking
   cross-series comparability. A full-history quantile threshold guarantees every series a
-  scoreable event rate (~5% by construction), is identical in meaning across series, and is
+  scoreable event rate (~1% by construction), is identical in meaning across series, and is
   stable across CV folds for the same reason the
   [effective-capacity denominator](../roadmap/metrics-and-leaderboard.md#normalising-nmae-by-effective_capacity)
   is computed over the full history.

--- a/docs/techniques/evaluation-metrics.md
+++ b/docs/techniques/evaluation-metrics.md
@@ -440,20 +440,19 @@ their scoring properties**, and state plainly that they are a proxy — these me
 "skill near a fixed line standing where the limit typically lives", not operational breach
 prediction:
 
-- **The threshold ladder: the P90 and P98 of each series' full observation history** (of
-  power in the constraint-side direction — see below). Labels `hist_p90` / `hist_p98` in
-  `metric_param`, deliberately distinct from forecast-quantile labels like `p95`: one names a
-  fixed power level derived from history, the other a level of the forecast distribution. The
-  two rungs give a "busy periods" and a "genuinely extreme" read without exploding the key
-  count.
+- **The threshold: the P95 of each series' full observation history** (of power in the
+  constraint-side direction — see below), the rung NGED endorsed. Its label in `metric_param`
+  is `historical_p95`, deliberately distinct from the forecast-quantile label `p95`: one names
+  a fixed power level derived from history, the other a level of the forecast distribution.
+  The prefix is spelled out rather than shortened to `hist_`, which reads as "histogram".
 
 - **Why historical quantiles rather than the physical ratings:** ratings are not available
   for every series; a rating that is never breached in a 12-month validation window yields
   *zero events* — and a warning system cannot be graded on events that never happen; and
   per-series ratings sit at wildly different points of each series' distribution, breaking
-  cross-series comparability. Full-history quantile thresholds guarantee every series a
-  scoreable event rate (~10% and ~2% by construction), are identical in meaning across
-  series, and are stable across CV folds for the same reason the
+  cross-series comparability. A full-history quantile threshold guarantees every series a
+  scoreable event rate (~5% by construction), is identical in meaning across series, and is
+  stable across CV folds for the same reason the
   [effective-capacity denominator](../roadmap/metrics-and-leaderboard.md#normalising-nmae-by-effective_capacity)
   is computed over the full history.
 

--- a/docs/techniques/evaluation-metrics.md
+++ b/docs/techniques/evaluation-metrics.md
@@ -479,8 +479,8 @@ To keep the leaderboard legible, parametric metrics are
 restricted in MLflow to a **headline subset**: `pinball_loss` at p10/p50/p90 and `picp` /
 `interval_width` at p10_p90 (the allowlist is `_MLFLOW_LOGGED_PARAMETRIC` in
 `ml_core.metrics`). The exact key count scales with how many distinct `time_series_type`
-values the scored population spans (each adds a per-type key family): 132 keys for the V1
-trial area's six types, versus roughly 340 if every quantile and band were logged. Anything
+values the scored population spans (each adds a per-type key family): 144 keys for the V1
+trial area's seven types, versus roughly 380 if every quantile and band were logged. Anything
 not in MLflow is still one Polars filter away in Delta.
 
 ## What is deliberately *not* here

--- a/docs/techniques/evaluation-metrics.md
+++ b/docs/techniques/evaluation-metrics.md
@@ -508,7 +508,8 @@ not in MLflow is still one Polars filter away in Delta.
 
 - **Cost-loss economic value curves** — the fully decision-theoretic summary of exceedance
   skill: for each ratio of "cost of acting on a warning" to "loss if an unwarned exceedance
-  occurs", how much of a perfect forecast's value does this model capture? This is the natural
-  bridge to the 🔬 v2 stretch goal of estimating **cost savings (£)** per leaderboard row
-  ([Grouping the results](../roadmap/metrics-and-leaderboard.md#grouping-the-results)); until
-  then it is an ad-hoc analysis.
+  occurs", how much of a perfect forecast's value does this model capture? We do not compute
+  these, because the loss term is a number NGED do not hold in usable form; the
+  [cost-savings metrics](../roadmap/cost-savings-metrics.md) reach the same comparison by holding
+  every model to equal risk and comparing what each spends. The curves remain a useful ad-hoc
+  analysis if that loss figure ever firms up.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,6 +97,7 @@ nav:
   - Roadmap:
       - Overview: roadmap/index.md
       - Capacity Estimation: roadmap/capacity-estimation.md
+      - Cost-Savings Metrics: roadmap/cost-savings-metrics.md
       - Data Sources: roadmap/data-sources.md
       - Delivery Tables: roadmap/delivery-tables.md
       - Engineering Health: roadmap/engineering-health.md

--- a/packages/ml_core/src/ml_core/metrics.py
+++ b/packages/ml_core/src/ml_core/metrics.py
@@ -90,7 +90,7 @@ _MLFLOW_LOGGED_PARAMETRIC: Final[frozenset[tuple[str, str]]] = frozenset(
 Metrics with ``metric_param="all"`` are always logged; parametric metrics are restricted to
 this headline subset to keep the MLflow leaderboard legible. The key count depends on how
 many distinct ``time_series_type`` values the scored population spans (each adds a per-type
-key family): 132 keys for the V1 trial area's ~6 types, versus ~340 if every parametric
+key family): 144 keys for the V1 trial area's seven types, versus ~380 if every parametric
 metric were logged. The full 13-quantile / 6-band detail is always queryable in the
 ``forecast_metrics`` Delta table.
 """


### PR DESCRIPTION
> 🤖 **This PR description was written by [Claude Code](https://claude.com/claude-code)**, acting on Jack's behalf.

Adds [`docs/roadmap/cost-savings-metrics.md`](https://openclimatefix.github.io/nged-substation-forecast/roadmap/cost-savings-metrics/) — a design for expressing forecast skill in pounds, written to be read by a numerate non-programmer and intended to go to NGED for review. Docs only; no code.

This follows the July NGED meeting, whose notes moved the "£ saved" idea from a vague v2 stretch goal to something buildable in v0.3.

## What the page proposes

**Two metrics, two numbers, never summed.** Flexibility procurement and curtailment have different prices and different beneficiaries. A third saving NGED raised — engineer-hours freed by replacing manual review of plots — is explicitly *not* a leaderboard metric, because it is identical for every model and so cannot rank them.

**Aim for equal risk, then compare the spend.** The textbook approach prices each model by what goes wrong, which needs the cost of an unwarned breach — a number NGED do not hold usably. So the design inverts it: each model's procurement quantile is calibrated until it leaves the same share of needed megawatt-hours uncovered, and only cost is compared. That matches NGED's own account — they are not suffering breaches, they are over-buying to avoid them.

**One synthetic limit**, the 99th percentile of each series' own history in the constrained direction, shared with the tail and exceedance metrics.

**Two reference points on every row**: manual review (the 13-analogue incumbent at its actual operating point) as the bar, and a perfect forecast as the floor.

## The honesty problem

A £ figure invites a skim-reader to take it for a rigorous cost analysis when it is deliberately not one. The page uses pounds anyway — the parameters really are prices, and a pound figure is the only forecast-quality number most readers can act on — but opens with that warning, lists twelve specific things the numbers do not capture, and puts six open questions to NGED.

## What the adversarial review changed

A reviewer with fresh context found real defects in the first commit. The second commit fixes them, and they are worth reading as design content rather than as a changelog:

- **The equal-risk claim only held in-sample.** τ is calibrated on training folds (it must be, or the saving is lookahead), so what a model realises on the scored fold is whatever its tail calibration delivers. An underdispersed model overshoots the target, spends less, and tops the leaderboard while being less safe. The realised out-of-sample unmet fraction is now reported beside every cost, and the page says a cost read without it is meaningless.
- **The perfect forecast was not a floor.** Held to zero unmet while models are allowed 5%, a calibrated model can spend *less* than "perfect" and score above 100% of the available saving. It is now held to the same unmet target.
- **The page contradicted itself on manual review** — calibrated to the common risk target in one place, pinned at its 95th-percentile operating point in another. It is now scored at its actual operating point, because the point is to measure what NGED do today, with the consequence stated: the saving against it mixes a change in spend with a change in risk.
- **The sign convention was wrong for most of the trial area.** `max(0, −y)` assumes the substation convention, but at a customer's meter positive means the customer is generating, so the curtailment metric would have silently returned £0 for every generator. Direction is now resolved per `time_series_type`, reusing the mapping the tail metrics already need.
- **The `metric_param` labels would have collided.** Bare `p95`/`p99` already exist in `QUANTILE_METRIC_PARAMS` meaning forecast quantiles; the tail-metric design had chosen a prefix specifically to keep a history-derived power level distinct from a level of the forecast distribution. Now `historical_p95`.
- **Storage conflicted with the `Metrics` contract.** Costs are now stored per `time_series_id`, summed over time only, so they fit the existing primary key. The needed `METRIC_NAMES`/`METRIC_PARAMS` additions are left as an open question to review when we implement, rather than presented as rows that just land.
- **Two limitations were missing**: the observed history is already post-intervention, so needed volume is understated and the percentile limit is itself shaped by the interventions being priced; and unmet energy pooled across series lets a model hit the target by covering the largest site and abandoning small ones.
- **Three overclaims aimed at the customer were cut**: that curtailment costs NGED money (it may fall on the generator under a non-firm connection — now question 3), that they avoid costing breaches for "politically loaded" reasons, and that "manual review" is a more accurate name than "forecast". The hedge that we have not confirmed NGED's 95th-percentile operating point is restored, and the page now asks for the trial-area capacities they offered instead of only calling its own limits invented.

## One threshold rung, across both metric families

The first draft left two threshold ladders on one leaderboard. Both metric families now use a single rung — the **99th percentile of each series' full observation history**, in the constrained direction, labelled `historical_p99` — and this applies to the pre-existing tail-metric design in `docs/roadmap/metrics-and-leaderboard.md` and `docs/techniques/evaluation-metrics.md` as well as to the new page.

The label spells out `historical_` rather than `hist_`, which reads as "histogram". It still has to stay distinct from the bare `p99` that already exists in `QUANTILE_METRIC_PARAMS` meaning a forecast quantile.

## What the second review changed

A second reviewer, fresh, went over the corrected draft. Two of its findings moved the numbers rather than the wording:

- **The rung had to be the 99th percentile, not the 95th.** A series exceeds its own P95 in 5% of half-hours — 876 a year — so even a perfect forecast "procured" hundreds of MWh a year at a single site, and the trial-area total ran several times the £2M figure the page invites NGED to cross-check against. P95 also sat *below* `effective_capacity`, which is the P99 of `|power|`, making the "limit" a level the site passes every couple of days. The 99th is also the rung NGED actually described.
- **Availability and utilisation are different prices, and over-procurement only attracts availability.** The cost is now `p_avail × Σ V + p_util × Σ min(V, N)`. The second term is near-identical across models, so the ranking is carried by the first. Charging one blended price against all procured volume overstated the cost of over-procurement several times over — and over-procurement is the entire subject of the metric.

The rest:

- **"NGED endorsed the P95" was a position they never took**, asserted in two files and contradicted by a third on the same branch. Everything attributed to NGED now carries its July 2026 provenance.
- **A series constrained in both directions needs a limit in each**, which one scalar per series cannot express. The threshold is now per `(time_series_id, direction)`, and each metric is computed only where its direction is constrained.
- **The perfect forecast had no mechanism.** Truth is not a distribution, so there is no quantile to calibrate; the floor is now stated in closed form.
- **τ is calibrated on the training window**, which is data the model was fitted to — so its residuals are too small, τ comes out too low, and the model that overfits hardest gains most. Named explicitly rather than attributed to "underdispersion".
- **The reason for rejecting NGED's real ratings did not hold.** Procurement volume is driven by the *forecast* crossing the limit, not the observation, so a never-breached rating still ranks models fine; only the unmet fraction goes undefined. The page now says we will compute against real ratings as case studies.
- **Ten trial-area sites are MVA-metered and cannot see direction at all** — reverse flow appears as a rise, and MVA × 0.5 h is not the megawatt-hour a flexibility price is quoted against.
- **`_log_metrics_to_mlflow` aggregates with `mean()`**, which is wrong for a metric whose headline is a sum over series, and wrong for a pooled `unmet_fraction`. Flagged as needing a per-metric rule.
- **Two stored quantities have nowhere to live** in `Metrics` — the half-hour count per row and the calibrated τ. Both folded into the contract question.

One finding I did not accept: the reviewer flagged several statements as putting words in NGED's mouth with no cited source. They come from the meeting notes, which the reviewer did not have — so they are sourced, just not in the repo. They now carry their provenance rather than being softened. Only one genuinely unsupported generalisation was cut.

Also spotted in passing, unrelated to this branch and not changed: `docs/techniques/evaluation-metrics.md:481` says "the V1 trial area's six types", but `power_schemas.py` lists seven, which also makes the "132 keys" arithmetic on that line wrong.

## Also in this PR

## Also in this PR

- Issue #606 created under epic #6, positioned after the tail-and-exceedance issue, with a body that just links to the rendered page.
- The v2 stretch-goal line in the roadmap index is replaced by a v0.3 milestone entry, and the note at the end of Metrics & leaderboard points at the new page.
- The cost-loss economic value bullet in the evaluation-metrics reference is rewritten: it described itself as a bridge to a v2 goal that no longer exists in that form.
- Issue #606 is marked as blocked by #147: without the `nged_incumbent` baseline there is no manual-review reference, only the perfect-forecast one.
- `mkdocs build --strict` is clean with no anchor warnings, and the rendered HTML was inspected for the nested-list and wrapped-link traps.

## For the reviewer

Two numbers on the page are placeholders pending NGED's answers: the 5% unmet target (question 5) and the £750/MWh used in the worked example (question 1).

The page is ~2,800 words and has grown at each round despite cutting the padding both reviewers named. The growth is all conceded limitations and the two-price cost model. A shorter page that drops them seemed worse for a document going to the customer, but say the word and it can be trimmed.
