### PR TITLE
Fix the final-review triage: hollow P99 test, six stale docs, five unpinned contract values

### DIFF
--- a/docs/api/contracts/index.md
+++ b/docs/api/contracts/index.md
@@ -9,3 +9,4 @@
 ::: contracts.ml_schemas
 ::: contracts.config_schemas
 ::: contracts.settings
+::: contracts.uri

--- a/docs/api/ml_core/index.md
+++ b/docs/api/ml_core/index.md
@@ -5,3 +5,7 @@
 ::: ml_core.features
 ::: ml_core.base_forecaster
 ::: ml_core.metrics
+::: ml_core.cv_helpers
+::: ml_core.mlflow_runs
+::: ml_core.production_helpers
+::: ml_core.repro

--- a/docs/architecture/adapting-to-another-geography.md
+++ b/docs/architecture/adapting-to-another-geography.md
@@ -1350,7 +1350,8 @@ so the byte reduction would land nearer the 4× than the 51×. That needs measur
 documented in
 [Performance and Scale](performance.md#the-other-hard-ceiling-polars-32-bit-row-index), row counts
 silently wrap past 2³² rows, and materialising a single frame of ≥2³² rows is unsupported outright.
-At V2 the cap affects one code path (the `metrics` asset's whole-fold collect). Here, **a single
+At V2 the cap affects one code path (`power_forecasts`, whose accumulated writes pass the cap at
+V2 scale, ~1 trillion rows/year). Here, **a single
 run's 6.9 billion forecast rows exceed the 4.29-billion cap on their own**, so the output of one
 inference run could not be materialised as one frame at all. Chunking the write is not an
 optimisation at this scale; it is a precondition.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -86,13 +86,14 @@ AWS — see [Live service](live-service.md).
 quality, reproducibility and observability hardening. **✅ Shipped 13 August 2026** (`v0.2.0`) —
 running on AWS.*
 
-- More unit tests, including feature-level lag-leakage and training-determinism tests ✅
+- More unit tests, including feature-level lag-leakage and forecaster-level determinism tests ✅
   ([#62](https://github.com/openclimatefix/nged-substation-forecast/issues/62); exercised by
   `test_nullify_leaky_lags`, `test_engineer_features_weather_lag_leakage_prevention` and
   `test_random_seed_makes_training_deterministic`, alongside new package coverage for
   `dynamical_data` ([#163](https://github.com/openclimatefix/nged-substation-forecast/issues/163))
   and `geo` ([#164](https://github.com/openclimatefix/nged-substation-forecast/issues/164))). The
-  CV-windowing no-lookahead and leaderboard-fairness guardrail tests remain unwritten — see
+  CV-windowing no-lookahead, leaderboard-fairness and fold-level determinism guardrail tests
+  remain unwritten — see
   [Engineering health](engineering-health.md#scientific-rigor-tests-and-cleanup)
 - CI on GitHub (ruff + ty + pytest on every PR) ✅ (per-PR gate + nightly network tests; see
   [Testing → Continuous integration](../architecture/testing.md#continuous-integration))

--- a/packages/contracts/tests/test_effective_capacity.py
+++ b/packages/contracts/tests/test_effective_capacity.py
@@ -1,0 +1,29 @@
+from datetime import UTC, datetime
+
+import patito as pt
+import pytest
+from contracts.power_schemas import EffectiveCapacity
+
+
+def _one_row(effective_capacity_mw: float) -> pt.DataFrame[EffectiveCapacity]:
+    return pt.DataFrame(
+        {
+            "time_series_id": [123],
+            "time": [datetime(2026, 1, 1, 0, 30, tzinfo=UTC)],
+            "effective_capacity_mw": [effective_capacity_mw],
+        }
+    ).set_model(EffectiveCapacity)
+
+
+def test_effective_capacity_validation() -> None:
+    _one_row(10.0).cast().validate()
+
+
+@pytest.mark.parametrize("bad_value", [0.0, -5.0])
+def test_effective_capacity_rejects_non_positive_value(bad_value: float) -> None:
+    """`effective_capacity_mw` must be strictly positive — it is the NMAE denominator, and a
+    zero or negative capacity would divide every error by a value that can't happen physically.
+    ``compute_effective_capacity`` relies on this: it drops non-positive P99s before they ever
+    reach this contract, and this pins the boundary it drops them at."""
+    with pytest.raises(Exception, match="effective_capacity_mw"):
+        _one_row(bad_value).cast().validate()

--- a/packages/contracts/tests/test_weather_schemas_validation.py
+++ b/packages/contracts/tests/test_weather_schemas_validation.py
@@ -245,6 +245,39 @@ def test_lead0_deaccumulated_nulls_are_allowed() -> None:
     assert assess_nwp_quality(validated).is_healthy
 
 
+@pytest.mark.parametrize(
+    ("column", "bad_value"),
+    [
+        ("temperature_2m", 150.0),  # exceeds le=100
+        ("temperature_2m", -150.0),  # exceeds ge=-100
+        ("wind_direction_10m", 400.0),  # exceeds le=360
+        ("wind_direction_10m", -10.0),  # exceeds ge=0
+    ],
+)
+def test_out_of_range_continuous_weather_var_is_fatal(column: str, bad_value: float) -> None:
+    """A continuous variable outside its physical range must fail ingest.
+
+    Guards `Nwp`'s declared `ge`/`le` bounds from inside the package that owns them: a widened
+    range (e.g. `temperature_2m`'s `le=100` relaxed to `le=10000`, or `wind_direction_10m`'s
+    `le=360` relaxed to `le=3600`) would otherwise pass every test in this file undetected.
+    """
+    df = _nwp_slice(overrides={column: [bad_value, bad_value, bad_value]})
+    with pytest.raises(pt.exceptions.DataFrameValidationError):
+        _validate(df)
+
+
+def test_continuous_weather_vars_are_stored_as_float32() -> None:
+    """`Nwp`'s continuous variables are declared `Float32`, the physical-unit dtype the on-disk
+    Delta table stores (see the `Nwp` docstring). Pins the literal dtype, not one derived from the
+    model, so a field's declared dtype widening to `Float64` fails here rather than only
+    downstream — as measured, such a change causes 26 failures elsewhere and none inside
+    `contracts`.
+    """
+    validated = _validate(_nwp_slice())
+    for var in sorted(Nwp.continuous_var_names()):
+        assert validated[var].dtype == pl.Float32, var
+
+
 def test_categorical_precipitation_type_surface_validation() -> None:
     # Test case 1: Valid data (all null before 2024-11-12, not null after)
     df_valid = pl.DataFrame(

--- a/packages/delta_store/tests/test_nwp.py
+++ b/packages/delta_store/tests/test_nwp.py
@@ -97,6 +97,17 @@ def test_continuous_vars_rounded_to_significand_bits(tmp_path: Path) -> None:
         assert (stored.view(np.dtype(np.uint32)) & discarded == 0).all(), var
 
 
+def test_the_nwp_significand_bits_is_thirteen() -> None:
+    """Pins the literal, not a value derived from the constant.
+
+    ``test_continuous_vars_rounded_to_significand_bits`` above computes its tolerance *from*
+    ``NWP_SIGNIFICAND_BITS``, so it stays green no matter what the constant is set to. The
+    ``power_forecasts`` sibling significand constant carries a matching relative-error claim in
+    ``PowerForecast.power_fcst``'s description that a changed constant would leave silently wrong.
+    """
+    assert NWP_SIGNIFICAND_BITS == 13
+
+
 def test_successive_runs_create_separate_partitions(tmp_path: Path) -> None:
     table = tmp_path / "nwp"
     n = 4

--- a/packages/delta_store/tests/test_power_forecasts.py
+++ b/packages/delta_store/tests/test_power_forecasts.py
@@ -89,6 +89,17 @@ def test_power_fcst_rounded_to_significand_bits(tmp_path: Path) -> None:
     assert (stored.view(np.dtype(np.uint32)) & discarded == 0).all()
 
 
+def test_the_power_fcst_significand_bits_is_thirteen() -> None:
+    """Pins the literal, not a value derived from the constant.
+
+    ``test_power_fcst_rounded_to_significand_bits`` above computes its tolerance *from*
+    ``POWER_FCST_SIGNIFICAND_BITS``, so it stays green no matter what the constant is set to.
+    ``PowerForecast.power_fcst``'s description asserts "max relative error 2^-13" in prose that a
+    changed constant would leave silently wrong.
+    """
+    assert POWER_FCST_SIGNIFICAND_BITS == 13
+
+
 def test_replace_partition_then_append(tmp_path: Path) -> None:
     table = tmp_path / "power_forecasts"
     partition = ("exp_storage_test", "smoke_test")

--- a/packages/ml_core/src/ml_core/features/_lags.py
+++ b/packages/ml_core/src/ml_core/features/_lags.py
@@ -104,8 +104,10 @@ def _apply_weather_lag(
         # available (bulk mode derives power_fcst_init_time = nwp_init_time + delay, exactly the
         # instant that run becomes usable), and no fresher run can be available at that instant
         # either — so the boundary belongs to the same-run branch, not the freshest-run one. This
-        # changes no output today (see the explanatory comment on the historical_weather
-        # construction in tabular_feature_engineer.py); it is defence in depth.
+        # changes output for every non-control ensemble member at that boundary: the freshest-run
+        # branch is `select_analysis_proxy`, which keeps only `ensemble_member == 0`, so a `>`
+        # boundary would read member 5's own row where `>=` reads member 0's. It is inconsequential
+        # today only because `conf/model/xgboost.yaml` selects no weather-lag features.
         pl.when(pl.col("target_time") >= pl.col("power_fcst_init_time"))
         .then(pl.col(f"{lag_feature.string_repr}_same_run"))
         .otherwise(pl.col(f"{lag_feature.string_repr}_freshest_run"))

--- a/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py
+++ b/packages/ml_core/src/ml_core/features/tabular_feature_engineer.py
@@ -156,9 +156,13 @@ def _engineer_features(
 
             Must be None when power_fcst_init_time is None (bulk mode).
 
-        nwp_publication_delay_hours: The delay in hours between the initialization time
-            of the NWP forecast and when it becomes publicly available. Used only when
-            nwp_init_time is None and power_fcst_init_time is not None.
+        nwp_publication_delay_hours: Hours after an NWP run's ``nwp_init_time`` before it is
+            usable — disk arrival, not upstream publication; see
+            ``weather_utils.analysis_proxy.NWP_PUBLICATION_DELAY_HOURS`` for what drives the
+            default and its derivation. Used throughout, not only in one mode: it derives
+            ``power_fcst_init_time`` from ``nwp_init_time`` in bulk mode, derives
+            ``nwp_init_time`` when it is omitted in single-run mode, and gates the single-run
+            analysis-proxy's ``available_at`` cut.
         local_timezone: IANA zone the local-time features (time of day, day of week, UTC
             offset) are computed in. Defaults to ``DEFAULT_LOCAL_TIMEZONE``.
     """

--- a/packages/ml_core/tests/test_feature_engineer.py
+++ b/packages/ml_core/tests/test_feature_engineer.py
@@ -217,12 +217,13 @@ def test_tabular_feature_engineer_default_local_timezone_is_london() -> None:
     """Calling ``engineer()`` with no ``local_timezone`` must default production to Europe/London.
 
     Every production and CV call site (``production_assets.py``, ``cv_assets.py``) calls
-    ``engineer()`` without passing ``local_timezone``, so this is the value they all actually get
-    — and it is invisible to every other test in this module, which passes ``local_timezone``
-    explicitly. British Summer Time gives a UTC+1 offset in June, so the correct default
-    (``Europe/London``) yields ``local_utc_offset_minutes == 60``; a wrong default (e.g.
-    ``Asia/Kolkata``'s fixed +5:30) would silently produce ``330`` instead, with every other test
-    in the suite still green.
+    ``engineer()`` without passing ``local_timezone`` as of writing, so a wrong default would
+    reach them silently. This test pins only the parameter's default value, not those call sites
+    themselves, and it is invisible to every other test in this module, which passes
+    ``local_timezone`` explicitly. British Summer Time gives a UTC+1 offset in June, so the
+    correct default (``Europe/London``) yields ``local_utc_offset_minutes == 60``; a wrong
+    default (e.g. ``Asia/Kolkata``'s fixed +5:30) would silently produce ``330`` instead, with
+    every other test in the suite still green.
     """
     valid_time = datetime(2024, 6, 1, 12, 0)
     power = pt.LazyFrame.from_existing(

--- a/packages/ml_core/tests/test_features.py
+++ b/packages/ml_core/tests/test_features.py
@@ -844,47 +844,6 @@ def test_engineer_features_weather_lag_leakage_prevention():
     assert engineered["temperature_2m_lag_36h"][0] == 8.0
 
 
-def test_engineer_features_weather_lag_freshest_run_reaches_older_run_only_data():
-    """The freshest-run branch must resolve to a value that only an OLDER run holds.
-
-    A fixture where the same-run and freshest-run branches happen to agree can't tell "always
-    same-run" apart from the real dual-strategy join. Here the row's own run (T1) has no
-    coverage at all at the lag's target_time, so the same-run join legitimately misses (null);
-    only the older run (T0) has real data there, so the freshest-run branch must reach past T1
-    to find it.
-    """
-    power_fcst_init_time = datetime(2026, 6, 11, 6, 0)
-    nwp_init_time = datetime(2026, 6, 11, 0, 0)  # T1: the row's own run
-    older_run_init_time = datetime(2026, 6, 10, 0, 0)  # T0: an earlier run
-    valid_time = datetime(2026, 6, 11, 12, 0)
-    # lag=24h -> target_time = 2026-06-10 12:00: before power_fcst_init_time (freshest-run
-    # branch), and T1 carries no row there at all, so only T0 can answer it.
-    target_time = valid_time - timedelta(hours=24)
-
-    nwp_df = pl.DataFrame(
-        {
-            "time_series_id": ["ts1", "ts1"],
-            "valid_time": [target_time, valid_time],
-            "ensemble_member": [0, 0],
-            "init_time": [older_run_init_time, nwp_init_time],
-            "temperature_2m": [8.0, 99.0],  # T0 at target_time; T1's own (unrelated) row
-        }
-    )
-    power_df = pl.DataFrame({"time_series_id": ["ts1"], "time": [valid_time], "power": [100.0]})
-    metadata_df = pl.DataFrame({"time_series_id": ["ts1"], "time_series_type": ["substation"]})
-
-    engineered = _engineer_features(
-        power_time_series=pt.LazyFrame.from_existing(power_df.lazy()).set_model(PowerTimeSeries),
-        time_series_metadata=pt.DataFrame(metadata_df).set_model(TimeSeriesMetadata),
-        nwp=nwp_df.lazy(),
-        selected_features={"temperature_2m_lag_24h"},
-        power_fcst_init_time=power_fcst_init_time,
-        nwp_init_time=nwp_init_time,
-    ).collect()
-
-    assert engineered["temperature_2m_lag_24h"][0] == 8.0
-
-
 def test_engineer_features_single_run_freshest_run_excludes_unpublished_nwp_run():
     """The single-run availability gate must reject a run not yet published by power_fcst_init_time.
 

--- a/packages/ml_core/tests/test_metrics.py
+++ b/packages/ml_core/tests/test_metrics.py
@@ -149,6 +149,22 @@ def test_compute_effective_capacity_drops_non_positive_series():
     assert result["effective_capacity_mw"].to_list() == pytest.approx([6.0])
 
 
+def test_compute_effective_capacity_is_the_99th_percentile_not_the_mean():
+    """A skewed series distinguishes P99 from mean() and from quantile(0.01).
+
+    50 observations at 1.0 MW plus one spike at 50.0 MW (51 total). Polars' default "nearest"
+    interpolation puts quantile(0.99) exactly on the spike (50.0), while mean() (~1.96) and
+    quantile(0.01) (1.0) fall far short of it. A fixture of constant power per series — as every
+    other test in this module uses — can't tell `quantile(0.99)` apart from either, because on a
+    constant series they all equal the same value.
+    """
+    times = [_utc(2022, 1, 1, 0, 0) + timedelta(minutes=30 * i) for i in range(51)]
+    power = [1.0] * 50 + [50.0]
+    power_lf = _make_actuals(1, times, power)
+    result = compute_effective_capacity(power_lf)
+    assert result["effective_capacity_mw"].to_list() == pytest.approx([50.0])
+
+
 # ---------------------------------------------------------------------------
 # compute_metrics tests
 # ---------------------------------------------------------------------------

--- a/src/nged_substation_forecast/defs/production_assets.py
+++ b/src/nged_substation_forecast/defs/production_assets.py
@@ -269,9 +269,13 @@ def live_forecasts(context: AssetExecutionContext, config: LiveForecastsConfig) 
     ``write_power_forecasts``'s ``replace_predicate_extra``, so re-running a 6-hourly slot (or
     replaying one) never duplicates rows or wipes the rest of the ``"live"`` fold.
 
-    Note: weather-lag features would go null at live time (only one NWP run is loaded here) —
-    none are in the current champion config, but a future feature change touching weather lags
-    should trip over this consciously.
+    Note: only one NWP run is loaded here, and "live" availability applies no publication delay,
+    so a weather-lag feature goes null only when that run is closer than
+    ``NWP_PUBLICATION_DELAY_HOURS`` to ``power_fcst_init_time`` — e.g. the 06:00 slot, when only
+    that morning's run has landed — and is populated at every other slot; see
+    ``test_live_weather_lag_nulls_only_when_the_selected_run_is_too_fresh``. None are in the
+    current champion config, but a future feature change touching weather lags should trip over
+    this consciously.
     """
     settings = Settings()
     power_fcst_init_time = context.partition_time_window.end

--- a/tests/_nwp_test_data.py
+++ b/tests/_nwp_test_data.py
@@ -107,9 +107,11 @@ def write_test_nwp(path: str, records: list[dict]) -> None:
     real table's on-disk size, not to serve a test fixture. Those two are deliberately *not*
     shared. What *is* shared with ``write_nwp`` — the ``(nwp_model_id, init_time)`` partitioning
     and the Enum-to-String strip delta-rs requires for ``nwp_model_id`` — is hand-copied below
-    because ``write_nwp`` doesn't expose it as an importable constant; a change to that layout
-    silently going stale here is caught by
-    ``tests/test_nwp_test_data.py::test_partition_layout_matches_write_nwp``, not by construction.
+    because ``write_nwp`` doesn't expose it as an importable constant. A change to the partition
+    *column names* going stale here is caught by
+    ``tests/test_nwp_test_data.py::test_partition_layout_matches_write_nwp``, which compares only
+    ``partition_columns``; a drift in the Enum-to-String strip itself is not covered by that test
+    and would surface only as a write failure.
     """
     df = pl.DataFrame(records).cast(
         {

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -44,6 +44,7 @@ from deltalake import write_deltalake
 from nged_substation_forecast import _sentry
 from nged_substation_forecast.defs import checks
 from nged_substation_forecast.defs.checks import (
+    LIVE_FORECAST_HORIZON,
     LiveForecastHealthResult,
     LiveForecastRows,
     PowerFreshnessResult,
@@ -119,6 +120,13 @@ def test_the_production_staleness_threshold_is_twenty_four_hours() -> None:
         threshold=checks._POWER_DATA_STALENESS_THRESHOLD,
     )
     assert result.late["time_series_id"].to_list() == [8]
+
+
+def test_the_live_forecast_horizon_is_fourteen_days() -> None:
+    """Pins the literal, not a value derived from the constant. ``_MIN_HORIZON_HOURS`` is
+    computed *from* ``LIVE_FORECAST_HORIZON`` (``checks.py``), so the truncated-horizon threshold
+    moves with the constant and a test built the same way could never catch a wrong value."""
+    assert timedelta(days=14) == LIVE_FORECAST_HORIZON
 
 
 def test_never_reported_ids_flagged_from_roster() -> None:

--- a/tests/test_live_forecasts.py
+++ b/tests/test_live_forecasts.py
@@ -456,10 +456,11 @@ def test_live_power_history_covers_the_longest_selected_power_lag(
     selects.
 
     Every other test in this file trains its fixture model on ``{"temperature_2m"}``, so a
-    ``LIVE_POWER_HISTORY`` too short to cover a real lag feature is invisible to them —
-    ``conf/model/xgboost.yaml`` selects ``power_lag_336h``, and shrinking the window from 15 days
-    to 1 hour leaves every other test in this file green. This test trains on ``power_lag_336h``
-    directly and spies on ``XGBoostForecaster.predict`` to capture the exact frame
+    ``LIVE_POWER_HISTORY`` too short to cover a real lag feature is invisible to them — the real
+    model config, ``conf/model/xgboost.yaml``, selects ``power_lag_336h`` as of writing, and
+    shrinking the window from 15 days to 1 hour leaves every other test in this file green. This
+    test hard-codes that same lag rather than reading the YAML, trains a fixture model on it
+    directly, and spies on ``XGBoostForecaster.predict`` to capture the exact frame
     ``live_forecasts`` hands it — the frame *after* production's own
     ``valid_time > power_fcst_init_time`` / ``ensemble_member is not null`` filter runs, so this
     test observes that filter's real output rather than re-deriving it — and pins that the
@@ -485,3 +486,110 @@ def test_live_power_history_covers_the_longest_selected_power_lag(
     genuine = predicted_from.collect()
     assert genuine.height > 0
     assert genuine["power_lag_336h"].null_count() == 0
+
+
+def _save_model_trained_on_weather_lag(path: Path, lag_hours: int) -> None:
+    """A tiny real ``XGBoostForecaster`` selecting a weather lag feature, trained on ts1 only."""
+    times = [datetime(2025, 1, 1, hour, tzinfo=UTC) for hour in (0, 1, 2)]
+    feature_name = f"temperature_2m_lag_{lag_hours}h"
+    train_df = pl.DataFrame(
+        {
+            "time_series_id": [1, 1, 1],
+            "valid_time": times,
+            "time_series_type": ["Primary"] * 3,
+            "power_fcst_init_time": times,
+            "power": [10.0, 12.0, 11.0],
+            feature_name: [9.0, 11.0, 10.5],
+        }
+    )
+    train_data = pt.LazyFrame.from_existing(train_df.lazy()).set_model(AllFeatures)
+    config = XGBoostConfig(
+        selected_features={feature_name}, experiment_name="live_test", n_estimators=5
+    )
+    forecaster = XGBoostForecaster(config)
+    forecaster.train(train_data, time_series_ids=[1])
+    forecaster.save(path)
+    write_trained_metadata(
+        model_dir=path, time_series_metadata=_metadata_for((1,), (_TRAINED_CELL,))
+    )
+
+
+@pytest.mark.parametrize(
+    ("gap_hours", "expect_null"),
+    [
+        pytest.param(6, True, id="6h_gap_below_the_publication_delay"),
+        pytest.param(9, False, id="9h_gap_at_the_publication_delay"),
+    ],
+)
+def test_live_weather_lag_nulls_only_when_the_selected_run_is_too_fresh(
+    monkeypatch: pytest.MonkeyPatch,
+    dagster_instance: DagsterInstance,
+    tmp_path: Path,
+    gap_hours: int,
+    expect_null: bool,
+) -> None:
+    """Pins today's asymmetry between "live" availability and the single-run publication-delay cut.
+
+    ``live_forecasts`` selects its one NWP run in ``"live"`` availability mode, which applies no
+    modelled delay — any run genuinely present in the Delta table qualifies. But the single-run
+    analysis-proxy inside ``_engineer_features`` still gates its freshest-run join with the
+    ``NWP_PUBLICATION_DELAY_HOURS`` (9h) ``available_at`` cut. When the selected run is closer
+    than 9 hours to ``power_fcst_init_time`` — as at the 06:00 slot, when only that morning's run
+    has landed — the cut excludes the run entirely from the freshest-run join and a weather lag
+    targeting an earlier time goes null; a run 9 hours or further back passes the cut and the lag
+    is populated. This pins the behaviour as it stands, not as a design endorsement: whether
+    "live" mode should apply the same delay is a serving-path semantic decision, tracked
+    separately from this test.
+    """
+    gap = timedelta(hours=gap_hours)
+    power_fcst_init_time = datetime(2026, 7, 4, 6, 0, tzinfo=UTC)
+    partition_key = "2026-07-04-00:00"  # window start; window end (= power_fcst_init_time) is 6h on
+    nwp_init = power_fcst_init_time - gap
+    forecast_valid_time = power_fcst_init_time + timedelta(minutes=30)
+    target_time = forecast_valid_time - gap  # == nwp_init + 30 min: inside the run's own coverage
+
+    nged_path = tmp_path / "NGED"
+    nged_path.mkdir()
+    production_model_path = tmp_path / "production_model"
+
+    monkeypatch.setenv("NGED_DATA_PATH", str(nged_path))
+    monkeypatch.setenv("NWP_DATA_PATH", str(tmp_path / "NWP"))
+    monkeypatch.setenv("POWER_FORECASTS_DATA_PATH", str(tmp_path / "power_forecasts"))
+    monkeypatch.setenv("PRODUCTION_MODEL_PATH", str(production_model_path))
+
+    _write_power_for(str(nged_path / "power_time_series.delta"), (1,))
+    records = nwp_records(
+        _TRAINED_CELL,
+        nwp_init,
+        (0,),
+        init_time=nwp_init,
+        valid_times=[target_time, forecast_valid_time],
+    )
+    write_test_nwp(str(tmp_path / "NWP"), records)
+    _save_model_trained_on_weather_lag(production_model_path, gap_hours)
+
+    captured: list[pt.LazyFrame[AllFeatures]] = []
+    real_predict = XGBoostForecaster.predict
+
+    def _spy_predict(
+        self: XGBoostForecaster, data: pt.LazyFrame[AllFeatures], *, fold_id: str = "live"
+    ) -> pt.DataFrame[PowerForecast]:
+        captured.append(data)
+        return real_predict(self, data, fold_id=fold_id)
+
+    monkeypatch.setattr(XGBoostForecaster, "predict", _spy_predict)
+
+    result = materialize(
+        [live_forecasts],
+        partition_key=partition_key,
+        run_config=RunConfig(ops={"live_forecasts": LiveForecastsConfig(availability_mode="live")}),
+        instance=dagster_instance,
+    )
+    assert result.success
+
+    (predicted_from,) = captured
+    genuine = predicted_from.collect()
+    assert genuine.height > 0
+    lag_col = f"temperature_2m_lag_{gap_hours}h"
+    lag_is_entirely_null = genuine[lag_col].null_count() == genuine.height
+    assert lag_is_entirely_null == expect_null


### PR DESCRIPTION
Generated with [Claude Code](https://claude.com/claude-code).

Implements the final-review triage for the whole day's work (range `48d415a7..46ed9b61` plus the wave-4-followup PR), covering every item under the triage's **Accept** headings and nothing under **Reject** or **No action**.

## Reviewer 1 (coherence)

**V1 — the blocking item.** `compute_effective_capacity`'s four existing unit tests all feed constant power within each series, where `quantile(0.99)`, `mean()`, `max()` and `median()` are all equal, so none of them actually exercises P99. Added `test_compute_effective_capacity_is_the_99th_percentile_not_the_mean`, a fixture of 50 observations at 1.0 MW plus one spike at 50.0 MW (51 rows): Polars' default `"nearest"` quantile interpolation puts `quantile(0.99)` exactly on the spike (50.0), while `mean()` (~1.96) and `quantile(0.01)` (1.0) fall far short. Kept all four existing tests — they pin the `max(time)` selection and the `abs()`, which are already proved.

V2 corrects a false comment in `_lags.py` claiming the `>=` boundary flip "changes no output today" — it changes output for every non-control ensemble member, and is inconsequential today only because the champion config selects no weather-lag features.

V3 fixes `docs/roadmap/index.md`, which had drifted from `docs/roadmap/engineering-health.md`: the roadmap page ticked "training-determinism" and listed only two remaining unwritten guardrail tests, while engineering-health.md (corrected by a previous wave) says fold-level determinism is a third, still-unwritten test that `test_random_seed_makes_training_deterministic` does not evidence.

V4 fixes a self-contradicting docstring on `_engineer_features`'s `nwp_publication_delay_hours` parameter: it described the delay as "until publicly available" (superseded by the switch to modelling disk-arrival) and claimed the parameter is "used only when `nwp_init_time is None` and `power_fcst_init_time is not None`", which the same docstring's own text three paragraphs later contradicts.

V5 deletes `test_engineer_features_weather_lag_freshest_run_reaches_older_run_only_data`, strictly subsumed by a test added 37 minutes later whose fixture is the same two rows plus one decoy, with identical call arguments and assertion.

V6 fixes the one stale clause `docs/architecture/adapting-to-another-geography.md` still had after PR 650: the row-index cap at V2 scale affects `power_forecasts`' accumulated writes, not "the `metrics` asset's whole-fold collect" (metrics batches four series at a time, as `docs/architecture/performance.md` already documents). Touched only that one clause, nothing else on the page.

Three over-claiming docstrings narrowed to what their assertions actually check: `tests/test_live_forecasts.py` (a test that hard-codes `power_lag_336h` rather than reading `conf/model/xgboost.yaml`), `tests/_nwp_test_data.py` (the partition-layout drift guard compares only column names, not the Enum-to-String strip itself), and `packages/ml_core/tests/test_feature_engineer.py` (the default-timezone test pins only the parameter's default, not the production call sites it describes).

## Reviewer 2 (mutation)

**W3 — the item with a boundary.** Today's `available_at`/9-hour-delay cut on the single-run analysis-proxy selection disagrees with `live_forecasts`' `"live"` availability mode, which by design applies no delay. The result: a weather lag goes null only when the selected NWP run is closer than 9 hours to `power_fcst_init_time` (e.g. a 6-hour gap), and is populated at every larger gap (9h+). Added `test_live_weather_lag_nulls_only_when_the_selected_run_is_too_fresh`, parametrized over both cases, and corrected `live_forecasts`' docstring, which previously predicted weather lags "would go null at live time" — they now go null only sometimes.

**This PR pins current behaviour; it does not change it and does not endorse it.** Whether `"live"` mode should apply the same publication delay as single-run replay is a serving-path semantic decision, not one this PR makes — tracked separately in issue #652 for the maintainer to decide.

W1 adds range and dtype coverage for `Nwp` inside `packages/contracts/tests/`, following the pattern `test_time_series_metadata.py` uses for `TimeSeriesMetadata.latitude`: out-of-range `temperature_2m` and `wind_direction_10m` values must fail validation, and every continuous weather variable must be stored as `Float32`.

W2 adds `packages/contracts/tests/test_effective_capacity.py`, pinning that `EffectiveCapacity.effective_capacity_mw` rejects zero and negative values — the NMAE denominator's zero-guard, previously untested from inside `contracts`.

W4 and W5 add literal pins for constants previously guarded only by tests that derive their expectation from the same constant, so a wrong value could never trip them: `LIVE_FORECAST_HORIZON == timedelta(days=14)` (`checks.py`'s `_MIN_HORIZON_HOURS` is computed from it) and both significand-bits constants, `POWER_FCST_SIGNIFICAND_BITS == 13` and `NWP_SIGNIFICAND_BITS == 13` (`PowerForecast.power_fcst`'s description asserts "max relative error 2^-13" in prose that a changed constant would leave silently wrong).

The five modules de-underscored in `9c49a453` (`contracts.uri`, `ml_core.cv_helpers`, `ml_core.mlflow_runs`, `ml_core.production_helpers`, `ml_core.repro`) are now listed on their package's mkdocstrings API page (`docs/api/contracts/index.md`, `docs/api/ml_core/index.md`).

## Mutations proved

Every new test below was run against the real bug it exists to catch, confirmed red, then reverted and confirmed green again.

| Test | Mutation | Result |
|---|---|---|
| `test_compute_effective_capacity_is_the_99th_percentile_not_the_mean` | `quantile(0.99)` → `mean()` | red (1.96 ≠ 50.0) |
| `test_compute_effective_capacity_is_the_99th_percentile_not_the_mean` | `quantile(0.99)` → `quantile(0.01)` | red (1.0 ≠ 50.0) |
| `test_live_weather_lag_nulls_only_when_the_selected_run_is_too_fresh[6h_gap]` | dropped the `available_at`/`publication_delay` cut in single-run mode | red (lag populated when the test expects null) |
| `test_out_of_range_continuous_weather_var_is_fatal[temperature_2m]` | `temperature_2m.le` 100 → 10000 | red (did not raise) |
| `test_out_of_range_continuous_weather_var_is_fatal[wind_direction_10m]` | `wind_direction_10m.le` 360 → 3600 | red (did not raise) |
| `test_continuous_weather_vars_are_stored_as_float32` | `temperature_2m.dtype` Float32 → Float64 | red (Float64 != Float32) |
| `test_effective_capacity_rejects_non_positive_value` (both cases) | `effective_capacity_mw.gt=0` → `ge=-100` | red (did not raise) |
| `test_the_live_forecast_horizon_is_fourteen_days` | `LIVE_FORECAST_HORIZON` 14 days → 2 days | red (2 days ≠ 14 days) |
| `test_the_power_fcst_significand_bits_is_thirteen` | `POWER_FCST_SIGNIFICAND_BITS` 13 → 10 | red (10 ≠ 13); the derived-tolerance sibling test stayed green, as the triage predicted |
| `test_the_nwp_significand_bits_is_thirteen` | `NWP_SIGNIFICAND_BITS` 13 → 10 | red (10 ≠ 13); the derived-tolerance sibling test stayed green, as the triage predicted |

All mutations reverted; `git status` was clean before this commit and the full verification set (ruff check, ruff format --check, ty check, pytest, pymarkdown scan, mkdocs build --strict) is green on the merged tree.

## Scope

Stayed inside the triage's Accept items — nothing under Reject or No action was touched, and nothing outside the triage was fixed even where noticed in passing.

No ML model was retrained and no large asset was materialised.
