### PR TITLE
Anchor the time_series_id regex so ids above 99 stop truncating

### DIFF
--- a/packages/nged_data/src/nged_data/storage.py
+++ b/packages/nged_data/src/nged_data/storage.py
@@ -93,7 +93,7 @@ def _process_file_listing(
             # timeseries/1774512000000_1774533600000/TimeSeries_23_20260326T080000Z_20260326T140000Z.json  # noqa: E501 — the arrows above must stay aligned with the real key.
             regex_captures=(
                 pl.col("path").str.extract_groups(
-                    r"/(?<start_time>\d+)_(?<end_time>\d+)/TimeSeries_(?<time_series_id>\d{1,2})"
+                    r"/(?<start_time>\d+)_(?<end_time>\d+)/TimeSeries_(?<time_series_id>\d+)_"
                 )
             )
         )

--- a/packages/nged_data/tests/test_storage.py
+++ b/packages/nged_data/tests/test_storage.py
@@ -321,10 +321,29 @@ _EXAMPLE_OBJECT_KEY = (
 """One real NGED object key, whose embedded epoch-millisecond window and id the parser extracts."""
 
 
-def test_parse_file_listing_valid():
+@pytest.mark.parametrize(
+    ("object_key", "expected_time_series_id"),
+    [
+        pytest.param(_EXAMPLE_OBJECT_KEY, 23, id="two_digit_id"),
+        pytest.param(
+            "timeseries/1774512000000_1774533600000/"
+            "TimeSeries_237_20260326T080000Z_20260326T140000Z.json",
+            237,
+            id="three_digit_id",
+        ),
+        pytest.param(
+            "timeseries/1774512000000_1774533600000/"
+            "TimeSeries_2372_20260326T080000Z_20260326T140000Z.json",
+            2372,
+            id="four_digit_id",
+        ),
+    ],
+)
+def test_parse_file_listing_valid(object_key: str, expected_time_series_id: int):
+    """The id capture group must not truncate above 99 (regression for the unanchored regex)."""
     raw_file_listing: list[_RawFileListItem] = [
         {
-            "path": _EXAMPLE_OBJECT_KEY,
+            "path": object_key,
             "filesize_bytes": 1024,
         }
     ]
@@ -332,8 +351,8 @@ def test_parse_file_listing_valid():
     result = _process_file_listing(raw_file_listing)
 
     assert result.height == 1
-    assert result["time_series_id"][0] == 23
-    assert result["path"][0] == _EXAMPLE_OBJECT_KEY
+    assert result["time_series_id"][0] == expected_time_series_id
+    assert result["path"][0] == object_key
     assert result["filesize_bytes"][0] == 1024
     assert result["start_time"][0] == datetime(2026, 3, 26, 8, 0, 0, tzinfo=UTC)
     assert result["end_time"][0] == datetime(2026, 3, 26, 14, 0, 0, tzinfo=UTC)


### PR DESCRIPTION
Written by Claude Code.

## Summary

The `time_series_id` capture group in `packages/nged_data/src/nged_data/storage.py` had no anchor after it, so `\d{1,2}` matched the first one or two digits of the id and stopped, silently truncating any three- or four-digit id: `TimeSeries_237_...` parsed as `23`, and `TimeSeries_2372_...` also parsed as `23`.

`_ProcessedFileListing.validate` only checks that the parsed id is a well-formed `Int32`, so the truncated value passes validation with no error anywhere in the pipeline.

The mislabelled id then gets joined to `time_series_coverage` in `select_new_rows`, so every file for series 237 is judged against series 23's `last_time` instead of its own.

Because the listing is re-derived identically every hour, series 237 is never ingested — not late, never, since the join always finds series 23's coverage already covers that time window.

This bug is dormant today because V1's 32 time series all happen to have one- or two-digit ids, so it should land before any V2 scale-up work, where ids run up to roughly 2,500.

## The change

Anchored the capture group on the underscore that actually follows the id: `TimeSeries_(?<time_series_id>\d+)_`, three characters shorter than the original and with no upper bound on digit count.

The ASCII arrow diagram above the regex annotates the literal example key in the docstring, not the regex source, and that example stays `TimeSeries_23_...`, so the arrows did not need realigning.

## Tests

Parametrized `test_parse_file_listing_valid` in `packages/nged_data/tests/test_storage.py` over a two-digit id (the existing case), a new three-digit case (`237`), and a new four-digit case (`2372`).

Verified both new cases fail against the old `\d{1,2}` pattern before restoring the fix: the three-digit case failed with `assert 23 == 237` and the four-digit case failed with `assert 23 == 2372`.

## Scope

This PR touches only the regex and its tests, per the plan.

It deliberately does not add cross-checking of the parsed id against the `time_series_id` inside the JSON body — that would catch a different class of bug and is a larger change worth considering separately.

It also does not touch `remove_small_files_from_listing` or `select_new_rows`, which have their own known defects being addressed in a separate PR.

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run --all-packages ty check`
- [x] `uv run pytest`
- [x] `uv run pymarkdown scan -r docs README.md CLAUDE.md packages/*/README.md`
