### PR TITLE
Fix four mutation-blind tests and strengthen three weak ones

### DIFF
--- a/packages/dashboard/tests/test_forecast_chart.py
+++ b/packages/dashboard/tests/test_forecast_chart.py
@@ -427,5 +427,12 @@ def test_nwp_rows_are_clipped_to_the_plotted_window() -> None:
 
 
 def test_chart_renders_to_html() -> None:
+    """``to_html()`` walks a different Altair code path from the ``.to_dict()`` calls elsewhere in
+    this module: it must produce a genuine, self-contained document that wires the spec up to
+    Vega-Embed, not merely a spec dict that happens to be well-formed. The spec's own field names
+    (e.g. ``"ensemble_member"``) are already pinned nineteen times over by those ``.to_dict()``
+    tests, so this one checks only what is specific to the HTML path.
+    """
     html = _build().to_html()
-    assert "ensemble_member" in html
+    assert html.startswith("<!DOCTYPE html>")
+    assert "vegaEmbed(" in html

--- a/packages/ml_core/tests/test_metrics.py
+++ b/packages/ml_core/tests/test_metrics.py
@@ -6,7 +6,6 @@ from datetime import UTC, datetime, timedelta
 import patito as pt
 import polars as pl
 import pytest
-from contracts.ml_schemas import Metrics
 from contracts.power_schemas import (
     LIST_OF_TIME_SERIES_TYPES,
     EffectiveCapacity,
@@ -100,15 +99,6 @@ def _make_metadata(
 # ---------------------------------------------------------------------------
 # compute_metrics tests
 # ---------------------------------------------------------------------------
-
-
-def test_compute_metrics_returns_metrics_schema():
-    times = [_utc(2022, 1, 1, 0, 0), _utc(2022, 1, 1, 0, 30)]
-    actuals = _make_actuals(1, times, [10.0, 10.0])
-    forecasts = _make_cv_forecasts(1, times, [12.0, 8.0])
-    result = compute_metrics(forecasts, actuals, _make_metadata([1]), _make_capacity([1], [10.0]))
-    assert isinstance(result, pl.DataFrame)
-    Metrics.validate(result, allow_superfluous_columns=True)
 
 
 def test_compute_metrics_mae_correctness():

--- a/packages/xgboost_forecaster/tests/test_forecaster.py
+++ b/packages/xgboost_forecaster/tests/test_forecaster.py
@@ -147,12 +147,20 @@ def test_save_creates_one_ubj_per_ts_id(tmp_path: Path) -> None:
 
 
 def test_selected_features_round_trips_through_save_load(tmp_path: Path) -> None:
-    extra_features = {"local_time_of_day_sin", "local_time_of_day_cos"}
+    """A ``selected_features`` narrower than the module default must survive save/load unchanged.
+
+    Every other save/load test in this module trains with the full ``_FEATURES`` set, so a save
+    path that silently fell back to that default instead of writing the configured value would
+    pass them all; picking a proper (non-default) subset here is what forces the real value
+    through the round trip.
+    """
+    restricted_features = {"local_time_of_day_sin"}
+    assert restricted_features < _FEATURES  # a genuine subset, not the module default
     df = _make_df()
-    forecaster = _trained(df, selected_features=extra_features)
+    forecaster = _trained(df, selected_features=restricted_features)
     forecaster.save(tmp_path / "m")
     loaded = XGBoostForecaster.load(tmp_path / "m")
-    assert loaded.model_params.selected_features == extra_features
+    assert loaded.model_params.selected_features == restricted_features
 
 
 def test_predict_stamps_experiment_name() -> None:

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -1435,7 +1435,9 @@ def test_live_forecasts_check_degrades_on_a_malformed_meta_json(env: Path) -> No
     directory = Path(settings.production_model_path)
     directory.mkdir(parents=True, exist_ok=True)
     (directory / "meta.json").write_text(
-        json.dumps({"trained_time_series_ids": "12", "model_params": {"experiment_name": None}})
+        json.dumps(
+            {"trained_time_series_ids": "12", "model_params": {"experiment_name": _EXPERIMENT}}
+        )
     )
 
     result = _run_live_check()

--- a/tests/test_live_forecasts.py
+++ b/tests/test_live_forecasts.py
@@ -16,7 +16,9 @@ import polars as pl
 import pytest
 from _nwp_test_data import NWP_CONTINUOUS_COL_VALUES
 from contracts.ml_schemas import AllFeatures
-from contracts.power_schemas import TimeSeriesMetadata
+from contracts.power_schemas import PowerTimeSeries, TimeSeriesMetadata
+from contracts.settings import Settings
+from contracts.weather_schemas import Nwp
 from dagster import (
     AssetCheckSeverity,
     DagsterInstance,
@@ -28,6 +30,7 @@ from deltalake import write_deltalake
 from ml_core.base_forecaster import write_trained_metadata
 from xgboost_forecaster.forecaster import XGBoostConfig, XGBoostForecaster
 
+from nged_substation_forecast.defs import production_assets
 from nged_substation_forecast.defs.checks import live_forecasts_are_healthy
 from nged_substation_forecast.defs.production_assets import LiveForecastsConfig, live_forecasts
 
@@ -210,10 +213,47 @@ def test_live_and_replay_select_different_nwp_runs(
 
 
 def test_only_trained_time_series_are_forecast(
-    env: dict[str, str], dagster_instance: DagsterInstance
+    env: dict[str, str], monkeypatch: pytest.MonkeyPatch, dagster_instance: DagsterInstance
 ) -> None:
+    """The live population is the model's trained population, narrowed before feature engineering.
+
+    ``_write_power`` writes history for both series 1 and 2, but only series 1 has a trained
+    booster. Spies on ``load_engineering_inputs`` to pin that ``live_forecasts`` passes it
+    ``forecaster.trained_time_series_ids`` rather than every series with power data — checking the
+    final output alone would pass even without that filter, because ``XGBoostForecaster.predict``
+    also skips any series its own booster dict has nothing for.
+    """
+    captured: list[list[int]] = []
+    real_load_engineering_inputs = production_assets.load_engineering_inputs
+
+    def _spy_load_engineering_inputs(
+        settings: Settings,
+        *,
+        time_series_ids: list[int],
+        metadata: pt.DataFrame[TimeSeriesMetadata],
+        window_start: datetime,
+        window_end: datetime,
+        ensemble_members: list[int] | None = None,
+        init_time_start: datetime | None = None,
+        init_time_end: datetime | None = None,
+    ) -> tuple[pt.LazyFrame[PowerTimeSeries], pt.LazyFrame[Nwp]]:
+        captured.append(time_series_ids)
+        return real_load_engineering_inputs(
+            settings,
+            time_series_ids=time_series_ids,
+            metadata=metadata,
+            window_start=window_start,
+            window_end=window_end,
+            ensemble_members=ensemble_members,
+            init_time_start=init_time_start,
+            init_time_end=init_time_end,
+        )
+
+    monkeypatch.setattr(production_assets, "load_engineering_inputs", _spy_load_engineering_inputs)
+
     assert _materialize(dagster_instance, "live").success
 
+    assert captured == [[1]]
     forecasts = _read_forecasts(env)
     assert set(forecasts["time_series_id"].unique().to_list()) == {1}
 

--- a/tests/test_promoted_model.py
+++ b/tests/test_promoted_model.py
@@ -43,6 +43,7 @@ def _save_trained_model_to_mlflow(
     experiment_name: str,
     n_estimators: int,
     selected_features: set[str] | None = None,
+    time_series_ids: tuple[int, ...] = (1,),
 ) -> str:
     """Train a tiny real ``XGBoostForecaster`` on synthetic data and save it to a new MLflow run.
 
@@ -51,19 +52,21 @@ def _save_trained_model_to_mlflow(
     same ``save_to_mlflow`` mechanism ``trained_cv_model`` uses.
 
     Every requested feature gets a synthetic column to train against, so a caller can save a model
-    whose feature vocabulary the current code does not recognise.
+    whose feature vocabulary the current code does not recognise. Trains one Booster per id in
+    ``time_series_ids``, so a caller can vary the trained population between two saved runs.
     """
     features = selected_features or {"temperature_2m"}
     times = [datetime(2025, 1, 1, hour, tzinfo=UTC) for hour in (0, 1, 2)]
+    n_ts = len(time_series_ids)
     spine = {
-        "time_series_id": [1, 1, 1],
-        "valid_time": times,
-        "time_series_type": ["Primary"] * 3,
-        "power_fcst_init_time": times,
-        "power": [10.0, 12.0, 11.0],
+        "time_series_id": [ts_id for ts_id in time_series_ids for _ in times],
+        "valid_time": times * n_ts,
+        "time_series_type": ["Primary"] * (len(times) * n_ts),
+        "power_fcst_init_time": times * n_ts,
+        "power": [10.0, 12.0, 11.0] * n_ts,
     }
     # Spine last, so a feature sharing a spine column's name cannot overwrite it with floats.
-    train_df = pl.DataFrame({name: [5.0, 6.0, 7.0] for name in features} | spine)
+    train_df = pl.DataFrame({name: [5.0, 6.0, 7.0] * n_ts for name in features} | spine)
     train_data = pt.LazyFrame.from_existing(train_df.lazy()).set_model(AllFeatures)
     config = XGBoostConfig(
         selected_features=features,
@@ -71,7 +74,7 @@ def _save_trained_model_to_mlflow(
         n_estimators=n_estimators,
     )
     forecaster = XGBoostForecaster(config)
-    forecaster.train(train_data, time_series_ids=[1])
+    forecaster.train(train_data, time_series_ids=list(time_series_ids))
 
     experiment_id = mlflow.create_experiment(experiment_name)
     with mlflow.start_run(experiment_id=experiment_id) as run:
@@ -82,8 +85,8 @@ def _save_trained_model_to_mlflow(
     metadata = pt.DataFrame(
         pl.DataFrame(
             {
-                "time_series_id": pl.Series([1], dtype=pl.Int32),
-                "h3_res_5": pl.Series([10], dtype=pl.UInt64),
+                "time_series_id": pl.Series(list(time_series_ids), dtype=pl.Int32),
+                "h3_res_5": pl.Series([10] * n_ts, dtype=pl.UInt64),
             }
         )
     ).set_model(TimeSeriesMetadata)
@@ -123,8 +126,18 @@ def test_promoted_model_promotes_and_populates_directory(
 def test_re_promotion_replaces_the_model(
     env: dict[str, str], dagster_instance: DagsterInstance
 ) -> None:
-    first_run_id = _save_trained_model_to_mlflow("promo_test_v1", n_estimators=5)
-    second_run_id = _save_trained_model_to_mlflow("promo_test_v2", n_estimators=7)
+    """Promoting a smaller second model must not leave the first model's booster files behind.
+
+    The first run trains series 1 and 2; the second trains only series 1 — so a merge of the
+    destination directory, rather than a replace, would leave series 2's ``.ubj`` file on disk
+    undetected.
+    """
+    first_run_id = _save_trained_model_to_mlflow(
+        "promo_test_v1", n_estimators=5, time_series_ids=(1, 2)
+    )
+    second_run_id = _save_trained_model_to_mlflow(
+        "promo_test_v2", n_estimators=7, time_series_ids=(1,)
+    )
 
     model_dir = Path(env["production_model_path"])
 
@@ -137,6 +150,7 @@ def test_re_promotion_replaces_the_model(
     ).success
     first_meta = json.loads((model_dir / "meta.json").read_text())
     assert first_meta["model_params"]["experiment_name"] == "promo_test_v1"
+    assert (model_dir / "2.ubj").exists()
 
     assert materialize(
         [promoted_model],
@@ -147,6 +161,7 @@ def test_re_promotion_replaces_the_model(
     ).success
     second_meta = json.loads((model_dir / "meta.json").read_text())
     assert second_meta["model_params"]["experiment_name"] == "promo_test_v2"
+    assert not (model_dir / "2.ubj").exists()
 
     promotion = json.loads((model_dir / "promotion.json").read_text())
     assert promotion["mlflow_run_id"] == second_run_id
@@ -155,12 +170,25 @@ def test_re_promotion_replaces_the_model(
 def test_promoted_model_refuses_a_model_with_an_unparseable_feature(
     env: dict[str, str], dagster_instance: DagsterInstance
 ) -> None:
-    """Promoting a model trained before a feature rename fails, leaving nothing behind on disk.
+    """Promoting a model trained before a feature rename fails, leaving the champion untouched.
 
     ``promotable_model_runs`` lists every fold run ever trained, so an operator picking by eye off
-    that table can reach a run this code no longer parses.
+    that table can reach a run this code no longer parses. The champion promoted before that
+    attempt must still be servable afterwards: the refusal has to happen before the destination
+    directory is touched, not merely before it is populated.
     """
-    run_id = _save_trained_model_to_mlflow(
+    good_run_id = _save_trained_model_to_mlflow("stale_vocabulary_champion", n_estimators=5)
+    assert materialize(
+        [promoted_model],
+        run_config=RunConfig(
+            ops={"promoted_model": PromotedModelConfig(mlflow_run_id=good_run_id)}
+        ),
+        instance=dagster_instance,
+    ).success
+    model_dir = Path(env["production_model_path"])
+    champion_meta = json.loads((model_dir / "meta.json").read_text())
+
+    bad_run_id = _save_trained_model_to_mlflow(
         experiment_name="stale_vocabulary",
         n_estimators=5,
         selected_features={"local_utc_offset"},
@@ -169,11 +197,13 @@ def test_promoted_model_refuses_a_model_with_an_unparseable_feature(
     with pytest.raises(ValueError, match="local_utc_offset"):
         materialize(
             [promoted_model],
-            run_config=RunConfig(ops={"promoted_model": PromotedModelConfig(mlflow_run_id=run_id)}),
+            run_config=RunConfig(
+                ops={"promoted_model": PromotedModelConfig(mlflow_run_id=bad_run_id)}
+            ),
             instance=dagster_instance,
         )
 
-    assert not Path(env["production_model_path"]).exists()
+    assert json.loads((model_dir / "meta.json").read_text()) == champion_meta
 
 
 def test_promotable_model_runs_lists_fold_run_candidates(


### PR DESCRIPTION
This is written by Claude Sonnet 5, an AI agent working from a task brief.

Fixes four tests whose docstrings name a guarantee they do not actually pin, plus three tests that assert almost nothing. Each fix was proven by applying the mutation the docstring describes, confirming the test goes red, then reverting.

## The four mutation-blind tests

**`tests/test_checks.py::test_live_forecasts_check_degrades_on_a_malformed_meta_json`** — the fixture set `model_params.experiment_name` to `None` in the same `meta.json`, so deleting the `trained_time_series_ids` isinstance guard still returned the unknown-population fallback, just via the `experiment_name is None` branch instead of the guard the test names. Gave the fixture a real experiment name so only the malformed-ids guard can produce the expected result. Mutation (deleting the guard): the malformed `"12"` gets silently iterated into `(1, 2)`, series 2 is reported missing, and the test fails as `assert False is True`.

**`tests/test_promoted_model.py::test_re_promotion_replaces_the_model`** — both fixtures trained only series 1, so a merge (rather than a replace) of the destination directory would leave a stale file behind undetected. The first run now trains series 1 and 2, the second trains only series 1, and the test checks the first run's `2.ubj` is gone after the second promotion. Mutation (swap `rmtree` + `move` for a non-clearing `copytree`): the stale `2.ubj` survives, caught.

**`tests/test_promoted_model.py::test_promoted_model_refuses_a_model_with_an_unparseable_feature`** — the destination was never populated before the refused promotion, so "nothing left behind" was true before the run even started. The test now promotes a real champion first and checks its `meta.json` is unchanged after the refused promotion. Mutation (move the servability checks to after the `rmtree`): the champion is destroyed before the refusal raises, and the final read is a bare `FileNotFoundError`, caught.

**`tests/test_live_forecasts.py::test_only_trained_time_series_are_forecast`** — checked only the final materialised output, which `XGBoostForecaster.predict` narrows to its own trained population regardless of what `live_forecasts` passed upstream, so the test passed whether or not the asset's own population filter did anything. Added a spy on `load_engineering_inputs` to pin the argument `live_forecasts` actually passes. Mutation (pass every series with power data instead of the trained population): the spy assertion catches it even though the materialisation still succeeds.

## Tests asserting almost nothing

**`packages/ml_core/tests/test_metrics.py::test_compute_metrics_returns_metrics_schema`** — deleted. `compute_metrics()` ends its own body with `return Metrics.validate(...)`, so neither assertion in the test could ever fail.

**`packages/xgboost_forecaster/tests/test_forecaster.py::test_selected_features_round_trips_through_save_load`** — its `extra_features` was identical to the module's default `_FEATURES`, which every other save/load test in the file already trains with, so a save path that silently discarded the configured value and fell back to that default would have passed this test too. Switched to a genuine subset. Mutation (hardcode `save()` to always write the two-feature default): caught by this test, and only this test — `test_save_load_roundtrip`, which also uses the default set, stays green under the same mutation.

**`packages/dashboard/tests/test_forecast_chart.py::test_chart_renders_to_html`** — its one assertion (`"ensemble_member" in html`) re-checked a spec field name that nineteen `.to_dict()` tests elsewhere in the module already pin. Strengthened it to check what is actually unique to the `to_html()` path: a genuine, self-contained document with a DOCTYPE and a `vegaEmbed()` call. Confirmed the new assertions are HTML-specific: rendering the same chart with `.to_dict()` instead satisfies neither.

## Verification

`ruff check`, `ruff format --check`, `ty check`, the full offline `pytest` suite (711 passed, 1 skipped network test), and `pymarkdown scan` all pass.
