### PR TITLE
Pin the weather-lag dual-strategy join's boundary and availability

### DIFF
--- a/packages/ml_core/src/ml_core/features/_lags.py
+++ b/packages/ml_core/src/ml_core/features/_lags.py
@@ -55,10 +55,11 @@ def _apply_weather_lag(
 ) -> pl.LazyFrame:
     """Applies a weather lag using a dual-strategy time-aware join.
 
-    - If target_time > power_fcst_init_time (in the NWP forecast window), uses the exact same
-      NWP run (nwp_init_time) and ensemble member as the weather used for valid_time.
-    - If target_time <= power_fcst_init_time (in the past), uses the freshest NWP run
-      (control member, ensemble 0) for that target time.
+    - If target_time >= power_fcst_init_time (in the NWP forecast window, including the
+      boundary), uses the exact same NWP run (nwp_init_time) and ensemble member as the weather
+      used for valid_time.
+    - If target_time < power_fcst_init_time (in the past), uses the freshest NWP run (control
+      member, ensemble 0) for that target time.
 
     Args:
         engineered_features_lf: The in-progress feature frame this helper attaches one lag
@@ -75,7 +76,7 @@ def _apply_weather_lag(
         target_time=pl.col("valid_time") - pl.duration(hours=lag_feature.hours)
     )
 
-    # Join 1: Same-Run Join (for target_time > power_fcst_init_time)
+    # Join 1: Same-Run Join (for target_time >= power_fcst_init_time)
     right_same_lf = nwp_lf.select(
         "time_series_id",
         "nwp_init_time",
@@ -90,7 +91,7 @@ def _apply_weather_lag(
         how="left",
     )
 
-    # Join 2: Freshest-Run Join (for target_time <= power_fcst_init_time)
+    # Join 2: Freshest-Run Join (for target_time < power_fcst_init_time)
     right_freshest_lf = historical_weather_lf.select(
         "time_series_id",
         pl.col("valid_time").alias("target_time"),
@@ -99,7 +100,13 @@ def _apply_weather_lag(
     lf_joined = lf_joined.join(right_freshest_lf, on=["time_series_id", "target_time"], how="left")
 
     return lf_joined.with_columns(
-        pl.when(pl.col("target_time") > pl.col("power_fcst_init_time"))
+        # >= rather than >: at target_time == power_fcst_init_time the row's own run is already
+        # available (bulk mode derives power_fcst_init_time = nwp_init_time + delay, exactly the
+        # instant that run becomes usable), and no fresher run can be available at that instant
+        # either — so the boundary belongs to the same-run branch, not the freshest-run one. This
+        # changes no output today (see the explanatory comment on the historical_weather
+        # construction in tabular_feature_engineer.py); it is defence in depth.
+        pl.when(pl.col("target_time") >= pl.col("power_fcst_init_time"))
         .then(pl.col(f"{lag_feature.string_repr}_same_run"))
         .otherwise(pl.col(f"{lag_feature.string_repr}_freshest_run"))
         .alias(lag_feature.string_repr)

--- a/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py
+++ b/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py
@@ -21,7 +21,7 @@ Nullify Leaky Lags Rationale:
 """
 
 import math
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import patito as pt
 import polars as pl
@@ -198,13 +198,32 @@ def _engineer_features(
             "Weather lag features require the NWP control member (ensemble_member == 0) "
             "to build historical weather, but no such rows were found in the NWP data."
         )
-    historical_weather = (
-        select_analysis_proxy(
+    if processed_nwp is None or not weather_lags:
+        historical_weather = None
+    elif power_fcst_init_time is not None:
+        # Single-run mode: gate the freshest-run (analysis-proxy) selection to runs available by
+        # this row's own power_fcst_init_time. This is the mode carrying the real risk: a caller
+        # can pass a wide multi-run `nwp` frame alongside an arbitrary explicit
+        # power_fcst_init_time, and without this cut nothing stops the freshest-run join from
+        # picking up a run that would not actually have been available yet.
+        historical_weather = select_analysis_proxy(
+            processed_nwp,
+            group_key="time_series_id",
+            init_time_col="nwp_init_time",
+            available_at=power_fcst_init_time,
+            publication_delay=timedelta(hours=nwp_publication_delay_hours),
+        )
+    else:
+        # Bulk mode: no available_at cut, deliberately. historical_weather is built once, globally,
+        # here — before every row gets its own derived power_fcst_init_time — so there is no single
+        # scalar cutoff to give it. None is needed either: for a hindcast target (valid_time <=
+        # that row's own power_fcst_init_time), the only causally-eligible runs are the row's own
+        # run or an earlier one, because an NWP run's earliest valid_time is its own init_time — a
+        # later run can never hold a valid_time that early. This is the invariant to re-check if
+        # this ever needs to become row-aware.
+        historical_weather = select_analysis_proxy(
             processed_nwp, group_key="time_series_id", init_time_col="nwp_init_time"
         )
-        if processed_nwp is not None and weather_lags
-        else None
-    )
 
     if power_fcst_init_time is None:
         raw_data = _join_nwp_bulk_mode(

--- a/packages/ml_core/tests/test_cross_mode_equivalence.py
+++ b/packages/ml_core/tests/test_cross_mode_equivalence.py
@@ -16,16 +16,20 @@ single-run mode keeps them for its caller to filter before predicting (as ``live
 does), so the replay side applies that same filter here. If a future change diverges the two
 modes, this fails.
 
-Scope note: this test exercises the **weather, time, power-lag, and weather-rolling** features.
-Weather/time features depend on the bulk-vs-single-run NWP join; power lags are included because
-both modes now source them from the same dense observed-power series (Phase 1.5 / Option B), so
-they are identical too. A weather rolling mean is included to lock the cross-mode invariant for
-rolling aggregations: single-run mode pads each ``(ts, nwp_init_time, member)`` group with
+Scope note: this test exercises the **weather, time, power-lag, weather-lag, and weather-rolling**
+features. Weather/time features depend on the bulk-vs-single-run NWP join; power lags are included
+because both modes now source them from the same dense observed-power series (Phase 1.5 / Option
+B), so they are identical too. A weather rolling mean is included to lock the cross-mode invariant
+for rolling aggregations: single-run mode pads each ``(ts, nwp_init_time, member)`` group with
 out-of-window null-weather rows, which a *null-skipping* aggregation (mean/min/max/std/median/sum)
 ignores — so values match bulk. This test guards against a future switch to a row-count-dependent
-aggregation (``.len()``) that would silently diverge. The fixture's power series extends back
-before each NWP window (the pre-window history) so that an in-window power lag resolves to a
-genuine observed value rather than being nullified or reaching off the edge of the data.
+aggregation (``.len()``) that would silently diverge. A weather lag is included, over
+**overlapping** NWP windows, so the dual-strategy join's freshest-run (analysis-proxy) selection
+sees genuine multi-run candidates rather than a single one by construction — a non-overlapping
+fixture can't tell a real freshest-run selection apart from a degenerate one that only ever has
+one choice. The fixture's power series extends back before each NWP window (the pre-window
+history) so that an in-window power lag resolves to a genuine observed value rather than being
+nullified or reaching off the edge of the data.
 """
 
 from datetime import datetime, timedelta
@@ -37,6 +41,7 @@ from ml_core.features.tabular_feature_engineer import _engineer_features
 from polars.testing import assert_frame_equal
 
 _DELAY_HOURS = 6
+_WINDOW_HOURS = 27  # > 24h between daily runs, so consecutive runs' windows overlap by 3h.
 _NWP_RUNS = [
     datetime(2024, 1, 1, 0, 0),
     datetime(2024, 1, 2, 0, 0),
@@ -50,6 +55,7 @@ _FEATURES = {
     "local_time_of_day_sin",
     "local_time_of_day_cos",
     "power_lag_3h",
+    "temperature_2m_lag_7h",
     "temperature_2m_rolling_mean_3h",
 }
 _COMPARE_COLS = [
@@ -66,22 +72,25 @@ _COMPARE_COLS = [
     "local_time_of_day_sin",
     "local_time_of_day_cos",
     "power_lag_3h",
+    "temperature_2m_lag_7h",
     "temperature_2m_rolling_mean_3h",
 ]
 _SORT_COLS = ["time_series_id", "power_fcst_init_time", "valid_time", "ensemble_member"]
 
 
 def _run_valid_times(run_init: datetime) -> list[datetime]:
-    """A non-overlapping 00:00–12:00 half-hourly window for each daily run.
+    """A half-hourly window for each daily run, deliberately overlapping the next run's start.
 
     Starting at the run's own init_time (like real ECMWF ENS) gives every run a full
     ``_DELAY_HOURS`` of hindcast valid times before its derived power_fcst_init_time. Those
     rows must feed window features (weather rolling means) as predecessors on both sides even
-    though they are dropped from the compared output. Non-overlapping windows mean each
-    (time_series_id, valid_time) appears in exactly one run, which keeps the bulk and
-    single-run row sets directly comparable.
+    though they are dropped from the compared output. ``_WINDOW_HOURS`` exceeds the 24h gap
+    between daily runs, so a (time_series_id, valid_time) in the overlap can appear in two runs —
+    this is what makes the weather-lag freshest-run selection choose between genuine multi-run
+    candidates rather than a single one by construction.
     """
-    return [run_init + timedelta(minutes=30 * i) for i in range(25)]  # 00:00 .. 12:00 inclusive
+    steps = int(_WINDOW_HOURS * 2) + 1  # half-hourly steps, 00:00 .. _WINDOW_HOURS:00 inclusive
+    return [run_init + timedelta(minutes=30 * i) for i in range(steps)]
 
 
 def _power_observation_times(run_init: datetime) -> list[datetime]:
@@ -90,7 +99,7 @@ def _power_observation_times(run_init: datetime) -> list[datetime]:
     Crucially this includes the pre-window history (init .. init + delay) so that a power lag on
     an in-window row reaches back to a genuine observed value instead of being nullified.
     """
-    return [run_init + timedelta(minutes=30 * i) for i in range(25)]  # 00:00 .. 12:00 inclusive
+    return _run_valid_times(run_init)
 
 
 def _build_fixtures() -> tuple[
@@ -155,6 +164,14 @@ def test_bulk_and_single_run_features_are_identical() -> None:
             nwp=nwp,
             power_fcst_init_time=run + timedelta(hours=_DELAY_HOURS),
             nwp_init_time=run,
+            # Must match bulk mode's nwp_publication_delay_hours: select_analysis_proxy's
+            # available_at cut uses this to gate which runs it treats as published, and this
+            # test's own power_fcst_init_time = nwp_init_time + _DELAY_HOURS derivation is only
+            # self-consistent if the same delay is used everywhere. Leaving this on the default
+            # (9h) instead of _DELAY_HOURS (6h) would make the row's own run look "not yet
+            # published" by this test's own power_fcst_init_time — exactly the mismatch the
+            # nwp_publication_delay_hours docstring warns callers about.
+            nwp_publication_delay_hours=_DELAY_HOURS,
         ).collect()
         # Keep only rows the NWP run actually covers (single-run mode is power-centric and
         # emits null-weather rows for valid_times outside this run's window), and only
@@ -169,10 +186,12 @@ def test_bulk_and_single_run_features_are_identical() -> None:
         )
     single_run = pl.concat(single_run_parts)
 
-    # 12 of each run's 25 half-hourly steps survive: the 12 negative-lead steps and the lead-0
-    # step land at or before the derived power_fcst_init_time, and bulk mode drops those
-    # undeliverable hindcast rows after computing features on the full window.
-    assert len(bulk) == len(_NWP_RUNS) * len(_MEMBERS) * 12
+    # Every run's hindcast steps (lead 0 .. _DELAY_HOURS inclusive, half-hourly) land at or before
+    # its own derived power_fcst_init_time, and bulk mode drops those undeliverable rows after
+    # computing features on the full window — only the remaining, later steps survive.
+    hindcast_steps_per_run = _DELAY_HOURS * 2 + 1
+    deliverable_steps_per_run = len(_run_valid_times(_NWP_RUNS[0])) - hindcast_steps_per_run
+    assert len(bulk) == len(_NWP_RUNS) * len(_MEMBERS) * deliverable_steps_per_run
     # Guard: no fan-out. The row count above already catches one, but only because it is pinned
     # to an exact expected value; state the invariant directly so that loosening the count later
     # cannot quietly take the fan-out guard with it.

--- a/packages/ml_core/tests/test_features.py
+++ b/packages/ml_core/tests/test_features.py
@@ -865,6 +865,50 @@ def test_engineer_features_weather_lag_freshest_run_reaches_older_run_only_data(
     assert engineered["temperature_2m_lag_24h"][0] == 8.0
 
 
+def test_engineer_features_single_run_freshest_run_excludes_unpublished_nwp_run():
+    """The single-run availability gate must reject a run not yet published by power_fcst_init_time.
+
+    Three runs carry a value at the same lag target_time: T0, legitimately available by
+    power_fcst_init_time; T1, the row's own run (nwp_init_time), with no row at target_time so
+    the same-run branch cannot answer and the freshest-run branch is exercised; and T2, fresher
+    than T1 but with ``init_time + publication_delay`` still after power_fcst_init_time — not yet
+    published. Without the ``available_at``/``publication_delay`` cut on ``select_analysis_proxy``
+    in single-run mode, the freshest-run join picks up T2's decoy value; with it, T2 is excluded
+    and T0 answers instead.
+    """
+    power_fcst_init_time = datetime(2026, 6, 11, 6, 0)
+    nwp_init_time = datetime(2026, 6, 11, 0, 0)  # T1: the row's own run
+    older_run_init_time = datetime(2026, 6, 10, 0, 0)  # T0: legitimately available
+    too_fresh_init_time = datetime(2026, 6, 11, 3, 0)  # T2: fresher than T1, not yet published
+    valid_time = datetime(2026, 6, 11, 12, 0)
+    # lag=24h -> target_time = 2026-06-10 12:00: before power_fcst_init_time (freshest-run
+    # branch), and T1 carries no row there at all, so only T0 or T2 can answer it.
+    target_time = valid_time - timedelta(hours=24)
+
+    nwp_df = pl.DataFrame(
+        {
+            "time_series_id": ["ts1", "ts1", "ts1"],
+            "valid_time": [target_time, valid_time, target_time],
+            "ensemble_member": [0, 0, 0],
+            "init_time": [older_run_init_time, nwp_init_time, too_fresh_init_time],
+            "temperature_2m": [8.0, 99.0, 999.0],  # T0 legit; T1's unrelated row; T2 decoy
+        }
+    )
+    power_df = pl.DataFrame({"time_series_id": ["ts1"], "time": [valid_time], "power": [100.0]})
+    metadata_df = pl.DataFrame({"time_series_id": ["ts1"], "time_series_type": ["substation"]})
+
+    engineered = _engineer_features(
+        power_time_series=pt.LazyFrame.from_existing(power_df.lazy()).set_model(PowerTimeSeries),
+        time_series_metadata=pt.DataFrame(metadata_df).set_model(TimeSeriesMetadata),
+        nwp=nwp_df.lazy(),
+        selected_features={"temperature_2m_lag_24h"},
+        power_fcst_init_time=power_fcst_init_time,
+        nwp_init_time=nwp_init_time,
+    ).collect()
+
+    assert engineered["temperature_2m_lag_24h"][0] == 8.0
+
+
 def test_apply_weather_lag_boundary_uses_same_run_at_exact_lead():
     """At target_time == power_fcst_init_time, the boundary belongs to the same-run branch.
 

--- a/packages/ml_core/tests/test_features.py
+++ b/packages/ml_core/tests/test_features.py
@@ -9,7 +9,7 @@ from contracts.power_schemas import (
     PowerTimeSeries,
     TimeSeriesMetadata,
 )
-from ml_core.features._lags import _apply_power_lag, _nullify_leaky_lags
+from ml_core.features._lags import _apply_power_lag, _apply_weather_lag, _nullify_leaky_lags
 from ml_core.features._nwp import _upsample_nwp_to_half_hourly
 from ml_core.features._parsed_features import (
     STATIC_FEATURE_REGISTRY,
@@ -23,6 +23,7 @@ from ml_core.features.tabular_feature_engineer import (
     _local_utc_offset_minutes,
 )
 from pydantic import ValidationError
+from weather_utils import NWP_PUBLICATION_DELAY_HOURS
 
 
 def test_apply_power_lag_with_source():
@@ -757,8 +758,10 @@ def test_engineer_features_raises_when_nwp_init_time_given_without_power_fcst_in
 def test_engineer_features_weather_lag_leakage_prevention():
     # Create dummy data to verify weather lag leakage prevention
     valid_time = datetime(2026, 6, 11, 12, 0)
-    power_fcst_init_time = datetime(2026, 6, 10, 6, 0)
     nwp_init_time = datetime(2026, 6, 10, 0, 0)
+    # power_fcst_init_time must clear select_analysis_proxy's default publication_delay
+    # (NWP_PUBLICATION_DELAY_HOURS) for run 1 to count as "available" for the freshest-run join.
+    power_fcst_init_time = nwp_init_time + timedelta(hours=NWP_PUBLICATION_DELAY_HOURS)
 
     # NWP data has two runs:
     # 1. Run initialized at 2026-06-10 00:00:00 (the one we should use)
@@ -819,6 +822,95 @@ def test_engineer_features_weather_lag_leakage_prevention():
 
     # Verify that temperature_2m_lag_36h is 8.0 (from freshest run)
     assert engineered["temperature_2m_lag_36h"][0] == 8.0
+
+
+def test_engineer_features_weather_lag_freshest_run_reaches_older_run_only_data():
+    """The freshest-run branch must resolve to a value that only an OLDER run holds.
+
+    A fixture where the same-run and freshest-run branches happen to agree can't tell "always
+    same-run" apart from the real dual-strategy join. Here the row's own run (T1) has no
+    coverage at all at the lag's target_time, so the same-run join legitimately misses (null);
+    only the older run (T0) has real data there, so the freshest-run branch must reach past T1
+    to find it.
+    """
+    power_fcst_init_time = datetime(2026, 6, 11, 6, 0)
+    nwp_init_time = datetime(2026, 6, 11, 0, 0)  # T1: the row's own run
+    older_run_init_time = datetime(2026, 6, 10, 0, 0)  # T0: an earlier run
+    valid_time = datetime(2026, 6, 11, 12, 0)
+    # lag=24h -> target_time = 2026-06-10 12:00: before power_fcst_init_time (freshest-run
+    # branch), and T1 carries no row there at all, so only T0 can answer it.
+    target_time = valid_time - timedelta(hours=24)
+
+    nwp_df = pl.DataFrame(
+        {
+            "time_series_id": ["ts1", "ts1"],
+            "valid_time": [target_time, valid_time],
+            "ensemble_member": [0, 0],
+            "init_time": [older_run_init_time, nwp_init_time],
+            "temperature_2m": [8.0, 99.0],  # T0 at target_time; T1's own (unrelated) row
+        }
+    )
+    power_df = pl.DataFrame({"time_series_id": ["ts1"], "time": [valid_time], "power": [100.0]})
+    metadata_df = pl.DataFrame({"time_series_id": ["ts1"], "time_series_type": ["substation"]})
+
+    engineered = _engineer_features(
+        power_time_series=pt.LazyFrame.from_existing(power_df.lazy()).set_model(PowerTimeSeries),
+        time_series_metadata=pt.DataFrame(metadata_df).set_model(TimeSeriesMetadata),
+        nwp=nwp_df.lazy(),
+        selected_features={"temperature_2m_lag_24h"},
+        power_fcst_init_time=power_fcst_init_time,
+        nwp_init_time=nwp_init_time,
+    ).collect()
+
+    assert engineered["temperature_2m_lag_24h"][0] == 8.0
+
+
+def test_apply_weather_lag_boundary_uses_same_run_at_exact_lead():
+    """At target_time == power_fcst_init_time, the boundary belongs to the same-run branch.
+
+    The row's own run is available by construction at exactly this instant — bulk mode derives
+    power_fcst_init_time = nwp_init_time + delay, the instant that run becomes usable — so `>=`
+    routes the boundary through the same-run join rather than the freshest-run join. Pins the
+    same-run value at a target_time deliberately given a *different* freshest-run value, so the
+    two branches are distinguishable at the boundary rather than coincidentally equal.
+    """
+    power_fcst_init_time = datetime(2023, 1, 2, 6, 0)
+    nwp_init_time = datetime(2023, 1, 2, 0, 0)
+    target_time = power_fcst_init_time  # exactly on the boundary
+    valid_time = target_time + timedelta(hours=3)  # lag_hours=3h -> target_time as above
+
+    engineered_features_df = pl.DataFrame(
+        {
+            "time_series_id": ["ts1"],
+            "nwp_init_time": [nwp_init_time],
+            "ensemble_member": [0],
+            "valid_time": [valid_time],
+            "power_fcst_init_time": [power_fcst_init_time],
+        }
+    )
+    nwp_df = pl.DataFrame(
+        {
+            "time_series_id": ["ts1"],
+            "nwp_init_time": [nwp_init_time],
+            "ensemble_member": [0],
+            "valid_time": [target_time],
+            "temperature_2m": [11.0],  # same-run value
+        }
+    )
+    historical_weather_df = pl.DataFrame(
+        {
+            "time_series_id": ["ts1"],
+            "valid_time": [target_time],
+            "temperature_2m": [22.0],  # freshest-run value, deliberately different
+        }
+    )
+
+    lag_feat = LagFeature.from_str("temperature_2m_lag_3h")
+    result = _apply_weather_lag(
+        engineered_features_df.lazy(), nwp_df.lazy(), lag_feat, historical_weather_df.lazy()
+    ).collect()
+
+    assert result["temperature_2m_lag_3h"][0] == 11.0
 
 
 def test_engineer_features_power_lag_nullification_end_to_end():


### PR DESCRIPTION
Written by Claude Code.

This is a v0.2 codebase review fix for the weather-lag dual-strategy join in `_apply_weather_lag` (`packages/ml_core/src/ml_core/features/_lags.py`), the machinery the no-lookahead invariant rests on for weather features.

**Problem 1 — no fixture could tell "always same-run" apart from the real dual-strategy join.** Every existing test happened to construct a scenario where the same-run and freshest-run branches resolved to the same value, so mutating the branch selection to always use the same-run join left the whole suite green. I verified this empirically before touching any code: with the mutation applied, `uv run pytest packages/ml_core/tests/test_features.py packages/ml_core/tests/test_cross_mode_equivalence.py` still passed 53/53.

Two new tests close that gap. `test_engineer_features_weather_lag_freshest_run_reaches_older_run_only_data` drives the full `_engineer_features` pipeline through a scenario where the row's own NWP run has no coverage at all at the lag's target time, so only an older run can supply the value — this forces the freshest-run branch to actually reach past the row's own run. `test_apply_weather_lag_boundary_uses_same_run_at_exact_lead` unit-tests `_apply_weather_lag` directly with deliberately different same-run and freshest-run values at the exact boundary target time, so branch selection at the boundary is observable rather than coincidentally equal.

Both fail correctly when the corresponding code change is mutated back — failure messages are in the verification section below.

**Problem 2 — the branch boundary used strict `>` instead of `>=`.** A lag whose target_time lands exactly on `power_fcst_init_time` took the freshest-run branch under the old code.

This is now `>=`: at that exact instant the row's own run is already available by construction, because bulk mode derives `power_fcst_init_time = nwp_init_time + delay`, which is exactly the instant that run becomes usable, and no fresher run can be available at that same instant either (a fresher run would need `init_time' + delay <= nwp_init_time + delay`, i.e. `init_time' <= nwp_init_time` — an equal-or-earlier run, never later).

**This changes no model output on real data today** — it is defence in depth, not a correction of an observed bug. The champion model config (`conf/model/xgboost.yaml`) requests no weather-lag features at all (only `power_lag_*h` and raw, unlagged weather), so `_apply_weather_lag` is not on the path that produced the currently-promoted model. No retrain is implied by this change.

**Problem 3 — the asymmetric `available_at` fix, and why bulk mode is correctly left unguarded.** `historical_weather` (the freshest-run analysis-proxy frame `_apply_weather_lag`'s freshest-run branch reads from) was built once, globally, in `tabular_feature_engineer.py`, with no `available_at` cut passed to `select_analysis_proxy`. In single-run mode this is a real risk: a caller can pass a wide multi-run NWP frame alongside an arbitrary explicit `power_fcst_init_time`, and nothing stopped the freshest-run join from picking up a run that would not actually have been available yet at that `power_fcst_init_time`. Single-run mode now passes `available_at=power_fcst_init_time`, and passes the matching `publication_delay=timedelta(hours=nwp_publication_delay_hours)` alongside it — `select_analysis_proxy`'s own `publication_delay` default is independent of `_engineer_features`' `nwp_publication_delay_hours` parameter, so passing only `available_at` would silently use the wrong delay whenever a caller overrides `nwp_publication_delay_hours`.

Bulk mode is deliberately left with no `available_at` cut, and this is correct rather than merely tolerable. `historical_weather` is built once, globally, before every row gets its own derived `power_fcst_init_time`, so there is no single scalar cutoff to give it. None is needed either: for a hindcast target (`valid_time <= that row's own power_fcst_init_time`), the only causally-eligible runs are the row's own run or an earlier one, because an NWP run's earliest `valid_time` is its own `init_time` — a later run can never hold a `valid_time` that early. This argument is recorded as a comment on the bulk-mode branch in `tabular_feature_engineer.py`, next to where a reader would look for the missing guard.

**Cross-mode equivalence fixture.** Per the plan, I added a weather-lag feature to `test_cross_mode_equivalence.py`'s `_FEATURES` and gave the fixture overlapping NWP windows (`_WINDOW_HOURS = 27` against a 24h daily-run gap), so the freshest-run selection sees genuine multi-run candidates instead of a single one by construction. This did go red once — but investigating it found a bug in the test fixture itself, not an asymmetry in production code: the single-run replay loop didn't pass `nwp_publication_delay_hours` to match bulk mode's value, so it silently defaulted to the module constant (9h) instead of the test's own 6h, which made the replayed run's own data look "not yet published" under the new availability gate. This is exactly the mismatch problem 3's fix docstring warns callers about, and fixing the test call (passing `nwp_publication_delay_hours=_DELAY_HOURS` explicitly, matching the bulk call) made the test green again with no production code change. I did not paper over this — the fix and the reasoning are both in the diff and in the test's own new comment.

**Verification — all green:**

```
uv run ruff check .
uv run ruff format --check .
uv run --all-packages ty check
uv run pytest                    # 707 passed, 1 skipped
uv run pymarkdown scan -r docs README.md CLAUDE.md packages/*/README.md
```

**Mutation testing, as required by the plan — both make a test fail:**

1. `_apply_weather_lag` forced to "always same-run" (replacing the `pl.when(...)` with the same-run column directly):

```
FAILED packages/ml_core/tests/test_features.py::test_engineer_features_weather_lag_freshest_run_reaches_older_run_only_data
assert engineered["temperature_2m_lag_24h"][0] == 8.0
E   assert None == 8.0
```

2. Branch boundary changed back from `>=` to `>`:

```
FAILED packages/ml_core/tests/test_features.py::test_apply_weather_lag_boundary_uses_same_run_at_exact_lead
assert result["temperature_2m_lag_3h"][0] == 11.0
E   assert 22.0 == 11.0
```

**Files changed:**

- `packages/ml_core/src/ml_core/features/_lags.py` — boundary `>` → `>=`, docstring and inline comments updated to match.
- `packages/ml_core/src/ml_core/features/tabular_feature_engineer.py` — `historical_weather` construction split into bulk (unguarded, with the causality comment) and single-run (`available_at` + matching `publication_delay`) branches.
- `packages/ml_core/tests/test_features.py` — two new tests (problems 1 and 2); the pre-existing `test_engineer_features_weather_lag_leakage_prevention` fixture's `power_fcst_init_time` was moved from `nwp_init_time + 6h` to `nwp_init_time + NWP_PUBLICATION_DELAY_HOURS` so its own run clears the new default availability gate.
- `packages/ml_core/tests/test_cross_mode_equivalence.py` — overlapping NWP windows, a weather-lag feature added to the compared feature set, the row-count assertion reworked from a hardcoded literal to a computed expression, and the single-run replay call fixed to pass `nwp_publication_delay_hours` explicitly.

No changes outside `packages/ml_core/`, `NWP_PUBLICATION_DELAY_HOURS`, `select_analysis_proxy`'s signature, or `weather_utils` — per the plan's scope limits.
