### PR TITLE
Warn against creating uv venvs under /tmp

### DIFF
--- a/.claude/skills/implement-issue/SKILL.md
+++ b/.claude/skills/implement-issue/SKILL.md
@@ -113,6 +113,9 @@ front — a report back after step 1 is not finished work.
     git worktree add --detach .claude/worktrees/mutate-<branch-name> <branch-name>
     ```
 
+    Keep this worktree (and its `uv sync`) here, not under `/tmp` — see CLAUDE.md, "never create a
+    `uv venv` ... under `/tmp`".
+
     Brief it to take each behavioural claim the diff makes, introduce the smallest bug that
     breaks that claim, run the tests covering it, then revert the bug before trying the next
     one. Mutations worth naming: flip a comparison or a boolean, swap two join keys, drop a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,15 @@ hook.
 with `monkeypatch`, network-gated tests, the moto S3 reset-per-test rule, and the Patito assertion
 house style — are documented on the **[Testing](docs/architecture/testing.md)** page.
 
+**Never create a `uv venv` or run `uv sync` with a target under `/tmp`.** `/tmp` on this machine is
+tmpfs, a different filesystem from `~/.cache/uv`, so uv can't hardlink packages from its cache
+across that boundary and silently falls back to a full byte-for-byte copy per package — costing
+real RAM instead of the near-zero marginal cost a same-filesystem venv gets. This has been seen to
+exhaust the tmpfs quota mid-install and abandon the venv half-built. The session scratchpad
+directory is under `/tmp` too, so it has the same problem — put throwaway venvs (a
+mutation-testing worktree, a version-bisection scratch build, a one-off repro) on the home
+partition instead, e.g. a worktree under `.claude/worktrees/`.
+
 ## Skills
 
 Detail that only matters while you are touching one specific thing lives in


### PR DESCRIPTION
Generated with [Claude Code](https://claude.com/claude-code)

## Summary

While investigating `/tmp` disk usage, two large leftover scratch directories turned out to be full venvs built under `/tmp` (a mutation-testing worktree cloned there instead of into `.claude/worktrees/`, and a multi-version bug-bisection scratch build). Reproduced the root cause directly: `/tmp` is tmpfs on this machine, a different filesystem from `~/.cache/uv`, so uv can't hardlink cached packages across that boundary. It silently falls back to a full byte-for-byte copy per package, and a repro attempt under `/tmp` failed outright with a tmpfs quota error mid-install once the filesystem was nearly full.

This PR adds guidance to avoid the pattern going forward: no code changes, no plan and no agentic review — mechanical docs-only change per CLAUDE.md's sizing rules.

- `CLAUDE.md`: new rule against creating a `uv venv` or running `uv sync` under `/tmp`, including the session scratchpad directory (also tmpfs).
- `.claude/skills/implement-issue/SKILL.md`: pointer to that rule at the mutation-testing worktree step, which already puts the worktree in the right place but didn't say why `/tmp` is wrong.

## Test plan

- [x] `uv run pymarkdown scan` on both changed files
- [x] Pre-commit hooks (ruff, ty, pymarkdown) passed on commit
