### PR TITLE
Model NWP availability from disk arrival, not publication (6h to 9h)

### DIFF
--- a/packages/ml_core/tests/test_features.py
+++ b/packages/ml_core/tests/test_features.py
@@ -924,7 +924,7 @@ def test_engineer_features_bulk_mode_derives_power_fcst_init_time():
     """In bulk mode, power_fcst_init_time must equal nwp_init_time + nwp_publication_delay_hours."""
     nwp_init_time = datetime(2023, 1, 1, 0, 0)
     valid_time = datetime(2023, 1, 1, 12, 0)
-    nwp_publication_delay_hours = 9  # non-default to confirm the parameter is used
+    nwp_publication_delay_hours = 3  # non-default to confirm the parameter is used
 
     nwp_df = pl.DataFrame(
         {

--- a/packages/ml_core/tests/test_production_helpers.py
+++ b/packages/ml_core/tests/test_production_helpers.py
@@ -22,6 +22,7 @@ from ml_core._production_helpers import (
     load_forecaster_from_dir,
     select_nwp_init_time,
 )
+from weather_utils import NWP_PUBLICATION_DELAY_HOURS
 from xgboost_forecaster.forecaster import XGBoostConfig, XGBoostForecaster
 
 _POWER_FCST_INIT_TIME = datetime(2026, 7, 4, 6, 0, tzinfo=UTC)
@@ -47,21 +48,50 @@ def test_live_picks_freshest_run_at_or_before_power_fcst_init_time() -> None:
 
 
 def test_replay_picks_freshest_run_at_or_before_delayed_cutoff() -> None:
-    available = [
-        _POWER_FCST_INIT_TIME - timedelta(hours=24),
-        _POWER_FCST_INIT_TIME - timedelta(hours=6),
-        _POWER_FCST_INIT_TIME,
-    ]
-    # Replay cutoff is power_fcst_init_time - 6h (the default delay): the run exactly there
-    # qualifies, not the run at power_fcst_init_time itself.
-    assert select_nwp_init_time(
-        available, power_fcst_init_time=_POWER_FCST_INIT_TIME, availability_mode="replay"
-    ) == _POWER_FCST_INIT_TIME - timedelta(hours=6)
+    # Derived from the constant rather than hard-coded, so changing the delay cannot leave this
+    # test asserting a superseded cutoff.
+    cutoff = _POWER_FCST_INIT_TIME - timedelta(hours=NWP_PUBLICATION_DELAY_HOURS)
+    available = [cutoff - timedelta(hours=24), cutoff, _POWER_FCST_INIT_TIME]
+    # The run exactly at the cutoff qualifies; the run at power_fcst_init_time itself does not.
+    assert (
+        select_nwp_init_time(
+            available, power_fcst_init_time=_POWER_FCST_INIT_TIME, availability_mode="replay"
+        )
+        == cutoff
+    )
+
+
+@pytest.mark.parametrize(
+    ("slot_hour", "expected_run_day_offset"),
+    [(0, -1), (6, -1), (12, 0), (18, 0)],
+    ids=["00:00", "06:00", "12:00", "18:00"],
+)
+def test_replay_reconstructs_the_run_that_had_genuinely_landed(
+    slot_hour: int, expected_run_day_offset: int
+) -> None:
+    """Replay must pick the run that was really on disk, at every one of the four slots.
+
+    Ground truth: we ingest one 00Z run a day and ``ecmwf_ens_schedule`` downloads it at 08:30 UTC,
+    so day D's run is ours from 08:30. The 00:00 and 06:00 slots therefore still see D-1's run; the
+    12:00 and 18:00 slots see D's. The 06:00 case is the one a too-small delay gets wrong, by
+    handing the slot a run that had not landed yet.
+    """
+    day = datetime(2026, 7, 4, tzinfo=UTC)
+    available = [day + timedelta(days=offset) for offset in (-2, -1, 0)]
+
+    picked = select_nwp_init_time(
+        available,
+        power_fcst_init_time=day + timedelta(hours=slot_hour),
+        availability_mode="replay",
+    )
+
+    assert picked == day + timedelta(days=expected_run_day_offset)
 
 
 def test_live_and_replay_diverge_when_a_fresher_run_exists_within_the_delay_window() -> None:
-    """The whole point of the two modes: a run inside (power_fcst_init_time-6h,
-    power_fcst_init_time] is live-only visible."""
+    """The whole point of the two modes: a run inside
+    ``(power_fcst_init_time - NWP_PUBLICATION_DELAY_HOURS, power_fcst_init_time]`` is
+    live-only visible."""
     available = [
         _POWER_FCST_INIT_TIME - timedelta(hours=24),
         _POWER_FCST_INIT_TIME - timedelta(hours=1),

--- a/packages/weather_utils/src/weather_utils/analysis_proxy.py
+++ b/packages/weather_utils/src/weather_utils/analysis_proxy.py
@@ -12,13 +12,21 @@ from typing import Final
 
 import polars as pl
 
-NWP_PUBLICATION_DELAY_HOURS: Final[int] = 6
-"""Default delay between an NWP run's ``init_time`` and when it becomes publicly available.
+NWP_PUBLICATION_DELAY_HOURS: Final[int] = 9
+"""Hours after an NWP run's ``init_time`` before we treat that run as usable.
 
-A run initialised at ``init_time`` cannot be used to reconstruct the analysis at an as-of time
-earlier than ``init_time + NWP_PUBLICATION_DELAY_HOURS`` — this is the delay
-``select_analysis_proxy`` applies for its optional ``available_at`` leakage cut, and the same delay
-the feature pipeline uses to derive ``power_fcst_init_time`` from ``nwp_init_time``.
+This models when a run reaches *our* disk, not when Dynamical publish it. Dynamical publish each
+00Z run between 08:05 and 08:20 UTC, and ``ecmwf_ens_schedule`` downloads it at 08:30 UTC, so a 00Z
+run is ours from roughly 08:30 — 8.5 hours. Nine is the nearest whole hour at or after that.
+
+``select_analysis_proxy`` applies it for the optional ``available_at`` leakage cut; the feature
+pipeline uses it to derive ``power_fcst_init_time`` from ``nwp_init_time`` in bulk mode; and
+``select_nwp_init_time`` uses it to reconstruct availability for ``"replay"`` backfills.
+
+Two bounds constrain the value, given one 00Z run a day and forecast slots at 00/06/12/18 UTC. The
+06:00 slot must *not* see that morning's run, which has not landed yet, so the value must exceed 6.
+The 12:00 slot *must* see it, so the value must not exceed 12. Both bounds move if
+``ecmwf_ens_schedule``'s start time changes.
 """
 
 NWP_ANALYSIS_MEMBER: Final[int] = 0

--- a/tests/_nwp_test_data.py
+++ b/tests/_nwp_test_data.py
@@ -2,11 +2,17 @@
 
 The several ``live_forecasts`` / CV / metrics integration tests each build a synthetic ``Nwp``
 frame; the physical-unit constants below were byte-identical across all of them, so they live
-here. The per-test *writers* (which differ in init-times, cells, and ensemble members) stay local
-to each test file. Importable by bare name via the ``pythonpath = ["tests"]`` pytest setting.
+here, as does ``half_hours``, which every one of them needs to place valid times correctly
+relative to the publication delay. The per-test *writers* (which differ in init-times, cells, and
+ensemble members) stay local to each test file. Importable by bare name via the
+``pythonpath = ["tests"]`` pytest setting.
 """
 
+from datetime import datetime, timedelta
 from typing import Final
+
+import polars as pl
+from weather_utils import NWP_PUBLICATION_DELAY_HOURS
 
 NWP_CONTINUOUS_COL_VALUES: Final[dict[str, float]] = {
     "temperature_2m": 15.0,
@@ -23,3 +29,17 @@ NWP_CONTINUOUS_COL_VALUES: Final[dict[str, float]] = {
     "precipitation_surface": 0.001,
 }
 """Physically plausible Float32 constants, one per continuous ``Nwp`` variable."""
+
+
+def half_hours(day: datetime) -> pl.Series:
+    """Half-hourly valid times inside a 00Z run's forecast window, after the publication delay.
+
+    The start is derived from ``NWP_PUBLICATION_DELAY_HOURS`` rather than hard-coded: bulk mode
+    stamps ``power_fcst_init_time = init_time + NWP_PUBLICATION_DELAY_HOURS`` and drops every
+    earlier valid time as a hindcast, so a fixed window silently empties the fixture — and the
+    asset then fails with "no usable rows" — if the delay ever grows.
+    """
+    first = day.replace(hour=0) + timedelta(hours=NWP_PUBLICATION_DELAY_HOURS + 1)
+    return pl.datetime_range(
+        first, first + timedelta(hours=2), interval="30m", time_zone="UTC", eager=True
+    )

--- a/tests/test_cv_power_forecasts.py
+++ b/tests/test_cv_power_forecasts.py
@@ -15,7 +15,7 @@ import numpy as np
 import polars as pl
 import pyarrow.parquet as pq
 import pytest
-from _nwp_test_data import NWP_CONTINUOUS_COL_VALUES
+from _nwp_test_data import NWP_CONTINUOUS_COL_VALUES, half_hours
 from contracts.ml_schemas import EligibleTimeSeries
 from dagster import DagsterInstance, RunConfig, materialize
 from deltalake import write_deltalake
@@ -38,17 +38,11 @@ _VAL_DAY = datetime(2025, 8, 1, tzinfo=UTC)  # inside val window [2025-07-01, 20
 _VAL_MEMBERS = (0, 1, 2)  # stands in for the full 51-member ensemble in this synthetic fixture
 
 
-def _half_hours(day: datetime) -> pl.Series:
-    return pl.datetime_range(
-        day.replace(hour=6), day.replace(hour=8), interval="30m", time_zone="UTC", eager=True
-    )
-
-
 def _write_power(path: str) -> None:
     """Observed power for ts1 in the training window (the validation forecast needs no actuals)."""
     rows = [
         {"time_series_id": 1, "time": t, "power": 100.0 + i}
-        for i, t in enumerate(_half_hours(_TRAIN_DAY))
+        for i, t in enumerate(half_hours(_TRAIN_DAY))
     ]
     pl.DataFrame(rows).cast(
         {"time_series_id": pl.Int32, "time": pl.Datetime("us", "UTC"), "power": pl.Float32}
@@ -59,7 +53,7 @@ def _nwp_records(cell: int, day: datetime, members: tuple[int, ...]) -> list[dic
     records = []
     init_time = day.replace(hour=0)
     for member in members:
-        for valid_time in _half_hours(day):
+        for valid_time in half_hours(day):
             record = {
                 "nwp_model_id": "ECMWF_ENS_0_25_degree",
                 "init_time": init_time,

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -25,6 +25,7 @@ import mlflow
 import patito as pt
 import polars as pl
 import pytest
+from _nwp_test_data import half_hours
 from contracts.ml_schemas import EligibleTimeSeries
 from contracts.power_schemas import (
     LIST_OF_TIME_SERIES_TYPES,
@@ -73,12 +74,6 @@ _NWP_CONTINUOUS_COLS = (
 )
 
 
-def _half_hours(day: datetime) -> pl.Series:
-    return pl.datetime_range(
-        day.replace(hour=6), day.replace(hour=8), interval="30m", time_zone="UTC", eager=True
-    )
-
-
 def _write_power_with_actuals(path: str) -> None:
     """Power for ts1 in both the training window and the validation window.
 
@@ -86,9 +81,9 @@ def _write_power_with_actuals(path: str) -> None:
     validation window (the forecast valid times) as well as training-window data.
     """
     rows = []
-    for i, t in enumerate(_half_hours(_TRAIN_DAY)):
+    for i, t in enumerate(half_hours(_TRAIN_DAY)):
         rows.append({"time_series_id": 1, "time": t, "power": 100.0 + i})
-    for i, t in enumerate(_half_hours(_VAL_DAY)):
+    for i, t in enumerate(half_hours(_VAL_DAY)):
         rows.append({"time_series_id": 1, "time": t, "power": 80.0 + i})
     pl.DataFrame(rows).cast(
         {"time_series_id": pl.Int32, "time": pl.Datetime("us", "UTC"), "power": pl.Float32}
@@ -99,7 +94,7 @@ def _nwp_records(cell: int, day: datetime, members: tuple[int, ...]) -> list[dic
     records = []
     init_time = day.replace(hour=0)
     for member in members:
-        for valid_time in _half_hours(day):
+        for valid_time in half_hours(day):
             record = {
                 "nwp_model_id": "ECMWF_ENS_0_25_degree",
                 "init_time": init_time,

--- a/tests/test_trained_cv_model.py
+++ b/tests/test_trained_cv_model.py
@@ -12,7 +12,7 @@ from pathlib import Path
 import mlflow
 import polars as pl
 import pytest
-from _nwp_test_data import NWP_CONTINUOUS_COL_VALUES
+from _nwp_test_data import NWP_CONTINUOUS_COL_VALUES, half_hours
 from contracts.ml_schemas import EligibleTimeSeries
 from contracts.settings import Settings
 from dagster import DagsterInstance, RunConfig, materialize
@@ -55,15 +55,7 @@ def _write_power(path: str) -> None:
     rows = [
         {"time_series_id": ts, "time": t, "power": 100.0 + i}
         for ts, day in ((1, _IN_WINDOW), (2, _AFTER_TRAIN_END))
-        for i, t in enumerate(
-            pl.datetime_range(
-                day.replace(hour=6),
-                day.replace(hour=8),
-                interval="30m",
-                time_zone="UTC",
-                eager=True,
-            )
-        )
+        for i, t in enumerate(half_hours(day))
     ]
     pl.DataFrame(rows).cast(
         {"time_series_id": pl.Int32, "time": pl.Datetime("us", "UTC"), "power": pl.Float32}
@@ -98,9 +90,7 @@ def _write_nwp(path: str) -> None:
         (_TS2_CELL, _IN_WINDOW, _IN_WINDOW.replace(hour=0)),
         (_TS1_CELL, _TRAIN_START, _EARLY_INIT_TIME),
     ):
-        for valid_time in pl.datetime_range(
-            day.replace(hour=6), day.replace(hour=8), interval="30m", time_zone="UTC", eager=True
-        ):
+        for valid_time in half_hours(day):
             for member in _NWP_ENSEMBLE_MEMBERS:
                 record = {
                     "nwp_model_id": "ECMWF_ENS_0_25_degree",


### PR DESCRIPTION
Written by Claude Code.

`NWP_PUBLICATION_DELAY_HOURS` was 6, which the repo's own measurements contradict. Dynamical publish each 00Z run between 08:05 and 08:20 UTC (`docs/architecture/ecmwf-ens-known-issues.md`), and `ecmwf_ens_schedule` downloads it at 08:30 (`docs/design-philosophy/inherent-stability.md`), so a 00Z run is genuinely ours from roughly 08:30 — 8.5 hours after `init_time`, not 6. No measurement was written down beside the constant, which design principle 12 asks for.

This came out of the whole-repo v0.2 review, where two reviewers reached it independently.

## The bug this caused

`select_nwp_init_time` uses the constant as its "what had landed by then" cutoff for `availability_mode="replay"`. With 6 hours, the 06:00 slot picked *that same morning's* 00Z run — which does not reach disk until 08:30, two and a half hours after the slot it was serving.

| Slot | Old cutoff (−6 h) | Run picked | Genuinely on disk then? |
|---|---|---|---|
| 00:00 | D−1 18:00 | D−1 00Z | yes |
| **06:00** | **D 00:00** | **D 00Z** | **no — lands 08:30** |
| 12:00 | D 06:00 | D 00Z | yes |
| 18:00 | D 12:00 | D 00Z | yes |

Those backfilled rows land in the `(experiment, "live")` partition indistinguishable from genuine live rows, so once production monitoring scores the live fold it would credit the forecast with weather it could not have had. One slot in four was affected.

## Why 9, and why no new parameter

Given one 00Z run a day and forecast slots at 00/06/12/18 UTC, two bounds constrain the value. The 06:00 slot must **not** see that morning's run, so the delay must exceed 6. The 12:00 slot **must** see it, so the delay must not exceed 12. Nine is the nearest whole hour at or above the measured 8.5, leaving three hours of margin on each bound. Both bounds move if `ecmwf_ens_schedule`'s start time changes, and the docstring now says so.

An earlier draft of the review proposed giving `select_nwp_init_time` a separate ingest-deadline parameter. That turned out to be unnecessary: every consumer already takes the delay as an argument defaulting to this constant, so changing the constant propagates with no signature changes at all. The same draft suggested 14 hours would also work — it would not, and the new test proves it: at 14 the 12:00 slot picks a run 24 hours staler than reality.

`_NWP_RUN_EXPECTED_ON_DISK_BY` in `checks.py` deliberately stays at 14 hours. That one is lenient enough to clear the download's retry ladder before complaining, which is a different job from modelling availability.

## Effect on training

Bulk feature engineering also derives `power_fcst_init_time = nwp_init_time + delay`, so training rows now sit 9 hours after their run rather than 6. Production first uses a run at the 12:00 slot, so the lead-time origin is still slightly early and power-lag nullification remains marginally optimistic — but the error is halved. Making it exact is a separate modelling decision, not attempted here.

No retraining is required by this PR, but any model trained before it saw a different lead-time origin.

## Tests

`test_production_helpers.py` gains a parametrised test over all four slots against the real daily-00Z cadence, with the ground truth (run lands 08:30) stated in its docstring. It is a genuine guard rather than a restatement of the constant — verified by running `select_nwp_init_time` across candidate delays:

```
delay= 6h  ->  WRONG: 06:00 picked D+0, truth D-1     <- the old bug
delay= 9h  ->  ALL FOUR SLOTS CORRECT
delay=12h  ->  ALL FOUR SLOTS CORRECT
delay=14h  ->  WRONG: 12:00 picked D-1, truth D+0
```

The existing replay test now derives its cutoff from the constant instead of hard-coding six hours, so it cannot rot the same way again.

## The fixture change, which is the least obvious part of this diff

Sixteen integration tests failed on the first run, and the cause is worth flagging: **the fixtures silently encoded the old constant.** `half_hours` placed valid times at 06:00–08:00 against a 00:00 `init_time`, so at 9 hours every fixture row fell inside the hindcast window that bulk mode drops, and the assets failed with "every eligible series had no usable rows". Nothing in those fixtures said they depended on the delay.

The window now derives from the constant. That helper existed as two byte-identical copies plus two inline ones, so fixing it in place would have written the same subtle constant-derived logic into three files; it now lives in `tests/_nwp_test_data.py`, which those files already import. That is a small piece of consolidation the review had listed separately — say if you would rather it stayed as local copies and I will split it out.

## Review status

**No sub-agent reviewed this diff**, so human review is the first line of defence here rather than the last. The change was designed in conversation during the review, and the reasoning above is the whole of it.

Verification set, all green: `ruff check`, `ruff format --check`, `ty check` (all packages), `pytest` — **694 passed, 1 skipped** (up from 690: the four new slot cases) — and `pymarkdown scan`.
