### PR TITLE
Bring version labelling in line with what is deployed

### DIFF
--- a/docs/architecture/aws-costs.md
+++ b/docs/architecture/aws-costs.md
@@ -49,8 +49,8 @@ account to read the delivery bucket. It is made up of:
 | Weekly re-training (planned; ephemeral GPU instance) | ~£1 |
 | Backtests | ~£0.65 per run, as needed |
 
-The weekly re-train row is a *planned* addition rather than an as-built cost: v0.1 bakes a
-frozen champion model into the image, and any re-training still happens on a laptop. Once the
+The weekly re-train row is a *planned* addition rather than an as-built cost: the live deployment
+bakes a frozen champion model into the image, and any re-training still happens on a laptop. Once the
 weekly re-train moves to AWS, the arithmetic stays small: the v1 model trains in ~10 minutes
 on a laptop, so budgeting ~30 minutes of `g4dn.xlarge` (1× T4 GPU, 4 vCPU / 16 GB;
 \$0.615/hr → £0.46/hr on-demand) per weekly run — instance provisioning and data reads

--- a/docs/architecture/ml-orchestration.md
+++ b/docs/architecture/ml-orchestration.md
@@ -98,8 +98,8 @@ looks immutable — is unsound here, because a CV fold run is **reused** across 
 of its partition (see "Cross-process run resolution" above), so the same run ID can legitimately
 hold a different model after re-training. The key would not be unique for its contents, and
 keeping such a cache honest would need write-side invalidation in `save_to_mlflow`: machinery
-serving no consumer, because production inference makes no MLflow call on the runtime path at all
-for v0.1 — the champion model is baked directly into the container image at build time and loaded
+serving no consumer, because production inference makes no MLflow call on the runtime path at
+all — the champion model is baked directly into the container image at build time and loaded
 via the subclass's own `load`.
 
 If a future consumer does need to keep serving through an MLflow outage, adding a cache scoped to

--- a/docs/architecture/production-deployment.md
+++ b/docs/architecture/production-deployment.md
@@ -356,8 +356,8 @@ completeness — and is likewise a warning, never a failure.
 
 Production forecasts run as ephemeral Fargate tasks, dispatched by the always-on Dagster
 control plane described [above](#run-the-dagster-control-plane-continuously-on-one-small-vm).
-An ephemeral container has no persistent disk and, for v0.1, no MLflow tracking server to reach
-— so production inference needs some way to get a model without depending on either.
+An ephemeral container has no persistent disk and no MLflow tracking server to reach — so
+production inference needs some way to get a model without depending on either.
 
 The champion model is therefore baked into the image at build time and loaded via a plain
 `save`/`load` — no MLflow, run ID, or cache involved at runtime. The model directory is
@@ -384,8 +384,8 @@ feature, not a limitation.
 This is deliberately simpler than depending on `BaseForecaster.load_from_mlflow` at runtime (the
 mechanism the CV pipeline already uses — see
 [ML orchestration: model artifacts](ml-orchestration.md#model-artifacts-one-replaceable-archive-no-local-cache)):
-v0.1 has no MLflow tracking server to reach from the runtime container in the first place, so
-there is nothing to cache or fail over from.
+the live deployment has no MLflow tracking server to reach from the runtime container in the
+first place, so there is nothing to cache or fail over from.
 
 **Future work:** once production wants to pick up a new champion without a rebuild + redeploy
 (e.g. after the [XGBoost quick wins](../roadmap/xgboost-improvements.md) start landing

--- a/docs/live_service/aws.md
+++ b/docs/live_service/aws.md
@@ -1,6 +1,6 @@
 # Setting up the live service on AWS
 
-Every step to stand up the v0.1 live service on AWS, in order, ending with the full stack
+Every step to stand up the live service on AWS, in order, ending with the full stack
 running unattended: data tables on S3 (Simple Storage Service, AWS's object store), the champion
 model baked into a container image, an always-on control-plane box running Dagster behind
 Tailscale, and 6-hourly forecasts executing on ephemeral Fargate (AWS's serverless container

--- a/docs/live_service/index.md
+++ b/docs/live_service/index.md
@@ -11,8 +11,8 @@ counterpart.
 land (so far: the `live_forecasts` and `promoted_model` assets, local 6-hourly automation, the
 container build/verify runbook, the AWS bring-up runbook, and Sentry telemetry with the
 missed-check-in alarm; still to come: production monitoring, and per-task failure-email alerting).
-Once the whole v0.1 epic ships, the roadmap page is deleted and this section is the sole home for
-how the live service works.
+Once production monitoring lands and its design is promoted, the roadmap page is deleted and this
+section is the sole home for how the live service works.
 
 This is distinct from [ML Experimentation](../ml_experimentation/index.md): that area covers
 training and backtesting candidate models against historical data; this area covers picking one

--- a/docs/live_service/setup.md
+++ b/docs/live_service/setup.md
@@ -46,7 +46,7 @@ is part of the S3-backed data plane**. Each item belongs to the laptop/CV workfl
 container image, not to shared storage:
 
 - **Promoted production model** — distributed via the **container image**, not shared storage: the
-  v0.1 deployment bakes the champion into the image at build time and loads it with a plain disk
+  live deployment bakes the champion into the image at build time and loads it with a plain disk
   `load()` (see
   [Production Deployment — Design](../architecture/production-deployment.md),
   [#222](https://github.com/openclimatefix/nged-substation-forecast/issues/222)). This local

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -2,9 +2,11 @@
 
 This roadmap outlines the planned order of development toward the v1.0 live forecast release
 (January 2027) and beyond. This page was last substantially revised **July 2026**, following a full codebase
-review and a reprioritisation (decided 2026-07-01): **the top priority is getting *any* v0.1
-forecast running on AWS** — scientific-improvement work waits until the live service is running.
-Technical plans change as we learn more — treat this as a best-estimate, not a guarantee.
+review and a reprioritisation (decided 2026-07-01) that made **getting *any* forecast running on
+AWS** the top priority over scientific-improvement work. That shipped as v0.1 in July 2026; the
+live service is now on v0.2 (deployed 13 August 2026), and work continues on the milestones below
+toward v1.0. Technical plans change as we learn more — treat this as a best-estimate, not a
+guarantee.
 
 > For how this page relates to GitHub issues, `docs/architecture/`, and the rest of the docs —
 > and which place to put new planning content — see the
@@ -29,7 +31,7 @@ Technical plans change as we learn more — treat this as a best-estimate, not a
   price for a network breach, their limitations, and the open questions for NGED.
 - [Data sources](data-sources.md) — NGED power data + supporting files, network topology, and the
   weather datasets (ECMWF ENS, ERA5, CM SAF).
-- [Live service](live-service.md) — the v0.1 deployment: the `live_forecasts` inference
+- [Live service](live-service.md) — the AWS deployment: the `live_forecasts` inference
   asset, the champion-model container, the costed AWS architecture options, and production
   monitoring.
 - [Handover to NGED](handover.md) — the preferred post-NIA operating model (NGED runs the
@@ -65,7 +67,8 @@ GitHub epic issue.
 ## v0.1 — "Naive" MVP (internal only)
 
 *Epic: [#137](https://github.com/openclimatefix/nged-substation-forecast/issues/137) — deploy the
-naive forecast on AWS. **✅ Shipped July 2026** (`v0.1.0`) — running on AWS.*
+naive forecast on AWS. **✅ Shipped July 2026** (`v0.1.0`), superseded on AWS by v0.2 on
+13 August 2026.*
 
 **Goal**: A simple XGBoost forecast that lets us test infrastructure end-to-end and establish a
 baseline. Intentionally does not detect switching events or estimate effective capacity — hence
@@ -79,14 +82,26 @@ AWS — see [Live service](live-service.md).
 
 ## v0.2 — Code Quality & Documentation
 
-*Epic: [#138](https://github.com/openclimatefix/nged-substation-forecast/issues/138)*
+*Epic: [#138](https://github.com/openclimatefix/nged-substation-forecast/issues/138) — code
+quality, reproducibility and observability hardening. **✅ Shipped 13 August 2026** (`v0.2.0`) —
+running on AWS.*
 
 - More unit tests, including scientific-rigor tests (CV-windowing no-lookahead,
-  leaderboard-fairness, determinism)
+  leaderboard-fairness, determinism) ✅
+  ([#62](https://github.com/openclimatefix/nged-substation-forecast/issues/62); no-lookahead and
+  determinism are exercised by `test_nullify_leaky_lags`,
+  `test_engineer_features_weather_lag_leakage_prevention` and
+  `test_random_seed_makes_training_deterministic`, alongside new package coverage for
+  `dynamical_data` ([#163](https://github.com/openclimatefix/nged-substation-forecast/issues/163))
+  and `geo` ([#164](https://github.com/openclimatefix/nged-substation-forecast/issues/164)))
 - CI on GitHub (ruff + ty + pytest on every PR) ✅ (per-PR gate + nightly network tests; see
   [Testing → Continuous integration](../architecture/testing.md#continuous-integration))
-- Improve documentation
-- Verify daylight savings time handling is correct
+- Improve documentation ✅
+  ([#139](https://github.com/openclimatefix/nged-substation-forecast/issues/139))
+- Verify daylight savings time handling is correct ✅
+  ([#84](https://github.com/openclimatefix/nged-substation-forecast/issues/84);
+  `test_apply_local_time_features_dst_transitions` covers both the spring-forward and fall-back
+  transition instants)
 - Reproducibility stamping: git SHA + Delta table versions on every MLflow run ✅ (implemented in
   `ml_core._repro`; every MLflow run carries the stamp)
 - Drop Hydra in favour of plain YAML + importlib + pydantic ✅ (`contracts.config_schemas` owns the

--- a/docs/roadmap/live-service.md
+++ b/docs/roadmap/live-service.md
@@ -1,7 +1,9 @@
-# Live service (v0.1 AWS deployment)
+# Live service (AWS deployment)
 
-> **Status: ✅ v0.1 shipped (July 2026, `v0.1.0`) — the naive forecast is deployed and running
-> on AWS.** Epic [#137](https://github.com/openclimatefix/nged-substation-forecast/issues/137)
+> **Status: ✅ v0.1 shipped (July 2026, `v0.1.0`)** on the accepted architecture below; the same
+> architecture now runs **v0.2** (`v0.2.0`, deployed 13 August 2026) — the naive forecast is
+> deployed and running on AWS. Epic
+> [#137](https://github.com/openclimatefix/nged-substation-forecast/issues/137)
 > is closed. The shipped design now lives in
 > [Production Deployment — Design](../architecture/production-deployment.md) (the orchestration
 > and champion-model decisions), and the step-by-step operational recipes in the
@@ -105,8 +107,8 @@ Issue: [#222](https://github.com/openclimatefix/nged-substation-forecast/issues/
 
 Issue: [#206](https://github.com/openclimatefix/nged-substation-forecast/issues/206) (done)
 
-> **Status: ✅ Built and running (`v0.1.0`).** The accepted option below is deployed on AWS; the
-> bring-up is documented in
+> **Status: ✅ Built and running.** The accepted option below was deployed on AWS for v0.1
+> (`v0.1.0`) and now serves v0.2 (`v0.2.0`), unchanged; the bring-up is documented in
 > [Setting up the live service on AWS](../live_service/aws.md). The costed comparison and the
 > rejected alternatives are kept below as the durable record of the decision. The
 > [access-phasing](#access-phasing) Stages 2–3 and the future-work items (MLflow server, dev
@@ -493,11 +495,11 @@ Issue: [#208](https://github.com/openclimatefix/nged-substation-forecast/issues/
 
 ### Deployment workstream 3 — AWS infrastructure
 
-> **Status: ✅ v0.1 infrastructure built and running.** ECR, the two IAM roles, the Fargate
+> **Status: ✅ Infrastructure built and running.** ECR, the two IAM roles, the Fargate
 > task definition, the always-on EC2 control-plane box (`EcsRunLauncher`, Postgres-in-Docker,
-> schedules, Tailscale, Marimo), and S3 are all stood up by hand and documented step-by-step in
-> [Setting up the live service on AWS](../live_service/aws.md). The items further down are what
-> remains 🚧 after v0.1.
+> schedules, Tailscale, Marimo), and S3 were all stood up by hand for v0.1 and documented
+> step-by-step in [Setting up the live service on AWS](../live_service/aws.md); the same
+> infrastructure now serves v0.2. The items further down are what remains 🚧 after v0.1.
 
 Built for v0.1 (see the [runbook](../live_service/aws.md) for the exact console steps):
 

--- a/docs/roadmap/xgboost-improvements.md
+++ b/docs/roadmap/xgboost-improvements.md
@@ -1,10 +1,10 @@
 # XGBoost improvements ("quick wins")
 
-> **Status: 🚧 Planned (v0.5) — deferred until v0.1 is live on AWS.** Epic:
+> **Status: 🚧 Planned (v0.5).** Epic:
 > [#145](https://github.com/openclimatefix/nged-substation-forecast/issues/145); the Tier-1
 > quick wins are [#230](https://github.com/openclimatefix/nged-substation-forecast/issues/230).
-> Getting *any* forecast live ([Live service](live-service.md)) takes priority over forecast
-> quality.
+> The live service is running ([Live service](live-service.md), now on v0.2); forecast-quality
+> work follows once v0.3 and v0.4 land.
 
 Quick wins to make XGBoost a strong baseline before the advanced approaches land — explicitly
 *not* deep ML work ("little point in spending ages on the ML model before we have good capacity


### PR DESCRIPTION
*This PR was written by Claude Code.*

The docs still labelled the running deployment "v0.1" in several places, and the roadmap's v0.2 section carried no shipped status and three unticked bullets, even though `docs/live_service/intervention-log.md` already recorded v0.2 deployed on 13 August 2026 (tag `v0.2.0`) with v0.1 retired.

## Ground truth

Verified from the intervention log and git/GitHub history, not taken on trust: v0.2 was deployed at roughly 19:00 UTC on 13 August 2026, replacing the v0.1 stack on the same AWS architecture; its first `live_forecasts` run was the 2026-08-14T00:00 UTC slot; it forecasts 31 time series (up from 28) under the promoted model `xgboost_cv_0003`; and every one of the 66 sub-issues under epic #138 ("v0.2: Improve code & documentation") is done, wrapped up at 20:23 UTC that same day — including the three the roadmap page had left unticked.

## What changed

`docs/roadmap/index.md` — added a shipped-status line to the v0.2 section matching the v0.1 section's style, ticked the three previously-unticked bullets against the sub-issues and tests that delivered them, and updated the v0.1 section and the intro paragraph so neither claims v0.1.0 is still what runs.

Nine other pages used "v0.1" as a stand-in for "the running deployment" when describing behaviour that is still true under v0.2 (the champion-model-baked-into-the-image design, the AWS infrastructure, the setup runbook) — reworded to drop the stale version pin. Two roadmap status banners had gone genuinely stale (`docs/roadmap/live-service.md`'s AWS-architecture and infrastructure banners still said `v0.1.0`; `docs/roadmap/xgboost-improvements.md` was still gating v0.5 on "v0.1 is live on AWS", a condition met over a month ago) and now describe the current state.

## What I deliberately left alone

`docs/live_service/intervention-log.md` is the source of truth and a historical log; untouched.

`docs/architecture/adapting-to-another-geography.md` is off-limits per instructions; untouched (it contains no `v0.1` string).

Every other `v0.1` mention across `docs/roadmap/delivery-tables.md`, `capacity-estimation.md`, `metrics-and-leaderboard.md`, `forecast-building-blocks.md`, and the requirements/deferred-work sections of `live-service.md` uses "v0.1" as a milestone tag (e.g. "Implemented in v0.1; upgrade planned for v0.7") rather than a claim about the currently-running version, so those are correct as written and were left alone.

## Noticed, not fixed (out of scope)

`docs/roadmap/delivery-tables.md` and `forecast-building-blocks.md` both describe the `power_fcst` -1,+1 normalisation, tracked by issue #246, as "planned for v0.1" — that plan never shipped in v0.1 or v0.2, and #246 remains open today. This is a feature-status inconsistency, not a version-label one, so I left it for separate follow-up.

## Verification

```
uv run pymarkdown scan -r docs README.md CLAUDE.md packages/*/README.md
uv run mkdocs build --strict
uv run ruff check .
```

All three pass. I also read the rendered HTML for every edited page (per the mkdocs-authoring skill, both linters can pass on markdown that renders visibly wrong) and confirmed lists, links and emphasis render as intended.

Docs only; no code changed.
