### PR TITLE
Record why a signed Int64 is safe for every H3 index

### DIFF
--- a/packages/contracts/src/contracts/weather_schemas.py
+++ b/packages/contracts/src/contracts/weather_schemas.py
@@ -152,6 +152,20 @@ class Nwp(pt.Model):
         description="Ensemble member index (0-based).",
     )
 
+    # `Int64`, not `UInt64`, because Delta has no unsigned integer types: the column is stored as
+    # `int64` whatever we declare, and declaring `UInt64` only bought a cast in `scan_delta` that
+    # stopped Polars pushing `h3_index` filters into the Parquet scan.
+    #
+    # Signed is safe for the whole H3 index space, not just the values we happen to store. H3
+    # reserves bit 63 of its 64-bit index as always zero — it is not a value bit in any index mode
+    # (cell, directed edge, vertex) at any resolution — so every H3 index is below 2**63, which is
+    # exactly the range a signed `Int64` covers. A cell index sets mode bits 59-62 to 1 and so tops
+    # out around 2**60, well inside that. Sampling every resolution 0-15 agrees: the largest index
+    # seen is ~6.5e17 against `Int64`'s ~9.2e18 ceiling, and bit 63 is never set.
+    #
+    # The guarantee does not depend on the resolution, so raising or lowering
+    # `ECMWF_ENS_H3_RESOLUTION`, or giving a future NWP model its own resolution (issue 114),
+    # cannot overflow this column. Resolution lives in bits 52-55 and leaves bit 63 alone.
     h3_index: int = pt.Field(
         dtype=pl.Int64,
         description=(

--- a/packages/dynamical_data/src/dynamical_data/ecmwf_ens/convert_to_polars.py
+++ b/packages/dynamical_data/src/dynamical_data/ecmwf_ens/convert_to_polars.py
@@ -70,9 +70,12 @@ def convert_nwp_xarray_dataset_to_polars_dataframe(
         .with_columns(
             nwp_model_id=pl.lit(NwpModelId.ECMWF_ENS_0_25_degree.name).cast(pl.String),
             init_time=pl.lit(ds["init_time"].values).cast(UTC_DATETIME_DTYPE),
-            # h3_grid.h3_index (H3GridWeights, joined in above) is UInt64 — that contract is out
-            # of this change's scope — but Nwp.h3_index is Int64, so it needs an explicit cast
-            # here rather than at H3GridWeights's boundary.
+            # h3_grid.h3_index (H3GridWeights, joined in above) is UInt64 — that contract is
+            # Parquet-backed, so it never had Delta's no-unsigned-integer constraint — but
+            # Nwp.h3_index is Int64, so it needs an explicit cast here rather than at
+            # H3GridWeights's boundary. The narrowing loses nothing at any resolution: H3 reserves
+            # bit 63 of every index as zero, so no H3 value reaches the bit a signed Int64 gives
+            # up. See Nwp.h3_index in contracts.weather_schemas for the full argument.
             h3_index=pl.col("h3_index").cast(pl.Int64),
             wind_speed_10m=_calc_wind_speed(height="10m"),
             wind_speed_100m=_calc_wind_speed(height="100m"),


### PR DESCRIPTION
*Written by Claude Code.*

`Nwp.h3_index` moved from `UInt64` to `Int64` so its declared dtype matches what Delta actually stores, but nothing recorded why signed is safe. That leaves the next reader to either re-derive the argument or wonder whether the column can overflow — and it is the kind of question that surfaces at exactly the wrong moment.

**The guarantee is a property of the H3 format, not of our data.** Bit 63 of a 64-bit H3 index is reserved and always zero — it is not a value bit in any index mode (cell, directed edge, vertex) at any resolution. So every H3 index is structurally below 2**63, which is exactly the range a signed `Int64` covers. A cell index sets mode bits 59-62 to 1 and so tops out around 2**60, well inside that.

Sampling agrees with the spec rather than merely failing to contradict it: across all sixteen resolutions the largest index observed is ~6.5e17, against `Int64`'s ~9.2e18 ceiling, and bit 63 was never set.

**It holds at any resolution**, which is the part worth writing down, because changing the resolution is the change most likely to prompt the question. Resolution lives in bits 52-55 and never touches bit 63, so raising or lowering `ECMWF_ENS_H3_RESOLUTION` — or giving a future NWP model its own resolution, tracked in #114 — cannot overflow this column.

The comment at the `convert_to_polars` cast now also says why narrowing `H3GridWeights`' `UInt64` to `Int64` loses nothing, and why that contract keeps `UInt64`: it is Parquet-backed, so it never had Delta's no-unsigned-integer constraint that forced `Nwp` to change.

## Verification

Comments only, no behaviour change. `ruff check`, `ruff format --check`, `ty check --all-packages`, and the `contracts` and `dynamical_data` suites (206 passed, 1 skipped) are green, and the pre-commit hook passed.
