### PR TITLE
Move _compute_effective_capacity into ml_core.metrics

### DIFF
--- a/packages/ml_core/src/ml_core/metrics.py
+++ b/packages/ml_core/src/ml_core/metrics.py
@@ -34,6 +34,41 @@ class NoOverlappingActualsError(ValueError):
     """
 
 
+def compute_effective_capacity(
+    power_lf: pt.LazyFrame[PowerTimeSeries],
+) -> pt.DataFrame[EffectiveCapacity]:
+    """Compute the v0.1 effective capacity (full-history P99 of ``|power|``) per time series.
+
+    One row per ``time_series_id``: ``effective_capacity_mw`` is the 99th percentile of
+    ``abs(power)`` over all non-null observations. Series whose P99 is null or non-positive (e.g.
+    all-null or all-zero power) are dropped, since ``EffectiveCapacity`` requires
+    ``effective_capacity_mw > 0``.
+
+    ``time`` is set to that series' **latest** observed timestep (``time.max()``). The v0.1 capacity
+    is a single scalar per series, so ``time`` is really an "as of" marker — it stamps the estimate
+    as current to the end of the observed history — rather than a timestep the value varies over.
+    The v0.7 upgrade makes capacity genuinely time-varying (one row per ``(time_series_id, time)``),
+    and only then does ``time`` carry per-row meaning. v0.1 stays one scalar row per series rather
+    than the value repeated at every half-hour: densifying a constant adds rows without information,
+    and the metrics join is by ``time_series_id`` alone until capacity varies.
+
+    Kept as a pure helper (no Dagster, no IO) so the P99 logic is unit-testable in isolation.
+    """
+    capacity = (
+        power_lf.filter(pl.col("power").is_not_null())
+        .group_by("time_series_id")
+        .agg(
+            effective_capacity_mw=pl.col("power").abs().quantile(0.99),
+            time=pl.col("time").max(),
+        )
+        .filter(pl.col("effective_capacity_mw") > 0)
+        .sort("time_series_id")
+        .collect()
+        .cast({"effective_capacity_mw": pl.Float32})
+    )
+    return EffectiveCapacity.validate(capacity)
+
+
 _INTRADAY_MAX_HOURS: Final[int] = 6
 """Exclusive upper bound (hours) of the ``"intraday"`` horizon slice: lead times in [0 h, 6 h)."""
 

--- a/packages/ml_core/tests/test_metrics.py
+++ b/packages/ml_core/tests/test_metrics.py
@@ -1,4 +1,4 @@
-"""Tests for compute_metrics() and build_mlflow_aggregate_metrics()."""
+"""Tests for compute_effective_capacity(), compute_metrics(), build_mlflow_aggregate_metrics()."""
 
 import math
 from datetime import UTC, datetime, timedelta
@@ -16,6 +16,7 @@ from contracts.power_schemas import (
 from ml_core.metrics import (
     NoOverlappingActualsError,
     build_mlflow_aggregate_metrics,
+    compute_effective_capacity,
     compute_metrics,
 )
 from polars.testing import assert_frame_equal
@@ -94,6 +95,58 @@ def _make_metadata(
             }
         )
     )
+
+
+# ---------------------------------------------------------------------------
+# compute_effective_capacity tests
+# ---------------------------------------------------------------------------
+
+
+def test_compute_effective_capacity_p99_and_latest_time():
+    """One row per series: P99(|power|) as `effective_capacity_mw`, `time` is the latest obs."""
+    times = [_utc(2022, 1, 1, 0, 0), _utc(2022, 1, 1, 0, 30), _utc(2022, 1, 1, 1, 0)]
+    power_lf = _make_actuals(1, times, [5.0, 5.0, 5.0])
+    result = compute_effective_capacity(power_lf)
+    assert result["time_series_id"].to_list() == [1]
+    assert result["effective_capacity_mw"].to_list() == pytest.approx([5.0])
+    assert result["time"][0] == times[-1]
+
+
+def test_compute_effective_capacity_uses_absolute_value():
+    """Negative power contributes its magnitude, not a negative capacity."""
+    times = [_utc(2022, 1, 1, 0, 0), _utc(2022, 1, 1, 0, 30)]
+    power_lf = _make_actuals(1, times, [-3.0, -3.0])
+    result = compute_effective_capacity(power_lf)
+    assert result["effective_capacity_mw"].to_list() == pytest.approx([3.0])
+
+
+def test_compute_effective_capacity_ignores_nulls():
+    """Null power observations are excluded from the P99 and don't shift `time`."""
+    times = [_utc(2022, 1, 1, 0, 0), _utc(2022, 1, 1, 0, 30), _utc(2022, 1, 1, 1, 0)]
+    df = pl.DataFrame(
+        {
+            "time_series_id": pl.Series([1, 1, 1], dtype=pl.Int32),
+            "time": pl.Series(times, dtype=pl.Datetime("us", "UTC")),
+            "power": pl.Series([4.0, 4.0, None], dtype=pl.Float32),
+        }
+    )
+    power_lf = pt.LazyFrame.from_existing(df.lazy()).set_model(PowerTimeSeries)
+    result = compute_effective_capacity(power_lf)
+    assert result["effective_capacity_mw"].to_list() == pytest.approx([4.0])
+    assert result["time"][0] == times[1]
+
+
+def test_compute_effective_capacity_drops_non_positive_series():
+    """A series whose P99 is zero (e.g. all-zero power) is dropped, not emitted as capacity 0."""
+    times = [_utc(2022, 1, 1, 0, 0), _utc(2022, 1, 1, 0, 30)]
+    zero_series = _make_actuals(1, times, [0.0, 0.0])
+    live_series = _make_actuals(2, times, [6.0, 6.0])
+    power_lf = pt.LazyFrame.from_existing(
+        pl.concat([zero_series.collect().lazy(), live_series.collect().lazy()])
+    ).set_model(PowerTimeSeries)
+    result = compute_effective_capacity(power_lf)
+    assert result["time_series_id"].to_list() == [2]
+    assert result["effective_capacity_mw"].to_list() == pytest.approx([6.0])
 
 
 # ---------------------------------------------------------------------------

--- a/src/nged_substation_forecast/defs/cv_assets.py
+++ b/src/nged_substation_forecast/defs/cv_assets.py
@@ -52,6 +52,7 @@ from ml_core._repro import MlflowTags, provenance_tags
 from ml_core.metrics import (
     NoOverlappingActualsError,
     build_mlflow_aggregate_metrics,
+    compute_effective_capacity,
     compute_metrics,
     enrich_metrics_rows,
 )
@@ -162,41 +163,6 @@ def eligible_time_series(context: AssetExecutionContext) -> None:
     )
 
 
-def _compute_effective_capacity(
-    power_lf: pt.LazyFrame[PowerTimeSeries],
-) -> pt.DataFrame[EffectiveCapacity]:
-    """Compute the v0.1 effective capacity (full-history P99 of ``|power|``) per time series.
-
-    One row per ``time_series_id``: ``effective_capacity_mw`` is the 99th percentile of
-    ``abs(power)`` over all non-null observations. Series whose P99 is null or non-positive (e.g.
-    all-null or all-zero power) are dropped, since ``EffectiveCapacity`` requires
-    ``effective_capacity_mw > 0``.
-
-    ``time`` is set to that series' **latest** observed timestep (``time.max()``). The v0.1 capacity
-    is a single scalar per series, so ``time`` is really an "as of" marker — it stamps the estimate
-    as current to the end of the observed history — rather than a timestep the value varies over.
-    The v0.7 upgrade makes capacity genuinely time-varying (one row per ``(time_series_id, time)``),
-    and only then does ``time`` carry per-row meaning. v0.1 stays one scalar row per series rather
-    than the value repeated at every half-hour: densifying a constant adds rows without information,
-    and the metrics join is by ``time_series_id`` alone until capacity varies.
-
-    Kept as a pure helper (no Dagster, no IO) so the P99 logic is unit-testable in isolation.
-    """
-    capacity = (
-        power_lf.filter(pl.col("power").is_not_null())
-        .group_by("time_series_id")
-        .agg(
-            effective_capacity_mw=pl.col("power").abs().quantile(0.99),
-            time=pl.col("time").max(),
-        )
-        .filter(pl.col("effective_capacity_mw") > 0)
-        .sort("time_series_id")
-        .collect()
-        .cast({"effective_capacity_mw": pl.Float32})
-    )
-    return EffectiveCapacity.validate(capacity)
-
-
 @asset(tags=RESEARCH_LAYER_TAGS, deps=["power_time_series_and_metadata"])
 def effective_capacity(context: AssetExecutionContext) -> None:
     """Compute and persist each series' v0.1 effective capacity (full-history P99 of ``|power|``).
@@ -223,7 +189,7 @@ def effective_capacity(context: AssetExecutionContext) -> None:
             settings.power_time_series_data_path, storage_options=typeddict_to_dict(storage_options)
         )
     ).set_model(PowerTimeSeries)
-    capacity_df = _compute_effective_capacity(power_lf)
+    capacity_df = compute_effective_capacity(power_lf)
 
     if_local_path_then_make_parent_dir(settings.effective_capacity_data_path)
     write_deltalake(


### PR DESCRIPTION
*This PR was written by Claude Code.*

## Summary

`_compute_effective_capacity` lived in `src/nged_substation_forecast/defs/cv_assets.py` with its only caller in the same file, even though its own docstring already argued for a `packages/` home: "no Dagster, no IO" so the P99 logic can be unit-tested in isolation.

`ml_core.metrics` is the natural home — it already consumes `EffectiveCapacity` as the NMAE denominator in `compute_metrics`, so the producer and the consumer of that contract now sit on the same side of the `src/`–`packages/` line.

## What changed

Moved the function to `packages/ml_core/src/ml_core/metrics.py`, dropping the leading underscore to `compute_effective_capacity` since it's now part of `ml_core`'s public surface, matching the naming of the module's other public functions (`compute_metrics`, `build_mlflow_aggregate_metrics`, `enrich_metrics_rows`).

Updated the one caller in `cv_assets.py` (the `effective_capacity` asset) to import and call it from `ml_core.metrics`.

The function had no existing direct unit test — only integration-style coverage through the `effective_capacity` Dagster asset in `tests/test_cv_assets.py`, which is unaffected by this move and stays green.

Added direct unit tests for the pure function alongside it in `packages/ml_core/tests/test_metrics.py`: P99 correctness, `time` set to the latest observation, `abs()` on negative power, null observations excluded, and a non-positive-P99 series dropped from the output.

Docstring and body are unchanged (behaviour is identical) — this is a move, not a rewrite.

`ml_core`'s existing dependencies (`patito`, `polars`, `contracts`) already cover everything the function needs, so `packages/ml_core/pyproject.toml` needed no changes.

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run --all-packages ty check`
- [x] `uv run pytest` (722 passed, 1 skipped)
- [x] `uv run pymarkdown scan -r docs README.md CLAUDE.md packages/*/README.md`
- [x] `uv run mkdocs build --strict`
- [x] Re-ran the full set after merging `origin/main` (no new commits there, so the merge was a no-op)
