### PR TITLE
Split the error categories in principle 1, and add principle 16 on self-explaining telemetry

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,10 @@ that come up constantly when editing `defs/`:
   training run poisons every comparison built on it.
 - **When a capability could live in the training loop or in the production service, put it in the
   training loop.** Keep the serving path close to "load a model, call `predict`".
+- **Make the telemetry name the fault.** An exception a warning path swallows still has to reach
+  Sentry, tagged with whatever an alert rule routes on, and its message has to name the series, the
+  run or the asset at fault rather than only the type of error. The operator reads the alert, not
+  the logs.
 
 Full rationale, the degradation ladder and the numbered rules:
 [`docs/design-philosophy/inherent-stability.md`](docs/design-philosophy/inherent-stability.md). The

--- a/docs/architecture/code-style.md
+++ b/docs/architecture/code-style.md
@@ -261,7 +261,10 @@ confusing failure:
   like the Python 2 syntax that Python 3 rejected for years, but
   [PEP 758](https://peps.python.org/pep-0758/) made it legal in Python 3.14. Parentheses are still
   required to bind the exception to a name: `except (OSError, ValueError) as err:`.
-- Leverage Sentry for observability in production-like code.
+- Leverage Sentry for observability in production-like code, and make each event name the fault:
+  the tag an alert rule routes on, and a message naming the series, the run or the asset that broke
+  rather than only the type of error. See [design principle
+  16](../design-philosophy/design-principles.md#16-a-failure-names-its-own-cause-in-the-telemetry).
 - Validate data at boundaries using data contracts.
 
 Production code is bound by a stronger rule about *when* to raise at all, summarised in

--- a/docs/design-philosophy/common-incident-classes.md
+++ b/docs/design-philosophy/common-incident-classes.md
@@ -27,8 +27,8 @@ makes the live-forecast asset **raise** rather than degrade — one of three har
 [failure-modes table](inherent-stability.md#failure-modes), and the only one tracked to change
 ([#446](https://github.com/openclimatefix/nged-substation-forecast/issues/446)). The other two stay
 deliberate raises: an empty or unloadable promoted model is a promotion bug rather than a data
-outage, and a duplicated forecast primary key means malformed input has fanned a join out, which
-rule 2 rejects at the contract boundary rather than delivering. The NWP gap is tracked, and the fix is deliberately sequenced behind training
+outage, and a duplicated forecast primary key means one of our own joins has fanned out, which
+`PowerForecast.validate` rejects at the contract boundary rather than delivering. The NWP gap is tracked, and the fix is deliberately sequenced behind training
 the model against realistic outages, so that a degraded forecast is measured rather than merely
 produced.
 

--- a/docs/design-philosophy/design-principles.md
+++ b/docs/design-philosophy/design-principles.md
@@ -68,8 +68,14 @@ principle behind it is a claim we are merely hoping comes true.
 If data inputs are disrupted, the forecast gets less certain instead of stopping — and should say
 so in the forecast itself, through wider uncertainty bands (band-widening is designed but not yet
 built — see [Widening bands](inherent-stability.md#widening-bands-the-in-band-signal)). The
-forecast always does the best it can with whatever data it has, rather than blowing up; raising
-is reserved for states that are our own bug. The plan is to deliver that through the **model
+forecast always does the best it can with whatever data it has, rather than blowing up. That
+covers errors in the **upstream data**, and only those. An error in **our own code** — an empty
+promoted model, a contract violation, a join that has fanned out — gets the opposite posture: fail
+as early as possible, and confine the failure to the one partition it happened in ([principle 10
+("*every write is atomic and idempotent, and every failure is confined to one
+partition*")](#10-every-write-is-atomic-and-idempotent-and-every-failure-is-confined-to-one-partition)).
+Degrading around our own bug would deliver a wrong forecast and bury its cause. The plan is to
+deliver the never-stop half through the **model
 itself** — an ML model that can, at least partially, handle missing inputs — rather than through
 fallback logic wrapped around a model that assumes complete data. (Note that this decision to
 "never stop" will not be appropriate for energy-forecasting systems where an uncertain forecast
@@ -82,7 +88,9 @@ because one meter went quiet, NGED open their dashboard to a gap instead of a fo
 developer spends the morning re-running a pipeline whose only real problem was a missing input.
 
 *Decided:* every asset check in the repo is non-blocking `WARN`; there is deliberately no
-`ERROR`-severity check anywhere.
+`ERROR`-severity check anywhere — while `PowerForecast.validate` still hard-fails a whole slot on a
+duplicated primary key, because a duplicated forecast row takes a bug of ours rather than a bad
+input.
 
 *Serves:* [Hypothesis 1: a service that mostly runs
 itself](engineering-hypotheses.md#h1-a-service-that-mostly-runs-itself).
@@ -605,6 +613,42 @@ frozen into the archive cannot be varied by an experiment.
 *Detail:* [NWP variable conventions](../architecture/nwp-variable-conventions.md),
 [Storage formats](../architecture/performance.md#storage-formats-measured-not-assumed).
 
+### 16 — A failure names its own cause in the telemetry
+
+When something goes wrong, the cause should be legible from the Sentry event and from what Dagster
+shows, rather than reconstructed by trawling logs. The standard to aim at is `rustc`'s diagnostics:
+name the thing that broke, say where, and leave the reader in no doubt what to do next. That makes
+each event a design surface rather than a by-product — its tags decide whether an alert rule can
+route it, its fingerprint decides whether a stall recurring hourly is one issue or twenty-four, and
+its message decides whether the operator can act without opening a shell on the box. Two things make
+this load-bearing rather than good manners. [Principle 1 ("*the power forecast never
+stops*")](#1-the-power-forecast-never-stops) makes failure quiet by design, so the telemetry is
+often the only thing that speaks at all; and under the preferred post-NIA operating model the reader
+of the alert is a non-expert at NGED holding the runbooks and nothing else.
+
+*Without it:* the alert says a run failed. The operator opens Dagster, finds the run, reads the
+step's logs, and works out from a stack trace which time series, which weather run or which of our
+own assumptions actually broke — the out-of-hours archaeology
+[T1.1](engineering-hypotheses.md#h1-a-service-that-mostly-runs-itself) says will never be needed.
+
+*Decided:* every Sentry sender carries a tag an alert rule can route on, including the failure
+hook's positive `fault_category:run_failed` marker rather than a rule phrased as "error level, and
+neither degradation tag is set", which would misclassify silently the day a fifth sender is added;
+an asset check that swallows its own exception still reports it through `report_check_degradation`,
+because log capture is off and the `ERROR` log alone would reach nobody; the stale-power event names
+each late series and how late it is (`series 12: 48.5h late`), carries the true count in an `n_late`
+tag so a truncated list cannot make a large stall look small, and is fingerprinted per environment
+so an hourly-repeating stall stays one issue; and `power_forecast_warnings` carries a
+`warning_source`, because a warning is only actionable if it names whose feed broke.
+
+*Serves:* [Hypothesis 1: a service that mostly runs
+itself](engineering-hypotheses.md#h1-a-service-that-mostly-runs-itself) — specifically T1.1,
+interventions per quarter, and T1.4, operability by a non-expert.
+
+*Detail:* [Send telemetry to Sentry, and alarm on
+absence](../architecture/production-deployment.md#send-telemetry-to-sentry-and-alarm-on-absence),
+[Three audiences, three channels](inherent-stability.md#three-audiences-three-channels).
+
 ## Deliberately absent
 
 We have **no availability service-level objective (SLO) and no error
@@ -721,8 +765,8 @@ left as decoration — the same discipline the hypotheses page applies to its th
 
 **Before copying a principle into another system, check the assumption it is a bet on.** Most of the
 list is portable as-is — strict contracts, one execution path, identically-scored experiments,
-provenance, atomic and idempotent writes, and measure-don't-assume are close to unconditional good
-practice, and
+provenance, atomic and idempotent writes, self-explaining telemetry, and measure-don't-assume are
+close to unconditional good practice, and
 cheap experiments are too for any project that is doing research rather than only operating a fixed
 model.
 [Principle 1 ("*the power forecast never stops*")](#1-the-power-forecast-never-stops) is the

--- a/docs/design-philosophy/design-principles.md
+++ b/docs/design-philosophy/design-principles.md
@@ -71,13 +71,13 @@ built — see [Widening bands](inherent-stability.md#widening-bands-the-in-band-
 forecast always does the best it can with whatever data it has, rather than blowing up. That
 covers errors in the **upstream data**, and only those. An error in **our own code** — an empty
 promoted model, a contract violation, a join that has fanned out — gets the opposite posture: fail
-as early as possible, and confine the failure to the one partition it happened in ([principle 10
-("*every write is atomic and idempotent, and every failure is confined to one
-partition*")](#10-every-write-is-atomic-and-idempotent-and-every-failure-is-confined-to-one-partition)).
-Degrading around our own bug would deliver a wrong forecast and bury its cause. The plan is to
-deliver the never-stop half through the **model
-itself** — an ML model that can, at least partially, handle missing inputs — rather than through
-fallback logic wrapped around a model that assumes complete data. (Note that this decision to
+as early as possible, because degrading around our own bug would deliver a wrong forecast and bury
+its cause. How far such a failure then spreads is a different axis, and the business of
+[principle 10 ("*every write is atomic and idempotent, and every failure is confined to one
+partition*")](#10-every-write-is-atomic-and-idempotent-and-every-failure-is-confined-to-one-partition)
+rather than of this one. The plan is to deliver the never-stop half through the **model itself** —
+an ML model that can, at least partially, handle missing inputs — rather than through fallback
+logic wrapped around a model that assumes complete data. (Note that this decision to
 "never stop" will not be appropriate for energy-forecasting systems where an uncertain forecast
 might be more harmful than *no* forecast. But, in Flexpectation, there are strong arguments that
 our forecast will *always* be better than NGED's incumbent baseline, even when we have no live
@@ -88,9 +88,12 @@ because one meter went quiet, NGED open their dashboard to a gap instead of a fo
 developer spends the morning re-running a pipeline whose only real problem was a missing input.
 
 *Decided:* every asset check in the repo is non-blocking `WARN`; there is deliberately no
-`ERROR`-severity check anywhere — while `PowerForecast.validate` still hard-fails a whole slot on a
-duplicated primary key, because a duplicated forecast row takes a bug of ours rather than a bad
-input.
+`ERROR`-severity check anywhere — while `PowerForecast.validate` hard-fails a whole slot on a
+duplicated primary key, because only a bug of ours can duplicate a forecast row: every NWP write
+replaces its partition, so the duplication cannot come from the data at rest. One production raise
+is not yet on the right side of the line this principle draws: a sustained NWP outage still fails
+`live_forecasts` rather than degrading to a weather-blind forecast
+([#446](https://github.com/openclimatefix/nged-substation-forecast/issues/446)).
 
 *Serves:* [Hypothesis 1: a service that mostly runs
 itself](engineering-hypotheses.md#h1-a-service-that-mostly-runs-itself).
@@ -617,33 +620,35 @@ frozen into the archive cannot be varied by an experiment.
 
 When something goes wrong, the cause should be legible from the Sentry event and from what Dagster
 shows, rather than reconstructed by trawling logs. The standard to aim at is `rustc`'s diagnostics:
-name the thing that broke, say where, and leave the reader in no doubt what to do next. That makes
+name the thing that broke, and say where. That makes
 each event a design surface rather than a by-product — its tags decide whether an alert rule can
 route it, its fingerprint decides whether a stall recurring hourly is one issue or twenty-four, and
 its message decides whether the operator can act without opening a shell on the box. Two things make
 this load-bearing rather than good manners. [Principle 1 ("*the power forecast never
 stops*")](#1-the-power-forecast-never-stops) makes failure quiet by design, so the telemetry is
-often the only thing that speaks at all; and under the preferred post-NIA operating model the reader
-of the alert is a non-expert at NGED holding the runbooks and nothing else.
+often the only thing that speaks at all; and under the operating model preferred once this
+project's funding ends, the reader of the alert is a non-expert at NGED holding the runbooks and
+nothing else.
 
 *Without it:* the alert says a run failed. The operator opens Dagster, finds the run, reads the
 step's logs, and works out from a stack trace which time series, which weather run or which of our
-own assumptions actually broke — the out-of-hours archaeology
-[T1.1](engineering-hypotheses.md#h1-a-service-that-mostly-runs-itself) says will never be needed.
+own assumptions actually broke — an hour per incident, and a cause recorded in the [intervention
+log](../live_service/intervention-log.md) that is a guess.
 
-*Decided:* every Sentry sender carries a tag an alert rule can route on, including the failure
-hook's positive `fault_category:run_failed` marker rather than a rule phrased as "error level, and
-neither degradation tag is set", which would misclassify silently the day a fifth sender is added;
-an asset check that swallows its own exception still reports it through `report_check_degradation`,
-because log capture is off and the `ERROR` log alone would reach nobody; the stale-power event names
-each late series and how late it is (`series 12: 48.5h late`), carries the true count in an `n_late`
-tag so a truncated list cannot make a large stall look small, and is fingerprinted per environment
-so an hourly-repeating stall stays one issue; and `power_forecast_warnings` carries a
-`warning_source`, because a warning is only actionable if it names whose feed broke.
+*Decided:* every Sentry *event* sender carries a tag an alert rule can route on, including the
+failure hook's positive `fault_category:run_failed` marker rather than a rule phrased as "error
+level, and neither degradation tag is set", which would misclassify silently the day a fifth sender
+is added; an asset check that swallows its own exception still reports it through
+`report_check_degradation`, because log capture is off and the `ERROR` log alone would reach
+nobody; and the stale-power event names the worst late series and how late each is (`series 12:
+48.5h late`), caps that list so a whole-feed stall cannot attach thousands of rows, carries the true
+count in an `n_late` tag so the cap cannot make a large stall look small, and is fingerprinted per
+environment so an hourly-repeating stall stays one issue.
 
 *Serves:* [Hypothesis 1: a service that mostly runs
-itself](engineering-hypotheses.md#h1-a-service-that-mostly-runs-itself) — specifically T1.1,
-interventions per quarter, and T1.4, operability by a non-expert.
+itself](engineering-hypotheses.md#h1-a-service-that-mostly-runs-itself) — specifically T1.4,
+operability by a non-expert, and T1.1's cause taxonomy, which is only as good as what the telemetry
+says caused the failure.
 
 *Detail:* [Send telemetry to Sentry, and alarm on
 absence](../architecture/production-deployment.md#send-telemetry-to-sentry-and-alarm-on-absence),
@@ -765,7 +770,8 @@ left as decoration — the same discipline the hypotheses page applies to its th
 
 **Before copying a principle into another system, check the assumption it is a bet on.** Most of the
 list is portable as-is — strict contracts, one execution path, identically-scored experiments,
-provenance, atomic and idempotent writes, self-explaining telemetry, and measure-don't-assume are
+provenance, atomic and idempotent writes, telemetry that names its own cause, and
+measure-don't-assume are
 close to unconditional good practice, and
 cheap experiments are too for any project that is doing research rather than only operating a fixed
 model.

--- a/docs/design-philosophy/inherent-stability.md
+++ b/docs/design-philosophy/inherent-stability.md
@@ -217,7 +217,7 @@ appear nowhere else.
 12. **Make the telemetry name the fault.** An exception a warning path swallows still has to reach
     Sentry, tagged with whatever an alert rule routes on, and its message has to name the series,
     the run or the asset at fault rather than only the type of error. The operator reads the alert,
-    not the logs. *(The [self-explaining-telemetry
+    not the logs. *(The [names-its-own-cause
     principle](design-principles.md#16-a-failure-names-its-own-cause-in-the-telemetry), in
     imperative form.)*
 

--- a/docs/design-philosophy/inherent-stability.md
+++ b/docs/design-philosophy/inherent-stability.md
@@ -214,6 +214,12 @@ appear nowhere else.
     [coupling-through-data-at-rest
     principle](design-principles.md#14-production-jobs-are-coupled-through-data-at-rest-never-through-run-status),
     in imperative form.)*
+12. **Make the telemetry name the fault.** An exception a warning path swallows still has to reach
+    Sentry, tagged with whatever an alert rule routes on, and its message has to name the series,
+    the run or the asset at fault rather than only the type of error. The operator reads the alert,
+    not the logs. *(The [self-explaining-telemetry
+    principle](design-principles.md#16-a-failure-names-its-own-cause-in-the-telemetry), in
+    imperative form.)*
 
 ## Where complexity should live
 


### PR DESCRIPTION
Written by Claude Code (Opus 5).

Two changes to the design principles, prompted by re-reading them against the Sentry section of `production-deployment.md`, plus the two pointers that make them reachable from where the code gets written.

## Principle 1 now states the two error categories outright

Principle 1 already carried the distinction, but in a half-clause — "raising is reserved for states that are our own bug" — which is easy to skim past when the heading says "the power forecast never stops". It now says that the never-stop rule covers errors in the **upstream data** and only those, and that an error in **our own code** (an empty promoted model, a contract violation, a join that has fanned out) gets the opposite posture: fail as early as possible, because degrading around our own bug would deliver a wrong forecast and bury its cause. How far such a failure spreads is attributed to principle 10 as a separate axis, since principle 10 and `inherent-stability.md` both warn by name against conflating the two.

Its *Decided* line now names both sides: `PowerForecast.validate` hard-failing a whole slot on a duplicated primary key (only a bug of ours can duplicate a forecast row, because every NWP write replaces its partition), and the one production raise that is **not** yet on the right side of the line — a sustained NWP outage, tracked by #446.

## New principle 16 — "a failure names its own cause in the telemetry"

This is the genuinely new content: nothing in `docs/` currently sets a quality bar for what an error says. The standard is `rustc`'s diagnostics — the cause should be legible from the Sentry event and from what Dagster shows, rather than reconstructed by trawling logs.

The framing is that a telemetry event is a *design surface*, not a by-product: its tags decide whether an alert rule can route it, its fingerprint decides whether an hourly-recurring stall is one issue or twenty-four, and its message decides whether the operator can act without opening a shell on the box. Two things make it load-bearing rather than good manners — principle 1 makes failure quiet by design, so telemetry is often the only thing that speaks; and once this project's funding ends, the reader of the alert is a non-expert at NGED with the runbooks and nothing else.

It passes the page's own admission test. *Serves* H1 — T1.4, and T1.1's cause taxonomy, which is only as good as what the telemetry says caused the failure. *Decided* names three shipped decisions, each verified against `_sentry.py` rather than against the prose describing it:

- the failure hook's positive `fault_category:run_failed` tag, rather than an alert rule phrased as "error level, and neither degradation tag is set", which would misclassify silently the day a fifth sender is added;
- `report_check_degradation` sending an exception a check swallowed, because log capture is off and the `ERROR` log alone would reach nobody;
- the stale-power event's per-series message, its caps, its `n_late` tag so the cap cannot make a large stall look small, and its per-environment fingerprint.

## Where the rule is reachable from

- **Rule 12 in `inherent-stability.md`** — the imperative form, marked as restating principle 16, since that rules list is the checklist someone follows while editing `defs/`.
- **`CLAUDE.md`** — the same rule as a corollary bullet, so it is in front of every session.
- **`code-style.md`** — the bare "Leverage Sentry for observability" bullet now says what a good event contains and links the principle.
- **"How to use this list"** names telemetry-that-names-its-own-cause among the principles portable as-is.

## Review, and what it caught

An adversarial sub-agent reviewed the prose against the code and the surrounding docs. It was not green, and two findings were real defects rather than style:

1. ***Decided* cited `power_forecast_warnings`' `warning_source` as a decision made.** That table is 🚧 in `delivery-tables.md` and appears nowhere in the code. Deleted rather than marked, because the clause also reproduced a sentence from the "three audiences, three channels" section the principle links as its *Detail*.
2. **The same list contradicted itself inside one sentence** — "names each late series" against "a truncated list cannot make a large stall look small". The message is capped at 20 series and the context at 50. Reworded to what the code does.

Four smaller ones also applied: the blast-radius conflation above; the missing #446 caveat above; principle 16 originally served T1.1 via "out-of-hours archaeology", but out-of-hours work is decided by the uptime posture rather than by how legible an event is, so it now serves T1.1's cause taxonomy; and "every Sentry sender carries a tag" over-counted, since `send_forecast_checkin` sends a check-in rather than a tagged event.

One reviewer suggestion was **rejected**: moving rule 12 next to rule 7 and renumbering. `ecmwf-ens-known-issues.md` cites rules 2 and 6 by number and `production-deployment.md` cites rule 7, so renumbering silently repoints those references.

## For the reviewer

- **Why principle 16 rather than a slot next to principle 1.** The numbers are anchor targets linked from `common-incident-classes.md`, `code-style.md` and elsewhere, so renumbering would break inbound links.
- **One change sits outside this PR's own files.** `common-incident-classes.md` called a duplicated forecast primary key "malformed input", which contradicts both `inherent-stability.md` and its own later paragraph. This PR makes that categorisation load-bearing, so the stale clause is corrected here — flagging it in case you would rather it went separately.
- **This conflicts with #609**, which edits the same paragraph of principle 1 and the same *Decided* line. `git merge-tree` confirms a conflict in `design-principles.md`; `inherent-stability.md` auto-merges. The two are complementary in substance — #609 says you must be *told* the forecast degraded, this says what you are told must *name the fault* — so whichever lands second should merge them into one argument by hand rather than taking either side wholesale.
- Docs-only, four files. `pymarkdown scan -r docs CLAUDE.md` and `mkdocs build --strict` are clean, and I read the generated HTML for the rendered pages: principle 16 is its own section with working links, and rule 12 renders as item 12 of the existing ordered list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
