### PR TITLE
Lower the small-file listing threshold from 1000 to 520 bytes

### DIFF
--- a/packages/nged_data/src/nged_data/storage.py
+++ b/packages/nged_data/src/nged_data/storage.py
@@ -113,18 +113,26 @@ def _process_file_listing(
 
 def remove_small_files_from_listing(
     file_listing: pt.DataFrame[_ProcessedFileListing],
-    size_threshold_bytes: int = 1000,
+    size_threshold_bytes: int = 520,
 ) -> pt.DataFrame[_ProcessedFileListing]:
-    """Remove files that are too small.
+    """Remove files too small to carry any readings.
 
-    This is used to remove NGED JSON files that have no `data` field.
+    This is used to skip NGED JSON files that have no `data` field, so `download_and_parse_files`
+    never has to fetch and parse them only to discard the result. It is an optimisation, not a
+    correctness requirement: `download_and_parse_files` already tolerates a null `data` field.
 
-    Typical files sizes for NGED JSON files:
-        -  486 bytes: no `data` and no `WKT`.
-        - 2011 bytes: 12 timesteps in `data` and no `WKT`.
-        - 4328 bytes: no `data` but a large `WKT` string.
+    `size_threshold_bytes` defaults to 520, derived from the real files on NGED's S3: a WKT-less
+    file with zero readings tops out at 488 bytes, and one with a single reading starts at 556
+    bytes, so 520 sits in the gap between them. WKT-bearing (Primary substation) files run far
+    larger — zero-reading examples measured between 4,405 and 20,148 bytes — so the WKT-less
+    floor is the binding constraint on the threshold.
     """
-    return file_listing.filter(pl.col("filesize_bytes") > size_threshold_bytes)
+    n_files_before_filter = file_listing.height
+    filtered = file_listing.filter(pl.col("filesize_bytes") > size_threshold_bytes)
+    log.info(
+        f"Files retained after the size filter: {filtered.height} out of {n_files_before_filter=}"
+    )
+    return filtered
 
 
 class NoNewData(Exception):

--- a/packages/nged_data/src/nged_data/storage.py
+++ b/packages/nged_data/src/nged_data/storage.py
@@ -126,6 +126,12 @@ def remove_small_files_from_listing(
     bytes, so 520 sits in the gap between them. WKT-bearing (Primary substation) files run far
     larger — zero-reading examples measured between 4,405 and 20,148 bytes — so the WKT-less
     floor is the binding constraint on the threshold.
+
+    That 68-byte gap comes from V1's 33 series, and it is narrow enough that V2's ~2,500 series
+    want re-measuring before this default is trusted there. Two things would close it: a populated
+    `information` field, which `TimeSeriesMetadata` records as always null in the V1 trial area,
+    would push a zero-reading file above 520; and a substation name shorter than any in V1 would
+    pull a one-reading file below it. Re-run the measurement rather than assume the gap survives.
     """
     n_files_before_filter = file_listing.height
     filtered = file_listing.filter(pl.col("filesize_bytes") > size_threshold_bytes)

--- a/packages/nged_data/tests/test_storage.py
+++ b/packages/nged_data/tests/test_storage.py
@@ -1,3 +1,4 @@
+import logging
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -10,10 +11,34 @@ from nged_data.storage import (
     _process_file_listing,
     _ProcessedFileListing,
     _RawFileListItem,
+    remove_small_files_from_listing,
     select_new_rows,
     time_series_coverage,
     upsert_metadata,
 )
+
+
+def _file_listing(filesize_bytes: list[int]) -> pt.DataFrame[_ProcessedFileListing]:
+    """Build a minimal, valid `_ProcessedFileListing` frame with the given file sizes.
+
+    `remove_small_files_from_listing` only reads `filesize_bytes`, so every other column is a
+    fixed placeholder.
+    """
+    n = len(filesize_bytes)
+    raw = pl.DataFrame(
+        {
+            "path": [f"timeseries/0_1/TimeSeries_1_{i}.json" for i in range(n)],
+            "filesize_bytes": pl.Series(filesize_bytes, dtype=pl.Int64),
+            "time_series_id": pl.Series([1] * n, dtype=pl.Int32),
+            "start_time": pl.Series([datetime(2026, 1, 1, tzinfo=UTC)] * n).cast(
+                UTC_DATETIME_DTYPE
+            ),
+            "end_time": pl.Series([datetime(2026, 1, 1, 6, tzinfo=UTC)] * n).cast(
+                UTC_DATETIME_DTYPE
+            ),
+        }
+    )
+    return pt.DataFrame(raw).set_model(_ProcessedFileListing).validate()
 
 
 def test_upsert_metadata_new_file(tmp_path: Path):
@@ -484,3 +509,50 @@ def test_parse_file_listing_invalid():
     # If the regex fails, the columns will be null, and validation should fail.
     with pytest.raises(pt.exceptions.DataFrameValidationError):
         _process_file_listing(raw_file_listing)
+
+
+def test_remove_small_files_from_listing_keeps_one_reading_file():
+    """A one-reading, WKT-less file is 556 bytes (measured on real NGED S3 downloads) and must
+    survive the default filter. It did not survive the old 1000-byte default — see
+    ``test_remove_small_files_from_listing_drops_one_reading_file_at_the_old_threshold``."""
+    file_listing = _file_listing([556])
+
+    result = remove_small_files_from_listing(file_listing)
+
+    assert result.height == 1
+    _ProcessedFileListing.validate(result)  # schema must survive filtering
+
+
+def test_remove_small_files_from_listing_drops_one_reading_file_at_the_old_threshold():
+    """Regression pin for the defect this change fixes: the old 1000-byte default dropped a
+    556-byte one-reading file. Kept so the fix cannot silently regress back to the old default."""
+    file_listing = _file_listing([556])
+
+    result = remove_small_files_from_listing(file_listing, size_threshold_bytes=1000)
+
+    assert result.height == 0
+
+
+def test_remove_small_files_from_listing_drops_genuinely_empty_file():
+    """A genuinely empty, WKT-less file is 430-488 bytes (measured on real NGED S3 downloads) and
+    must still be dropped by the default filter."""
+    file_listing = _file_listing([430, 488])
+
+    result = remove_small_files_from_listing(file_listing)
+
+    assert result.height == 0
+
+
+def test_remove_small_files_from_listing_logs_dropped_count(
+    caplog: pytest.LogCaptureFixture,
+):
+    """The number of files retained/dropped must be logged at INFO, or the loss stays invisible."""
+    file_listing = _file_listing([430, 556])
+
+    with caplog.at_level(logging.INFO, logger="nged_data.storage"):
+        remove_small_files_from_listing(file_listing)
+
+    assert any(
+        "1 out of n_files_before_filter=2" in r.message and r.levelno == logging.INFO
+        for r in caplog.records
+    )

--- a/src/nged_substation_forecast/defs/assets.py
+++ b/src/nged_substation_forecast/defs/assets.py
@@ -128,7 +128,7 @@ def power_time_series_and_metadata(context: AssetExecutionContext) -> None:
                 "nged_s3_paths",
                 {
                     "All JSON files on S3": list_of_all_json_files,
-                    "Files larger than 1kB": list_of_large_json_files,
+                    "Files above the size threshold": list_of_large_json_files,
                     "Files with new data": list_of_new_json_files,
                 },
             )


### PR DESCRIPTION
Written by Claude Code.

`remove_small_files_from_listing` (in `packages/nged_data/src/nged_data/storage.py`) drops any S3 object at or below a byte threshold, on the theory that a small file has no readings worth downloading.

Its own docstring gave the arithmetic that condemned the old 1000-byte default: a WKT-less file with 4 readings measures under 1000 bytes, so it was silently dropped every time it was still the newest window for its series.

The blast radius is wider than "generation meters": it is any non-Primary substation type, which at V1 is 17 of the 33 series — the BSP and GSP substations (`TimeSeriesType: "Raw Flow"`) as well as the EHV/HV customer meters, not only the PV/generation ones.

I measured real file sizes against NGED's S3 rather than trusting the old docstring's numbers, sampling one representative file per distinct byte size across the small end of the listing (18,645 files total).

| readings | WKT | measured size (bytes) |
|---|---|---|
| 0 | no | 430 – 488 |
| 1 | no | 556 – 617 |
| 2 | no | 685 – 711 |
| 3 | no | 810 – 870 |
| 4 | no | 936 – 995 (dropped by the old 1000-byte default) |
| 5 | no | 1,061 – 1,122 (survived the old default) |
| 0 | yes (Primary) | 4,405 – 20,148 |

There is a clean gap between the zero-reading ceiling (488 bytes) and the one-reading floor (556 bytes), with no observed file size in between anywhere in the corpus, so I set the new default to 520 bytes — comfortably inside that gap — and put the derivation in the docstring in place of the old, unsourced arithmetic.

WKT-bearing (Primary) files run far larger even with zero readings, so the WKT-less floor is what has to set the threshold; Primary files were never at risk from the old default.

The fix also logs how many files survive the filter, at INFO, because previously the drop was invisible: `Files retained after the size filter: {filtered.height} out of {n_files_before_filter=}`.

**Caveat on what this actually recovers.** `remove_small_files_from_listing` feeds straight into `select_new_rows`, which still applies a high-water mark per series (`time > last_time`) — a defect I did not touch here.

So raising the threshold recovers a small file only when it is still the newest window for its series; a low-reading file that arrives out of order still passes this filter and is then dropped by the high-water mark.

The ordinary forward-flowing case — the normal way files arrive — is unaffected by that interaction, so the split is defensible, but this PR does not recover every previously-dropped file, only the ones still at the front of their series' coverage.

The high-water-mark defect needs a decision about where "paths already ingested" would be stored, which is a storage design question, so it is being tracked separately rather than addressed here.

**Why the filter is kept, not deleted.** Per file the saving is trivial at V1's 33 series — about 1 KB and one caught exception — but at V2's roughly 2,500 series, every genuinely-empty meter-window skipped saves an S3 GET, a JSON parse and a caught exception, so the filter's value scales with fleet size even though its per-file saving does not.

Scope: `packages/nged_data/` only.

`select_new_rows` and the `time_series_id` regex are untouched.

No data contract changed.

## Verification

`ruff check`, `ruff format --check`, `ty check`, `pytest` (709 passed, 1 skipped) and `pymarkdown scan` all pass.

I reverted the threshold to 1000 and confirmed the new "one reading survives" test fails: `assert 0 == 1`, with the filtered frame showing 0 rows for a 556-byte input — then restored 520 and re-ran the full suite green.
