### PR TITLE
Fix wave-4 review follow-ups: local_timezone default, PICP bands, tz relabel

### DIFF
--- a/docs/ml_experimentation/model-configuration.md
+++ b/docs/ml_experimentation/model-configuration.md
@@ -35,9 +35,10 @@ cannot drift apart.
 
 ## Features (`selected_features`)
 
-`selected_features` is a list of strings. Registration only checks that it is a list of
-strings — a typo'd top-level key (e.g. `selected_featuers`) is rejected there, by pydantic's
-`extra="forbid"` on `BaseForecasterConfig`. The individual strings inside the list are not
+`selected_features` is a set of strings, written in the YAML as a list. Registration only checks
+that it is a list of strings coercible to that set — a typo'd top-level key (e.g.
+`selected_featuers`) is rejected there, by pydantic's `extra="forbid"` on `BaseForecasterConfig`.
+The individual strings inside the list are not
 parsed until training runs: the feature engineering pipeline
 (`ml_core.features._parsed_features.ParsedFeatures.from_strings`) parses each one into a typed
 descriptor and raises `ValueError` on any unrecognised or forbidden name, so a typo'd feature

--- a/packages/contracts/src/contracts/settings.py
+++ b/packages/contracts/src/contracts/settings.py
@@ -342,7 +342,7 @@ class Settings(BaseSettings):
         )
         # NGED-facing delivery tables derive from data_path_delivery instead, so a new delivery
         # table can't silently land in the internal bucket by inheriting the default derivation.
-        # `power_forecasts` and `effective_capacity` are two of the five tables in NGED's stable
+        # `power_forecast` and `effective_capacity` are two of the five tables in NGED's stable
         # delivery contract; see
         # <https://openclimatefix.github.io/nged-substation-forecast/architecture/forecast-delivery/#securing-it>
         # for the rest and why they live in a separate bucket.

--- a/packages/contracts/tests/test_power_forecast.py
+++ b/packages/contracts/tests/test_power_forecast.py
@@ -2,8 +2,20 @@ from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import patito as pt
+import polars as pl
 import pytest
 from contracts.power_schemas import PowerForecast
+
+
+def test_power_forecast_power_fcst_is_float32():
+    """``power_fcst`` must stay ``Float32`` — the dtype ``delta_store`` writes and rounds.
+
+    ``packages/delta_store/tests/test_power_forecasts.py`` exercises the write path and would
+    catch a widened dtype too, but only there — nothing inside `contracts` itself pins the dtype
+    this schema declares, so a `contracts`-only change could widen it with every test in this
+    package still green.
+    """
+    assert PowerForecast.dtypes["power_fcst"] == pl.Float32
 
 
 def test_power_forecast_validation():

--- a/packages/dashboard/tests/test_forecast_chart.py
+++ b/packages/dashboard/tests/test_forecast_chart.py
@@ -113,6 +113,16 @@ def test_shade_weekends_false_omits_the_band_layer() -> None:
     assert "weekends" not in " ".join(spec["title"]["subtitle"])
 
 
+def test_shade_weekends_true_adds_subtitle_note() -> None:
+    """The default (``shade_weekends=True``) must advertise the band it draws, not just draw it.
+
+    The false-direction sibling above pins the band layer's absence; this pins the subtitle note
+    that says why a band is there when it is, which nothing else in this file checks.
+    """
+    spec = _build(shade_weekends=True).to_dict()
+    assert "Shaded: weekends" in " ".join(spec["title"]["subtitle"])
+
+
 def test_weekend_bands_sit_at_wall_midnights_clipped_to_window() -> None:
     spec = _build().to_dict()
     bands = spec["datasets"][spec["layer"][0]["data"]["name"]]

--- a/packages/ml_core/tests/test_feature_engineer.py
+++ b/packages/ml_core/tests/test_feature_engineer.py
@@ -1,11 +1,13 @@
 """Unit tests for the FeatureEngineer strategy and its nearest-cell NWP spatial join."""
 
+import inspect
 from datetime import datetime
 
 import patito as pt
 import polars as pl
 from contracts.power_schemas import PowerTimeSeries, TimeSeriesMetadata
 from contracts.weather_schemas import Nwp
+from ml_core.features.feature_engineer import DEFAULT_LOCAL_TIMEZONE, FeatureEngineer
 from ml_core.features.tabular_feature_engineer import (
     TabularFeatureEngineer,
     _attach_nearest_nwp_cell,
@@ -209,3 +211,49 @@ def test_tabular_feature_engineer_threads_local_timezone() -> None:
     # power observation; every row shares the same valid_time, so every offset is 330.
     assert set(result["local_utc_offset_minutes"].to_list()) == {330}
     assert result.height == 2
+
+
+def test_tabular_feature_engineer_default_local_timezone_is_london() -> None:
+    """Calling ``engineer()`` with no ``local_timezone`` must default production to Europe/London.
+
+    Every production and CV call site (``production_assets.py``, ``cv_assets.py``) calls
+    ``engineer()`` without passing ``local_timezone``, so this is the value they all actually get
+    — and it is invisible to every other test in this module, which passes ``local_timezone``
+    explicitly. British Summer Time gives a UTC+1 offset in June, so the correct default
+    (``Europe/London``) yields ``local_utc_offset_minutes == 60``; a wrong default (e.g.
+    ``Asia/Kolkata``'s fixed +5:30) would silently produce ``330`` instead, with every other test
+    in the suite still green.
+    """
+    valid_time = datetime(2024, 6, 1, 12, 0)
+    power = pt.LazyFrame.from_existing(
+        pl.DataFrame({"time_series_id": [1], "time": [valid_time], "power": [100.0]}).lazy()
+    ).set_model(PowerTimeSeries)
+
+    result = (
+        TabularFeatureEngineer()
+        .engineer(
+            selected_features={"local_utc_offset_minutes"},
+            power_time_series=power,
+            time_series_metadata=_metadata_two_series(),
+            nwp=_nwp_two_cells(),
+        )
+        .collect()
+    )
+
+    assert set(result["local_utc_offset_minutes"].to_list()) == {60}
+
+
+def test_feature_engineer_abc_declares_local_timezone_parameter() -> None:
+    """``local_timezone`` is part of the ``FeatureEngineer`` interface, not just the one subclass.
+
+    Inspects the *abstract* method's own signature, deliberately not a concrete instance assigned
+    to a ``FeatureEngineer``-typed variable: ``ty`` narrows a declared-``FeatureEngineer`` receiver
+    back to the concrete ``TabularFeatureEngineer`` on assignment, so a test written that way would
+    still type-check even if ``local_timezone`` were deleted from the ABC — silently passing both
+    pytest and ``ty``. Reading ``FeatureEngineer.engineer``'s signature directly has no such
+    loophole: a future ``FeatureEngineer`` implementation for another region can only be relied on
+    to accept ``local_timezone`` if the interface itself declares it.
+    """
+    parameters = inspect.signature(FeatureEngineer.engineer).parameters
+    assert "local_timezone" in parameters
+    assert parameters["local_timezone"].default == DEFAULT_LOCAL_TIMEZONE

--- a/packages/ml_core/tests/test_metrics.py
+++ b/packages/ml_core/tests/test_metrics.py
@@ -585,6 +585,33 @@ def test_compute_metrics_picp_boundary_is_inclusive():
     assert _metric_value(result, "picp", metric_param="p10_p90") == 1.0
 
 
+def test_compute_metrics_picp_distinguishes_bands():
+    """Each band's PICP comes from its own quantile pair, not one pair shared by every band.
+
+    101 members evenly spaced 0..100 give every ``DELIVERY_QUANTILES`` level ``q`` an exact
+    empirical quantile of ``100*q`` (linear interpolation lands on an integer member for every
+    level in that tuple), so each band's bounds are exactly its own p-labels: ``p35_p65`` =
+    [35, 65], ``p20_p80`` = [20, 80]. An actual of 30 sits inside ``p20_p80`` but outside
+    ``p35_p65``. Every other PICP assertion in this file uses only ``p10_p90``, with an actual
+    that is inside every band, outside every band, or on every bound — so a mutation that scored
+    every band's PICP off one shared pair (e.g. always the widest, ``p1_p99``) would still pass
+    them all. This is the one case that catches that: it requires two bands' PICPs to differ.
+    """
+    times = [_utc(2022, 1, 1, 0, 0)]
+    actuals = _make_actuals(1, times, [30.0])
+    forecasts = _make_ensemble_forecasts(1, times, [[float(m) for m in range(101)]])
+    result = compute_metrics(forecasts, actuals, _make_metadata([1]), _make_capacity([1], [100.0]))
+
+    assert _metric_value(result, "picp", metric_param="p20_p80") == 1.0
+    assert _metric_value(result, "picp", metric_param="p35_p65") == 0.0
+    assert math.isclose(
+        _metric_value(result, "interval_width", metric_param="p20_p80"), 60.0, rel_tol=1e-6
+    )
+    assert math.isclose(
+        _metric_value(result, "interval_width", metric_param="p35_p65"), 30.0, rel_tol=1e-6
+    )
+
+
 def test_compute_metrics_perfect_forecast_scores_finite_zero_spread_skill():
     """A perfect deterministic forecast (RMSE = 0, spread = 0) scores 0, never NaN.
 

--- a/src/nged_substation_forecast/defs/production_assets.py
+++ b/src/nged_substation_forecast/defs/production_assets.py
@@ -159,22 +159,33 @@ def promoted_model(context: AssetExecutionContext, config: PromotedModelConfig) 
     )
 
 
+def _parse_utc_init_time(value: str) -> datetime:
+    """Parse one partition-value ``init_time`` string into a tz-aware UTC datetime.
+
+    delta-rs renders our own writes as naive ``"YYYY-MM-DD HH:MM:SS[.ffffff]"`` strings, so the
+    common case just attaches UTC. An offset-carrying string is handled separately —
+    ``.replace(tzinfo=UTC)`` would silently *relabel* it to the wrong instant rather than convert
+    it, and nothing upstream guarantees delta-rs never renders one.
+    """
+    parsed = datetime.fromisoformat(value)
+    return parsed.astimezone(UTC) if parsed.tzinfo is not None else parsed.replace(tzinfo=UTC)
+
+
 def _available_nwp_init_times(settings: Settings) -> list[datetime]:
     """Return the distinct ``init_time``s present in the ``nwp`` Delta table.
 
     Reads only Delta partition metadata (``DeltaTable.partitions()``, no data scan) and parses
-    the ``init_time`` partition values — naive ``"YYYY-MM-DD HH:MM:SS[.ffffff]"`` strings on disk
-    — into tz-aware UTC datetimes. Uses ``datetime.fromisoformat`` rather than a fixed
-    ``strptime`` pattern so a delta-rs rendering that drops the fractional seconds (whole-second
-    ``init_time``s have no fractional part to keep) parses the same as one that keeps them —
-    ``strptime``'s ``%f`` requires at least one fractional digit and would raise on that
-    rendering.
+    the ``init_time`` partition values into tz-aware UTC datetimes via ``_parse_utc_init_time``.
+    Uses ``datetime.fromisoformat`` rather than a fixed ``strptime`` pattern so a delta-rs
+    rendering that drops the fractional seconds (whole-second ``init_time``s have no fractional
+    part to keep) parses the same as one that keeps them — ``strptime``'s ``%f`` requires at
+    least one fractional digit and would raise on that rendering.
     """
     delta_table = DeltaTable(
         settings.nwp_data_path, storage_options=typeddict_to_dict(settings.storage_options)
     )
     raw_values = {partition["init_time"] for partition in delta_table.partitions()}
-    return [datetime.fromisoformat(value).replace(tzinfo=UTC) for value in raw_values]
+    return [_parse_utc_init_time(value) for value in raw_values]
 
 
 class LiveForecastsConfig(Config):
@@ -199,13 +210,10 @@ class LiveForecastsConfig(Config):
             # back 16 * 6h = 4 days, not 16 days. This is a lineage-only safety margin (it decides
             # what the Dagster UI graph and a `--with upstream` materialisation consider a parent,
             # not what live_forecasts actually reads): comfortably more than the ~30h a healthy
-            # NWP run is ever stale (see checks._NWP_RUN_EXPECTED_ON_DISK_BY), so it still covers
-            # several consecutive missed daily runs before live_forecasts_are_healthy's missed-run
-            # check would already have alarmed. It is deliberately unrelated to MAX_NWP_LEAD (16
-            # *days*, in defs._engineering_inputs): that bounds how far back an init_time can be
-            # and still cover a future valid_time window, for callers that scan a range of NWP
-            # runs. live_forecasts instead joins a single run picked by select_nwp_init_time, so
-            # MAX_NWP_LEAD's range-based pruning never applies here.
+            # NWP run is ever stale — the 00Z run lands around 08:30 UTC (see
+            # schedules.ecmwf_ens_schedule), so the 06:00 slot still uses the previous day's run, a
+            # worst case of 30h — so it still covers several consecutive missed daily runs before
+            # live_forecasts_are_healthy's missed-run check would already have alarmed.
             partition_mapping=TimeWindowPartitionMapping(start_offset=-16, end_offset=0),
         ),
         "power_time_series_and_metadata",

--- a/tests/test_production_assets.py
+++ b/tests/test_production_assets.py
@@ -31,22 +31,29 @@ def _patch_delta_table(monkeypatch: pytest.MonkeyPatch, raw_init_times: set[str]
 
 
 @pytest.mark.parametrize(
-    "raw_value",
+    ("raw_value", "expected"),
     [
-        "2026-07-04 00:00:00.000000",  # delta-rs' current rendering: always six fractional digits
-        "2026-07-04 00:00:00",  # a hypothetical future delta-rs release dropping trailing zeros
+        # delta-rs' current rendering: always six fractional digits.
+        ("2026-07-04 00:00:00.000000", datetime(2026, 7, 4, 0, 0, tzinfo=UTC)),
+        # A hypothetical future delta-rs release dropping trailing zeros.
+        ("2026-07-04 00:00:00", datetime(2026, 7, 4, 0, 0, tzinfo=UTC)),
+        # An offset-carrying rendering: must be *converted* to the same instant, not relabelled.
+        # ``.replace(tzinfo=UTC)`` would wrongly yield 2026-07-04 00:00:00+00:00 here.
+        ("2026-07-04 00:00:00+02:00", datetime(2026, 7, 3, 22, 0, tzinfo=UTC)),
     ],
 )
 def test_available_nwp_init_times_parses_both_fractional_second_renderings(
-    monkeypatch: pytest.MonkeyPatch, raw_value: str
+    monkeypatch: pytest.MonkeyPatch, raw_value: str, expected: datetime
 ) -> None:
     """Must survive either spelling delta-rs might emit for a whole-second ``init_time``.
 
     ``datetime.strptime``'s ``%f`` directive requires at least one fractional digit, so it would
     raise on the second rendering; ``datetime.fromisoformat`` (what the code uses) accepts both.
+    An offset-carrying string is not one delta-rs emits today, but the parser must convert it to
+    the correct UTC instant rather than silently relabelling its wall-clock digits as UTC.
     """
     _patch_delta_table(monkeypatch, {raw_value})
 
     result = production_assets._available_nwp_init_times(Settings())
 
-    assert result == [datetime(2026, 7, 4, 0, 0, tzinfo=UTC)]
+    assert result == [expected]


### PR DESCRIPTION
Implements the items filed as Accept in the wave-4 end-of-wave follow-up triage — the triage is the spec, not the reviewers' raw reports.

## Substantive fixes

**R1 — `local_timezone`'s default at the public `TabularFeatureEngineer.engineer()` entry point was pinned by nothing.** Every production and CV call site calls `engineer()` without passing `local_timezone`, so a wrong default there would silently build every live and CV forecast on the wrong wall-clock time while every other test in the suite — all of which pass `local_timezone` explicitly — stayed green. Added `test_tabular_feature_engineer_default_local_timezone_is_london`, which calls `engineer()` with no `local_timezone` argument and asserts `local_utc_offset_minutes == 60` (BST, June).

**R3 — no test distinguished one PICP band's coverage from another's.** `_wide_metrics` computes each band's PICP from its own quantile pair, but every existing assertion used only `p10_p90` with an actual that was inside every band, outside every band, or exactly on a bound — never inside one band and outside another — so a mutation that scored every band off one shared pair (e.g. always the widest, `p1_p99`) would have passed all of them. Added `test_compute_metrics_picp_distinguishes_bands`: 101 evenly-spaced ensemble members give exact integer quantile bounds, and an actual of 30 sits inside `p20_p80` but outside `p35_p65`.

**T1 — `fromisoformat(value).replace(tzinfo=UTC)` silently relabels an offset-carrying string instead of converting it.** Not reachable today (delta-rs renders our own writes as naive strings), but "unreachable now" plus "silent when it happens" is the combination that produces a bad incident later. Extracted `_parse_utc_init_time`, which converts via `astimezone(UTC)` when `parsed.tzinfo is not None` and only attaches UTC directly for the naive case. Added the offset-carrying case to the existing parametrised test.

**R2 — the `FeatureEngineer` ABC's `local_timezone` parameter was unpinned in both pytest and `ty`.** Added `test_feature_engineer_abc_declares_local_timezone_parameter`, which reads `inspect.signature(FeatureEngineer.engineer)` directly rather than assigning a concrete instance to a `FeatureEngineer`-typed variable — `ty` narrows a declared-`FeatureEngineer` receiver back to the concrete `TabularFeatureEngineer` on assignment, so that form would still type-check even with the parameter deleted from the ABC.

## Smaller fixes

- **T2 — the "~30h" comment.** Verified with the maintainer rather than changed: the 30h figure is correct (a normal-day 00Z run lands ~08:30 UTC, so the 06:00 slot still uses the previous day's run — 30h old), but the comment's citation was wrong. `checks._NWP_RUN_EXPECTED_ON_DISK_BY` (14h) measures the health check's missed-run tolerance, not the real staleness a healthy day produces; citing it as the source of "~30h" conflated the two. The comment now keeps "~30h" and cites `schedules.ecmwf_ens_schedule`'s 08:30 UTC firing time instead. `CLAUDE.md`'s "12–30 hours" is untouched and was confirmed correct as written.
- **T3 — trimmed the same comment.** Dropped the paragraph explaining what `start_offset=-16` is *not* related to (`MAX_NWP_LEAD`); kept the units-correction and the staleness-margin rationale.
- **T6 — `model-configuration.md`** said `selected_features` "is a list of strings" twice. The Python contract is `set[str]` (`BaseForecasterConfig`); the doc now says it is a set written as a YAML list.
- **T7 — `settings.py`'s delivery-table comment** named the table `power_forecasts`; the NGED delivery contract calls it `power_forecast`, singular (`docs/roadmap/delivery-tables.md`). Fixed the comment only — the physical Delta path and the `power_forecasts_data_path` attribute are unchanged.
- **The `"Shaded: weekends"` subtitle note** was pinned by nothing — deleting it left all 23 dashboard tests green. Added `test_shade_weekends_true_adds_subtitle_note`.
- **`PowerForecast.power_fcst`'s `Float32` dtype** was guarded only from outside `contracts` (`packages/delta_store/tests/test_power_forecasts.py`). Added a same-package pin, `test_power_forecast_power_fcst_is_float32`. No dtype, constraint or validator changed — this adds a test only.

## Mutations, each watched red then reverted

1. **R1** — changed `TabularFeatureEngineer.engineer`'s `local_timezone` default (`tabular_feature_engineer.py:83`) to a hardcoded `"Asia/Kolkata"`. Result: exactly the new test failed (`{330} == {60}`); all 164 other `ml_core` tests, including the existing test that passes `local_timezone` explicitly, stayed green.
2. **R3** — made every band's PICP use the widest (`p1_p99`) quantile pair while leaving `interval_width` untouched. Result: exactly the new test failed (`p35_p65` PICP came back `1.0` instead of `0.0`); all 164 other `ml_core` tests stayed green.
3. **T1** — reverted `_parse_utc_init_time` to the old unconditional `.replace(tzinfo=UTC)`. Result: exactly the offset-carrying parametrised case failed (`2026-07-04T00:00:00+02:00` came back relabelled as `00:00 UTC` instead of converted to `22:00 UTC` the previous day); the other two parametrised cases stayed green.
4. **R2** — deleted `local_timezone` from `FeatureEngineer.engineer`'s abstract signature. Result: exactly the new `inspect.signature` test failed; every other pytest test and `uv run --package ml-core ty check packages/ml_core` both stayed green — confirming the `ty`-narrowing trap the triage described is real.
5. **Shaded: weekends** — deleted the `subtitle_notes.append("Shaded: weekends")` line. Result: exactly the new test failed; all 23 other dashboard tests, including the one pinning the band layer's *absence* when `shade_weekends=False`, stayed green.
6. **contracts dtype** — changed `PowerForecast.power_fcst`'s dtype to `pl.Float64`. Result: exactly the new `contracts` test failed (140 other `contracts` tests stayed green, matching the triage's count), and separately confirmed `packages/delta_store/tests/test_power_forecasts.py::test_power_fcst_rounded_to_significand_bits` also fails under the same mutation, as the triage described.

`git status` was clean after every revert, confirmed before committing.

## Scope

Implements only the **Accept** items (T1, T2, T3, T6, T7; R1, R2, R3, the subtitle pin, the dtype pin). Nothing under Reject, No action, or Open question was touched — in particular `local_timezone`/`DEFAULT_LOCAL_TIMEZONE` itself (T4) and `test_apply_local_time_features_non_london_timezone` (T5) are untouched, and the v0.5 roadmap-index question was left for the maintainer. No ML model was retrained and no large asset was materialised. `docs/architecture/adapting-to-another-geography.md` and `CLAUDE.md` were not touched.

## Verification

`uv run ruff check .`, `uv run ruff format --check .`, `uv run --all-packages ty check`, `uv run pytest` (730 passed, 1 skipped), `uv run pymarkdown scan -r docs README.md CLAUDE.md packages/*/README.md`, and `uv run mkdocs build --strict` all pass, run again after merging `origin/main` (a clean merge, no conflicts).
