### PR TITLE
Fix leaderboard metrics to skip non-leaderboard folds, not just undefined ones

### DIFF
--- a/docs/ml_experimentation/dagster-workflow.md
+++ b/docs/ml_experimentation/dagster-workflow.md
@@ -235,12 +235,13 @@ in the run config dialog before launching.
    partition columns (`experiment_name` / `fold_id`) are `String`, matching what delta-rs stores,
    so the predicates push straight into the Delta scan: naming an experiment/fold prunes to just
    that partition rather than reading the whole (unbounded) table.
-2. In `leaderboard` scope, drops any group whose `fold_id` is not defined in the CV config, naming
-   the dropped ids in a warning and in the asset's `skipped_fold_ids` metadata. The live service
-   writes to this same table under `fold_id="live"`, so an unfiltered leaderboard run finds it;
-   leaderboard scope dates its evaluation window from the CV config and has none for those rows.
-   To score live output, run the asset with `evaluation_scope="ad_hoc"`, which takes the window
-   from the forecast rows themselves.
+2. In `leaderboard` scope, drops any group whose `fold_id` is not a leaderboard fold in the CV
+   config, naming the dropped ids in a warning and in the asset's `skipped_fold_ids` metadata. The
+   live service writes to this same table under `fold_id="live"`, and a non-leaderboard dev fold
+   such as `smoke_test` lands there too, so an unfiltered leaderboard run finds both; leaderboard
+   scope dates its evaluation window from the CV config's leaderboard folds and has none for those
+   rows. To score live output or a dev fold, run the asset with `evaluation_scope="ad_hoc"`, which
+   takes the window from the forecast rows themselves.
 3. Discovers the matching `(experiment_name, fold_id)` groups, then loads and scores **one group at
    a time** — peak memory is a single fold, not the entire matched population. (A whole fold is
    the *coarsest* chunk Polars can safely materialise: fine at V1 scale, but a V2-scale fold will

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -956,11 +956,12 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     Dagster retries and safe across processes; see "Cross-process run resolution" in
     <https://openclimatefix.github.io/nged-substation-forecast/architecture/ml-orchestration/>.
 
-    ``power_forecasts`` also holds the live service's output under ``fold_id="live"``. Leaderboard
-    scope skips any ``fold_id`` the CV config does not define, naming them in a warning and in the
+    ``power_forecasts`` also holds the live service's output under ``fold_id="live"`` and any
+    non-leaderboard dev fold such as ``smoke_test``. Leaderboard scope skips any ``fold_id`` that
+    is not a leaderboard fold in the CV config, naming them in a warning and in the
     ``skipped_fold_ids`` output metadata, because it dates its evaluation window from that config
-    and has none for them. Use ``evaluation_scope="ad_hoc"`` to score live rows: it takes the
-    window from the rows themselves.
+    and has none for them. Use ``evaluation_scope="ad_hoc"`` to score live or dev-fold rows: it
+    takes the window from the rows themselves.
 
     Args:
         context: Dagster execution context; used for logging and ``add_output_metadata``.
@@ -997,16 +998,19 @@ def metrics(context: AssetExecutionContext, config: MetricsConfig) -> None:
     # `live_forecasts` writes its output to this same table under `fold_id="live"`, so an
     # unfiltered leaderboard run — which the operator guide tells you to launch, leaving
     # `fold_id` null to score every fold — discovers a group the CV config has never heard of.
-    # Leaderboard scope dates its window from that config, so those rows have no window to be
-    # scored against; skip them rather than fail the whole run on the first one. Ad-hoc scope
-    # takes its window from the rows themselves and is the supported way to score live output.
+    # The same table also holds any non-leaderboard dev fold (e.g. `smoke_test`), which the CV
+    # config does define but which is not part of the leaderboard's evaluation protocol. Either
+    # way, leaderboard scope dates its window from the config's leaderboard folds, so those rows
+    # have no window to be scored against; skip them rather than fail the whole run on the first
+    # one. Ad-hoc scope takes its window from the rows themselves and is the supported way to
+    # score live output or dev folds.
     skipped_fold_ids: list[str] = []
     if config.evaluation_scope == "leaderboard":
-        configured_fold_ids = set(_cv_config.fold_ids)
+        configured_fold_ids = set(_cv_config.leaderboard_fold_ids)
         skipped_fold_ids = sorted({fold for _, fold in groups if fold not in configured_fold_ids})
         if skipped_fold_ids:
             context.log.warning(
-                f"Skipping {skipped_fold_ids} — not folds in the CV config "
+                f"Skipping {skipped_fold_ids} — not leaderboard folds in the CV config "
                 f"({sorted(configured_fold_ids)}), so leaderboard scope has no evaluation window "
                 'for them. Score these with evaluation_scope="ad_hoc", which dates its window '
                 "from the forecast rows themselves."

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -685,6 +685,52 @@ def test_metrics_leaderboard_skips_fold_ids_the_cv_config_does_not_define(
     assert materialisation.metadata["skipped_fold_ids"].value == "['live']"
 
 
+def _append_smoke_test_fold_rows(forecasts_path: str) -> None:
+    """Copy the produced forecasts into a ``fold_id="smoke_test"`` partition of the same table.
+
+    Unlike ``fold_id="live"``, ``smoke_test`` genuinely is a fold in ``conf/cv/default.yaml`` —
+    it is just declared ``leaderboard: false``, so it must be excluded from leaderboard scope the
+    same way ``"live"`` is.
+    """
+    smoke_test = pl.read_delta(forecasts_path).with_columns(fold_id=pl.lit("smoke_test"))
+    write_deltalake(
+        table_or_uri=forecasts_path,
+        data=smoke_test.to_arrow(),
+        mode="append",
+        partition_by=["experiment_name", "fold_id"],
+    )
+
+
+def test_metrics_leaderboard_skips_smoke_test_fold(
+    file_mlflow_env: dict[str, Path], dagster_instance: DagsterInstance
+) -> None:
+    """Leaderboard scope skips ``smoke_test`` even though the CV config defines that fold.
+
+    This is the case that discriminates the fix from the bug it replaces:
+    ``smoke_test`` *is* present in ``CvConfig.fold_ids`` (every fold), so a check against that
+    property lets it through to the parent-run average. It is absent from
+    ``CvConfig.leaderboard_fold_ids`` (leaderboard folds only, since ``smoke_test`` is declared
+    ``leaderboard: false``), so a check against that property correctly skips it — unlike
+    ``fold_id="live"``, which both properties skip identically, since the CV config has no entry
+    for ``"live"`` at all.
+    """
+    _run_cv_pipeline(dagster_instance)
+    _append_smoke_test_fold_rows(str(file_mlflow_env["forecasts"]))
+
+    result = materialize(
+        [metrics],
+        run_config=RunConfig(ops={"metrics": MetricsConfig(evaluation_scope="leaderboard")}),
+        instance=dagster_instance,
+    )
+    assert result.success
+
+    fm = pl.read_delta(str(file_mlflow_env["metrics"]))
+    assert set(fm["fold_id"].unique().to_list()) == {FOLD_ID}
+
+    (materialisation,) = result.asset_materializations_for_node("metrics")
+    assert materialisation.metadata["skipped_fold_ids"].value == "['smoke_test']"
+
+
 def test_metrics_ad_hoc_scores_fold_ids_the_cv_config_does_not_define(
     file_mlflow_env: dict[str, Path], dagster_instance: DagsterInstance
 ) -> None:


### PR DESCRIPTION
Written by Claude Code.

`metrics` scored the `smoke_test` fold into the leaderboard's MLflow parent run instead of skipping it.

`configured_fold_ids` in `src/nged_substation_forecast/defs/cv_assets.py` was built from `CVConfig.fold_ids`, which returns every fold in `conf/cv/default.yaml`, including `smoke_test` (declared `leaderboard: false`).

The skip-and-warn path that already excludes `fold_id="live"` from leaderboard scope therefore let `smoke_test` rows through, because `smoke_test` genuinely is a fold the CV config defines — only `fold_ids` versus `leaderboard_fold_ids` distinguishes it from `live`.

This is the documented happy path, not an exotic one: `docs/ml_experimentation/dagster-workflow.md` recommends a `smoke_test` run first, `register_experiment` is idempotent, and the operator guide tells you to launch `metrics` unfiltered.

An experiment that happened to run a smoke test carried `mean(1-month dev fold, 12-month leaderboard fold)` in its parent-run metrics and was silently no longer comparable with one that did not.

## The fix

Switch `configured_fold_ids` to `CVConfig.leaderboard_fold_ids`, the property `jobs.py` already uses for the same purpose, and reword the warning and the surrounding comments/docstring so they describe "leaderboard folds in the CV config" rather than "folds in the CV config".

Updated `docs/ml_experimentation/dagster-workflow.md` to match: it previously said leaderboard scope drops any group not defined in the CV config, which is now false in a new way, since `smoke_test` is defined and is still dropped.

## What I verified

`uv run ruff check .`, `uv run ruff format --check .`, `uv run --all-packages ty check`, `uv run pytest` (695 passed, 1 skipped), and `uv run pymarkdown scan -r docs README.md CLAUDE.md packages/*/README.md` are all green.

Added `test_metrics_leaderboard_skips_smoke_test_fold`, which appends forecasts under the real `smoke_test` fold and asserts both that it appears in `skipped_fold_ids` metadata and that it is absent from the scored output's `fold_id` values.

I reverted the one-identifier fix (`leaderboard_fold_ids` back to `fold_ids`) and reran the new test to confirm it fails against the old code: `assert set(fm["fold_id"].unique().to_list()) == {FOLD_ID}` failed with `AssertionError: assert {'mid_2025_to_mid_2026', 'smoke_test'} == {'mid_2025_to_mid_2026'}` — the smoke_test rows flowed through into the scored output exactly as the bug report predicted. I then restored the fix and reran the full suite green.

The existing `test_metrics_leaderboard_writes_forecast_metrics_delta` already confirms a genuine leaderboard fold is still scored under leaderboard scope, so this fix cannot regress to "skip everything".

## Follow-up (not in this PR)

A related question was flagged during review: whether leaderboard scope should constrain `PopulationFilter`'s own population to the leaderboard window, rather than trusting its caller to pass sane filters. That is out of scope here and should be tracked as a separate follow-up.

## Scope

No changes to `CVConfig` or `conf/cv/default.yaml`, and no changes to `jobs.py`, per the plan's scope limits.
