### PR TITLE
Rename export_forecasts_for_alex.py to export_baseline_forecasts.py

### DIFF
--- a/packages/notebooks/view_baseline_export.py
+++ b/packages/notebooks/view_baseline_export.py
@@ -1,4 +1,4 @@
-"""Inspect the three baseline-export parquets produced by ``scripts/export_forecasts_for_alex.py``.
+"""Inspect the three baseline-export parquets produced by ``scripts/export_baseline_forecasts.py``.
 
 For a chosen time series it overlays observed power against the forecast (ensemble mean, p50, and
 the p10-p90 band), plots the observed-minus-expected residual (the raw material for switching-event

--- a/scripts/export_baseline_forecasts.py
+++ b/scripts/export_baseline_forecasts.py
@@ -23,7 +23,7 @@ units), left-joined from the ``power_time_series`` table so residuals can be com
 
 Run from a checkout where ``.env`` resolves (in a worktree, ``.env`` must be symlinked):
 
-    uv run python scripts/export_forecasts_for_alex.py \
+    uv run python scripts/export_baseline_forecasts.py \
         --experiment-name xgboost_no_power_lags \
         --fold-id mid_2025_to_mid_2026
 """

--- a/scripts/run_baseline_experiment.py
+++ b/scripts/run_baseline_experiment.py
@@ -168,7 +168,7 @@ def main() -> None:
         _run_pipeline(instance)
 
     _report_metrics()
-    print("\nDone. Now run: uv run python scripts/export_forecasts_for_alex.py")
+    print("\nDone. Now run: uv run python scripts/export_baseline_forecasts.py")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

This renames `scripts/export_forecasts_for_alex.py` to `scripts/export_baseline_forecasts.py`, using `git mv` so the history is recorded as a rename.

The old name is a person's name, which tells a reader nothing about what the script does and dates badly. The new name slots into the sequence the surrounding scripts already form: `run_baseline_experiment` -> `export_baseline_forecasts` -> `view_baseline_export`.

Updated every reference to the old name, including inside the script's own module docstring and usage example:

- `scripts/export_baseline_forecasts.py` — the `uv run python scripts/...` example in its own module docstring
- `scripts/run_baseline_experiment.py` — the "Now run" hint printed at the end of `main()`
- `packages/notebooks/view_baseline_export.py` — the module docstring's reference to the export script (this is a marimo notebook; edited directly, not through `ruff check --fix`)

A repo-wide grep for `export_forecasts_for_alex`, `for_alex`, and `alex` turned up nothing else tied to the script or the person; the only remaining `alex` hits are unrelated example laptop names (`alexs-laptop`) in the Sentry-naming docs.

No behaviour changed: same arguments, same output files, same docstring content beyond the file name it names itself by.

Ran the full verification set (`ruff check`, `ruff format --check`, `ty check`, `pytest`, `pymarkdown scan`, `mkdocs build --strict`) — all green.
