### PR TITLE
Trigger docs deploy on packages/** changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # Installs the Python version pinned in .python-version; no setup-python step needed.
+      # Resolves and downloads an interpreter satisfying requires-python; no setup-python step needed.
       - name: Set up uv
         uses: astral-sh/setup-uv@v9.0.0
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -8,6 +8,7 @@ on:
       - 'docs/**'      # Only run if you change the docs
       - 'mkdocs.yml'
       - 'src/**'       # Or if you change the source code (for mkdocstrings)
+      - 'packages/**'  # Most of the API reference is generated from packages/, not src/
   # Lets us re-deploy by hand from the Actions tab. GitHub drops queued events during an Actions
   # outage and never backfills them, so a merge that lands mid-outage silently never publishes.
   workflow_dispatch:
@@ -21,17 +22,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v9.0.0
         with:
           enable-cache: true
 
       - name: Install Python and Dependencies
-        run: |
-          uv python install 3.12
-          uv sync --dev
+        run: uv sync --dev
 
       - name: Build and Deploy to GitHub Pages
         run: uv run mkdocs gh-deploy --force


### PR DESCRIPTION
Written by Claude Code.

`.github/workflows/docs.yml` only triggers on `docs/**`, `mkdocs.yml` and `src/**`, but 7 of the 8 API-reference pages under `docs/api/` are generated from `packages/`, not `src/` — each one opens with a Jinja `{% include %}` of a package README followed by `::: package.module` mkdocstrings directives.

`packages/` holds far more library code than `src/` holds orchestration (8,118 non-blank Python lines against 3,738), so most docstring work in this repo never triggered a deploy — the published site lagged until an unrelated `docs/` change happened to push it.

This adds `packages/**` to the `paths:` filter so a packages-only change deploys the docs on merge, same as a `docs/**` or `src/**` change does today.

While in the file: `uv python install 3.12` is removed because the workspace declares `requires-python = ">=3.14"` — that line installed a Python the project cannot run, and `uv sync` resolves and downloads a satisfying interpreter on its own. The two pinned actions (`actions/checkout`, `astral-sh/setup-uv`) are bumped to the versions `ci.yml` already uses, `@v7` and `@v9.0.0`.

`uv sync --dev` is left as-is. All seven documented packages are plain `[project] dependencies` in the root `pyproject.toml`, not merely workspace members, so a bare `uv sync` already pulls them in for mkdocstrings; `dashboard` is separately pinned in the `dev` group. Verified locally: `uv run mkdocs build --strict` succeeds from a `--dev`-only environment with real page content, e.g. `site/api/contracts/index.html` at 671 KB, not an empty stub.

Also fixed the stale comment in `ci.yml` above the `setup-uv` step, which said it "installs the Python version pinned in .python-version" — there is no `.python-version` at the repo root, only inside `packages/dashboard`, `packages/dynamical_data` and `packages/notebooks`. CI works anyway because uv resolves the interpreter from `requires-python`, so this was a stale comment, not a fault; the comment now says that.

Merging this PR will not itself retrigger a deploy, because `docs.yml` is not itself under `docs/**`, `src/**` or the new `packages/**` filter. The first `packages/**` change after merge is what exercises the new trigger. `workflow_dispatch` is already wired up if an immediate deploy is wanted sooner.

## Verification

- `uv run ruff check .` — pass
- `uv run ruff format --check .` — pass
- `uv run --all-packages ty check` — pass
- `uv run pytest` — pass
- `uv run pymarkdown scan -r docs README.md CLAUDE.md packages/*/README.md` — pass
- `uv run mkdocs build --strict` — pass
- `actionlint` is not installed in this environment; re-read the final YAML by hand instead, and parsed it with `yaml.safe_load` to confirm the `paths:` list and step structure are well-formed
- Confirmed by reading all eight `docs/api/*/index.md` pages: 7 of 8 include from `packages/` (`contracts`, `delta_store`, `dynamical_data`, `geo`, `ml_core`, `nged_data`, `xgboost_forecaster`); the eighth, `docs/api/index.md`, documents `src/nged_substation_forecast` directly with no `{% include %}`
