### PR TITLE
Pin the NWP test-fixture writer's layout against write_nwp

### DIFF
--- a/tests/_nwp_test_data.py
+++ b/tests/_nwp_test_data.py
@@ -97,9 +97,19 @@ def write_test_nwp(path: str, records: list[dict]) -> None:
     declares (never the raw ints a hand-rolled sentinel could hide behind), and calls
     ``Nwp.validate`` so a dtype or range mistake in ``records`` raises here — loudly, and before
     the frame ever reaches the CV pipeline the caller's test is exercising — rather than silently
-    training and scoring a model on data the contract would reject. Partitioned by
-    ``(nwp_model_id, init_time)``, matching the layout ``delta_store.nwp.write_nwp`` produces for
-    the real table.
+    training and scoring a model on data the contract would reject.
+
+    This can't simply call ``delta_store.nwp.write_nwp``: that function also rounds every
+    continuous variable to a 13-bit significand, which would silently perturb some of this
+    fixture's hand-picked values (measured: ``pressure_surface`` 101000.0 -> 100992.0,
+    ``pressure_reduced_to_mean_sea_level`` 101500.0 -> 101504.0, ``precipitation_surface`` rounds
+    too), and applies writer properties (compression level, encoding) that exist to optimise the
+    real table's on-disk size, not to serve a test fixture. Those two are deliberately *not*
+    shared. What *is* shared with ``write_nwp`` — the ``(nwp_model_id, init_time)`` partitioning
+    and the Enum-to-String strip delta-rs requires for ``nwp_model_id`` — is hand-copied below
+    because ``write_nwp`` doesn't expose it as an importable constant; a change to that layout
+    silently going stale here is caught by
+    ``tests/test_nwp_test_data.py::test_partition_layout_matches_write_nwp``, not by construction.
     """
     df = pl.DataFrame(records).cast(
         {
@@ -116,6 +126,8 @@ def write_test_nwp(path: str, records: list[dict]) -> None:
     # Strip the Patito model before reverting nwp_model_id to String: delta-rs cannot store an
     # Enum column, matching how `delta_store.nwp.write_nwp` prepares the real table for disk.
     prepared = pl.DataFrame._from_pydf(validated._df).cast({"nwp_model_id": pl.String})
+    # `partition_by` hand-copies `delta_store.nwp.write_nwp`'s layout — see the docstring above
+    # for why this can't just call `write_nwp`, and `test_nwp_test_data.py` for the drift guard.
     write_deltalake(
         table_or_uri=path, data=prepared.to_arrow(), partition_by=["nwp_model_id", "init_time"]
     )

--- a/tests/test_nwp_test_data.py
+++ b/tests/test_nwp_test_data.py
@@ -1,0 +1,67 @@
+"""Tests for ``tests/_nwp_test_data.py`` — the shared synthetic-``Nwp`` fixture writer.
+
+``write_test_nwp`` hand-copies part of ``delta_store.nwp.write_nwp``'s storage layout rather than
+calling it directly — its docstring explains why: ``write_nwp``'s significand rounding would
+perturb some of this fixture's exact values. This module is the guard against that hand-copy
+silently drifting from the real writer, and it pins the contract-validation gate that stops a
+hand-rolled, contract-invalid fixture reaching a test undetected.
+"""
+
+from datetime import UTC, datetime
+from pathlib import Path
+
+import patito as pt
+import pytest
+from _nwp_test_data import nwp_records, write_test_nwp
+from contracts.weather_schemas import Nwp
+from delta_store.nwp import write_nwp
+from deltalake import DeltaTable
+from patito.exceptions import DataFrameValidationError
+
+_INIT_TIME = datetime(2025, 6, 1, tzinfo=UTC)
+
+
+def _as_real_nwp(records: list[dict]) -> pt.DataFrame[Nwp]:
+    """Build the same rows as a validated ``Nwp`` frame, independently of ``write_test_nwp``.
+
+    Uses Patito's own no-arg ``.cast()`` (casts every column to the model's declared dtype)
+    rather than ``write_test_nwp``'s hand-written cast dict, so this doesn't just check
+    ``write_test_nwp`` against its own casting logic.
+    """
+    columnar = {key: [record[key] for record in records] for key in records[0]}
+    return Nwp.DataFrame(columnar).cast().validate()
+
+
+def test_partition_layout_matches_write_nwp(tmp_path: Path) -> None:
+    """Pin ``write_test_nwp``'s hard-copied ``partition_by`` to ``write_nwp``'s real layout.
+
+    If ``write_nwp``'s partitioning ever changes, this fails and names exactly what to update in
+    ``write_test_nwp`` — see that function's docstring for why it can't just call ``write_nwp``
+    for the whole fixture instead.
+    """
+    records = nwp_records(cell=1, day=_INIT_TIME, members=(0,))
+
+    fixture_table = tmp_path / "fixture"
+    write_test_nwp(str(fixture_table), records)
+
+    real_table = tmp_path / "real"
+    write_nwp(nwp=_as_real_nwp(records), table_uri=real_table)
+
+    assert (
+        DeltaTable(str(fixture_table)).metadata().partition_columns
+        == DeltaTable(str(real_table)).metadata().partition_columns
+    )
+
+
+def test_rejects_contract_invalid_records(tmp_path: Path) -> None:
+    """``write_test_nwp`` calls ``Nwp.validate`` before writing, so a bad fixture raises here.
+
+    Guards against a repeat of the earlier fixture that wrote contract-invalid NWP that no test
+    noticed: an out-of-range ``wind_direction_10m`` (``Nwp`` declares ``ge=0, le=360``) must raise,
+    not write.
+    """
+    records = nwp_records(cell=1, day=_INIT_TIME, members=(0,))
+    records[0]["wind_direction_10m"] = 400.0
+
+    with pytest.raises(DataFrameValidationError):
+        write_test_nwp(str(tmp_path / "invalid"), records)


### PR DESCRIPTION
Generated with [Claude Code](https://claude.com/claude-code).

`tests/_nwp_test_data.py`'s `write_test_nwp` hand-copies part of `delta_store.nwp.write_nwp`'s storage layout — the `partition_by=["nwp_model_id", "init_time"]` list and the Enum-to-String strip for `nwp_model_id` — instead of calling `write_nwp` directly, so a future change to the real writer's layout could silently leave the fixture behind.

I checked whether the fixture could just call `write_nwp` per `(nwp_model_id, init_time)` group, as suggested, and measured that it can't without changing what the four caller test files receive: `write_nwp` also rounds every continuous variable to a 13-bit significand, and that rounding is not a no-op on this fixture's values — `pressure_surface` 101000.0 becomes 100992.0, `pressure_reduced_to_mean_sea_level` 101500.0 becomes 101504.0, and `precipitation_surface` rounds too (all confirmed empirically against `delta_store.precision.round_to_significand_bits`).

So this PR keeps `write_test_nwp`'s own write path unchanged and instead makes the remaining, now-necessary duplication explicit and guarded rather than silent:

- `write_test_nwp`'s docstring now names exactly what is and isn't shared with `write_nwp`, and why — significand rounding and writer properties are deliberately not shared (they'd perturb fixture values or exist purely for the real table's on-disk size), while the partition columns and the Enum strip are shared in spirit but hand-copied because `write_nwp` doesn't expose them as an importable constant.
- New `tests/test_nwp_test_data.py` adds `test_partition_layout_matches_write_nwp`, which writes the same records through both `write_test_nwp` and `write_nwp` and asserts the two Delta tables report the same `partition_columns`. I verified it actually catches drift: temporarily changing `write_nwp`'s `partition_by` to `["nwp_model_id"]` made this test fail with a clear diff, then reverted the production file.
- The same new file adds `test_rejects_contract_invalid_records`, which feeds `write_test_nwp` a record with `wind_direction_10m` out of the contract's `[0, 360]` range and asserts `Nwp.validate` raises before the write happens — pinning the validation gate the task asked me to confirm is still active.

No production code changed. The only change to `tests/_nwp_test_data.py` is docstring and comment text — the diff touches zero executable lines in `write_test_nwp`, which is itself the proof that the four caller test files (`test_metrics.py`, `test_cv_power_forecasts.py`, `test_trained_cv_model.py`, `test_live_forecasts.py`) receive byte-identical frames to before. All 33 of their tests pass unchanged.

## Test plan

- [x] `uv run pytest tests/test_nwp_test_data.py` — both new tests pass, including the drift guard verified against a deliberately broken `write_nwp` (reverted afterwards)
- [x] `uv run pytest tests/test_metrics.py tests/test_cv_power_forecasts.py tests/test_trained_cv_model.py tests/test_live_forecasts.py` — 33 passed
- [x] `uv run pytest` — full suite green
- [x] `uv run ruff check .`, `uv run ruff format --check .`, `uv run --all-packages ty check`, `uv run pymarkdown scan -r docs README.md CLAUDE.md packages/*/README.md`, `uv run mkdocs build --strict`
