### PR TITLE
Assert RMSE and model-family identity by value, not just as fixture input

### DIFF
--- a/packages/ml_core/tests/test_metrics.py
+++ b/packages/ml_core/tests/test_metrics.py
@@ -112,14 +112,27 @@ def test_compute_metrics_returns_metrics_schema():
 
 
 def test_compute_metrics_mae_correctness():
-    """MAE should equal mean absolute error of (fcst - actual)."""
+    """MAE, RMSE and MBE are mutually distinguishable, so this test cannot pass by accident.
+
+    Errors +3, −1 give mae = 2.0, rmse = sqrt(5) ≈ 2.236, mbe = 1.0 — three different values,
+    so a metric mixed up with one of the others (RMSE swapped for MAE, say) fails here even
+    though errors of equal magnitude (as in a symmetric +2/−2 fixture) would not reveal it.
+    """
     times = [_utc(2022, 1, 1, 0, 0), _utc(2022, 1, 1, 0, 30)]
     actuals = _make_actuals(1, times, [10.0, 10.0])
-    # errors: +2, -2 → MAE = 2.0
-    forecasts = _make_cv_forecasts(1, times, [12.0, 8.0])
+    # errors: +3, -1
+    forecasts = _make_cv_forecasts(1, times, [13.0, 9.0])
     result = compute_metrics(forecasts, actuals, _make_metadata([1]), _make_capacity([1], [10.0]))
-    mae_row = result.filter((pl.col("metric_name") == "mae") & (pl.col("horizon_slice") == "all"))
-    assert math.isclose(mae_row["metric_value"][0], 2.0, rel_tol=1e-5)
+
+    def _metric(metric_name: str) -> float:
+        row = result.filter(
+            (pl.col("metric_name") == metric_name) & (pl.col("horizon_slice") == "all")
+        )
+        return float(row["metric_value"][0])
+
+    assert math.isclose(_metric("mae"), 2.0, rel_tol=1e-5)
+    assert math.isclose(_metric("rmse"), math.sqrt(5.0), rel_tol=1e-5)
+    assert math.isclose(_metric("mbe"), 1.0, rel_tol=1e-5)
 
 
 def test_compute_metrics_mbe_sign():

--- a/packages/xgboost_forecaster/tests/test_forecaster.py
+++ b/packages/xgboost_forecaster/tests/test_forecaster.py
@@ -78,7 +78,11 @@ def test_train_creates_one_booster_per_ts_id() -> None:
 def test_predict_output_schema() -> None:
     df = _make_df()
     lf = pt.LazyFrame.from_existing(df.lazy())
-    result = _trained(df).predict(lf)
+    # experiment_name is deliberately distinct from XGBoostForecaster.MODEL_NAME ("xgboost"), so
+    # an implementation that sourced the two model-family columns from the config instead of the
+    # class constants would fail here.
+    experiment_name = "distinct_experiment"
+    result = _trained(df, experiment_name=experiment_name).predict(lf)
 
     assert len(result) == len(df)
     assert result["power_fcst"].dtype == pl.Float32
@@ -86,6 +90,12 @@ def test_predict_output_schema() -> None:
     assert result["power_fcst_model_version"].dtype == pl.Int16
     # ml_flow_experiment_id=None → every row is null
     assert result["ml_flow_experiment_id"].is_null().all()
+
+    # Model-family identity comes from the class constants, not the config.
+    assert (result["power_fcst_model_name"] == XGBoostForecaster.MODEL_NAME).all()
+    assert (result["power_fcst_model_version"] == XGBoostForecaster.MODEL_VERSION).all()
+    # Experiment identity comes from the config, and stays distinct from model-family identity.
+    assert (result["experiment_name"] == experiment_name).all()
 
 
 def test_predict_with_mlflow_experiment_id() -> None:


### PR DESCRIPTION
Written by Claude Code.

Two documented invariants could be broken while the whole suite stayed green: RMSE could be swapped for MAE in `compute_metrics`, and `predict` could stamp `power_fcst_model_name` from the config's `experiment_name` instead of the class's `MODEL_NAME` constant.
RMSE is a headline leaderboard metric and the denominator of the spread-skill ratio, so a silent error there corrupts model comparison.
Model-family identity (`MODEL_NAME`/`MODEL_VERSION`) and experiment identity (`experiment_name`/`ml_flow_experiment_id`) are deliberately split across two levels, per `CLAUDE.md`, `base_forecaster.py` and `power_schemas.py` — collapsing them was previously untested.

Every `rmse` in the suite was either a fixture *label* fed into `build_mlflow_aggregate_metrics`, or an assertion that that function correctly averages values it was handed — nothing asserted an `rmse` number that `compute_metrics` itself computed.
The one test that exercised `compute_metrics`'s own RMSE used symmetric errors, where RMSE and MAE (or, in a separate single-timestamp test, MAE and MBE too) are numerically indistinguishable.
`test_compute_metrics_mae_correctness` (`packages/ml_core/tests/test_metrics.py`) now uses errors of +3 and −1, which separate `mae` (2.0), `rmse` (√5), and `mbe` (1.0) into three mutually distinguishable values, and asserts all three.

`test_predict_output_schema` (`packages/xgboost_forecaster/tests/test_forecaster.py`) previously only checked the *dtypes* of `power_fcst_model_name`/`power_fcst_model_version`, never their values.
It now asserts those two columns equal `XGBoostForecaster.MODEL_NAME`/`MODEL_VERSION` (referencing the class constants, not string literals, so the test pins the source of the column rather than a coincidental value), and asserts `experiment_name` equals a config value deliberately distinct from `MODEL_NAME`, so a column sourced from the wrong place fails the test.

`XGBoostForecaster` is the only concrete `BaseForecaster` subclass today, so this is a single-implementation test, not a shared conformance test — a future second subclass would need the same coverage applied to it, or factored into something shared.

Verification: `ruff check`, `ruff format --check`, `ty check`, `pytest` (705 passed, 1 skipped), and `pymarkdown scan` are all green.
Both mutations described above were applied by hand and confirmed to make the new assertions fail, then reverted; only the new tests caught them, no existing test did.
