### PR TITLE
Correct four places where docs disagreed with the code

### DIFF
--- a/docs/architecture/performance.md
+++ b/docs/architecture/performance.md
@@ -123,8 +123,7 @@ The rules that follow:
   V2-scale table wouldn't just OOM, its row accounting would be wrong.
 * Tables past the cap today: **NWP** (~5.9B rows). **`power_forecasts`** will pass it at V2 scale
   (~1 trillion rows — see [forecast delivery](forecast-delivery.md#how-big-is-flexpectations-power-forecast-data)).
-  The one code path that must be re-chunked before then is the `metrics` asset, which currently
-  collects a whole `(experiment_name, fold_id)` group of `power_forecasts` at once and discovers
-  groups via a full-table `unique()` — fine at V1 (≤ ~414M rows/fold), but a V2 fold is tens of
-  billions of rows, so scoring will need to chunk within a fold (e.g. by `valid_time` window or
-  `time_series_id` batch) for RAM reasons anyway; the index cap makes it correctness-critical too.
+  The `metrics` asset discovers `(experiment_name, fold_id)` groups via a streaming `unique()`
+  scan, then scores each group in batches of four `time_series_id` values at a time, so peak
+  memory is one batch, never a whole fold or the whole matched population — the same chunking
+  that keeps the row-index cap out of reach.

--- a/docs/ml_experimentation/dagster-workflow.md
+++ b/docs/ml_experimentation/dagster-workflow.md
@@ -252,11 +252,11 @@ in the run config dialog before launching.
    scope dates its evaluation window from the CV config's leaderboard folds and has none for those
    rows. To score live output or a dev fold, run the asset with `evaluation_scope="ad_hoc"`, which
    takes the window from the forecast rows themselves.
-3. Discovers the matching `(experiment_name, fold_id)` groups, then loads and scores **one group at
-   a time** — peak memory is a single fold, not the entire matched population. (A whole fold is
-   the *coarsest* chunk Polars can safely materialise: fine at V1 scale, but a V2-scale fold will
-   need sub-fold chunking — see
-   [The other hard ceiling: Polars' 32-bit row index](../architecture/performance.md#the-other-hard-ceiling-polars-32-bit-row-index).)
+3. Discovers the matching `(experiment_name, fold_id)` groups, then scores each group in batches of
+   four `time_series_id` values at a time — peak memory is one batch, never a whole fold or the
+   entire matched population. See
+   [The other hard ceiling: Polars' 32-bit row index](../architecture/performance.md#the-other-hard-ceiling-polars-32-bit-row-index)
+   for why this chunking also keeps the row-index cap out of reach at V2 scale.
    For each group:
    a. Calls `compute_metrics()` — joins observed power, collapses each forecast run's ensemble
       members into per-timestamp quantities, and computes the deterministic metrics

--- a/docs/ml_experimentation/model-configuration.md
+++ b/docs/ml_experimentation/model-configuration.md
@@ -35,10 +35,13 @@ cannot drift apart.
 
 ## Features (`selected_features`)
 
-`selected_features` is a list of strings. The feature engineering pipeline
-(`ml_core.features._parsed_features.ParsedFeatures.from_strings`) parses each string into a
-typed descriptor at registration time and raises `ValueError` immediately on any unrecognised or
-forbidden name.
+`selected_features` is a list of strings. Registration only checks that it is a list of
+strings — a typo'd top-level key (e.g. `selected_featuers`) is rejected there, by pydantic's
+`extra="forbid"` on `BaseForecasterConfig`. The individual strings inside the list are not
+parsed until training runs: the feature engineering pipeline
+(`ml_core.features._parsed_features.ParsedFeatures.from_strings`) parses each one into a typed
+descriptor and raises `ValueError` on any unrecognised or forbidden name, so a typo'd feature
+name (e.g. `tempurature_2m`) surfaces only then, not at registration.
 
 ### Power lags
 

--- a/docs/roadmap/delivery-tables.md
+++ b/docs/roadmap/delivery-tables.md
@@ -116,12 +116,12 @@ filter on `fold_id` to select the population you need. See
 | `power_fcst` | `float32` | OCF's power forecast. **In this early version** the value is in physical units (MW for active power, MVA for apparent power). Sign convention depends on `substation_type` — see [Sign convention](forecast-building-blocks.md#sign-convention). |
 
 > **🚧 Planned change — normalise `power_fcst` to [−1, +1]
-> ([#246](https://github.com/openclimatefix/nged-substation-forecast/issues/246), v0.1).** The
+> ([#246](https://github.com/openclimatefix/nged-substation-forecast/issues/246), v0.5).** The
 > delivery contract is a normalised forecast in the range **[−1, +1]**, which NGED multiplies by a
 > capacity to obtain MW/MVA (see [forecast building blocks](forecast-building-blocks.md)). The code
 > still forecasts raw MW/MVA, but now that the static P99 `effective_capacity` estimate exists
 > there is no need to wait for dynamic capacity estimation: the switch to [−1, +1] is planned for
-> **v0.1**. This is also noted in a comment on the `PowerForecast.power_fcst` field in
+> **v0.5**. This is also noted in a comment on the `PowerForecast.power_fcst` field in
 > `power_schemas.py`.
 
 ### Representation 2 — percentiles 🚧

--- a/docs/roadmap/forecast-building-blocks.md
+++ b/docs/roadmap/forecast-building-blocks.md
@@ -2,7 +2,7 @@
 
 How NGED assembles different kinds of forecast from the "Lego blocks" OCF delivers.
 
-> **Status: 🚧 Planned.** The normalised [−1, +1] forecast is planned for **v0.1**, scaled by the
+> **Status: 🚧 Planned.** The normalised [−1, +1] forecast is planned for **v0.5**, scaled by the
 > static P99 capacity
 > ([#246](https://github.com/openclimatefix/nged-substation-forecast/issues/246); the code still
 > forecasts raw MW/MVA today — see

--- a/packages/contracts/src/contracts/power_schemas.py
+++ b/packages/contracts/src/contracts/power_schemas.py
@@ -402,10 +402,10 @@ class PowerForecast(pt.Model):
             " see `delta_store.power_forecasts`."
             # PLANNED: We intend to change `power_fcst` to a normalised value in the range
             # [-1, +1] (which NGED multiplies by a capacity to recover MW/MVA), per the
-            # delivery-contract design agreed with NGED in the Milestone 1 report.
-            # For this very early version we forecast raw MW/MVA because we are not yet
-            # estimating capacity; we will switch to the scaled value once capacity estimation
-            # lands (roadmap v0.7).
+            # delivery-contract design agreed with NGED in the Milestone 1 report. The switch is
+            # planned for v0.5, using the static P99 `effective_capacity` estimate that already
+            # exists — the same scalar the `metrics` pipeline already divides by for NMAE — so it
+            # no longer needs to wait for a time-varying capacity estimate.
         ),
     )
 

--- a/packages/contracts/src/contracts/settings.py
+++ b/packages/contracts/src/contracts/settings.py
@@ -342,8 +342,10 @@ class Settings(BaseSettings):
         )
         # NGED-facing delivery tables derive from data_path_delivery instead, so a new delivery
         # table can't silently land in the internal bucket by inheriting the default derivation.
-        # Which tables those are:
-        # <https://openclimatefix.github.io/nged-substation-forecast/roadmap/delivery-tables/>.
+        # `power_forecasts` and `effective_capacity` are two of the five tables in NGED's stable
+        # delivery contract; see
+        # <https://openclimatefix.github.io/nged-substation-forecast/architecture/forecast-delivery/#securing-it>
+        # for the rest and why they live in a separate bucket.
         self.power_forecasts_data_path = self.power_forecasts_data_path or uri_join(
             self.data_path_delivery, "power_forecasts"
         )


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Corrects four places where prose or a code comment disagreed with the code it describes.
The `metrics` asset already scores each `(experiment_name, fold_id)` group in batches of four `time_series_id` values rather than materialising the whole group, so `docs/architecture/performance.md` and `docs/ml_experimentation/dagster-workflow.md` were describing work that has already shipped.
Both pages now describe the per-series batching, and the "outstanding work" framing is gone.
`docs/ml_experimentation/model-configuration.md` said feature names are validated at registration.
They are not: registration only checks that `selected_features` is a list of strings (pydantic's `extra="forbid"` catches a typo'd config key there), and an individual feature name is first parsed — and any typo caught — only when training runs `_engineer_features` → `ParsedFeatures.from_strings`.
The page now states both surfaces correctly.
`packages/contracts/src/contracts/settings.py` linked from code to a `docs/roadmap/` page, which `docs/architecture/code-style.md` forbids because roadmap pages are deleted at ship time and the reference rots.
The comment now inlines the one sentence of context it needs — `power_forecasts` and `effective_capacity` are two of NGED's five delivery tables — and retargets the link to the durable `docs/architecture/forecast-delivery.md` page.
`docs/roadmap/delivery-tables.md` and `docs/roadmap/forecast-building-blocks.md` both dated the `power_fcst` → `[−1, +1]` normalisation to v0.1 via issue #246.
It shipped in neither v0.1 nor v0.2; issue #246 stays open, and its parent epic is #145 ("v0.5: Improve XGBoost performance"), so both pages now say v0.5.
The `PowerForecast.power_fcst` field comment in `packages/contracts/src/contracts/power_schemas.py` carried the same disagreement, gating the switch on v0.7 capacity estimation and saying capacity isn't yet estimated.
Issue #246 records a 2026-07-03 decision that supersedes that: the static P99 `effective_capacity` estimate already exists and is already the NMAE denominator, so the switch no longer waits on the time-varying estimate.
The comment now says v0.5 and states that the P99 estimate it needs already exists, matching the roadmap pages above.
This is a comment inside a Patito field description; no dtype or constraint changed.
One claim from the brief turned out to still be true after checking the current code, so nothing was skipped: the `metrics` batch size (`_METRICS_SERIES_BATCH_SIZE = 4`) and its docstring's "peak memory is a batch, not a fold" claim both hold as described.

## Verification

`uv run ruff check .`, `uv run ruff format --check .`, `uv run --all-packages ty check`, `uv run pytest` (712 passed, 1 skipped), `uv run pymarkdown scan -r docs README.md CLAUDE.md packages/*/README.md`, and `uv run mkdocs build --strict` all pass, and I spot-checked the rendered HTML for the changed pages to confirm nothing rendered as a stray heading or broken list item.
