### PR TITLE
Correct the false [-1, +1] forecast-scaling claim in docs

### DIFF
--- a/docs/background/requirements.md
+++ b/docs/background/requirements.md
@@ -197,5 +197,5 @@ feeding a runbook rather than any paging or failover machinery.
 
 OCF delivers forecasts as **Delta Lake tables on AWS S3**, updated every 6 hours. Delta Lake provides ACID transactions, meaning NGED never reads an incomplete forecast. (Why Delta Lake rather than a REST API? See [Forecast Delivery](../architecture/forecast-delivery.md).) The tables are designed as "building blocks" that NGED can combine to construct:
 
-* A **Normal Operation Forecast** (MW or MVA): the [−1, +1] forecast multiplied by the site's nominal capacity. Assumes the grid is in a normal running arrangement with all generators at full unconstrained capacity.
-* A **Prevailing Conditions Forecast** (MW or MVA): the [−1, +1] forecast multiplied by the most recently observed effective capacity, reflecting current switching state and any reduced generator capacity.
+* A **Normal Operation Forecast** (MW or MVA): the `power_forecast` table delivers this today — its `power_fcst` column is already in MW (active power) or MVA (apparent power), with the unit given per time series in `TimeSeriesMetadata`. Assumes the grid is in a normal running arrangement with all generators at full unconstrained capacity.
+* A **Prevailing Conditions Forecast** (MW or MVA): planned. It will combine the forecast with the most recently observed effective capacity, reflecting current switching state and any reduced generator capacity — see [Forecast building blocks](../roadmap/forecast-building-blocks.md).

--- a/docs/background/requirements.md
+++ b/docs/background/requirements.md
@@ -197,5 +197,5 @@ feeding a runbook rather than any paging or failover machinery.
 
 OCF delivers forecasts as **Delta Lake tables on AWS S3**, updated every 6 hours. Delta Lake provides ACID transactions, meaning NGED never reads an incomplete forecast. (Why Delta Lake rather than a REST API? See [Forecast Delivery](../architecture/forecast-delivery.md).) The tables are designed as "building blocks" that NGED can combine to construct:
 
-* A **Normal Operation Forecast** (MW or MVA): the `power_forecast` table delivers this today — its `power_fcst` column is already in MW (active power) or MVA (apparent power), with the unit given per time series in `TimeSeriesMetadata`. Assumes the grid is in a normal running arrangement with all generators at full unconstrained capacity.
+* A **Normal Operation Forecast** (MW or MVA): the `power_fcst` column is in MW (active power) or MVA (apparent power), with the unit given per time series in `TimeSeriesMetadata`. Assumes the grid is in a normal running arrangement with all generators at full unconstrained capacity.
 * A **Prevailing Conditions Forecast** (MW or MVA): planned. It will combine the forecast with the most recently observed effective capacity, reflecting current switching state and any reduced generator capacity — see [Forecast building blocks](../roadmap/forecast-building-blocks.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,10 +8,10 @@
 
 Each forecast is:
 
-- **Probabilistic** — expressed as an ensemble of 51 members (one per ECMWF ENS member), or as percentiles
+- **Probabilistic** — expressed as an ensemble of 51 members, one per ECMWF ENS member
 - **14-day horizon**, half-hourly temporal resolution
 - Refreshed **every 6 hours**
-- **Scaled to [−1, +1]** — a normalised value that NGED multiplies by the site's capacity to get MW/MVA
+- **In MW (active power) or MVA (apparent power)** — the unit is given per `time_series_id` in `TimeSeriesMetadata`
 - **Sign convention** depends on the time series type:
     - *Substations*: positive = power flowing towards end-users; negative = excess generation flowing back into the grid
     - *Customer meters (generators)*: positive = generator sending power to NGED's grid; negative = customer consuming power

--- a/packages/contracts/README.md
+++ b/packages/contracts/README.md
@@ -16,7 +16,7 @@ This package is designed to be extremely lightweight. It defines the *shape* of 
 - **`TimeSeriesMetadata`**: Substation and customer meter metadata, including lat/lon, H3 index, and asset type (primary substation, GSP, BSP, solar PV, wind, BESS, etc.).
 - **`Nwp`**: ECMWF ENS NWP weather data in physical units (`Float32`), on disk and in memory alike. The on-disk copy is rounded to a 13-bit significand and laid out for compression and row-group pruning by `delta_store.nwp`.
 - **`AllFeatures`**: The final joined dataset passed to ML models. Primary key is `(time_series_id, power_fcst_init_time, valid_time[, ensemble_member])`. Includes NWP weather variables, power lag/rolling features and datetime features. `time_series_type` is the one metadata column it can carry, and only when a feature set asks for it.
-- **`PowerForecast`**: ML model output schema. Power values are in the range [−1, +1] (normalised). Includes `power_fcst_model_name`, `power_fcst_model_version`, `power_fcst_init_time`, `nwp_init_time`, `valid_time`, `time_series_id`, and `ensemble_member`.
+- **`PowerForecast`**: ML model output schema. `power_fcst` is in MW (active power) or MVA (apparent power), with the unit given per `time_series_id` in `TimeSeriesMetadata`. A planned change will normalise it to [−1, +1] for NGED to multiply by a capacity — see [Forecast Building Blocks](https://openclimatefix.github.io/nged-substation-forecast/roadmap/forecast-building-blocks/). Includes `power_fcst_model_name`, `power_fcst_model_version`, `power_fcst_init_time`, `nwp_init_time`, `valid_time`, `time_series_id`, and `ensemble_member`.
 
 ## Design Principles
 


### PR DESCRIPTION
Written by Claude Code.

## What this fixes

`docs/index.md`, `packages/contracts/README.md` and `docs/background/requirements.md` all stated, as current fact, that `power_fcst` is scaled to the range [−1, +1] and that NGED multiplies it by a site's capacity to recover MW/MVA.

That is false today. `packages/contracts/src/contracts/power_schemas.py` declares `power_fcst` as the forecast itself, in MW (active power) or MVA (apparent power), with the unit given per `time_series_id` in `TimeSeriesMetadata`. The field carries an inline `# PLANNED:` comment saying the switch to a normalised [−1, +1] value is intended later, once capacity estimation lands.

This was a design intention written as a description of current behaviour, and it was corroborated across three separate pages, so each page made the others look more credible. A reader who trusted any one of them and multiplied a raw megawatt value by a site's capacity would get a number with no meaning.

`docs/index.md` also claimed forecasts are expressed "as an ensemble of 51 members … or as percentiles." We do not emit percentiles — `PowerForecast` carries `ensemble_member` only — so that clause is dropped too.

## What changed

`docs/index.md` — the "Scaled to [−1, +1]" bullet now says forecasts are in MW (active power) or MVA (apparent power), unit given per `time_series_id` in `TimeSeriesMetadata`. No mention of the planned normalisation: this is a front page describing current output, and the whole defect here was a plan written as a fact, so I judged that repeating the plan — even hedged — risked the same skim-read misunderstanding. The "or as percentiles" clause is dropped from the Probabilistic bullet.

`packages/contracts/README.md` — the `PowerForecast` bullet now states the current MW/MVA behaviour the same way, plus one clearly future-tense sentence pointing at the planned normalisation and linking to the roadmap page that already documents it correctly.

`docs/background/requirements.md` — the two Forecast Delivery bullets ("Normal Operation Forecast" and "Prevailing Conditions Forecast") no longer assert a [−1, +1] forecast exists to multiply. The Normal Operation bullet states what `power_forecast` delivers today. The Prevailing Conditions bullet is marked planned and links to `roadmap/forecast-building-blocks.md`, which already carries the correct 🚧 Planned framing.

`docs/design-philosophy/common-incident-classes.md` was left untouched — plan review found it already states the position correctly ("planned rather than shipped … the code today still forecasts raw MW/MVA").

Nothing under `docs/roadmap/` was touched — another PR is in flight there, and every roadmap mention of [−1, +1] normalisation I found is already correctly hedged as planned/future.

`packages/contracts/src/contracts/power_schemas.py` and the contract itself are unchanged, as scoped — the `# PLANNED:` comment there is already correct.

## A contradiction I found but did not fix

There is a real, unresolved contradiction in the sign convention for `power_fcst`, and I want a human decision on it rather than picking one myself.

`power_schemas.py` documents one global convention for `power_fcst`: positive means "power sent to NGED's grid."

`docs/index.md` (and `docs/roadmap/forecast-building-blocks.md`, which I did not touch) instead document a per-type convention: for substations, positive means "power flowing towards end-users" — the opposite sense from the contract's global rule.

`PowerTimeSeries.power` documents no sign convention at all, and no code anywhere flips sign by time-series type — the model trains directly on raw `power`.

Substations, GSPs and BSPs make up 20 of the 32 V1 time series, so this affects the majority of the fleet. This is a question about what we've agreed to deliver to NGED, not a wording choice, so I left it alone and I'm flagging it here for a decision.

## Grep verification

After making the edits I searched the whole repo again for anything claiming forecasts are normalised, scaled, in [−1, +1], or multiplied by capacity. Full categorised results:

**Fixed by this PR:**
- `docs/index.md` (the "Scaled to [−1, +1]" bullet, now MW/MVA)
- `packages/contracts/README.md:19` (the `PowerForecast` bullet, now MW/MVA + one future sentence)
- `docs/background/requirements.md:200-201` (the two Forecast Delivery bullets)

**Correctly hedged as planned/future, left alone:**
- `docs/design-philosophy/common-incident-classes.md:55-56` — "🚧 planned rather than shipped … the code today still forecasts raw MW/MVA"
- `packages/contracts/src/contracts/power_schemas.py:391-392` — the `# PLANNED:` comment on `power_fcst`
- `docs/roadmap/forecast-building-blocks.md:5,25,59,91,100` — carries a `🚧 Planned` status banner up top
- `docs/roadmap/delivery-tables.md:118-123,138,205` — carries a `🚧 Planned change` callout
- `docs/roadmap/live-service.md:566` — lists #246 as "an open follow-up, not required for v0.1"
- `docs/roadmap/index.md:338` — under the "Target: January 2027" v1.0 milestone, describing a future deliverable

**Out of scope (docs/roadmap/, untouched — another PR is in flight there):**
- All of the above roadmap hits, plus `docs/roadmap/switching-events.md`, `docs/roadmap/xgboost-improvements.md`, `docs/roadmap/metrics-and-leaderboard.md`, `docs/roadmap/disaggregation.md`, `docs/roadmap/capacity-estimation.md` — none of these claim `power_fcst` is currently scaled; every hit there is either about a different quantity (NMAE, switching residuals, clear-sky ratios) or already future-tense.

**Unrelated topic, not about `power_fcst` scaling (no action needed):**
- `docs/architecture/ecmwf-ens-known-issues.md` and `packages/dynamical_data/src/dynamical_data/ecmwf_ens/convert_to_polars.py` — NWP cell renormalisation across ensemble members, a different pipeline stage
- `packages/dynamical_data/tests/test_convert_to_polars.py` — tests for the same NWP renormalisation
- `packages/contracts/src/contracts/ml_schemas.py:183`, `packages/ml_core/src/ml_core/metrics.py:248`, `docs/techniques/evaluation-metrics.md:61`, `docs/roadmap/metrics-and-leaderboard.md:440` — NMAE, a metric normalised by effective capacity, not the `power_fcst` value itself
- `docs/architecture/adapting-to-another-geography.md:1542` — residual normalisation for switching-event detection, unrelated to forecast output scaling
- `docs/techniques/differentiable-physics.md:110,363` — POA irradiance normalisation inside the physics model, unrelated
- `packages/notebooks/plot_nwp_map.py` — colour-scale normalisation for a map plot, unrelated

No surviving hit states, as current fact, that `power_fcst` is normalised, scaled to [−1, +1], or multiplied by capacity.

## Verification

- `uv run ruff check .` — pass
- `uv run ruff format --check .` — pass
- `uv run --all-packages ty check` — pass
- `uv run pytest` — pass
- `uv run pymarkdown scan -r docs README.md CLAUDE.md packages/*/README.md` — pass
- `uv run mkdocs build --strict` — pass, and I read the rendered HTML for all three changed pages to confirm the lists and the new links render correctly
