### PR TITLE
Fix power sign convention: it is per-type, not global

### DIFF
--- a/docs/roadmap/delivery-tables.md
+++ b/docs/roadmap/delivery-tables.md
@@ -113,7 +113,7 @@ filter on `fold_id` to select the population you need. See
 | Field | Data type | Notes |
 |---|---|---|
 | `ensemble_member` | `int8` | ID of the NWP ensemble member driving this forecast. ECMWF ENS has 51 members. |
-| `power_fcst` | `float32` | OCF's power forecast. **In this early version** the value is in physical units (MW for active power, MVA for apparent power). |
+| `power_fcst` | `float32` | OCF's power forecast. **In this early version** the value is in physical units (MW for active power, MVA for apparent power). Sign convention depends on `time_series_type` — see [Sign convention](forecast-building-blocks.md#sign-convention). |
 
 > **🚧 Planned change — normalise `power_fcst` to [−1, +1]
 > ([#246](https://github.com/openclimatefix/nged-substation-forecast/issues/246), v0.1).** The

--- a/packages/contracts/src/contracts/power_schemas.py
+++ b/packages/contracts/src/contracts/power_schemas.py
@@ -46,11 +46,13 @@ class PowerTimeSeries(pt.Model):
         description=(
             "Average power (MW or MVA) over the preceding 30-minute period. Unit defined in "
             "TimeSeriesMetadata."
-            " Sign convention depends on `time_series_type`: for substations, positive means"
-            " power flowing towards end-users and negative means excess generation flowing back"
-            " into the grid; for customer meters (generators), positive means the customer is"
-            " generating power sent to NGED's grid and negative means the customer is consuming"
-            " power."
+            " Sign convention depends on `substation_type` in `TimeSeriesMetadata`. At a"
+            " substation (`BSP`, `GSP`, `Primary`), positive means power flowing towards"
+            " end-users and negative means excess generation flowing back into the grid. At a"
+            " customer meter (`EHV Customer`, `HV Customer`), positive means the customer is"
+            " sending power to NGED's grid and negative means the customer is drawing power from"
+            " it. Those five values are the whole enum, so every series falls into exactly one"
+            " case."
         ),
     )
 
@@ -387,11 +389,13 @@ class PowerForecast(pt.Model):
         description=(
             "The power forecast itself in units of MW (active power) or MVA (apparent power)."
             " The unit is defined in the `TimeSeriesMetadata` for this `time_series_id`."
-            " Sign convention depends on `time_series_type`: for substations, positive means"
-            " power flowing towards end-users and negative means excess generation flowing back"
-            " into the grid; for customer meters (generators), positive means the customer is"
-            " generating power sent to NGED's grid and negative means the customer is consuming"
-            " power."
+            " Sign convention depends on `substation_type` in `TimeSeriesMetadata`. At a"
+            " substation (`BSP`, `GSP`, `Primary`), positive means power flowing towards"
+            " end-users and negative means excess generation flowing back into the grid. At a"
+            " customer meter (`EHV Customer`, `HV Customer`), positive means the customer is"
+            " sending power to NGED's grid and negative means the customer is drawing power from"
+            " it. Those five values are the whole enum, so every series falls into exactly one"
+            " case."
             " Rows read back from the internal `power_forecasts` Delta table carry reduced"
             " precision: values are rounded to a 13-bit significand at write time"
             " (max relative error 2^-13 ≈ 1.2e-4, far below forecast error) to aid compression;"

--- a/packages/contracts/src/contracts/power_schemas.py
+++ b/packages/contracts/src/contracts/power_schemas.py
@@ -46,6 +46,11 @@ class PowerTimeSeries(pt.Model):
         description=(
             "Average power (MW or MVA) over the preceding 30-minute period. Unit defined in "
             "TimeSeriesMetadata."
+            " Sign convention depends on `time_series_type`: for substations, positive means"
+            " power flowing towards end-users and negative means excess generation flowing back"
+            " into the grid; for customer meters (generators), positive means the customer is"
+            " generating power sent to NGED's grid and negative means the customer is consuming"
+            " power."
         ),
     )
 
@@ -382,8 +387,11 @@ class PowerForecast(pt.Model):
         description=(
             "The power forecast itself in units of MW (active power) or MVA (apparent power)."
             " The unit is defined in the `TimeSeriesMetadata` for this `time_series_id`."
-            """ Positive values mean "power sent to NGED's grid","""
-            """ and negative values mean "power drawn from NGED's grid"."""
+            " Sign convention depends on `time_series_type`: for substations, positive means"
+            " power flowing towards end-users and negative means excess generation flowing back"
+            " into the grid; for customer meters (generators), positive means the customer is"
+            " generating power sent to NGED's grid and negative means the customer is consuming"
+            " power."
             " Rows read back from the internal `power_forecasts` Delta table carry reduced"
             " precision: values are rounded to a 13-bit significand at write time"
             " (max relative error 2^-13 ≈ 1.2e-4, far below forecast error) to aid compression;"


### PR DESCRIPTION
Written by Claude Code.

`PowerForecast.power_fcst`'s Patito description asserted a single global sign convention: positive means power sent to NGED's grid, negative means power drawn from it.

That convention is wrong for substations, which are 20 of the 32 V1 trial series (16 primary substations, 2 GSPs, 2 BSPs) — so the contract had the sign backwards for the majority of the fleet.

`docs/index.md` already documents the correct, per-type convention: for substations, positive means power flowing towards end-users (demand); for customer meters (generators), positive means the customer is generating and sending power to NGED's grid.

The old contract wording is word-for-word the customer-meter case, generalised to every series.

This is a contract change, not a docs-only edit — `packages/contracts/README.md` calls the contract "the authoritative account of what the data means", and a field's description is the part of a Patito model that encodes a sign convention, since dtype and bounds cannot express "positive means demand".

Per the repo's rule to get a contract change agreed before making it, I confirmed the correct convention with the maintainer, who supplied the ground truth above: for substations, positive means demand.

## Changes

`PowerForecast.power_fcst` — replaced the global convention with the per-type one (substation vs. customer meter).

`PowerTimeSeries.power` — the observation column the forecast mirrors previously stated no sign convention at all; added the same per-type convention.

`docs/roadmap/delivery-tables.md` — the NGED-facing delivery table described `power_fcst` with no sign convention at all, which is exactly where an external reader most needs it; added a pointer to the sign-convention section in `forecast-building-blocks.md`.

`EffectiveCapacity.effective_capacity_mw` needs no change: it is `abs(power)` P99 with `gt=0`, a magnitude with no sign to document.

## Completeness check

I grepped the whole repo (docs, package READMEs, docstrings, dashboard code, notebooks, source) for every statement of a power sign convention and classified each hit.

| Location | Verdict |
|---|---|
| `packages/contracts/src/contracts/power_schemas.py` (`PowerForecast.power_fcst`) | Wrongly global — fixed in this PR |
| `packages/contracts/src/contracts/power_schemas.py` (`PowerTimeSeries.power`) | No convention stated — added in this PR |
| `docs/index.md:16-17` | Correct per-type, left alone |
| `docs/roadmap/forecast-building-blocks.md:46-51` | Correct per-type, left alone |
| `docs/roadmap/cost-savings-metrics.md:126-127` | Correct per-type, left alone |
| `docs/roadmap/delivery-tables.md:116` | Gap — no convention stated at all; added a pointer in this PR |
| `docs/roadmap/switching-events.md:943` | About something else (signed incidence matrix for load transfer), not touched |
| `docs/architecture/adapting-to-another-geography.md:1063` | About something else (MVA meters reporting `abs(flow)`), not touched |
| `docs/background/data-quality.md:29` | About something else (MVA meters reporting `abs(flow)`), not touched |
| `packages/contracts/src/contracts/settings.py:65-72` | About something else (data-quality magnitude bounds), not touched |

## Does any code depend on the old wording?

No. I grepped `packages/ml_core`, `packages/xgboost_forecaster`, `packages/dashboard`, and `src/` for `time_series_type ==` branches (none), for tests that assert a sign convention (none), and for any negation of a power column (`power_fcst * -1`, `-power_fcst`, `-power`, `.neg()`, etc. — none).

The only sign-related use anywhere is `abs(power)` for the `EffectiveCapacity` P99 in `src/nged_substation_forecast/defs/cv_assets.py:168-172`, which is magnitude-only and unaffected by which sign means what.

## Verification

`ruff check .`, `ruff format --check .`, `ty check --all-packages`, `pytest`, `pymarkdown scan`, and `mkdocs build --strict` all pass.
