### PR TITLE
Fix _camel_to_snake dropping area_center_lat/lon from TimeSeriesMetadata

### DIFF
--- a/packages/nged_data/src/nged_data/read_nged_json.py
+++ b/packages/nged_data/src/nged_data/read_nged_json.py
@@ -109,4 +109,8 @@ def _extract_power_time_series(df: pl.DataFrame, time_series_id: int) -> Extract
 def _camel_to_snake(camel_str: str) -> str:
     """Converts a CamelCase string to snake_case."""
     s1 = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", camel_str)
-    return re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+    s2 = re.sub("([a-z0-9])([A-Z])", r"\1_\2", s1).lower()
+    # A string already containing an underscore (e.g. "Area_CenterLat", produced by the
+    # `unnest("Area", separator="_")` above) collects a second one from the substitutions above,
+    # so collapse repeats before returning.
+    return re.sub("_+", "_", s2)

--- a/packages/nged_data/tests/test_read_nged_json.py
+++ b/packages/nged_data/tests/test_read_nged_json.py
@@ -4,14 +4,42 @@ import patito as pt
 import polars as pl
 import pytest
 from contracts.power_schemas import PowerTimeSeries, TimeSeriesMetadata
-from nged_data.read_nged_json import _extract_power_time_series, _extract_time_series_metadata
+from nged_data.read_nged_json import (
+    _camel_to_snake,
+    _extract_power_time_series,
+    _extract_time_series_metadata,
+)
 
 
 @pytest.mark.parametrize(
-    ("filename", "expected_time_series_id", "expected_name", "expected_units", "expected_h3"),
+    (
+        "filename",
+        "expected_time_series_id",
+        "expected_name",
+        "expected_units",
+        "expected_h3",
+        "expected_area_center_lat",
+        "expected_area_center_lon",
+    ),
     [
-        ("TimeSeries_10.json", 10, "SPILSBY 33 11kV S STN", "MW", 599423199024775167),
-        ("TimeSeries_11.json", 11, "INGOLDMELLS 33 11kV S STN", "MVA", 599422966022799359),
+        (
+            "TimeSeries_10.json",
+            10,
+            "SPILSBY 33 11kV S STN",
+            "MW",
+            599423199024775167,
+            53.16901628579017,
+            0.1034432744480572,
+        ),
+        (
+            "TimeSeries_11.json",
+            11,
+            "INGOLDMELLS 33 11kV S STN",
+            "MVA",
+            599422966022799359,
+            53.17889721242274,
+            0.3222337410952147,
+        ),
     ],
 )
 def test_nged_json_to_metadata_df_and_time_series_df(
@@ -20,6 +48,8 @@ def test_nged_json_to_metadata_df_and_time_series_df(
     expected_name: str,
     expected_units: str,
     expected_h3: int,
+    expected_area_center_lat: float,
+    expected_area_center_lon: float,
 ):
     file_path = Path(__file__).parent / "data" / filename
 
@@ -46,6 +76,30 @@ def test_nged_json_to_metadata_df_and_time_series_df(
     assert metadata_df["substation_type"].item() == "Primary"
     assert "POLYGON" in metadata_df["area_wkt"].item()
     assert metadata_df["h3_res_5"].item() == expected_h3
+    # The field is pl.Float32, so the cast value differs from the raw JSON float above this
+    # precision; compare against the raw value with pytest.approx rather than the cast one.
+    assert metadata_df["area_center_lat"].item() == pytest.approx(expected_area_center_lat)
+    assert metadata_df["area_center_lon"].item() == pytest.approx(expected_area_center_lon)
+
+
+@pytest.mark.parametrize(
+    ("camel_str", "expected_snake_str"),
+    [
+        ("Area_WKT", "area_wkt"),
+        ("Area_CenterLat", "area_center_lat"),
+        ("Area_CenterLon", "area_center_lon"),
+        ("Area_GeometryType", "area_geometry_type"),
+        ("TimeSeriesId", "time_series_id"),
+        ("SubstationNumber", "substation_number"),
+    ],
+)
+def test_camel_to_snake_collapses_double_underscore(camel_str: str, expected_snake_str: str):
+    """`Area_CenterLat` etc. already have an underscore before the CamelCase substitution runs.
+
+    That used to leave a double underscore (`area__center_lat`) that never matched the contract's
+    single-underscore `area_center_lat` field.
+    """
+    assert _camel_to_snake(camel_str) == expected_snake_str
 
 
 def test_nged_json_to_metadata_df_and_time_series_df_invalid_json():


### PR DESCRIPTION
Written by Claude Code.

`_camel_to_snake` in `packages/nged_data/src/nged_data/read_nged_json.py` inserted a second underscore before a word that was already underscore-prefixed, so `Area_CenterLat` became `area__center_lat` and `Area_CenterLon` became `area__center_lon` instead of matching the `TimeSeriesMetadata` contract's single-underscore `area_center_lat` / `area_center_lon` fields.

Two independent design choices compounded to hide this, and neither alone would have: the `.drop()` that follows `set_model()` silently discards any column the model does not name, so the mismatched double-underscore columns vanished with no error; and both fields are declared `allow_missing=True`, so `validate()` passed even with them gone entirely.

The fix collapses repeated underscores with a final `re.sub(r"_+", "_", ...)` pass over the existing substitution result. Verified by hand against every key in the real committed fixtures that this regresses nothing already correct and recovers exactly the two contract fields.

Before the fix, the parsed metadata roster for the committed fixture is 12 columns, missing the centroid fields entirely.

After the fix it is 14 columns, with `area_center_lat` and `area_center_lon` present and holding the correct values.

`Area_GeometryType` is recovered by the same fix (`area__geometry_type` → `area_geometry_type`) but is still dropped, because the contract does not declare `area_geometry_type`. That is correct and intentional, not a gap this PR should also close.

An explicit alias map (`{"Area_CenterLat": "area_center_lat", ...}`) was considered as a more contract-driven alternative to the collapse-underscores approach, and rejected as more machinery than the problem currently needs.

These two columns have never existed in any output of this pipeline, so nothing downstream reads them and nothing is broken by their sudden appearance. But the next `upsert_metadata` run will start populating them for every row it touches. Whether to backfill the existing metadata roster with the now-recoverable centroid values is a data question for the maintainer, not something this PR does — it only fixes the parsing bug going forward.

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run --all-packages ty check`
- [x] `uv run pytest` (700 passed, 1 skipped network test)
- [x] `uv run pymarkdown scan -r docs README.md CLAUDE.md packages/*/README.md`
- [x] New `test_camel_to_snake_collapses_double_underscore` pins the double-underscore case directly against the function.
- [x] New value assertions on `area_center_lat` / `area_center_lon` against the real committed fixtures (`TimeSeries_10.json`, `TimeSeries_11.json`), using `pytest.approx` against the raw JSON float since the field casts to `Float32`.
- [x] Reverted the fix by hand and confirmed the new tests fail with `AssertionError: assert 'area__center_lat' == 'area_center_lat'` (unit test) and `polars.exceptions.ColumnNotFoundError: "area_center_lat" not found` (value-assertion test), then restored the fix and confirmed all tests pass again.
