### PR TITLE
Fix four wrong operational facts in the docs

### DIFF
--- a/docs/architecture/aws-costs.md
+++ b/docs/architecture/aws-costs.md
@@ -68,11 +68,11 @@ same-shaped workload in
 
 ### Workload model
 
-Live cadence: `ecmwf_ens` 1/day (daily 00Z partition), `power_time_series_and_metadata` 4/day,
-`live_forecasts` 4/day (6-hourly partitions), the monitoring `metrics(production_monitoring)`
-step ~4/day (planned —
+Live cadence: `ecmwf_ens` 1/day (daily 00Z partition), `power_time_series_and_metadata` 24/day
+(hourly, at :55 past the hour), `live_forecasts` 4/day (6-hourly partitions), the monitoring
+`metrics(production_monitoring)` step ~4/day (planned —
 [#224](https://github.com/openclimatefix/nged-substation-forecast/issues/224)) →
-**~13 materialisations/day ≈ 395/month**. This cadence ingests only ECMWF ENS and
+**~33 materialisations/day ≈ 1,000/month**. This cadence ingests only ECMWF ENS and
 the NGED power feed today; a near-real-time ERA5/ERA5T ingest would join it *only if* live capacity
 estimation is made to depend on ERA5 — a new external dependency we may prefer to avoid by
 [keeping ERA5 offline](../roadmap/capacity-estimation.md#irradiance-inputs). A backtest
@@ -99,17 +99,23 @@ at v1 scale come to **~£2–4/month in total**:
   [How big is Flexpectation's power forecast data?](forecast-delivery.md#how-big-is-flexpectations-power-forecast-data))
   — at £0.018/GB-month → ~£1.80/month, plus headroom for Delta version history between
   vacuums. Grows ~40 GB/year as daily NWP partitions accumulate.
-- **S3 requests — ~£0.50–1.50/month.** Delta Lake is request-heavy (transaction-log JSON
-  reads, checkpoints, many small parquet GETs per scan), but ~13 materialisations/day is
-  tiny volume: a generous 1–2 M GET (£0.00031/1k) + 100–200 k PUT/COPY/POST/LIST
-  (£0.0040/1k) per month lands well under £1.50.
+- **S3 requests — ~£1–2/month.** Delta Lake is request-heavy (transaction-log JSON reads,
+  checkpoints, many small parquet GETs per scan). The materialisation count is now ~33/day,
+  most of the rise coming from the 24 hourly `power_time_series_and_metadata` ingests — each a
+  small incremental append rather than a full-table scan — so request volume grows more slowly
+  than the materialisation count. A generous 2–3 M GET (£0.00031/1k) + 150–250 k
+  PUT/COPY/POST/LIST (£0.0040/1k) per month lands at roughly £1.20–1.90, above the earlier
+  £0.50–1.50 estimate but still a small line item.
 - **Data transfer — ≈£0/month.** Ingress is free (the daily NWP download from Dynamical
   costs nothing on the AWS side); S3 ↔ Fargate/EC2 traffic within eu-west-2 is free;
   internet egress (the Tailscale-tunnelled Dagster UI and Marimo dashboard) is a few
   GB/month, inside AWS's account-wide 100 GB/month free egress allowance (£0.067/GB
   beyond).
-- **Everything else — pennies.** ECR image storage and CloudWatch Logs ingestion for ~700
-  task runs/month are each well under £0.50/month.
+- **Everything else — pennies.** ECR image storage and CloudWatch Logs ingestion for ~1,000
+  task runs/month — one Fargate task per schedule tick, matching the ~1,000 materialisations/month
+  above (see
+  [Production Deployment — Design](production-deployment.md#running-the-data-ingest-runs-on-the-control-plane-vm))
+  — are each well under £0.50/month.
 
 ## v2 scale (~2,500 time series): projected ~£70–140/month
 

--- a/docs/architecture/aws-costs.md
+++ b/docs/architecture/aws-costs.md
@@ -100,12 +100,11 @@ at v1 scale come to **~£2–4/month in total**:
   — at £0.018/GB-month → ~£1.80/month, plus headroom for Delta version history between
   vacuums. Grows ~40 GB/year as daily NWP partitions accumulate.
 - **S3 requests — ~£1–2/month.** Delta Lake is request-heavy (transaction-log JSON reads,
-  checkpoints, many small parquet GETs per scan). The materialisation count is now ~33/day,
-  most of the rise coming from the 24 hourly `power_time_series_and_metadata` ingests — each a
-  small incremental append rather than a full-table scan — so request volume grows more slowly
-  than the materialisation count. A generous 2–3 M GET (£0.00031/1k) + 150–250 k
-  PUT/COPY/POST/LIST (£0.0040/1k) per month lands at roughly £1.20–1.90, above the earlier
-  £0.50–1.50 estimate but still a small line item.
+  checkpoints, many small parquet GETs per scan). The materialisation count is ~33/day, most of
+  it the 24 hourly `power_time_series_and_metadata` ingests — each a small incremental append
+  rather than a full-table scan — so request volume grows more slowly than the materialisation
+  count. A generous 2–3 M GET (£0.00031/1k) + 150–250 k PUT/COPY/POST/LIST (£0.0040/1k) per
+  month lands at roughly £1.20–1.90, a small line item.
 - **Data transfer — ≈£0/month.** Ingress is free (the daily NWP download from Dynamical
   costs nothing on the AWS side); S3 ↔ Fargate/EC2 traffic within eu-west-2 is free;
   internet egress (the Tailscale-tunnelled Dagster UI and Marimo dashboard) is a few

--- a/docs/live_service/aws.md
+++ b/docs/live_service/aws.md
@@ -193,7 +193,7 @@ emulator is registered and prints the one-time fix
 
 > Note that, during the smoke test, **Dagster is EXPECTED halt with the exception**
 > `_internal.TableNotFoundError: Local path
-"/app/.venv/data/NWP" does not exist or you don't have access!`. That is correct behaviour.
+"/app/data/NWP" does not exist or you don't have access!`. That is correct behaviour.
 
 The script builds the image tagged with the promoted model's run id, runs it offline, and prints
 the container log with a pass/fail summary. (The smoke test's one-shot run uses a hard-coded,

--- a/docs/ml_experimentation/dagster-workflow.md
+++ b/docs/ml_experimentation/dagster-workflow.md
@@ -2,8 +2,8 @@
 
 How to go from raw data to a trained, MLflow-tracked model using the Dagster pipeline.
 
-The pipeline has two layers. The **data layer** (steps 1–4) is built once and refreshed as new
-data arrives; it is shared by all experiments. The **experiment layer** (steps 5–8) is repeated
+The pipeline has two layers. The **data layer** (steps 1–5) is built once and refreshed as new
+data arrives; it is shared by all experiments. The **experiment layer** (steps 6–9) is repeated
 for each new model or hyperparameter configuration — see [Model configuration](model-configuration.md)
 for how to choose features and set hyperparameters.
 
@@ -51,9 +51,19 @@ Eligibility is a function of data coverage only — it is independent of any mod
 so every experiment is scored on the identical population for a given fold. **Do not skip this
 step before training.**
 
+## Step 5 — Materialise `effective_capacity`
+
+**Trigger:** Materialise (unpartitioned). Re-materialise whenever step 1 has pulled in enough new
+telemetry to shift a series' full-history P99.
+
+Reads the full `power_time_series` Delta and writes one row per `time_series_id` to the
+`effective_capacity` Delta table: the 99th percentile of `abs(power)` over the series' entire
+observed history. This is the NMAE denominator the `metrics` asset (step 9) reads — materialise it
+before running `metrics`, or that step raises `FileNotFoundError`.
+
 ---
 
-## Step 5 — Launch `register_experiment_job`
+## Step 6 — Launch `register_experiment_job`
 
 **Trigger:** Dagster UI → Jobs → `register_experiment_job` → "Launch run". Fill in the
 `RegisterExperimentConfig` fields in the run config dialog:
@@ -100,10 +110,10 @@ un-trained, and `trained_cv_model` reads the config back from the experiment's `
 mid-flight would change what later folds train on. The refusal happens before anything is
 written, so a rejected re-registration leaves the experiment exactly as it was.
 
-## Step 6 — Materialise `trained_cv_model`
+## Step 7 — Materialise `trained_cv_model`
 
 **Trigger:** Materialise the partition `"{experiment_name}__{fold_id}"`, e.g.
-`"xgboost_smoke_test__smoke_test"`. The partition only appears after step 5 has run.
+`"xgboost_smoke_test__smoke_test"`. The partition only appears after step 6 has run.
 
 **What the asset does:**
 
@@ -152,7 +162,7 @@ Experiment "xgboost_smoke_test"
 
 ---
 
-## Step 7 — Materialise `cv_power_forecasts`
+## Step 8 — Materialise `cv_power_forecasts`
 
 **Trigger:** Materialise the same `"{experiment_name}__{fold_id}"` partition (it depends on
 `trained_cv_model`).
@@ -217,7 +227,7 @@ for the production workflow.
 
 ---
 
-## Step 8 — Materialise `metrics`
+## Step 9 — Materialise `metrics`
 
 **Trigger:** Materialise (unpartitioned — not tied to a single fold). Fill in `MetricsConfig`
 in the run config dialog before launching.
@@ -268,7 +278,7 @@ in the run config dialog before launching.
    `picp`/`interval_width` at p10_p90) — the full 13-quantile / 6-band detail stays in the
    `forecast_metrics` Delta table.
 
-After step 8, the MLflow run structure looks like this:
+After step 9, the MLflow run structure looks like this:
 
 ```text
 Experiment "xgboost_smoke_test"
@@ -342,7 +352,7 @@ source for the experiment's config.
    the experiment and training fold 2. Reading from MLflow guarantees every fold of the same
    experiment trains on exactly the config that was registered, no matter when it runs. The tag
    is immutable in turn: re-registering the experiment name under a changed config is refused
-   rather than re-pointing it (see step 5 above).
+   rather than re-pointing it (see step 6 above).
 
 2. **Process independence.** Each `trained_cv_model` materialisation is a separate Dagster
    process. There is no live handle to pass between the job and the asset; the MLflow experiment

--- a/docs/ml_experimentation/model-configuration.md
+++ b/docs/ml_experimentation/model-configuration.md
@@ -129,7 +129,7 @@ Two feature names are **forbidden** and raise `ValueError` at parse time:
 - **`valid_time`** — an index column; use time features (e.g. `local_time_of_day_sin`) instead.
 
 **Power lags** are automatically nullified by the feature engineering pipeline when the lag is
-shorter than or equal to the forecast lead time. For example, `power_lag_2h` would leak
+shorter than or equal to the forecast lead time. For example, `power_lag_1h` would leak
 observed power into a 1-hour-ahead forecast, so its value is set to `null` for those rows. The
 model sees a null and treats it as a missing value (XGBoost handles nulls natively). This
 nullification happens per-row in `_nullify_leaky_lags()`, not at config time — the feature name

--- a/docs/roadmap/metrics-and-leaderboard.md
+++ b/docs/roadmap/metrics-and-leaderboard.md
@@ -456,7 +456,7 @@ and nothing is logged to the leaderboard MLflow runs.
 > for PICP (`p10_p90`). The `metrics` Dagster asset computes every ✅ metric above and writes
 > per-series rows to `forecast_metrics` Delta (partitioned by `experiment_name, fold_id`), with
 > per-fold and mean-across-folds aggregates logged to MLflow — see
-> [Running an ML experiment end-to-end](../ml_experimentation/dagster-workflow.md#step-8-materialise-metrics).
+> [Running an ML experiment end-to-end](../ml_experimentation/dagster-workflow.md#step-9-materialise-metrics).
 
 **Every metric above is also broken out by named population-filter slices**, which appear as
 extra leaderboard columns. Most are legitimate ranking columns, because the filter is fixed by

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -615,7 +615,7 @@ def cv_power_forecasts(context: AssetExecutionContext) -> None:
 class PopulationFilter(Config):
     """Typed filter over ``power_forecasts`` rows to score.
 
-    Every field is tabulated with a worked example under "Step 8 — Materialise ``metrics``":
+    Every field is tabulated with a worked example under "Step 9 — Materialise ``metrics``":
     <https://openclimatefix.github.io/nged-substation-forecast/ml_experimentation/dagster-workflow/>
 
     All fields default to ``None`` (= no filter on that dimension). A mistyped field name is a
@@ -668,7 +668,7 @@ class PopulationFilter(Config):
 class MetricsConfig(Config):
     """Run config for the ``metrics`` asset.
 
-    Filled in from the Dagster run-config dialog; see "Step 8 — Materialise ``metrics``":
+    Filled in from the Dagster run-config dialog; see "Step 9 — Materialise ``metrics``":
     <https://openclimatefix.github.io/nged-substation-forecast/ml_experimentation/dagster-workflow/>
     """
 


### PR DESCRIPTION
Written by Claude Code.

Four independent operational facts in the docs were wrong. Each is fixed here, verified against the code rather than against another doc page.

## 1. The end-to-end recipe raised at its last step

Verified against `src/nged_substation_forecast/defs/cv_assets.py:942-943` (the `metrics` asset declares `deps=["cv_power_forecasts", "effective_capacity"]`) and `cv_assets.py:1039-1043` (it raises `FileNotFoundError` when the `effective_capacity` Delta table is absent).

`docs/ml_experimentation/dagster-workflow.md` never mentioned materialising `effective_capacity` anywhere in its eight numbered steps, and `metrics` was step 8, the last one, so an operator following the page exactly hit an error at the finish line.

`effective_capacity` (`cv_assets.py:200`, `deps=["power_time_series_and_metadata"]`) is unpartitioned, full-overwrite, and independent of any fold or experiment, the same shape as `h3_grid_weights`, so it belongs in the data layer, not wedged in front of `metrics`.

Added it as step 5 (end of the data layer) and renumbered steps 5-8 to 6-9, updating the "steps 1-4 / steps 5-8" layer description and the two in-page cross-references that named a step number by hand.

`docs/getting-started.md` stops at its own step 4 (register the experiment, link out to the full recipe) and never reaches `metrics`, so the gap did not bite there; left it unchanged.

One knock-on fix outside the plan's file list: `docs/roadmap/metrics-and-leaderboard.md:459` linked to `dagster-workflow.md#step-8-materialise-metrics`, an anchor the renumbering breaks under this repo's `mkdocs build --strict` (`validation.links.anchors: warn`, which strict mode turns into a build failure). Updated that one link to `#step-9-materialise-metrics` so the build stays green; nothing else in `docs/roadmap/` was touched.

## 2. The lag-nullification worked example was inverted

Verified against `packages/ml_core/src/ml_core/features/_lags.py:135-139`, which nullifies when `power_lead_time_hours >= feature.hours` (nullify when lead >= lag), with a comment confirming `>=` rather than `>` is deliberate at equality.

`docs/ml_experimentation/model-configuration.md:131-133` said `power_lag_2h` "would leak observed power into a 1-hour-ahead forecast". With lag 2 and lead 1, `1 >= 2` is false, so that feature is kept, not nullified, contradicting the rule stated one sentence earlier.

Fixed by changing the numbers, not the rule: `power_lag_2h` to `power_lag_1h` (lag 1, lead 1, `1 >= 1` is true, so it is nullified), keeping the "1-hour-ahead forecast" framing.

## 3. The AWS smoke-test doc quoted a path the image cannot produce

Verified against `Dockerfile:53` (`WORKDIR /app`) and `packages/contracts/src/contracts/settings.py` (`PROJECT_ROOT` resolves to `/app` in the image; `data_path_internal` defaults to `PROJECT_ROOT / "data"`; `nwp_data_path` is `uri_join(data_path_internal, "NWP")`). There is no `.venv` segment anywhere in that chain.

`docs/live_service/aws.md:195-196` quoted the smoke test's expected failure as `Local path "/app/.venv/data/NWP" does not exist`. Corrected to the real path, `/app/data/NWP`.

## 4. The telemetry pull was priced at 4 runs/day; it runs 24

Verified against `src/nged_substation_forecast/defs/schedules.py:22-25`, `cron_schedule="55 * * * *"`, with a docstring confirming "Fires at :55 past every hour" — 24 runs/day, not 4.

Re-derived the whole workload model in `docs/architecture/aws-costs.md` rather than patching the one number:

- Daily materialisation count: `ecmwf_ens` 1 + `power_time_series_and_metadata` 24 + `live_forecasts` 4 (verified against `production_assets.py:65`, `cron_schedule="0 0,6,12,18 * * *"`) + the planned `metrics(production_monitoring)` step ~4 = **33/day**.
- Month figure: the page's own day-to-month factor is implicit in its old numbers (13/day to 395/month is x30.4), so 33 x 30.4 is approximately **1,000/month**.
- The S3-requests bullet also cited the old 13/day figure. Updated it to ~33/day and re-checked whether the stated £0.50-1.50/month conclusion still held: the old top end (2M GET + 200k PUT/COPY/POST/LIST at the page's own per-1k rates) already worked out to about £1.42, within a few pence of its own £1.50 ceiling, so a straight proportional scale-up of the request count (x2.54, matching the materialisation-count increase) would clear £1.50 by a wide margin. I judged that proportional scaling overstates it, because the extra 20 daily runs are `power_time_series_and_metadata`'s hourly incremental appends, not full-table scans like `ecmwf_ens` or `metrics`, so they should add fewer requests per run than the page's original per-materialisation average. I widened the estimate to a generous 2-3M GET + 150-250k PUT/COPY/POST/LIST, landing at roughly £1.20-1.90/month, and said so explicitly in the doc rather than keeping the old range unchanged. This line is a judgement call without an AWS measurement behind it; flagging it in case a real Cost Explorer check should supersede it later.
- **On "~700 task runs/month" (lines 111-112):** this number does not derive cleanly from either the old 13/day or the corrected 33/day figure. The closest match is hourly-polling-alone, 24 x 30.4 is approximately 730, which suggests it came from a calculation that used the (correct) hourly cadence for polling but forgot to add the other three schedules — the opposite bug from the "4/day" one being fixed elsewhere on the same page. `docs/architecture/production-deployment.md:564` establishes that one schedule tick becomes exactly one Fargate task, so "task runs/month" and "materialisations/month" are the same count in this architecture. I corrected it to **~1,000/month**, matching the corrected total above, and added a one-line pointer to that equivalence so the two numbers stay visibly tied together.

Also fixed the pre-existing internal contradiction the plan flagged: line 85 already said "hourly polling wake-ups", one paragraph after the (now-corrected) line 71 said 4/day — that inconsistency is gone now that both lines agree on 24/day (hourly).

## Verification

```
uv run ruff check .
uv run ruff format --check .
uv run --all-packages ty check
uv run pytest
uv run pymarkdown scan -r docs README.md CLAUDE.md packages/*/README.md
uv run mkdocs build --strict
```

All green (705 passed, 1 skipped in pytest; no warnings from the strict mkdocs build). Also read the rendered HTML under `site/` for every edited page (`dagster-workflow`, `model-configuration`, `aws`, `aws-costs`, `metrics-and-leaderboard`) to confirm the new step heading, the reflowed list items, and the cross-page anchor link all render as intended, not just that the linters passed.

## Scope

Touched only the five pages above. No code changes. Did not go hunting for other wrong facts beyond the four in the plan; nothing else looked suspicious while reading the surrounding prose on these pages.
