### PR TITLE
Guard init_sentry and send_forecast_checkin so Sentry can't kill the service

### DIFF
--- a/src/nged_substation_forecast/_sentry.py
+++ b/src/nged_substation_forecast/_sentry.py
@@ -98,7 +98,15 @@ def init_sentry(settings: Settings) -> None:
 
     A no-op when ``settings.sentry_dsn`` is empty (the default), so nothing is sent from laptops
     or CI unless a DSN is explicitly configured. Called once per process at import of the Dagster
-    definitions module, so it runs in the daemon, the webserver, and every run worker.
+    definitions module, so it runs in the daemon, the webserver, and every run worker. Never
+    raises: a malformed DSN must not stop the Dagster code location from loading, or the daemon
+    runs no schedule and no forecast is produced at all — the worst possible outcome for a typo in
+    one environment variable, and one Sentry itself cannot alert on. ``sentry_sdk.init`` raises
+    ``BadDsn`` early in ``Client.__init__``, during DSN parsing, before any global state is
+    touched, so a caught failure leaves the SDK with a ``NonRecordingClient``
+    (``is_active() == False``) — identical to never having called ``init`` at all. Every other
+    sender in this module already treats an inactive/uninitialised client as a silent no-op, so
+    none of them needs extra guarding as a consequence of this one being guarded.
 
     Log-to-event capture is deliberately switched off: passing a ``LoggingIntegration`` with
     ``event_level=None`` overrides the SDK's default integration (whose default ``event_level`` is
@@ -115,13 +123,18 @@ def init_sentry(settings: Settings) -> None:
     """
     if not settings.sentry_dsn:
         return
-    sentry_sdk.init(
-        dsn=settings.sentry_dsn,
-        environment=settings.sentry_environment,
-        traces_sample_rate=settings.sentry_traces_sample_rate,
-        send_default_pii=False,
-        integrations=[LoggingIntegration(event_level=None)],
-    )
+    try:
+        sentry_sdk.init(
+            dsn=settings.sentry_dsn,
+            environment=settings.sentry_environment,
+            traces_sample_rate=settings.sentry_traces_sample_rate,
+            send_default_pii=False,
+            integrations=[LoggingIntegration(event_level=None)],
+        )
+    except Exception:
+        # Telemetry is best-effort, but a genuine bug in here must still be visible, so log at ERROR
+        # with the traceback rather than swallowing.
+        logger.exception("Failed to initialise the Sentry SDK")
 
 
 FAULT_CATEGORY_TAG: Final[str] = "fault_category"
@@ -258,7 +271,10 @@ def send_forecast_checkin(
     A no-op unless ``settings.sentry_monitor_forecasts`` is set (True only on the always-on
     production box), so a laptop never registers a monitor environment that Sentry would then mark
     as missed. Sends a single ``OK`` check-in — never ``in_progress`` or ``error`` — so the alarm
-    fires purely on the *absence* of a heartbeat.
+    fires purely on the *absence* of a heartbeat. Never raises: this runs after ``live_forecasts``
+    has already committed its Delta write, so a raise here would leave the run reported as failed
+    while the rows it produced sit committed — the run looking like it produced nothing when it in
+    fact produced everything.
 
     Args:
         settings: The project settings carrying ``sentry_monitor_forecasts`` and the environment.
@@ -267,11 +283,16 @@ def send_forecast_checkin(
     """
     if not settings.sentry_monitor_forecasts:
         return
-    capture_checkin(
-        monitor_slug=monitor_slug,
-        status=MonitorStatus.OK,
-        monitor_config=LIVE_FORECAST_MONITOR_CONFIG,
-    )
+    try:
+        capture_checkin(
+            monitor_slug=monitor_slug,
+            status=MonitorStatus.OK,
+            monitor_config=LIVE_FORECAST_MONITOR_CONFIG,
+        )
+    except Exception:
+        # Telemetry is best-effort, but a genuine bug in here must still be visible, so log at ERROR
+        # with the traceback rather than swallowing.
+        logger.exception("Failed to send the live-forecasts heartbeat check-in to Sentry")
 
 
 POWER_DATA_STALE_FINGERPRINT: Final[str] = "nged-power-data-stale"

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -183,6 +183,21 @@ def test_init_sentry_disables_log_to_event_capture(monkeypatch: pytest.MonkeyPat
     assert logging_integrations[0]._handler is None
 
 
+def test_init_sentry_survives_a_malformed_dsn(caplog: pytest.LogCaptureFixture) -> None:
+    """A malformed DSN must not stop the Dagster code location from loading — a typo in one
+    environment variable would otherwise take down the whole service (no schedule, no forecasts),
+    with Sentry itself unreachable so the only signal is the missed-check-in alarm hours later.
+
+    Uses a real DSN string that genuinely makes ``sentry_sdk.init`` raise ``BadDsn``, rather than
+    monkeypatching ``init`` to raise, so this pins the actual failure mode instead of passing even
+    if real DSN parsing were fine.
+    """
+    with caplog.at_level(logging.ERROR, logger="nged_substation_forecast._sentry"):
+        _sentry.init_sentry(_settings(sentry_dsn="not-a-dsn"))
+    assert any(r.levelno == logging.ERROR for r in caplog.records)
+    assert any(r.exc_info is not None for r in caplog.records)  # traceback attached
+
+
 def test_send_forecast_checkin_is_noop_when_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:
     """``sentry_monitor_forecasts`` False (the default) ⇒ no check-in is sent."""
     calls: list[dict[str, Any]] = []
@@ -210,6 +225,24 @@ def test_send_forecast_checkin_uses_given_slug(monkeypatch: pytest.MonkeyPatch) 
         _settings(sentry_monitor_forecasts=True), monitor_slug="live-forecasts-test"
     )
     assert calls[0]["monitor_slug"] == "live-forecasts-test"
+
+
+def test_send_forecast_checkin_swallows_and_logs_on_send_error(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """This runs after ``live_forecasts`` has already committed its Delta write, so a raise here
+    would leave the run reported as failed on a run that in fact produced everything. There is no
+    input that reliably makes the real ``capture_checkin`` call fail offline, so the sender is
+    monkeypatched to raise instead (unlike the DSN test above, which needs a real failure mode)."""
+
+    def boom(*_: Any, **__: Any) -> None:
+        raise RuntimeError("sentry down")
+
+    monkeypatch.setattr(_sentry, "capture_checkin", boom)
+    with caplog.at_level(logging.ERROR, logger="nged_substation_forecast._sentry"):
+        _sentry.send_forecast_checkin(_settings(sentry_monitor_forecasts=True))
+    assert any(r.levelno == logging.ERROR for r in caplog.records)
+    assert any(r.exc_info is not None for r in caplog.records)  # traceback attached
 
 
 def test_failure_hook_captures_the_real_exception(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -194,8 +194,13 @@ def test_init_sentry_survives_a_malformed_dsn(caplog: pytest.LogCaptureFixture) 
     """
     with caplog.at_level(logging.ERROR, logger="nged_substation_forecast._sentry"):
         _sentry.init_sentry(_settings(sentry_dsn="not-a-dsn"))
-    assert any(r.levelno == logging.ERROR for r in caplog.records)
-    assert any(r.exc_info is not None for r in caplog.records)  # traceback attached
+    # One record must carry all three: a message naming what failed, ERROR level, and the
+    # traceback. Asserting them separately would pass on three different records. The message
+    # matters here because it is the only signal a malformed DSN ever produces.
+    assert any(
+        "Sentry SDK" in r.message and r.levelno == logging.ERROR and r.exc_info is not None
+        for r in caplog.records
+    )
 
 
 def test_send_forecast_checkin_is_noop_when_flag_off(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -241,8 +246,12 @@ def test_send_forecast_checkin_swallows_and_logs_on_send_error(
     monkeypatch.setattr(_sentry, "capture_checkin", boom)
     with caplog.at_level(logging.ERROR, logger="nged_substation_forecast._sentry"):
         _sentry.send_forecast_checkin(_settings(sentry_monitor_forecasts=True))
-    assert any(r.levelno == logging.ERROR for r in caplog.records)
-    assert any(r.exc_info is not None for r in caplog.records)  # traceback attached
+    # One record must carry all three: a message naming what failed, ERROR level, and the
+    # traceback. Asserting them separately would pass on three different records.
+    assert any(
+        "heartbeat" in r.message and r.levelno == logging.ERROR and r.exc_info is not None
+        for r in caplog.records
+    )
 
 
 def test_failure_hook_captures_the_real_exception(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Written by Claude Code.

`sentry_sdk.init(...)` in `init_sentry` (`src/nged_substation_forecast/_sentry.py`) was unguarded, and `init_sentry` is called at Dagster definitions import time (`definitions.py`), so it runs in the daemon, the webserver, and every run worker.

`sentry_sdk.init` raises `BadDsn` on a malformed DSN — verified empirically against three real inputs: `'not-a-dsn'` → `BadDsn: Unsupported scheme ''`, `'https://example.com'` → `BadDsn: Missing public key`, `'htp://k@o.io/1'` → `BadDsn: Unsupported scheme 'htp'`.

A typo in one environment variable therefore stopped the whole Dagster code location from loading, so the daemon ran no schedule and no forecast was produced at all — with Sentry itself down, so the only signal was the missed-check-in alarm hours later.

This is the same failure mode rule 7 of the inherent-stability rules names for an asset check ("never let the warning path be able to fail the thing it is warning about"), one layer up. Every other Sentry sender in this module was already guarded and documented as "never raises"; `init_sentry` had the largest blast radius and was the one that could still bring the service down.

A second, related gap: `send_forecast_checkin`'s `capture_checkin(...)` call was the only other unguarded sender, and it runs *after* the Delta write inside `live_forecasts`. A raise there would leave rows committed on a run Dagster reports as failed — the run looking like it produced nothing when it in fact produced everything. The heartbeat has to stay after the write (it is a success heartbeat, so it cannot honestly be sent before the thing it attests to), so guarding is the only available fix.

## The change

Both calls are now wrapped in `try`/`except Exception`, logging via `logger.exception(...)` — matching the module's existing `_capture_tagged` idiom exactly. Neither catches `BaseException`, so `KeyboardInterrupt`/`SystemExit` still propagate. Both docstrings now say the function never raises.

**Why swallowing `init`'s exception is safe:** `BadDsn` is raised early in `Client.__init__`, during DSN parsing, before any global state is touched. After a caught failure the SDK holds a `NonRecordingClient` with `is_active() == False` — identical to never having called `init` at all. `capture_exception`, `capture_message` and `capture_checkin` all become silent no-ops rather than raising, `sys.excepthook` is unmodified, and `LoggingIntegration` was never installed. So no downstream sender needs extra guarding as a consequence of this change.

## Tests

`tests/test_sentry.py` gains `test_init_sentry_survives_a_malformed_dsn`, which calls `init_sentry` with a real DSN string that genuinely makes `sentry_sdk.init` raise (rather than monkeypatching `init` to raise, which would pass even if real DSN parsing were fine), and asserts the call returns without raising and logs the failure at `ERROR` with a traceback.

`test_send_forecast_checkin_swallows_and_logs_on_send_error` covers the checkin path the same way, monkeypatching `capture_checkin` to raise — legitimate here because there is no input that reliably makes the real call fail offline.

Both new tests were verified against a temporarily-unguarded version of the code: with the `try`/`except` removed from `init_sentry`, `test_init_sentry_survives_a_malformed_dsn` fails with `sentry_sdk.utils.BadDsn: Unsupported scheme ''` propagating out of the test. With the `try`/`except` removed from `send_forecast_checkin`, the companion test fails with the monkeypatched `RuntimeError: sentry down` propagating out of the test. Both guards were then restored and the full verification set re-run green.

## Known limitation, not fixed here

If a DSN is malformed from the very first deployment, the result after this change is permanent silence from Sentry — no error capture, no degradation reports, no heartbeat — with an `ERROR` log line as the only signal. The missed-check-in alarm cannot help in that case, because Sentry's server-side monitor never learns to expect a heartbeat in the first place. A DSN that breaks *after* a working deployment is fine: the existing monitor goes quiet and the alarm fires as designed.

That is a narrow, genuine hole in the "us, the developers" telemetry channel. The mitigation is a one-off check that Sentry is receiving events after a fresh deployment, not new machinery — none is built in this PR.

## Verification

- `uv run ruff check .` — passed
- `uv run ruff format --check .` — passed
- `uv run --all-packages ty check` — passed
- `uv run pytest` — 696 passed, 1 skipped
- `uv run pymarkdown scan -r docs README.md CLAUDE.md packages/*/README.md` — no output, no issues

## Scope

No change to `definitions.py`, to any other already-guarded sender, or to Sentry configuration/DSN handling/`Settings` — matching the plan's scope limits.
